### PR TITLE
Refactor: Remove duplicate GTFS source field from Manager

### DIFF
--- a/internal/gtfs/gtfs_manager.go
+++ b/internal/gtfs/gtfs_manager.go
@@ -23,7 +23,7 @@ const NoRadiusLimit = -1
 
 // Manager manages the GTFS data and provides methods to access it
 type Manager struct {
-	gtfsSource                     string
+	
 	gtfsData                       *gtfs.Static
 	GtfsDB                         *gtfsdb.Client
 	lastUpdated                    time.Time
@@ -56,7 +56,6 @@ func InitGTFSManager(config Config) (*Manager, error) {
 	}
 
 	manager := &Manager{
-		gtfsSource:                     config.GtfsURL,
 		isLocalFile:                    isLocalFile,
 		config:                         config,
 		shutdownChan:                   make(chan struct{}),
@@ -430,7 +429,7 @@ func (manager *Manager) GetAllTripUpdates() []gtfs.Trip {
 
 // IMPORTANT: Caller must hold manager.RLock() before calling this method.
 func (manager *Manager) PrintStatistics() {
-	fmt.Printf("Source: %s (Local File: %v)\n", manager.gtfsSource, manager.isLocalFile)
+	fmt.Printf("Source: %s (Local File: %v)\n", manager.config.GtfsURL, manager.isLocalFile)
 	fmt.Printf("Last Updated: %s\n", manager.lastUpdated)
 	fmt.Println("Stops Count: ", len(manager.gtfsData.Stops))
 	fmt.Println("Routes Count: ", len(manager.gtfsData.Routes))

--- a/internal/gtfs/hot_swap_test.go
+++ b/internal/gtfs/hot_swap_test.go
@@ -85,7 +85,7 @@ func TestHotSwap_QueriesCompleteDuringSwap(t *testing.T) {
 	}
 
 	newSource := models.GetFixturePath(t, "gtfs.zip")
-	manager.gtfsSource = newSource
+	manager.config.GtfsURL = newSource
 
 	time.Sleep(50 * time.Millisecond)
 
@@ -128,7 +128,7 @@ func TestHotSwap_FailureRecovery(t *testing.T) {
 	assert.Equal(t, 1, len(agencies))
 	assert.Equal(t, "25", agencies[0].ID)
 
-	manager.gtfsSource = "/path/to/non/existent/file.zip"
+	manager.config.GtfsURL = "/path/to/non/existent/file.zip"
 
 	err = manager.ForceUpdate(context.Background())
 
@@ -172,7 +172,7 @@ func TestHotSwap_OldDatabaseCleanup(t *testing.T) {
 	}
 	defer manager.Shutdown()
 
-	manager.gtfsSource = gtfsNew
+	manager.config.GtfsURL = gtfsNew
 	err = manager.ForceUpdate(context.Background())
 	require.NoError(t, err, "ForceUpdate failed for new GTFS")
 
@@ -228,7 +228,7 @@ func TestHotSwap_MutexProtectedSwap(t *testing.T) {
 	oldBlockLayoverIndices := manager.blockLayoverIndices
 	manager.RUnlock()
 
-	manager.gtfsSource = gtfsNew
+	manager.config.GtfsURL = gtfsNew
 	err = manager.ForceUpdate(context.Background())
 	assert.Nil(t, err, "ForceUpdate should succeed")
 
@@ -273,7 +273,7 @@ func TestHotSwap_ConcurrentForceUpdate(t *testing.T) {
 
 	// Prepare to update to "gtfs.zip"
 	newSource := models.GetFixturePath(t, "gtfs.zip")
-	manager.gtfsSource = newSource
+	manager.config.GtfsURL = newSource
 
 	// Launch concurrent ForceUpdate calls
 	concurrency := 2

--- a/internal/gtfs/static.go
+++ b/internal/gtfs/static.go
@@ -132,7 +132,7 @@ func (manager *Manager) updateStaticGTFS() { // nolint
 	// If it's a local file, don't update periodically
 	if manager.isLocalFile {
 		logging.LogOperation(logger, "gtfs_source_is_local_file_skipping_periodic_updates",
-			slog.String("source", manager.gtfsSource))
+			slog.String("source", manager.config.GtfsURL))
 		return
 	}
 
@@ -151,7 +151,7 @@ func (manager *Manager) updateStaticGTFS() { // nolint
 
 			if err != nil {
 				logging.LogError(logger, "Error updating GTFS data", err,
-					slog.String("source", manager.gtfsSource))
+					slog.String("source", manager.config.GtfsURL))
 				continue
 			}
 
@@ -183,10 +183,10 @@ func (manager *Manager) ForceUpdate(ctx context.Context) error {
 
 	logger := slog.Default().With(slog.String("component", "gtfs_updater"))
 
-	newStaticData, err := loadGTFSData(manager.gtfsSource, manager.isLocalFile, manager.config)
+	newStaticData, err := loadGTFSData(manager.config.GtfsURL, manager.isLocalFile, manager.config)
 	if err != nil {
 		logging.LogError(logger, "Error updating GTFS data", err,
-			slog.String("source", manager.gtfsSource))
+			slog.String("source", manager.config.GtfsURL))
 		return err
 	}
 
@@ -203,7 +203,7 @@ func (manager *Manager) ForceUpdate(ctx context.Context) error {
 
 	// Create a config copy with the updated source URL
 	newConfig := manager.config
-	newConfig.GtfsURL = manager.gtfsSource
+	
 
 	newGtfsDB, err := buildGtfsDB(newConfig, manager.isLocalFile, tempDBPath)
 	if err != nil {
@@ -303,7 +303,7 @@ func (manager *Manager) ForceUpdate(ctx context.Context) error {
 	manager.lastUpdated = time.Now()
 
 	logging.LogOperation(logger, "gtfs_static_data_updated_hot_swap",
-		slog.String("source", manager.gtfsSource),
+		slog.String("source", manager.config.GtfsURL),
 		slog.String("db_path", finalDBPath))
 
 	return nil
@@ -334,7 +334,7 @@ func (manager *Manager) setStaticGTFS(staticData *gtfs.Static) {
 	if manager.config.Verbose {
 		logger := slog.Default().With(slog.String("component", "gtfs_manager"))
 		logging.LogOperation(logger, "gtfs_data_set_successfully",
-			slog.String("source", manager.gtfsSource),
+			slog.String("source", manager.config.GtfsURL),
 			slog.Int("layover_indices_built", len(manager.blockLayoverIndices)))
 	}
 }


### PR DESCRIPTION
## Summary
This PR removes the duplicate `gtfsSource` field from the `Manager` struct and uses `config.GtfsURL` as the single source of truth.

## Problem
We currently define the GTFS source in two places:
- `Manager.gtfsSource` (string field)
- `Manager.config.GtfsURL` (Config field)

Both represent the same concept, creating ambiguity about which is authoritative. This duplication leads to:
- Potential inconsistency when updating the source
- Extra memory usage
- Confusion about which field to use
- Tests needing to update both fields

## Changes
- ✅ Removed `gtfsSource` field from `Manager` struct
- ✅ Updated all references to use `config.GtfsURL` consistently
- ✅ Updated initialization to not set duplicate field
- ✅ Fixed all logging statements to use `config.GtfsURL`
- ✅ Updated all tests to modify `config.GtfsURL` directly

## Impact
- Single source of truth for GTFS source URL
- No synchronization issues between fields
- Simpler, cleaner code
- Easier to maintain and understand
- Reduced memory footprint

## Testing
- ✅ All existing tests pass
- ✅ Hot swap tests updated and working
- ✅ ForceUpdate functionality unchanged