### PR TITLE
Fix: Allow Future Date Queries in API

### DIFF
--- a/internal/utils/api.go
+++ b/internal/utils/api.go
@@ -115,18 +115,6 @@ func ParseTimeParameter(timeParam string, currentLocation *time.Location) (strin
 		return "", time.Time{}, fieldErrors, false
 	}
 
-	// Set time to midnight for accurate comparison
-	currentTime := time.Now().In(currentLocation)
-	todayMidnight := time.Date(currentTime.Year(), currentTime.Month(), currentTime.Day(), 0, 0, 0, 0, currentLocation)
-	parsedTimeMidnight := time.Date(parsedTime.Year(), parsedTime.Month(), parsedTime.Day(), 0, 0, 0, 0, currentLocation)
-
-	if parsedTimeMidnight.After(todayMidnight) {
-		fieldErrors := map[string][]string{
-			"time": {"Invalid field value for field \"time\"."},
-		}
-		return "", time.Time{}, fieldErrors, false
-	}
-
 	// Valid date, use it
 	return parsedTime.Format("20060102"), parsedTime, nil, true
 }

--- a/internal/utils/api_test.go
+++ b/internal/utils/api_test.go
@@ -444,18 +444,28 @@ func TestParseTimeParameter(t *testing.T) {
 			expectedErrorKey: "time",
 		},
 		{
-			name:             "Future date (should fail)",
-			timeParam:        now.AddDate(0, 0, 1).Format("2006-01-02"),
-			expectedDate:     "",
-			expectError:      true,
-			expectedErrorKey: "time",
+			name:         "Future date",
+			timeParam:    now.AddDate(0, 0, 1).Format("2006-01-02"),
+			expectedDate: now.AddDate(0, 0, 1).Format("20060102"),
+			expectError:  false,
+			validateParsedTime: func(t *testing.T, parsedTime time.Time) {
+				tomorrow := now.AddDate(0, 0, 1)
+				assert.Equal(t, tomorrow.Year(), parsedTime.Year())
+				assert.Equal(t, tomorrow.Month(), parsedTime.Month())
+				assert.Equal(t, tomorrow.Day(), parsedTime.Day())
+			},
 		},
 		{
-			name:             "Future epoch (should fail)",
-			timeParam:        fmt.Sprintf("%d", now.AddDate(0, 0, 1).Unix()*1000),
-			expectedDate:     "",
-			expectError:      true,
-			expectedErrorKey: "time",
+			name:         "Future epoch",
+			timeParam:    fmt.Sprintf("%d", now.AddDate(0, 0, 1).Unix()*1000),
+			expectedDate: now.AddDate(0, 0, 1).Format("20060102"),
+			expectError:  false,
+			validateParsedTime: func(t *testing.T, parsedTime time.Time) {
+				tomorrow := now.AddDate(0, 0, 1)
+				assert.Equal(t, tomorrow.Year(), parsedTime.Year())
+				assert.Equal(t, tomorrow.Month(), parsedTime.Month())
+				assert.Equal(t, tomorrow.Day(), parsedTime.Day())
+			},
 		},
 	}
 


### PR DESCRIPTION
## Description
Removes the validation that prevented users from querying transit schedules for future dates. This fix enables proper trip planning functionality by allowing queries for tomorrow and beyond.

## Problem
The API was incorrectly rejecting all date queries for any date after today, blocking a core use case: planning trips in advance. This behavior was inconsistent with standard OneBusAway API expectations where future scheduling is essential.

### Example of Previous Behavior
```bash
# Query for tomorrow's schedule - would fail with 400 error
curl "http://localhost:4000/api/where/schedule-for-stop/25_123?key=test&date=2026-02-02"

# Response: 400 Bad Request - "Invalid field value for field 'time'"
```

## Changes Made

### `internal/utils/api.go`
- Removed lines 85-91 in `ParseTimeParameter` function that validated dates against today's midnight
- Function now accepts any valid date format (past, present, or future)
- Date availability is determined by GTFS data, not arbitrary validation

### `internal/utils/api_test.go`
- Updated test case "Future date (should fail)" → "Future date" to expect success
- Updated test case "Future epoch (should fail)" → "Future epoch" to expect success
- Added `validateParsedTime` functions to both tests to verify correct date parsing
- Tests now verify that future dates are properly accepted and parsed

## Testing
- ✅ All existing tests pass
- ✅ Future date tests now verify correct behavior
- ✅ Edge cases (today, yesterday, invalid formats) still work correctly
- ✅ `make test` passes
- ✅ `make lint` passes

## Impact
- ✅ Users can now query schedules for future dates
- ✅ Trip planning functionality is restored
- ✅ API now complies with OneBusAway standard behavior
- ✅ No breaking changes to existing functionality

## Related Issue
Fixes #277 