### PR TITLE
Make health check API key configurable via environment variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,9 +49,12 @@ USER maglev
 # Expose API port
 EXPOSE 4000
 
+# Health check API key (override via docker run -e or docker-compose environment)
+ENV HEALTH_CHECK_KEY=test
+
 # Health check using the current-time endpoint
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
-    CMD wget -q --spider http://localhost:4000/api/where/current-time.json?key=test || exit 1
+    CMD wget -q --spider "http://localhost:4000/api/where/current-time.json?key=${HEALTH_CHECK_KEY}" || exit 1
 
 # Default command - run with config file
 # Users should mount config.json or use command-line flags

--- a/README.markdown
+++ b/README.markdown
@@ -287,13 +287,20 @@ The container includes a health check that verifies the API is responding:
 docker inspect --format='{{.State.Health.Status}}' maglev
 ```
 
-**Important:** The health checks in `Dockerfile`, `docker-compose.yml`, and `docker-compose.dev.yml` use `key=test` by default. If you change your API keys in the configuration, make sure to update the health check commands accordingly to avoid container restart loops.
+**Important:** The health checks use the `HEALTH_CHECK_KEY` environment variable (defaults to `test`). If you change your API keys in the configuration, update this environment variable to match:
+
+```yaml
+# In docker-compose.yml or docker-compose.dev.yml
+environment:
+  - HEALTH_CHECK_KEY=your-api-key
+```
 
 ### Environment Variables
 
-| Variable | Description                | Default |
-| -------- | -------------------------- | ------- |
-| `TZ`     | Timezone for the container | `UTC`   |
+| Variable           | Description                              | Default |
+| ------------------ | ---------------------------------------- | ------- |
+| `TZ`               | Timezone for the container               | `UTC`   |
+| `HEALTH_CHECK_KEY` | API key used for health check endpoint   | `test`  |
 
 ### Troubleshooting
 
@@ -312,6 +319,10 @@ ls -la config.json
 ```bash
 # Test the endpoint manually
 curl http://localhost:4000/api/where/current-time.json?key=test
+
+# If you changed api-keys, make sure HEALTH_CHECK_KEY matches
+# Check the current health check key
+docker-compose exec maglev printenv HEALTH_CHECK_KEY
 ```
 
 **Permission issues:**

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -19,11 +19,13 @@ services:
     environment:
       - TZ=UTC
       - CGO_ENABLED=1
+      # Health check API key - change this if you modify api-keys in config
+      - HEALTH_CHECK_KEY=test
     working_dir: /app
     # Use Air for live reload during development (Docker-specific config)
     command: ["air", "-c", ".air.docker.toml"]
     healthcheck:
-      test: ["CMD", "wget", "-q", "--spider", "http://localhost:4000/api/where/current-time.json?key=test"]
+      test: ["CMD-SHELL", "wget -q --spider \"http://localhost:4000/api/where/current-time.json?key=$$HEALTH_CHECK_KEY\" || exit 1"]
       interval: 30s
       timeout: 5s
       retries: 3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,8 +14,10 @@ services:
       - ./config.docker.json:/app/config.json:ro
     environment:
       - TZ=UTC
+      # Health check API key - change this if you modify api-keys in config
+      - HEALTH_CHECK_KEY=test
     healthcheck:
-      test: ["CMD", "wget", "-q", "--spider", "http://localhost:4000/api/where/current-time.json?key=test"]
+      test: ["CMD-SHELL", "wget -q --spider \"http://localhost:4000/api/where/current-time.json?key=$$HEALTH_CHECK_KEY\" || exit 1"]
       interval: 30s
       timeout: 5s
       retries: 3


### PR DESCRIPTION
## Summary

- Adds `HEALTH_CHECK_KEY` environment variable to Docker configuration (defaults to `test`)
- Allows users to update the health check key when they change their API keys
- Prevents health check failures and container restart loops when using custom API keys

## Changes

- **Dockerfile**: Added `ENV HEALTH_CHECK_KEY=test` and updated HEALTHCHECK to use the variable
- **docker-compose.yml**: Added `HEALTH_CHECK_KEY` to environment section with `CMD-SHELL` for variable expansion
- **docker-compose.dev.yml**: Same changes as docker-compose.yml
- **README.markdown**: Documented the new environment variable and updated troubleshooting section

## Usage

Users who change their API key can update the environment variable:

```yaml
# docker-compose.yml
environment:
  - HEALTH_CHECK_KEY=your-production-api-key
```

Or with `docker run`:
```bash
docker run -e HEALTH_CHECK_KEY=your-api-key -p 4000:4000 maglev
```

## Test plan

- [x] Verify `docker-compose up` works with default `test` key
- [x] Verify changing `HEALTH_CHECK_KEY` to a valid API key keeps container healthy
- [x] Verify changing `HEALTH_CHECK_KEY` to an invalid key makes container unhealthy (expected behavior)