### PR TITLE
Fix: Real-time predictions and nearby stops logic in arrivals endpoint

### DIFF
--- a/internal/restapi/arrivals_and_departure_for_stop.go
+++ b/internal/restapi/arrivals_and_departure_for_stop.go
@@ -190,10 +190,13 @@ func (api *RestAPI) arrivalsAndDeparturesForStopHandler(w http.ResponseWriter, r
 		if vehicle != nil && vehicle.Trip != nil {
 			vehicleID = vehicle.ID.ID
 
-			// Check if we have stop time updates for this trip
-			if len(vehicle.Trip.StopTimeUpdates) > 0 {
+			// Fetch the Trip Update separately
+			tripUpdate, _ := api.GtfsManager.GetTripUpdateByID(st.TripID)
+
+			// Use the tripUpdate for predictions
+			if tripUpdate != nil && len(tripUpdate.StopTimeUpdates) > 0 {
 				// Look for StopTimeUpdate that matches this stop
-				for _, stopTimeUpdate := range vehicle.Trip.StopTimeUpdates {
+				for _, stopTimeUpdate := range tripUpdate.StopTimeUpdates {
 					// Match by stop sequence or stop ID
 					if (stopTimeUpdate.StopSequence != nil && int64(*stopTimeUpdate.StopSequence) == st.StopSequence) ||
 						(stopTimeUpdate.StopID != nil && *stopTimeUpdate.StopID == stopCode) {
@@ -400,8 +403,7 @@ func getNearbyStopIDs(api *RestAPI, ctx context.Context, lat, lon float64, stopI
 	var nearbyStopIDs []string
 	for _, s := range nearbyStops {
 		if s.ID != stopID {
-			nearbyStopIDs = []string{utils.FormCombinedID(agencyID, s.ID)}
-			break
+			nearbyStopIDs = append(nearbyStopIDs, utils.FormCombinedID(agencyID, s.ID))
 		}
 	}
 	return nearbyStopIDs


### PR DESCRIPTION
#### Summary

Closes #253 

This PR resolves two critical bugs in the `/arrivals-and-departures-for-stop` endpoint:

1. **Missing Real-Time Predictions:** The endpoint was failing to show arrival/departure delays because it attempted to read `StopTimeUpdates` from the `Vehicle` object (which does not contain them in this data model).
2. **Incomplete Nearby Stops:** The `getNearbyStopIDs` helper function contained a logic error that caused it to return only a single nearby stop instead of the full list.

#### Changes

* **File:** `internal/restapi/arrivals_and_departure_for_stop.go`
* **Fix 1:** Updated `arrivalsAndDeparturesForStopHandler` to explicitly call `api.GtfsManager.GetTripUpdateByID(st.TripID)`. The handler now correctly uses the fetched `TripUpdate` object to calculate predicted arrival and departure times.
* **Fix 2:** Updated the loop in `getNearbyStopIDs` to use `append` instead of overwriting the slice, ensuring all found nearby stops are returned.



#### Impact

* **Accuracy:** The arrivals board will now correctly display "X min late" or "X min early" based on real-time GTFS-RT data.
* **Completeness:** The "Nearby Stops" field in the response will now correctly populate with up to 5 stops (or the configured limit) instead of just one.