### PR TITLE
fix(logic): validate NullString fields in trip handler before formatting

### DIFF
--- a/internal/restapi/trip_handler.go
+++ b/internal/restapi/trip_handler.go
@@ -56,13 +56,21 @@ func (api *RestAPI) tripHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	var blockID, shapeID string
+	if trip.BlockID.Valid {
+		blockID = utils.FormCombinedID(agencyID, trip.BlockID.String)
+	}
+	if trip.ShapeID.Valid {
+		shapeID = utils.FormCombinedID(agencyID, trip.ShapeID.String)
+	}
+
 	tripModel := &models.Trip{
 		ID:             utils.FormCombinedID(agencyID, trip.ID),
 		RouteID:        utils.FormCombinedID(agencyID, trip.RouteID),
 		ServiceID:      utils.FormCombinedID(agencyID, trip.ServiceID),
 		DirectionID:    trip.DirectionID.Int64,
-		BlockID:        utils.FormCombinedID(agencyID, trip.BlockID.String),
-		ShapeID:        utils.FormCombinedID(agencyID, trip.ShapeID.String),
+		BlockID:        blockID,
+		ShapeID:        shapeID,
 		TripHeadsign:   trip.TripHeadsign.String,
 		TripShortName:  trip.TripShortName.String,
 		RouteShortName: route.ShortName.String,


### PR DESCRIPTION
### Description
This PR fixes a logic issue in `tripHandler` where `BlockID` and `ShapeID` were being formatted even when they were NULL in the database.

### The Fix
Added explicit checks for `.Valid` on `sql.NullString` fields.
* If valid: Format the ID normally.
* If invalid: Keep it as an empty string.

This prevents malformed IDs (e.g., `agency_`) from appearing in the API response.

@aaronbrethorst 
fixes : #285 