### PR TITLE
fix(gtfs): validate HTTP status code when downloading data

### DIFF
--- a/internal/gtfs/static.go
+++ b/internal/gtfs/static.go
@@ -53,6 +53,10 @@ func rawGtfsData(source string, isLocalFile bool, config Config) ([]byte, error)
 			slog.Default().With(slog.String("component", "gtfs_downloader")),
 			"http_response_body")
 
+		if resp.StatusCode != http.StatusOK {
+			return nil, fmt.Errorf("failed to download GTFS data: received HTTP status %s", resp.Status)
+		}
+
 		b, err = io.ReadAll(resp.Body)
 		if err != nil {
 			return nil, fmt.Errorf("error reading GTFS data: %w", err)


### PR DESCRIPTION
### Description
This PR addresses the missing HTTP status code validation in the GTFS downloader (`internal/gtfs/static.go`). 

Previously, the code would attempt to read and process the response body regardless of the status code. This meant that 404 (Not Found) or 500 (Server Error) HTML responses were being passed to the GTFS parser, causing confusing downstream errors.

### Changes
- Added a check to ensure `resp.StatusCode` is `http.StatusOK` (200).
- Returns a descriptive error if the status code is not 200.

@aaronbrethorst 
fixes : #302 