### PR TITLE
Remove test case for remote GTFS file handling.

### DIFF
--- a/internal/gtfs/gtfs_manager_test.go
+++ b/internal/gtfs/gtfs_manager_test.go
@@ -16,10 +16,6 @@ func TestManager_GetAgencies(t *testing.T) {
 			name:     "FromLocalFile",
 			dataPath: models.GetFixturePath(t, "gtfs.zip"),
 		},
-		{
-			name:     "FromRemoteFile",
-			dataPath: "https://www.soundtransit.org/GTFS-rail/40_gtfs.zip",
-		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
We don't need to do a web request in our tests