### PR TITLE
fix: add missing .env.example and service-alerts-url flag

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+# Environment variables for Maglev OneBusAway API Server
+# Copy this file to .env and fill in the required values
+
+# Real-time data authentication header value for Unitrans GTFS-RT feeds
+# This is required for accessing the UMO IQ API for real-time transit data
+REALTIME_AUTH_HEADER_VALUE=your_api_key_here

--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,8 @@ run: build
     	-trip-updates-url=https://webservices.umoiq.com/api/gtfs-rt/v1/trip-updates/unitrans \
     	-vehicle-positions-url=https://webservices.umoiq.com/api/gtfs-rt/v1/vehicle-positions/unitrans \
     	-realtime-auth-header-name=x-umo-iq-api-key \
-    	-realtime-auth-header-value=$(REALTIME_AUTH_HEADER_VALUE)
-		-service-alerts-url=https://webservices.umoiq.com/api/gtfs-rt/v1/service-alerts/unitrans \
+    	-realtime-auth-header-value=$(REALTIME_AUTH_HEADER_VALUE) \
+    	-service-alerts-url=https://webservices.umoiq.com/api/gtfs-rt/v1/service-alerts/unitrans
 
 build:
 	go build -gcflags "all=-N -l" -o bin/maglev ./cmd/api

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -34,6 +34,7 @@ func main() {
 	flag.StringVar(&gtfsCfg.VehiclePositionsURL, "vehicle-positions-url", "https://api.pugetsound.onebusaway.org/api/gtfs_realtime/vehicle-positions-for-agency/40.pb?key=org.onebusaway.iphone", "URL for a GTFS-RT vehicle positions feed")
 	flag.StringVar(&gtfsCfg.RealTimeAuthHeaderKey, "realtime-auth-header-name", "", "Optional header name for GTFS-RT auth")
 	flag.StringVar(&gtfsCfg.RealTimeAuthHeaderValue, "realtime-auth-header-value", "", "Optional header value for GTFS-RT auth")
+	flag.StringVar(&gtfsCfg.ServiceAlertsURL, "service-alerts-url", "", "URL for a GTFS-RT service alerts feed")
 	flag.StringVar(&gtfsCfg.GTFSDataPath, "data-path", "./gtfs.db", "Path to the SQLite database containing GTFS data")
 	flag.Parse()
 


### PR DESCRIPTION
- Add .env.example with required REALTIME_AUTH_HEADER_VALUE
- Add missing -service-alerts-url flag to main.go
- Fix Makefile to properly use service-alerts-url flag

Fixes #116