### PR TITLE
chore: enable verbose output for docker health checks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,7 @@ ENV HEALTH_CHECK_KEY=test
 
 # Health check using the current-time endpoint
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
-    CMD wget -q --spider "http://localhost:4000/api/where/current-time.json?key=${HEALTH_CHECK_KEY}" || exit 1
+    CMD wget --spider "http://localhost:4000/api/where/current-time.json?key=${HEALTH_CHECK_KEY}" 2>&1 || exit 1
 
 # Default command - run with config file
 # Users should mount config.json or use command-line flags

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -23,9 +23,9 @@ services:
       - HEALTH_CHECK_KEY=test
     working_dir: /app
     # Use Air for live reload during development (Docker-specific config)
-    command: ["air", "-c", ".air.docker.toml"]
+    command: [ "air", "-c", ".air.docker.toml" ]
     healthcheck:
-      test: ["CMD-SHELL", "wget -q --spider \"http://localhost:4000/api/where/current-time.json?key=$$HEALTH_CHECK_KEY\" || exit 1"]
+      test: [ "CMD-SHELL", "wget --spider \"http://localhost:4000/api/where/current-time.json?key=$$HEALTH_CHECK_KEY\" 2>&1 || exit 1" ]
       interval: 30s
       timeout: 5s
       retries: 3
@@ -37,4 +37,3 @@ volumes:
     driver: local
   go-mod-cache:
     driver: local
-

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       # Health check API key - change this if you modify api-keys in config
       - HEALTH_CHECK_KEY=test
     healthcheck:
-      test: ["CMD-SHELL", "wget -q --spider \"http://localhost:4000/api/where/current-time.json?key=$$HEALTH_CHECK_KEY\" || exit 1"]
+      test: [ "CMD-SHELL", "wget --spider \"http://localhost:4000/api/where/current-time.json?key=$$HEALTH_CHECK_KEY\" 2>&1 || exit 1" ]
       interval: 30s
       timeout: 5s
       retries: 3
@@ -32,4 +32,3 @@ services:
 volumes:
   maglev-data:
     driver: local
-


### PR DESCRIPTION
Fixes #186
## Summary
This PR improves the Docker health check configuration by enabling verbose output for the `wget` command. Previously, health checks used the `-q` (quiet) flag, which suppressed all output, making it impossible to diagnose failure causes from the container logs.

## Changes
- **Dockerfile**: Removed `-q` flag and added `2>&1` to `wget` command in `HEALTHCHECK`.
- **docker-compose.yml**: Updated health check command to match.
- **docker-compose.dev.yml**: Updated health check command to match.

## Verification
- [x] Rebuilt Docker images successfully (`make docker-build`).
- [x] Verified failure output is now visible in logs.