### PR TITLE
chore: enable verbose output for docker health checks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,7 @@ ENV HEALTH_CHECK_KEY=test
 
 # Health check using the current-time endpoint
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
-    CMD wget -q --spider "http://localhost:4000/api/where/current-time.json?key=${HEALTH_CHECK_KEY}" || exit 1
+    CMD wget --spider "http://localhost:4000/api/where/current-time.json?key=${HEALTH_CHECK_KEY}" 2>&1 || exit 1
 
 # Default command - run with config file
 # Users should mount config.json or use command-line flags

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -25,7 +25,7 @@ services:
     # Use Air for live reload during development (Docker-specific config)
     command: ["air", "-c", ".air.docker.toml"]
     healthcheck:
-      test: ["CMD-SHELL", "wget -q --spider \"http://localhost:4000/api/where/current-time.json?key=$$HEALTH_CHECK_KEY\" || exit 1"]
+      test: ["CMD-SHELL", "wget --spider \"http://localhost:4000/api/where/current-time.json?key=$$HEALTH_CHECK_KEY\" 2>&1 || exit 1"]
       interval: 30s
       timeout: 5s
       retries: 3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       # Health check API key - change this if you modify api-keys in config
       - HEALTH_CHECK_KEY=test
     healthcheck:
-      test: ["CMD-SHELL", "wget -q --spider \"http://localhost:4000/api/where/current-time.json?key=$$HEALTH_CHECK_KEY\" || exit 1"]
+      test: ["CMD-SHELL", "wget --spider \"http://localhost:4000/api/where/current-time.json?key=$$HEALTH_CHECK_KEY\" 2>&1 || exit 1"]
       interval: 30s
       timeout: 5s
       retries: 3

--- a/internal/restapi/rate_limit_shutdown_test.go
+++ b/internal/restapi/rate_limit_shutdown_test.go
@@ -64,7 +64,7 @@ func TestRateLimitMiddleware_GoroutineActuallyExits(t *testing.T) {
 	// Force garbage collection to clean up any lingering goroutines from previous tests
 	runtime.GC()
 	time.Sleep(50 * time.Millisecond)
-	
+
 	// Get baseline goroutine count
 	initial := runtime.NumGoroutine()
 
@@ -80,4 +80,3 @@ func TestRateLimitMiddleware_GoroutineActuallyExits(t *testing.T) {
 	afterStop := runtime.NumGoroutine()
 	assert.LessOrEqual(t, afterStop, initial, "cleanup goroutine should have exited")
 }
-


### PR DESCRIPTION
## Summary
This PR improves the Docker health check configuration by enabling verbose output for the `wget` command. Previously, health checks used the `-q` (quiet) flag, which suppressed all output, making it impossible to diagnose failure causes (e.g., connection refused vs. 401 Unauthorized vs. timeout) from the container logs.

## Changes
- **Dockerfile**: Removed `-q` flag and added `2>&1` to `wget` command in `HEALTHCHECK`.
- **docker-compose.yml**: Updated health check command to match.
- **docker-compose.dev.yml**: Updated health check command to match.

## Motivation
When a container becomes unhealthy, the logs previously showed only `Exit 1` with no context. By enabling verbose output, operators can now see the specific error message (e.g., `Connection refused`, `bad address`, or HTTP error codes) directly in `docker logs`, significantly reducing troubleshooting time.

## Verification
- **Build**: Rebuilt Docker images successfully.
- **Test**: Manually ran the health check command inside a running container with an invalid port to simulate failure.
- **Result**: Confirmed that error details (e.g., "Connection refused") are now visible in the output.

## Check
- [x] `make lint` passed
- [x] `make test` passed
- [x] `go fmt` applied