### PR TITLE
Fix: unify stop direction logic in stops-for-location to match OBA Java (#135)

### DIFF
--- a/internal/gtfs/direction_calculator.go
+++ b/internal/gtfs/direction_calculator.go
@@ -77,7 +77,7 @@ func (dc *DirectionCalculator) calculateFromShape(ctx context.Context, stopID st
 			directions[direction]++
 		}
 	}
-
+	// Return the most common direction found in the directions map
 	return dc.getMostCommonDirection(directions)
 }
 

--- a/internal/restapi/stops_for_location_handler.go
+++ b/internal/restapi/stops_for_location_handler.go
@@ -129,11 +129,8 @@ func (api *RestAPI) stopsForLocationHandler(w http.ResponseWriter, r *http.Reque
 		if len(rids) == 0 || agency == nil {
 			continue
 		}
-
-		direction := models.UnknownValue
-		if stop.Direction.Valid && stop.Direction.String != "" {
-			direction = stop.Direction.String
-		}
+		// Use the shared OBA direction pipeline (precomputed DB or shape-based fallback) for consistency.
+		direction := api.calculateStopDirection(ctx, stop.ID)
 
 		results = append(results, models.NewStop(
 			utils.NullStringOrEmpty(stop.Code),


### PR DESCRIPTION


# Hi team 👋 and @Ahmedhossamdev ,

This PR makes the **`stops-for-location`** endpoint consistent with the rest of the Maglev API by using the same shared direction-calculation pipeline already used in endpoints like **`stops-for-route`**, **`trip-details`**, and others.

---

## **What was the issue?**

In the original **Java OneBusAway API**, all stops get their compass direction using the same unified logic.

But in Maglev:

* Most endpoints use `api.calculateStopDirection(...)`
* **Only `stops-for-location`** directly returned `stop.Direction` from the DB

This caused mismatches like the one shown in **issue #135**, where the same stop returned different directions depending on which endpoint you called.

---

## **What this PR does**

### ✅ Replaces the direct DB read with:

```go
direction := api.calculateStopDirection(ctx, stop.ID)
```

### As a result, the endpoint now:

* Uses DB-precomputed directions from **AdvancedDirectionCalculator**
* Falls back to **shape-based** direction
* Falls back to **next-stop** direction
* Returns `"UNKNOWN"` consistently when nothing is available

This aligns the endpoint with the rest of the system.

---

## **Manual Verification**

I compared Maglev’s output against the official OBA Java API using the **SoundTransit** feed.

### **Java OBA output:**

```
https://api.pugetsound.onebusaway.org/api/where/stops-for-location.json?key=TEST&lat=47.608013&lon=-122.335167
```

### **Maglev (local) output:**

```
http://localhost:4000/api/where/stops-for-location.json?key=TEST&lat=47.608013&lon=-122.335167
```

Several stops — e.g., **40_565 (“Symphony”)** and **40_455** — now match perfectly in:

* id
* direction
* lat/lon
* route memberships

📸 Screenshots are attached (Java OBA vs Maglev).


![maglev-local-stops-for-location-output](https://github.com/user-attachments/assets/a9eda464-bffb-446f-b04f-c60fb2c55091)



![java-oba-stops-for-location-output](https://github.com/user-attachments/assets/e8139676-43ef-4009-814a-68bc0f9ba01b)
---

## **Tests added**

### ✔️ `TestStopsForLocationReturnsDirection`

Ensures every stop returns either a valid compass direction or `"UNKNOWN"`.

### ✔️ `TestStopsForLocationMatchesStopsForRoute`

Ensures the **same stop** has the **same direction** across both endpoints.

Both tests pass on the full SoundTransit dataset.

---

## **Additional Notes**

* No schema or migration changes.
* No changes to other endpoints — this fix only aligns `/stops-for-location` with already existing direction logic.
* Follows the same pattern already used in `/stops-for-route`, `/trip-details`, etc.

---

## **If maintainers need anything**

If you’d like adjustments (naming, test coverage, or structure), I’m happy to update the PR.

Also — if there are other endpoints or checks, where direction consistency should be enforced, I’m happy to help in a follow-up PR.

Thanks! 🙌

---





Fixes #135