### PR TITLE
test: skip slow Hot Swap tests on Windows CI

### DIFF
--- a/internal/gtfs/hot_swap_test.go
+++ b/internal/gtfs/hot_swap_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"runtime"
 	"strings"
 	"sync"
 	"testing"
@@ -21,6 +22,9 @@ func loggerErrorf(format string, args ...interface{}) error {
 }
 
 func TestHotSwap_QueriesCompleteDuringSwap(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Skipping on Windows: SQLite file I/O is too slow for CI timeout")
+	}
 	tempDir := t.TempDir()
 
 	gtfsConfig := Config{
@@ -148,6 +152,9 @@ func TestHotSwap_FailureRecovery(t *testing.T) {
 }
 
 func TestHotSwap_OldDatabaseCleanup(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Skipping on Windows: SQLite file I/O is too slow for CI timeout")
+	}
 	tempDir := t.TempDir()
 
 	gtfsOriginal := models.GetFixturePath(t, "raba.zip")
@@ -186,6 +193,9 @@ func TestHotSwap_OldDatabaseCleanup(t *testing.T) {
 }
 
 func TestHotSwap_MutexProtectedSwap(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Skipping on Windows: SQLite file I/O is too slow for CI timeout")
+	}
 	tempDir := t.TempDir()
 
 	gtfsOriginal := models.GetFixturePath(t, "raba.zip")
@@ -240,6 +250,9 @@ func TestHotSwap_MutexProtectedSwap(t *testing.T) {
 }
 
 func TestHotSwap_ConcurrentForceUpdate(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Skipping on Windows: SQLite file I/O is too slow for CI timeout")
+	}
 	tempDir := t.TempDir()
 
 	// Initial setup with "raba.zip"


### PR DESCRIPTION
## Summary
- Skip 4 slow Hot Swap tests on Windows to fix CI timeout failures
- Tests still run on Linux/macOS for full coverage

## Problem
The Hot Swap tests introduced in PR #158 create SQLite databases from GTFS zip files. On Windows, this takes 5-10 minutes per test due to slow file I/O, causing the 40-minute CI timeout to be exceeded.

| Test | Time on Windows |
|------|-----------------|
| `TestHotSwap_QueriesCompleteDuringSwap` | 300-600s |
| `TestHotSwap_OldDatabaseCleanup` | 300-500s |
| `TestHotSwap_MutexProtectedSwap` | 300-500s |
| `TestHotSwap_ConcurrentForceUpdate` | 500-650s |

## Solution
Add `runtime.GOOS == "windows"` skip checks to the slow tests. `TestHotSwap_FailureRecovery` remains enabled since it completes in ~10 seconds.

## Test plan
- [x] `make lint` passes
- [x] `make test` passes locally
- [x] Windows CI completes within timeout