### PR TITLE
fix: log error if GTFS database fails to close on shutdown

### DIFF
--- a/internal/gtfs/gtfs_manager.go
+++ b/internal/gtfs/gtfs_manager.go
@@ -16,6 +16,7 @@ import (
 	"github.com/OneBusAway/go-gtfs"
 	_ "github.com/mattn/go-sqlite3" // CGo-based SQLite driver
 	"github.com/tidwall/rtree"
+	"maglev.onebusaway.org/internal/logging"
 )
 
 const NoRadiusLimit = -1
@@ -101,7 +102,8 @@ func (manager *Manager) Shutdown() {
 		manager.wg.Wait()
 		if manager.GtfsDB != nil {
 			if err := manager.GtfsDB.Close(); err != nil {
-				slog.Error("failed to close GTFS database", "error", err)
+				logger := slog.Default().With(slog.String("component", "gtfs_manager"))
+				logging.LogError(logger, "failed to close GTFS database", err)
 			}
 		}
 	})


### PR DESCRIPTION
### Description
This PR addresses an issue where errors occurring during the closure of the GTFS database were being silently ignored.

Previously:
```go
_ = manager.GtfsDB.Close()
```

Now, any error returned by Close() is logged using slog.Error, ensuring that potential resource leaks or database locking issues are visible to operators during shutdown.

Changes
 * Imported log/slog in gtfs_manager.go.

 * Added error checking and logging to the Shutdown method.

Related Issue
Fixes : #215
@aaronbrethorst @Ahmedhossamdev 