### PR TITLE
fix(gtfs): validate HTTP status codes in GTFS downloader

### DIFF
--- a/internal/gtfs/static.go
+++ b/internal/gtfs/static.go
@@ -53,6 +53,11 @@ func rawGtfsData(source string, isLocalFile bool, config Config) ([]byte, error)
 			slog.Default().With(slog.String("component", "gtfs_downloader")),
 			"http_response_body")
 
+		// Validate HTTP status code before processing response
+		if resp.StatusCode != http.StatusOK {
+			return nil, fmt.Errorf("GTFS download failed: server returned HTTP %d %s", resp.StatusCode, http.StatusText(resp.StatusCode))
+		}
+
 		b, err = io.ReadAll(resp.Body)
 		if err != nil {
 			return nil, fmt.Errorf("error reading GTFS data: %w", err)


### PR DESCRIPTION
Found a bug in the GTFS downloader ,

When fetching GTFS data from a remote URL, we weren't checking the HTTP status code before trying to parse the response. So if the server returned a 404 or 500 error page, we'd try to parse that HTML as GTFS data and get really confusing errors downstream.

Now we check for HTTP 200 OK before processing, and return a clear error message like:
> "GTFS download failed: server returned HTTP 404 Not Found"

Much easier to debug!

Fixes #302