### PR TITLE
fix: change arrival and departure time to seconds only from trips_helper

### DIFF
--- a/gtfsdb/helpers.go
+++ b/gtfsdb/helpers.go
@@ -268,8 +268,8 @@ func (c *Client) processAndStoreGTFSDataWithSource(b []byte, source string) erro
 
 			params := CreateStopTimeParams{
 				TripID:            t.ID,
-				ArrivalTime:       int64(st.ArrivalTime.Seconds()),
-				DepartureTime:     int64(st.DepartureTime.Seconds()),
+				ArrivalTime:       int64(st.ArrivalTime),
+				DepartureTime:     int64(st.DepartureTime),
 				StopID:            st.Stop.Id,
 				StopSequence:      int64(st.StopSequence),
 				StopHeadsign:      toNullString(st.Headsign),

--- a/internal/restapi/trips_helper.go
+++ b/internal/restapi/trips_helper.go
@@ -170,8 +170,8 @@ func (api *RestAPI) BuildTripSchedule(ctx context.Context, agencyID string, serv
 		}
 
 		stopTimesVals[i] = models.StopTime{
-			ArrivalTime:         int(st.ArrivalTime),
-			DepartureTime:       int(st.DepartureTime),
+			ArrivalTime:         int(st.ArrivalTime / 1e9),
+			DepartureTime:       int(st.DepartureTime / 1e9),
 			StopID:              utils.FormCombinedID(agencyID, st.StopID),
 			StopHeadsign:        st.StopHeadsign.String,
 			DistanceAlongTrip:   distanceAlongTrip,


### PR DESCRIPTION
#161 
changed back the insertion of the time in nanoseconds in the database since the values are always treated as nanoseconds in the codebase 
converted the arrival and departure time to seconds from the trips_helper instead 