### PR TITLE
fix: arrival and departure time changed from milliseconds to seconds

### DIFF
--- a/gtfsdb/helpers.go
+++ b/gtfsdb/helpers.go
@@ -268,8 +268,8 @@ func (c *Client) processAndStoreGTFSDataWithSource(b []byte, source string) erro
 
 			params := CreateStopTimeParams{
 				TripID:            t.ID,
-				ArrivalTime:       int64(st.ArrivalTime),
-				DepartureTime:     int64(st.DepartureTime),
+				ArrivalTime:       int64(st.ArrivalTime.Seconds()),
+				DepartureTime:     int64(st.DepartureTime.Seconds()),
 				StopID:            st.Stop.Id,
 				StopSequence:      int64(st.StopSequence),
 				StopHeadsign:      toNullString(st.Headsign),


### PR DESCRIPTION
solves issue #161 
the data itself were being inserted in the database at the beginning in milliseconds; I just had to add a .Seconds() call 
will further investigate this endpoint and will open an issue if I find something else. 

All tests are passing. 