### PR TITLE
fix(concurrency): add missing RLock in debugIndexHandler

### DIFF
--- a/internal/webui/debug_index_handler.go
+++ b/internal/webui/debug_index_handler.go
@@ -47,6 +47,9 @@ func (webUI *WebUI) debugIndexHandler(w http.ResponseWriter, r *http.Request) {
 	var data interface{}
 	var title string
 
+	webUI.GtfsManager.RLock()
+	defer webUI.GtfsManager.RUnlock()
+
 	staticData := webUI.GtfsManager.GetStaticData()
 
 	switch dataType {


### PR DESCRIPTION
### Description
This PR addresses a data race condition in `internal/webui/debug_index_handler.go`. 

The `debugIndexHandler` was calling `GetStaticData()` without first acquiring a read lock (`RLock`), which violates the method's contract and could lead to race conditions during concurrent updates.

### Changes
* Added `webUI.GtfsManager.RLock()` before retrieving static data.
* Added `defer webUI.GtfsManager.RUnlock()` to ensure the lock is safely released after the handler executes.

@aaronbrethorst 
fixes : #270 