### PR TITLE
fix: add explicit date param to schedule handler tests

### DIFF
--- a/internal/restapi/schedule_for_route_handler_test.go
+++ b/internal/restapi/schedule_for_route_handler_test.go
@@ -22,7 +22,7 @@ func TestScheduleForRouteHandler(t *testing.T) {
 	routeID := utils.FormCombinedID(agencies[0].Id, static.Routes[0].Id)
 
 	t.Run("Valid route", func(t *testing.T) {
-		resp, model := serveApiAndRetrieveEndpoint(t, api, "/api/where/schedule-for-route/"+routeID+".json?key=TEST")
+		resp, model := serveApiAndRetrieveEndpoint(t, api, "/api/where/schedule-for-route/"+routeID+".json?key=TEST&date=2025-06-12")
 
 		assert.Equal(t, http.StatusOK, resp.StatusCode)
 		assert.Equal(t, http.StatusOK, model.Code)

--- a/internal/restapi/schedule_for_stop_handler_test.go
+++ b/internal/restapi/schedule_for_stop_handler_test.go
@@ -42,7 +42,7 @@ func TestScheduleForStopHandler(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			resp, model := serveApiAndRetrieveEndpoint(t, api, "/api/where/schedule-for-stop/"+tt.stopID+".json?key=TEST")
+			resp, model := serveApiAndRetrieveEndpoint(t, api, "/api/where/schedule-for-stop/"+tt.stopID+".json?key=TEST&date=2025-06-12")
 
 			assert.Equal(t, tt.expectedStatus, resp.StatusCode)
 			assert.Equal(t, tt.expectedStatus, model.Code)
@@ -258,7 +258,7 @@ func TestScheduleForStopHandlerEmptyRoutes(t *testing.T) {
 
 	t.Run("Stop with no routes returns empty schedule", func(t *testing.T) {
 		stopID := utils.FormCombinedID(agencies[0].Id, stops[0].Id)
-		endpoint := "/api/where/schedule-for-stop/" + stopID + ".json?key=TEST"
+		endpoint := "/api/where/schedule-for-stop/" + stopID + ".json?key=TEST&date=2025-06-12"
 		resp, model := serveApiAndRetrieveEndpoint(t, api, endpoint)
 
 		assert.Equal(t, http.StatusOK, resp.StatusCode)


### PR DESCRIPTION
Tests were failing because they used time.Now() which is now beyond the RABA test data's calendar range (ending 2025-12-31). Adding an explicit date parameter ensures tests use a date with active services.