### PR TITLE
fix: log ignored json encoding errors in rate limit middleware

### DIFF
--- a/internal/restapi/rate_limit_middleware.go
+++ b/internal/restapi/rate_limit_middleware.go
@@ -2,6 +2,7 @@ package restapi
 
 import (
 	"encoding/json"
+	"log/slog"
 	"net/http"
 	"strconv"
 	"sync"
@@ -160,7 +161,9 @@ func (rl *RateLimitMiddleware) sendRateLimitExceeded(w http.ResponseWriter, r *h
 		"version":     2,
 	}
 
-	_ = json.NewEncoder(w).Encode(errorResponse)
+	if err := json.NewEncoder(w).Encode(errorResponse); err != nil {
+		slog.Error("failed to encode rate limit response", "error", err)
+	}
 }
 
 // cleanup periodically removes old, unused limiters to prevent memory leaks


### PR DESCRIPTION
### Description
The `rateLimitHandler` was silently ignoring errors returned by `json.NewEncoder(w).Encode()`.

### The Fix
Added error checking and structured logging (`slog.Error`) to capture any encoding failures or network issues during response writing. This improves system observability.

@aaronbrethorst 
fixes : #283 