### PR TITLE
fix: prevent panic in tripsForLocationHandler when no agencies exist

### DIFF
--- a/internal/restapi/trips_for_location_handler.go
+++ b/internal/restapi/trips_for_location_handler.go
@@ -2,6 +2,7 @@ package restapi
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"time"
 
@@ -58,7 +59,13 @@ func (api *RestAPI) parseAndValidateRequest(w http.ResponseWriter, r *http.Reque
 	includeTrip = queryParams.Get("includeTrip") == "true"
 	includeSchedule = queryParams.Get("includeSchedule") == "true"
 
-	currentAgency := api.GtfsManager.GetAgencies()[0]
+	agencies := api.GtfsManager.GetAgencies()
+	if len(agencies) == 0 {
+		err := errors.New("no agencies configured in GTFS manager")
+		api.serverErrorResponse(w, r, err)
+		return 0, 0, 0, 0, false, false, nil, time.Time{}, time.Time{}, err
+	}
+	currentAgency := agencies[0]
 	currentLocation, _ = time.LoadLocation(currentAgency.Timezone)
 	timeParam := queryParams.Get("time")
 	currentTime := api.Clock.Now().In(currentLocation)


### PR DESCRIPTION
### Description
This PR addresses a critical stability issue in `tripsForLocationHandler` where the code assumes `GetAgencies()` always returns a non-empty slice.

### Problem
Previously, the handler accessed `api.GtfsManager.GetAgencies()[0]` directly. If the agencies list was empty (e.g., due to misconfiguration or startup timing), this would cause a runtime panic (index out of range) and crash the request.

### Changes
- Added a defensive check `if len(agencies) == 0`.
- Returns a `500 Internal Server Error` with a descriptive message instead of panicking.

### Verification
<img width="1920" height="417" alt="Screenshot From 2026-01-29 14-31-43" src="https://github.com/user-attachments/assets/77a1f5fe-39c6-4298-a05b-ae209aa937b8" />


### Related Issue
Fixes : #232
@aaronbrethorst 