### PR TITLE
fix: return compound route IDs for routes-for-agency

### DIFF
--- a/internal/restapi/routes_for_agency_handler.go
+++ b/internal/restapi/routes_for_agency_handler.go
@@ -19,7 +19,7 @@ func (api *RestAPI) routesForAgencyHandler(w http.ResponseWriter, r *http.Reques
 	routesList := make([]models.Route, 0, len(routesForAgency))
 	for _, route := range routesForAgency {
 		routesList = append(routesList, models.NewRoute(
-			route.Id, route.Agency.Id, route.ShortName, route.LongName,
+			utils.FormCombinedID(route.Agency.Id, route.Id), route.Agency.Id, route.ShortName, route.LongName,
 			route.Description, models.RouteType(route.Type),
 			route.Url, route.Color, route.TextColor, route.ShortName,
 		))


### PR DESCRIPTION
### Changes
- Updated the route_for_agency endpoint to return compound route IDs:
data.list[].id == "{agencyId}_{routeId}"
This aligns Maglev behavior with the Java production server.
- Added a test asserting the compound route ID format to prevent future regressions.

fixes #231