### PR TITLE
 Optimize memory allocation in stops-for-route polyline generation

### DIFF
--- a/internal/restapi/stops_for_route_handler.go
+++ b/internal/restapi/stops_for_route_handler.go
@@ -388,7 +388,8 @@ func processTripGroups(
 
 func generatePolylines(shapes []gtfsdb.GetShapesGroupedByTripHeadSignRow) []models.Polyline {
 	var polylines []models.Polyline
-	var coords [][]float64
+	// This prevents repeated memory re-allocation during the loop.
+	coords := make([][]float64, 0, len(shapes))
 	for _, shape := range shapes {
 		coords = append(coords, []float64{shape.Lat, shape.Lon})
 	}


### PR DESCRIPTION
**Description:**
This PR optimizes the `generatePolylines` function in `internal/restapi/stops_for_route_handler.go` by pre-allocating the coordinate slice.

**Changes:**

* Pre-allocated the `coords` slice to `len(shapes)` to prevent repeated memory re-allocations during iteration.
* Reduces garbage collection pressure for routes with significant shape data.

*Note: This applies the same optimization pattern recently added to the shapes handler.*

Closes #298 