### PR TITLE
perf(stops-for-route): pre-allocate slices to avoid reallocations

### DIFF
--- a/internal/restapi/stops_for_route_handler.go
+++ b/internal/restapi/stops_for_route_handler.go
@@ -387,8 +387,8 @@ func processTripGroups(
 }
 
 func generatePolylines(shapes []gtfsdb.GetShapesGroupedByTripHeadSignRow) []models.Polyline {
-	var polylines []models.Polyline
-	var coords [][]float64
+	polylines := make([]models.Polyline, 0, 1)
+	coords := make([][]float64, 0, len(shapes))
 	for _, shape := range shapes {
 		coords = append(coords, []float64{shape.Lat, shape.Lon})
 	}
@@ -402,7 +402,7 @@ func generatePolylines(shapes []gtfsdb.GetShapesGroupedByTripHeadSignRow) []mode
 }
 
 func formatStopIDs(agencyID string, stops map[string]bool) []string {
-	var stopIDs []string
+	stopIDs := make([]string, 0, len(stops))
 	for key := range stops {
 		stopID := utils.FormCombinedID(agencyID, key)
 		stopIDs = append(stopIDs, stopID)


### PR DESCRIPTION
Hey @aaronbrethorst small performance tweak here. 
The [generatePolylines](cci:1://file:///c:/Users/user/OneDrive/Desktop/Projects/open/maglev/internal/restapi/stops_for_route_handler.go:388:0-401:1) and [formatStopIDs](cci:1://file:///c:/Users/user/OneDrive/Desktop/Projects/open/maglev/internal/restapi/stops_for_route_handler.go:403:0-410:1) functions were starting with nil slices and growing them with `append()` inside loops. This causes Go to repeatedly reallocate memory as the slice grows.

Since we know the final size upfront (from `len(shapes)` and `len(stops)`), we can pre-allocate with `make()` and avoid all those reallocations.

Changes:
- `coords := make([][]float64, 0, len(shapes))` instead of `var coords [][]float64`
- `polylines := make([]models.Polyline, 0, 1)` since we always create exactly one
- Same treatment for [formatStopIDs](cci:1://file:///c:/Users/user/OneDrive/Desktop/Projects/open/maglev/internal/restapi/stops_for_route_handler.go:403:0-410:1)

Reduces GC pressure in the hot path. Straightforward optimization!

Fixes #298