### PR TITLE
fix(security): prevent timing attacks in API key validation

### DIFF
--- a/internal/app/api_keys.go
+++ b/internal/app/api_keys.go
@@ -1,6 +1,9 @@
 package app
 
-import "net/http"
+import (
+	"crypto/subtle"
+	"net/http"
+)
 
 func (app *Application) RequestHasInvalidAPIKey(r *http.Request) bool {
 	key := r.URL.Query().Get("key")
@@ -12,10 +15,10 @@ func (app *Application) IsInvalidAPIKey(key string) bool {
 		return true
 	}
 
-	// For example, checking against keys stored in your app Config:
 	validKeys := app.Config.ApiKeys
 	for _, validKey := range validKeys {
-		if key == validKey {
+		// Use constant-time comparison to prevent timing attacks
+		if subtle.ConstantTimeCompare([]byte(key), []byte(validKey)) == 1 {
 			return false
 		}
 	}


### PR DESCRIPTION
## Security Fix: API Key Timing Attack Vulnerability

### Description
This PR addresses a potential **Timing Attack** vulnerability in the API key verification process identified in `internal/app/api_keys.go`.

### The Issue
The existing implementation used standard string comparison (`==`). This creates a **timing leak** because the comparison returns as soon as a character mismatch is found. Attackers can exploit this by measuring minute differences in response times to iteratively guess valid API keys.

### The Fix
* Replaced direct comparison with `crypto/subtle.ConstantTimeCompare`.
* This ensures the comparison operation takes a **consistent amount of time** regardless of the input or where the mismatch occurs, effectively mitigating side-channel timing attacks.

@aaronbrethorst 
fixes : #258