### PR TITLE
Fixed Windows test failure in TestBuildApplicationWithConfigFile

### DIFF
--- a/cmd/api/app_test.go
+++ b/cmd/api/app_test.go
@@ -445,6 +445,7 @@ func TestBuildApplicationWithConfigFile(t *testing.T) {
 		// Convert to absolute path to avoid path traversal validation issues
 		absTestDataPath, err := filepath.Abs(testDataPath)
 		require.NoError(t, err)
+		absTestDataPath = filepath.ToSlash(absTestDataPath)
 
 		// Create a test config file that uses the test data
 		testConfigPath := filepath.Join("..", "..", "testdata", "config_test_build.json")


### PR DESCRIPTION
### Why this change was added
On Windows, file paths contain backslashes (`\`), which are treated as escape characters in JSON strings. When such paths are embedded directly into JSON, this causes JSON parsing errors (see issue #148 ).

### What this change does
This line converts Windows-style backslashes to forward slashes using `filepath.ToSlash()`. Forward slashes are valid in JSON and are correctly handled by Windows file paths, ensuring the test works consistently across all platforms.
