### PR TITLE
Add sqlite_fts5 build tag to all build and test commands

### DIFF
--- a/.air.docker.toml
+++ b/.air.docker.toml
@@ -6,7 +6,7 @@ tmp_dir = "tmp"
 
 [build]
 # Build command - output to tmp directory for Docker
-cmd = "go build -gcflags 'all=-N -l' -o ./tmp/maglev ./cmd/api"
+cmd = "CGO_ENABLED=1 go build -tags sqlite_fts5 -gcflags 'all=-N -l' -o ./tmp/maglev ./cmd/api"
 # Binary to run with Docker config (uses /app/data/gtfs.db for persistence)
 bin = "./tmp/maglev -f config.docker.json"
 # Watch these extensions

--- a/.air.toml
+++ b/.air.toml
@@ -2,7 +2,7 @@ root = "."
 tmp_dir = "tmp"
 
 [build]
-  cmd = "go build -gcflags 'all=-N -l' -o bin/maglev ./cmd/api"
+  cmd = "CGO_ENABLED=1 go build -tags sqlite_fts5 -gcflags 'all=-N -l' -o bin/maglev ./cmd/api"
   bin = "bin/maglev"
   full_bin = "make run"
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -25,7 +25,7 @@ jobs:
         uses: golangci/golangci-lint-action@v3
         with:
           version: latest
-          args: --timeout=5m --build-tags=fts5
+          args: --timeout=5m --build-tags=sqlite_fts5
 
   test:
     name: Test
@@ -49,7 +49,7 @@ jobs:
         run: go mod verify
 
       - name: Run tests
-        run: go test -v -tags=fts5 -coverprofile=profile.cov ./...
+        run: go test -v -tags=sqlite_fts5 -coverprofile=profile.cov ./...
         env:
           CGO_ENABLED: 1
         shell: bash

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN go mod download
 COPY . .
 
 # Build the application with CGO enabled (required for SQLite)
-RUN CGO_ENABLED=1 GOOS=linux go build -o maglev ./cmd/api
+RUN CGO_ENABLED=1 GOOS=linux go build -tags sqlite_fts5 -o maglev ./cmd/api
 
 # Runtime stage
 FROM alpine:3.21

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ run: build
 	bin/maglev -f config.json
 
 build: gtfstidy
-	go build -gcflags "all=-N -l" -o bin/maglev ./cmd/api
+	CGO_ENABLED=1 go build -tags "sqlite_fts5" -gcflags "all=-N -l" -o bin/maglev ./cmd/api
 
 gtfstidy:
 	go build -o bin/gtfstidy github.com/patrickbr/gtfstidy
@@ -16,7 +16,7 @@ clean:
 	rm -f coverage.out
 
 coverage:
-	go test -coverprofile=coverage.out ./...
+	CGO_ENABLED=1 go test -tags "sqlite_fts5" -coverprofile=coverage.out ./...
 	go tool cover -html=coverage.out
 
 check-golangci-lint:
@@ -29,7 +29,7 @@ fmt:
 	go fmt ./...
 
 test:
-	go test ./...
+	CGO_ENABLED=1 go test -tags "sqlite_fts5" ./...
 
 models:
 	go tool sqlc generate -f gtfsdb/sqlc.yml

--- a/go.mod
+++ b/go.mod
@@ -74,4 +74,5 @@ require (
 )
 
 tool github.com/sqlc-dev/sqlc/cmd/sqlc
+
 tool github.com/patrickbr/gtfstidy


### PR DESCRIPTION
The route search feature requires SQLite FTS5 support, which is enabled via the sqlite_fts5 build tag for mattn/go-sqlite3. This tag was missing from several build configurations, causing local builds and tests to fail.

Updated files:
- Makefile: build, test, and coverage targets
- Dockerfile: production build
- .air.toml: local dev build
- .air.docker.toml: Docker dev build
- .github/workflows/go.yml: standardize on sqlite_fts5 (was fts5)