### PR TITLE
refactor: return explicit copy in FindAgency to avoid pointer export

### DIFF
--- a/internal/gtfs/gtfs_manager.go
+++ b/internal/gtfs/gtfs_manager.go
@@ -139,7 +139,8 @@ func (manager *Manager) FindAgency(id string) *gtfs.Agency {
 	defer manager.staticMutex.RUnlock()
 	for _, agency := range manager.gtfsData.Agencies {
 		if agency.Id == id {
-			return &agency
+			agencyCopy := agency
+			return &agencyCopy
 		}
 	}
 	return nil


### PR DESCRIPTION
### Description
This PR refactors `FindAgency` to return a pointer to an explicit copy of the agency struct, rather than a pointer to the loop variable.

### Reasoning
Taking the address of a loop variable (`&agency`) can lead to subtle bugs or be flagged by linters (like `exportloopref`) as unsafe in older Go versions or specific contexts.
By creating `agencyCopy := agency` and returning `&agencyCopy`, we ensure:
1. **Safety:** The returned pointer is distinct and safe from loop iteration mutations.
2. **Clarity:** The intent to return a copy is explicit.
3. **Clean Code:** Adheres to Go best practices and linter standards.

### Changes
- Updated `FindAgency` in `gtfs_manager.go` to create a local copy before returning its address.

@aaronbrethorst @Ahmedhossamdev 
fixes : #210 