### PR TITLE
fix(security): prevent error detail leakage in debug handler

### DIFF
--- a/internal/webui/debug_index_handler.go
+++ b/internal/webui/debug_index_handler.go
@@ -3,6 +3,7 @@ package webui
 import (
 	"embed"
 	"html/template"
+	"log/slog"
 	"net/http"
 
 	"github.com/davecgh/go-spew/spew"
@@ -22,7 +23,9 @@ func writeDebugData(w http.ResponseWriter, title string, data interface{}) {
 	w.Header().Set("Content-Type", "text/html")
 	tmpl, err := template.ParseFS(templateFS, "debug_index.html")
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		// Log the actual error server-side
+		slog.Error("failed to parse debug template", "error", err)
+		http.Error(w, "Internal server error", http.StatusInternalServerError)
 		return
 	}
 
@@ -33,7 +36,8 @@ func writeDebugData(w http.ResponseWriter, title string, data interface{}) {
 
 	err = tmpl.Execute(w, dataStruct)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		slog.Error("failed to execute debug template", "error", err)
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 	}
 }
 


### PR DESCRIPTION
### Description
This PR mitigates a potential **Information Disclosure** issue in `writeDebugData`.

### The Issue
The code was returning raw `err.Error()` messages directly to the HTTP response. This could leak internal implementation details if an error occurs.

### The Fix
* Replaced raw error output with a generic "Internal Server Error" message.
* Added server-side structured logging (`slog.Error`) to capture the actual error details for administrators.

@aaronbrethorst 
fixes : #275 