### PR TITLE
security: disable debug handler in production

### DIFF
--- a/internal/webui/debug_index_handler.go
+++ b/internal/webui/debug_index_handler.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 
 	"github.com/davecgh/go-spew/spew"
+
 	"maglev.onebusaway.org/internal/appconf"
 )
 
@@ -38,10 +39,12 @@ func writeDebugData(w http.ResponseWriter, title string, data interface{}) {
 }
 
 func (webUI *WebUI) debugIndexHandler(w http.ResponseWriter, r *http.Request) {
+	// Disable debug endpoint in production to prevent information disclosure and DoS
 	if webUI.Config.Env == appconf.Production {
 		http.NotFound(w, r)
 		return
 	}
+
 	dataType := r.URL.Query().Get("dataType")
 
 	var data interface{}


### PR DESCRIPTION
## Security: Disable debug handler in production

Fixes #239

- Returns 404 when `Config.Env == appconf.Production`
- Prevents information disclosure and DoS attacks
- Tests already exist verifying the behavior

Signed-off-by: ARYAN RAJ SINGH <arajsingh0505@gmail.com>