### PR TITLE
fix: remove duplicate line in `cmd/api/app_test.go`

### DIFF
--- a/cmd/api/app_test.go
+++ b/cmd/api/app_test.go
@@ -444,7 +444,6 @@ func TestBuildApplicationWithConfigFile(t *testing.T) {
 
 		// Convert to absolute path to avoid path traversal validation issues
 		absTestDataPath, err := filepath.Abs(testDataPath)
-		absTestDataPath = filepath.ToSlash(absTestDataPath)
 		require.NoError(t, err)
 		absTestDataPath = filepath.ToSlash(absTestDataPath)
 


### PR DESCRIPTION
This removes a duplicate line that was accidentally introduced during the merge of PR #153

at this function "TestBuildApplicationWithConfigFile"

I missed syncing with upstream before my previous merge, resulting in this redundancy.
@aaronbrethorst  