### PR TITLE
fix: resolve N+1 query bottleneck in trips-for-location endpoint

### DIFF
--- a/gtfsdb/db.go
+++ b/gtfsdb/db.go
@@ -216,6 +216,9 @@ func Prepare(ctx context.Context, db DBTX) (*Queries, error) {
 	if q.getStopTimesForTripStmt, err = db.PrepareContext(ctx, getStopTimesForTrip); err != nil {
 		return nil, fmt.Errorf("error preparing query GetStopTimesForTrip: %w", err)
 	}
+	if q.getStopTimesForTripIDsStmt, err = db.PrepareContext(ctx, getStopTimesForTripIDs); err != nil {
+		return nil, fmt.Errorf("error preparing query GetStopTimesForTripIDs: %w", err)
+	}
 	if q.getStopsByIDsStmt, err = db.PrepareContext(ctx, getStopsByIDs); err != nil {
 		return nil, fmt.Errorf("error preparing query GetStopsByIDs: %w", err)
 	}
@@ -242,6 +245,9 @@ func Prepare(ctx context.Context, db DBTX) (*Queries, error) {
 	}
 	if q.getTripsByBlockIDOrderedStmt, err = db.PrepareContext(ctx, getTripsByBlockIDOrdered); err != nil {
 		return nil, fmt.Errorf("error preparing query GetTripsByBlockIDOrdered: %w", err)
+	}
+	if q.getTripsByBlockIDsStmt, err = db.PrepareContext(ctx, getTripsByBlockIDs); err != nil {
+		return nil, fmt.Errorf("error preparing query GetTripsByBlockIDs: %w", err)
 	}
 	if q.getTripsByBlockTripIndexIDsStmt, err = db.PrepareContext(ctx, getTripsByBlockTripIndexIDs); err != nil {
 		return nil, fmt.Errorf("error preparing query GetTripsByBlockTripIndexIDs: %w", err)
@@ -601,6 +607,11 @@ func (q *Queries) Close() error {
 			err = fmt.Errorf("error closing getStopTimesForTripStmt: %w", cerr)
 		}
 	}
+	if q.getStopTimesForTripIDsStmt != nil {
+		if cerr := q.getStopTimesForTripIDsStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing getStopTimesForTripIDsStmt: %w", cerr)
+		}
+	}
 	if q.getStopsByIDsStmt != nil {
 		if cerr := q.getStopsByIDsStmt.Close(); cerr != nil {
 			err = fmt.Errorf("error closing getStopsByIDsStmt: %w", cerr)
@@ -644,6 +655,11 @@ func (q *Queries) Close() error {
 	if q.getTripsByBlockIDOrderedStmt != nil {
 		if cerr := q.getTripsByBlockIDOrderedStmt.Close(); cerr != nil {
 			err = fmt.Errorf("error closing getTripsByBlockIDOrderedStmt: %w", cerr)
+		}
+	}
+	if q.getTripsByBlockIDsStmt != nil {
+		if cerr := q.getTripsByBlockIDsStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing getTripsByBlockIDsStmt: %w", cerr)
 		}
 	}
 	if q.getTripsByBlockTripIndexIDsStmt != nil {
@@ -804,6 +820,7 @@ type Queries struct {
 	getStopTimesByStopIDsStmt                 *sql.Stmt
 	getStopTimesForStopInWindowStmt           *sql.Stmt
 	getStopTimesForTripStmt                   *sql.Stmt
+	getStopTimesForTripIDsStmt                *sql.Stmt
 	getStopsByIDsStmt                         *sql.Stmt
 	getStopsForRouteStmt                      *sql.Stmt
 	getStopsWithActiveServiceOnDateStmt       *sql.Stmt
@@ -813,6 +830,7 @@ type Queries struct {
 	getTripStmt                               *sql.Stmt
 	getTripsByBlockIDStmt                     *sql.Stmt
 	getTripsByBlockIDOrderedStmt              *sql.Stmt
+	getTripsByBlockIDsStmt                    *sql.Stmt
 	getTripsByBlockTripIndexIDsStmt           *sql.Stmt
 	getTripsByIDsStmt                         *sql.Stmt
 	getTripsByServiceIDStmt                   *sql.Stmt
@@ -894,6 +912,7 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		getStopTimesByStopIDsStmt:                 q.getStopTimesByStopIDsStmt,
 		getStopTimesForStopInWindowStmt:           q.getStopTimesForStopInWindowStmt,
 		getStopTimesForTripStmt:                   q.getStopTimesForTripStmt,
+		getStopTimesForTripIDsStmt:                q.getStopTimesForTripIDsStmt,
 		getStopsByIDsStmt:                         q.getStopsByIDsStmt,
 		getStopsForRouteStmt:                      q.getStopsForRouteStmt,
 		getStopsWithActiveServiceOnDateStmt:       q.getStopsWithActiveServiceOnDateStmt,
@@ -903,6 +922,7 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		getTripStmt:                               q.getTripStmt,
 		getTripsByBlockIDStmt:                     q.getTripsByBlockIDStmt,
 		getTripsByBlockIDOrderedStmt:              q.getTripsByBlockIDOrderedStmt,
+		getTripsByBlockIDsStmt:                    q.getTripsByBlockIDsStmt,
 		getTripsByBlockTripIndexIDsStmt:           q.getTripsByBlockTripIndexIDsStmt,
 		getTripsByIDsStmt:                         q.getTripsByIDsStmt,
 		getTripsByServiceIDStmt:                   q.getTripsByServiceIDStmt,

--- a/gtfsdb/query.sql
+++ b/gtfsdb/query.sql
@@ -960,3 +960,16 @@ SELECT * FROM shapes
 WHERE shape_id IN (sqlc.slice('shape_ids'))
 ORDER BY shape_id, shape_pt_sequence;
 
+-- name: GetStopTimesForTripIDs :many
+SELECT * FROM stop_times
+WHERE trip_id IN (sqlc.slice('trip_ids'))
+ORDER BY trip_id, stop_sequence;
+
+-- name: GetTripsByBlockIDs :many
+SELECT t.*
+FROM trips t
+JOIN stop_times st ON t.id = st.trip_id
+WHERE t.block_id IN (sqlc.slice('block_ids'))
+  AND t.service_id IN (sqlc.slice('service_ids'))
+GROUP BY t.id
+ORDER BY t.block_id, MIN(st.departure_time), t.id;


### PR DESCRIPTION
### Summary

This PR fixes a critical performance issue in the `trips-for-location` endpoint where database queries were scaling linearly with the number of visible vehicles (O(N)). The handler has been refactored to use a "Bulk Retrieval" pattern, reducing database interactions to a constant number (O(1)) regardless of traffic density.

Closes #316 

### The Problem

Previously, for every vehicle in the view, the handler executed 4 separate synchronous database queries inside a loop.

* **Scenario:** 50 visible buses.
* **Impact:** 200+ database queries per request.
* **Result:** High latency and potential database starvation under load.

### The Solution

Refactored `buildTripsForLocationEntries` to fetch all necessary data in 5 batch queries before processing:

1. **Collected IDs:** Aggregated Trip IDs and unique Block IDs from visible vehicles.
2. **Batch Fetching:** Added new SQL queries to fetch all Trips, Shapes, StopTimes, and Block-Trips in single calls using `IN (?)` clauses.
3. **In-Memory Assembly:** Replaced iterative database lookups with instant map-based lookups for building schedules and calculating "Next/Previous" trips.

### Technical Changes

* **`gtfsdb/query.sql`**: Added `GetStopTimesForTripIDs` and `GetTripsByBlockIDs` (with JOINs for correct ordering).
* **`internal/restapi/trips_for_location_handler.go`**: Complete rewrite of the entry builder to use the bulk fetch pattern.
* **Optimization**: Added deduplication for Block IDs to prevent redundant queries when multiple vehicles share the same block.

### Performance Impact

* **Before:** ~305 queries for 50 vehicles.
* **After:** ~5 queries for 50 vehicles.
* **Improvement:** ~98% reduction in database round-trips for high-density views.

### Verification & Testing

* [x] **Unit Tests:** Ran `go test ./internal/restapi/trips_for_location_handler_test.go` - All tests passed, ensuring no regression in logic.
* [x] **Code Gen:** Ran `make models` to verify valid SQLC generation.
* [x] **Logic Check:** Verified that `NextTripId` and `PreviousTripId` are correctly calculated using the new in-memory block logic.