### PR TITLE
Fix N+1 query in buildStopList — replace per-stop GetRouteIDsForStop …

### DIFF
--- a/internal/restapi/trips_for_location_handler.go
+++ b/internal/restapi/trips_for_location_handler.go
@@ -362,16 +362,23 @@ func (rb *referenceBuilder) buildStopList(stops []gtfsdb.Stop) {
 		stopIDs = append(stopIDs, stop.ID)
 	}
 
-	routesForStops, err := rb.api.GtfsManager.GtfsDB.Queries.GetRoutesForStops(rb.ctx, stopIDs)
+	routesForStops, err := rb.api.GtfsManager.GtfsDB.Queries.GetRouteIDsForStops(rb.ctx, stopIDs)
 	if err != nil {
+		logging.LogError(rb.api.Logger, "failed to batch fetch routes for stops", err)
 		return
 	}
 
 	stopRouteMap := make(map[string][]string)
+
 	for _, r := range routesForStops {
 		stopRouteMap[r.StopID] = append(stopRouteMap[r.StopID], r.ID)
 	}
-
+	// This registers all the routes that were in stopRouteMap as present, even if they don't have a trip in the current set. This ensures that any route that has a stop in the area is included in the references, even if no active trips for that route are currently visible.
+	for _, routeIDs := range stopRouteMap {
+		for _, routeID := range routeIDs {
+			rb.presentRoutes[routeID] = models.Route{}
+		}
+	}
 	for _, stop := range stops {
 		routeIdsString := stopRouteMap[stop.ID]
 		if routeIdsString == nil {
@@ -379,15 +386,6 @@ func (rb *referenceBuilder) buildStopList(stops []gtfsdb.Stop) {
 		}
 		rb.stopList = append(rb.stopList, rb.createStop(stop, routeIdsString))
 	}
-}
-func (rb *referenceBuilder) processRouteIds(routeIds []interface{}) []string {
-	routeIdsString := make([]string, len(routeIds))
-	for i, id := range routeIds {
-		routeId := id.(string)
-		rb.presentRoutes[routeId] = models.Route{}
-		routeIdsString[i] = routeId
-	}
-	return routeIdsString
 }
 
 func (rb *referenceBuilder) createStop(stop gtfsdb.Stop, routeIds []string) models.Stop {


### PR DESCRIPTION
…with batch GetRoutesForStops

Fixes #304

- Modified buildStopList to collect all stop IDs first
- Replaced loop calling GetRouteIDsForStop for each stop with single GetRoutesForStops batch query
- Built stopRouteMap in memory for O(1) lookups instead of database queries in loop

Performance improvement for 40 stops:
- Before: 41 queries (1 GetStopsByIDs + 40 GetRouteIDsForStop)
- After: 2 queries (1 GetStopsByIDs + 1 GetRoutesForStops)