### PR TITLE
Fix gtfstidy import

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -74,3 +74,4 @@ require (
 )
 
 tool github.com/sqlc-dev/sqlc/cmd/sqlc
+tool github.com/patrickbr/gtfstidy


### PR DESCRIPTION
per @mann-patwa:

> `gtftidy` dependency was getting removed when running `go mod tidy` since it was not imported anywhere. It's used as a tool during the makefile build. Added it as a tool in the go.mod file

this PR replaces #155, and was opened so that I could rebase against main to pick up test fixes.