### PR TITLE
security: disable debug handler in production

### DIFF
--- a/internal/webui/debug_index_handler.go
+++ b/internal/webui/debug_index_handler.go
@@ -2,9 +2,12 @@ package webui
 
 import (
 	"embed"
-	"github.com/davecgh/go-spew/spew"
 	"html/template"
 	"net/http"
+
+	"github.com/davecgh/go-spew/spew"
+
+	"maglev.onebusaway.org/internal/appconf"
 )
 
 //go:embed debug_index.html
@@ -36,6 +39,12 @@ func writeDebugData(w http.ResponseWriter, title string, data interface{}) {
 }
 
 func (webUI *WebUI) debugIndexHandler(w http.ResponseWriter, r *http.Request) {
+	// Disable debug endpoint in production to prevent information disclosure and DoS
+	if webUI.Config.Env == appconf.Production {
+		http.NotFound(w, r)
+		return
+	}
+
 	dataType := r.URL.Query().Get("dataType")
 
 	var data interface{}


### PR DESCRIPTION
Add environment check to debugIndexHandler to return 404 in production, preventing information disclosure and potential DoS attacks.

The debug endpoint exposes internal GTFS state via spew.Sdump which could reveal sensitive configuration and data structures. Serializing large datasets also poses DoS risk.

Fixes #239