### PR TITLE
Fix: populate missing direction value in stop response

### DIFF
--- a/internal/restapi/stop_handler.go
+++ b/internal/restapi/stop_handler.go
@@ -52,11 +52,11 @@ func (api *RestAPI) stopHandler(w http.ResponseWriter, r *http.Request) {
 
 	stopData := &models.Stop{
 		ID:                 utils.FormCombinedID(agencyID, stop.ID),
-		Name:               stop.Name.String,
+		Name:               utils.NullStringOrEmpty(stop.Name),
 		Lat:                stop.Lat,
 		Lon:                stop.Lon,
-		Code:               stop.Code.String,
-		Direction:          "",
+		Code:               utils.NullStringOrEmpty(stop.Code),
+		Direction:          utils.NullStringOrEmpty(stop.Direction),
 		LocationType:       int(stop.LocationType.Int64),
 		WheelchairBoarding: utils.MapWheelchairBoarding(utils.NullWheelchairBoardingOrUnknown(stop.WheelchairBoarding)),
 		RouteIDs:           combinedRouteIDs,

--- a/internal/restapi/stop_handler_test.go
+++ b/internal/restapi/stop_handler_test.go
@@ -57,6 +57,8 @@ func TestStopHandlerEndToEnd(t *testing.T) {
 	assert.Equal(t, models.UnknownValue, entry["wheelchairBoarding"])
 	assert.Equal(t, *stops[0].Latitude, entry["lat"])
 	assert.Equal(t, *stops[0].Longitude, entry["lon"])
+	
+	assert.Contains(t, entry, "direction", "direction field should exist")
 
 	routeIds, ok := entry["routeIds"].([]interface{})
 	assert.True(t, ok, "routeIds should exist and be an array")

--- a/internal/restapi/stops_for_agency_handler.go
+++ b/internal/restapi/stops_for_agency_handler.go
@@ -98,14 +98,9 @@ func (api *RestAPI) buildStopsListForAgency(ctx context.Context, agencyID string
 			routeIdsString[i] = utils.FormCombinedID(agencyID, id.(string))
 		}
 
-		direction := models.UnknownValue
-		if stop.Direction.Valid && stop.Direction.String != "" {
-			direction = stop.Direction.String
-		}
-
 		stopsList = append(stopsList, models.Stop{
 			Code:               stop.Code.String,
-			Direction:          direction,
+			Direction:          utils.NullStringOrEmpty(stop.Direction),
 			ID:                 utils.FormCombinedID(agencyID, stop.ID),
 			Lat:                stop.Lat,
 			LocationType:       int(stop.LocationType.Int64),

--- a/internal/restapi/test_helper_test.go
+++ b/internal/restapi/test_helper_test.go
@@ -22,10 +22,8 @@ func (m *mockTestingFatalf) Fatalf(format string, args ...any) {
 
 func TestCollectAllNestedIdsFromObjects(t *testing.T) {
 	data := []interface{}{
-		map[string]interface{}{"routes": []interface{}{"234", "235"},
-		},
-		map[string]interface{}{"routes": []interface{}{"345"},
-		},
+		map[string]interface{}{"routes": []interface{}{"234", "235"}},
+		map[string]interface{}{"routes": []interface{}{"345"}},
 	}
 	expected := []string{"234", "235", "345"}
 	actual := collectAllNestedIdsFromObjects(t, data, "routes")
@@ -63,8 +61,7 @@ func TestCollectAllNestedIdsFromObjectsFailures(t *testing.T) {
 		{
 			name: "Invalid nested array type",
 			data: []interface{}{
-				map[string]interface{}{"routes": []interface{}{234},
-				},
+				map[string]interface{}{"routes": []interface{}{234}},
 			},
 			expectedError: "item 0 key \"routes\" index 0 is not a string: int",
 		},


### PR DESCRIPTION
### Changes:
- Populated missing direction value: The stop endpoint now returns direction data, matching the OneBusAway production server implementation.
- Normalized nullable GTFS fields: Ensured consistent API responses by handling null values, aligning Maglev's behavior with the Java OBA production environment.
- Code Formatting: Applied go fmt to the project to maintain standard styling.

fixes: #287 