### PR TITLE
feat: add /route/{id} endpoint

### DIFF
--- a/internal/gtfs/gtfs_manager.go
+++ b/internal/gtfs/gtfs_manager.go
@@ -145,6 +145,12 @@ func (manager *Manager) FindAgency(id string) *gtfs.Agency {
 	return nil
 }
 
+func (manager *Manager) GetRoutes() []gtfs.Route {
+	manager.staticMutex.RLock()
+	defer manager.staticMutex.RUnlock()
+	return manager.gtfsData.Routes
+}
+
 // RoutesForAgencyID retrieves all routes associated with the specified agency ID from the GTFS data.
 func (manager *Manager) RoutesForAgencyID(agencyID string) []*gtfs.Route {
 	manager.staticMutex.RLock()

--- a/internal/restapi/route_handler.go
+++ b/internal/restapi/route_handler.go
@@ -19,7 +19,7 @@ func (api *RestAPI) routeHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	_, routeID, err := utils.ExtractAgencyIDAndCodeID(queryParamID)
+	agencyID, routeID, err := utils.ExtractAgencyIDAndCodeID(queryParamID)
 	if err != nil {
 		api.serverErrorResponse(w, r, err)
 		return
@@ -33,22 +33,22 @@ func (api *RestAPI) routeHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	routeData := &models.Route{
-		ID:                utils.FormCombinedID(route.AgencyID, route.ID),
-		AgencyID:          route.AgencyID,
-		Color:             route.Color.String,
-		Description:       route.Desc.String,
-		ShortName:         route.ShortName.String,
-		LongName:          route.LongName.String,
-		NullSafeShortName: utils.NullStringOrEmpty(route.ShortName),
-		TextColor:         route.TextColor.String,
-		Type:              models.RouteType(route.Type),
-		URL:               route.Url.String,
-	}
+	routeData := models.NewRoute(
+		utils.FormCombinedID(agencyID, route.ID),
+		agencyID,
+		route.ShortName.String,
+		route.LongName.String,
+		route.Desc.String,
+		models.RouteType(route.Type),
+		route.Url.String,
+		route.Color.String,
+		route.TextColor.String,
+		utils.NullStringOrEmpty(route.ShortName),
+	)
 
 	references := models.NewEmptyReferences()
 
-	agency, err := api.GtfsManager.GtfsDB.Queries.GetAgency(ctx, route.AgencyID)
+	agency, err := api.GtfsManager.GtfsDB.Queries.GetAgency(ctx, agencyID)
 	if err == nil {
 		agencyModel := models.NewAgencyReference(
 			agency.ID,

--- a/internal/restapi/route_handler.go
+++ b/internal/restapi/route_handler.go
@@ -1,0 +1,70 @@
+package restapi
+
+import (
+	"net/http"
+
+	"maglev.onebusaway.org/internal/models"
+	"maglev.onebusaway.org/internal/utils"
+)
+
+func (api *RestAPI) routeHandler(w http.ResponseWriter, r *http.Request) {
+	queryParamID := utils.ExtractIDFromParams(r)
+
+	// Validate ID
+	if err := utils.ValidateID(queryParamID); err != nil {
+		fieldErrors := map[string][]string{
+			"id": {err.Error()},
+		}
+		api.validationErrorResponse(w, r, fieldErrors)
+		return
+	}
+
+	_, routeID, err := utils.ExtractAgencyIDAndCodeID(queryParamID)
+	if err != nil {
+		api.serverErrorResponse(w, r, err)
+		return
+	}
+
+	ctx := r.Context()
+
+	route, err := api.GtfsManager.GtfsDB.Queries.GetRoute(ctx, routeID)
+	if err != nil || route.ID == "" {
+		api.sendNotFound(w, r)
+		return
+	}
+
+	routeData := &models.Route{
+		ID:                utils.FormCombinedID(route.AgencyID, route.ID),
+		AgencyID:          route.AgencyID,
+		Color:             route.Color.String,
+		Description:       route.Desc.String,
+		ShortName:         route.ShortName.String,
+		LongName:          route.LongName.String,
+		NullSafeShortName: utils.NullStringOrEmpty(route.ShortName),
+		TextColor:         route.TextColor.String,
+		Type:              models.RouteType(route.Type),
+		URL:               route.Url.String,
+	}
+
+	references := models.NewEmptyReferences()
+
+	agency, err := api.GtfsManager.GtfsDB.Queries.GetAgency(ctx, route.AgencyID)
+	if err == nil {
+		agencyModel := models.NewAgencyReference(
+			agency.ID,
+			agency.Name,
+			agency.Url,
+			agency.Timezone,
+			agency.Lang.String,
+			agency.Phone.String,
+			agency.Email.String,
+			agency.FareUrl.String,
+			"",    // disclaimer
+			false, // privateService
+		)
+		references.Agencies = append(references.Agencies, agencyModel)
+	}
+
+	response := models.NewEntryResponse(routeData, references)
+	api.sendResponse(w, r, response)
+}

--- a/internal/restapi/route_handler_test.go
+++ b/internal/restapi/route_handler_test.go
@@ -1,0 +1,116 @@
+package restapi
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"maglev.onebusaway.org/internal/utils"
+)
+
+func TestRouteHandlerRequiresValidApiKey(t *testing.T) {
+	api := createTestApi(t)
+
+	agencies := api.GtfsManager.GetAgencies()
+	assert.NotEmpty(t, agencies, "Test data should contain at least one agency")
+
+	routes := api.GtfsManager.GetRoutes()
+	assert.NotEmpty(t, routes, "Test data should contain at least one route")
+
+	routeID := utils.FormCombinedID(agencies[0].Id, routes[0].Id)
+
+	resp, model := serveApiAndRetrieveEndpoint(t, api, "/api/where/route/"+routeID+".json?key=invalid")
+	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+	assert.Equal(t, http.StatusUnauthorized, model.Code)
+	assert.Equal(t, "permission denied", model.Text)
+}
+
+func TestRouteHandlerEndToEnd(t *testing.T) {
+	api := createTestApi(t)
+
+	agencies := api.GtfsManager.GetAgencies()
+	assert.NotEmpty(t, agencies, "Test data should contain at least one agency")
+
+	routes := api.GtfsManager.GetRoutes()
+	assert.NotEmpty(t, routes, "Test data should contain at least one route")
+
+	routeID := utils.FormCombinedID(agencies[0].Id, routes[0].Id)
+	resp, model := serveApiAndRetrieveEndpoint(t, api, "/api/where/route/"+routeID+".json?key=TEST")
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, http.StatusOK, model.Code)
+	assert.Equal(t, "OK", model.Text)
+
+	data, ok := model.Data.(map[string]interface{})
+	assert.True(t, ok)
+	assert.NotEmpty(t, data)
+
+	entry, ok := data["entry"].(map[string]interface{})
+	assert.True(t, ok)
+
+	assert.Equal(t, routeID, entry["id"])
+	assert.Equal(t, routes[0].Agency.Id, entry["agencyId"])
+	assert.Equal(t, routes[0].ShortName, entry["shortName"])
+	assert.Equal(t, routes[0].LongName, entry["longName"])
+	assert.Equal(t, routes[0].Description, entry["description"])
+	assert.Equal(t, routes[0].Url, entry["url"])
+	assert.Equal(t, routes[0].Color, entry["color"])
+	assert.Equal(t, routes[0].TextColor, entry["textColor"])
+	assert.Equal(t, int(routes[0].Type), int(entry["type"].(float64)))
+
+	references, ok := data["references"].(map[string]interface{})
+	assert.True(t, ok, "References section should exist")
+	assert.NotEmpty(t, references, "References section should not be nil")
+
+	agenciesRef, ok := references["agencies"].([]interface{})
+	assert.True(t, ok, "Agencies reference should exist and be an array")
+	agencyRef := agenciesRef[0].(map[string]interface{})
+	assert.Equal(t, agencies[0].Id, agencyRef["id"])
+	assert.NotEmpty(t, agenciesRef, "Agencies reference should not be empty")
+}
+
+func TestInvalidRouteID(t *testing.T) {
+	api := createTestApi(t)
+
+	agencies := api.GtfsManager.GetAgencies()
+	assert.NotEmpty(t, agencies, "Test data should contain at least one agency")
+
+	invalidRouteID := utils.FormCombinedID(agencies[0].Id, "invalid_route_id")
+
+	resp, model := serveApiAndRetrieveEndpoint(t, api, "/api/where/route/"+invalidRouteID+".json?key=TEST")
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+	assert.Equal(t, http.StatusNotFound, model.Code)
+	assert.Equal(t, "resource not found", model.Text)
+}
+
+func TestRouteHandlerVerifiesReferences(t *testing.T) {
+	api := createTestApi(t)
+
+	agencies := api.GtfsManager.GetAgencies()
+	assert.NotEmpty(t, agencies, "Test data should contain at least one agency")
+
+	routes := api.GtfsManager.GetRoutes()
+	assert.NotEmpty(t, routes, "Test data should contain at least one route")
+
+	routeID := utils.FormCombinedID(agencies[0].Id, routes[0].Id)
+
+	resp, model := serveApiAndRetrieveEndpoint(t, api, "/api/where/route/"+routeID+".json?key=TEST")
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	data, ok := model.Data.(map[string]interface{})
+	require.True(t, ok)
+
+	references, ok := data["references"].(map[string]interface{})
+	require.True(t, ok)
+
+	// Verify agencies are included
+	agenciesRef, ok := references["agencies"].([]interface{})
+	assert.True(t, ok, "Agencies should be in references")
+	if len(agenciesRef) > 0 {
+		agency, ok := agenciesRef[0].(map[string]interface{})
+		assert.True(t, ok)
+		assert.NotEmpty(t, agency["id"], "Agency should have an ID")
+		assert.Equal(t, agencies[0].Id, agency["id"])
+		assert.NotEmpty(t, agency["name"], "Agency should have a name")
+	}
+}

--- a/internal/restapi/route_handler_test.go
+++ b/internal/restapi/route_handler_test.go
@@ -18,7 +18,7 @@ func TestRouteHandlerRequiresValidApiKey(t *testing.T) {
 	routes := api.GtfsManager.GetRoutes()
 	assert.NotEmpty(t, routes, "Test data should contain at least one route")
 
-	routeID := utils.FormCombinedID(agencies[0].Id, routes[0].Id)
+	routeID := utils.FormCombinedID(routes[0].Agency.Id, routes[0].Id)
 
 	resp, model := serveApiAndRetrieveEndpoint(t, api, "/api/where/route/"+routeID+".json?key=invalid")
 	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
@@ -35,7 +35,7 @@ func TestRouteHandlerEndToEnd(t *testing.T) {
 	routes := api.GtfsManager.GetRoutes()
 	assert.NotEmpty(t, routes, "Test data should contain at least one route")
 
-	routeID := utils.FormCombinedID(agencies[0].Id, routes[0].Id)
+	routeID := utils.FormCombinedID(routes[0].Agency.Id, routes[0].Id)
 	resp, model := serveApiAndRetrieveEndpoint(t, api, "/api/where/route/"+routeID+".json?key=TEST")
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, http.StatusOK, model.Code)
@@ -75,7 +75,10 @@ func TestInvalidRouteID(t *testing.T) {
 	agencies := api.GtfsManager.GetAgencies()
 	assert.NotEmpty(t, agencies, "Test data should contain at least one agency")
 
-	invalidRouteID := utils.FormCombinedID(agencies[0].Id, "invalid_route_id")
+	routes := api.GtfsManager.GetRoutes()
+	assert.NotEmpty(t, routes, "Test data should contain at least one route")
+
+	invalidRouteID := utils.FormCombinedID(routes[0].Agency.Id, "invalid_route_id")
 
 	resp, model := serveApiAndRetrieveEndpoint(t, api, "/api/where/route/"+invalidRouteID+".json?key=TEST")
 	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
@@ -92,7 +95,7 @@ func TestRouteHandlerVerifiesReferences(t *testing.T) {
 	routes := api.GtfsManager.GetRoutes()
 	assert.NotEmpty(t, routes, "Test data should contain at least one route")
 
-	routeID := utils.FormCombinedID(agencies[0].Id, routes[0].Id)
+	routeID := utils.FormCombinedID(routes[0].Agency.Id, routes[0].Id)
 
 	resp, model := serveApiAndRetrieveEndpoint(t, api, "/api/where/route/"+routeID+".json?key=TEST")
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
@@ -110,7 +113,7 @@ func TestRouteHandlerVerifiesReferences(t *testing.T) {
 		agency, ok := agenciesRef[0].(map[string]interface{})
 		assert.True(t, ok)
 		assert.NotEmpty(t, agency["id"], "Agency should have an ID")
-		assert.Equal(t, agencies[0].Id, agency["id"])
+		assert.Equal(t, routes[0].Agency.Id, agency["id"])
 		assert.NotEmpty(t, agency["name"], "Agency should have a name")
 	}
 }

--- a/internal/restapi/routes.go
+++ b/internal/restapi/routes.go
@@ -62,6 +62,7 @@ func (api *RestAPI) SetRoutes(mux *http.ServeMux) {
 	mux.Handle("GET /api/where/report-problem-with-stop/{id}", rateLimitAndValidateAPIKey(api, api.reportProblemWithStopHandler))
 	mux.Handle("GET /api/where/trip/{id}", rateLimitAndValidateAPIKey(api, api.tripHandler))
 	mux.Handle("GET /api/where/route-ids-for-agency/{id}", rateLimitAndValidateAPIKey(api, api.routeIDsForAgencyHandler))
+	mux.Handle("GET /api/where/route/{id}", rateLimitAndValidateAPIKey(api, api.routeHandler))
 	mux.Handle("GET /api/where/stop/{id}", rateLimitAndValidateAPIKey(api, api.stopHandler))
 	mux.Handle("GET /api/where/shape/{id}", rateLimitAndValidateAPIKey(api, api.shapesHandler))
 	mux.Handle("GET /api/where/routes-for-location.json", rateLimitAndValidateAPIKey(api, api.routesForLocationHandler))


### PR DESCRIPTION
fix: #156 

This PR adds the /route/{id} endpoint, with proper (unit)end to end testing ensuring that the Java production server’s output is followed and also follows the codebase coding style.