### PR TITLE
perf(search): precompile regex for FTS5 query sanitization

### DIFF
--- a/internal/restapi/search_stops_handler.go
+++ b/internal/restapi/search_stops_handler.go
@@ -13,16 +13,21 @@ import (
 	"maglev.onebusaway.org/internal/utils"
 )
 
+// Pre-compiled regexes for FTS5 query sanitization.
+// Compiled once at package initialization for performance (regexp.Regexp is thread-safe).
+var (
+	fts5SpecialCharsRegex = regexp.MustCompile(`[*"():^$@#~<>{}[\]\\|&!]`)
+	fts5OperatorsRegex    = regexp.MustCompile(`(?i)\b(AND|OR|NOT|NEAR)\b`)
+)
+
 // sanitizeFTS5Query removes special FTS5 characters by replacing them with spaces
 // to prevent query syntax errors. Does not preserve the original characters.
 func sanitizeFTS5Query(input string) string {
 	// 1. Remove ALL FTS5 special characters
-	specialChars := regexp.MustCompile(`[*"():^$@#~<>{}[\]\\|&!]`)
-	sanitized := specialChars.ReplaceAllString(input, " ")
+	sanitized := fts5SpecialCharsRegex.ReplaceAllString(input, " ")
 
 	// 2. Remove FTS5 operators (AND, OR, NOT, NEAR) case-insensitive
-	re := regexp.MustCompile(`(?i)\b(AND|OR|NOT|NEAR)\b`)
-	sanitized = re.ReplaceAllString(sanitized, " ")
+	sanitized = fts5OperatorsRegex.ReplaceAllString(sanitized, " ")
 
 	// 3. Trim and collapse whitespace
 	sanitized = strings.TrimSpace(sanitized)


### PR DESCRIPTION
Hey @aaronbrethorst 
I noticed that the [sanitizeFTS5Query](cci:1://file:///c:/Users/user/OneDrive/Desktop/Projects/open/maglev/internal/restapi/search_stops_handler.go:15:0-31:1) function was compiling two regex patterns on every single search request. That's pretty expensive - regex compilation can take ~100,000ns while execution only takes ~1,000ns.

This PR moves the regex compilation to package-level variables so they're compiled once at startup and reused. It's a simple change but should give us roughly 100x improvement in the search endpoint's regex handling.

All existing tests pass and the behavior is unchanged - just faster.

Fixes #293