### PR TITLE
refactor: replace fmt.Printf with structured logging

### DIFF
--- a/gtfsdb/helpers.go
+++ b/gtfsdb/helpers.go
@@ -116,15 +116,15 @@ func (c *Client) processAndStoreGTFSDataWithSource(b []byte, source string) erro
 		return err
 	}
 
-	fmt.Printf("retrieved static data (warnings: %d)\n", len(staticData.Warnings))
-	fmt.Print("========\n\n")
+	logging.LogOperation(logger, "static_data_retrieved",
+		slog.Int("warnings", len(staticData.Warnings)))
 
 	staticCounts = c.staticDataCounts(staticData)
 	for k, v := range staticCounts {
-		fmt.Printf("%s: %d\n", k, v)
+		logging.LogOperation(logger, "static_count",
+			slog.String("table", k),
+			slog.Int("count", v))
 	}
-
-	fmt.Print("========\n\n")
 
 	logging.LogOperation(logger, "starting_database_import")
 
@@ -329,7 +329,10 @@ func (c *Client) processAndStoreGTFSDataWithSource(b []byte, source string) erro
 		return fmt.Errorf("failed to get table counts: %w", err)
 	}
 	for k, v := range counts {
-		fmt.Printf("%s: %d (Static matches? %v)\n", k, v, v == staticCounts[k])
+		logging.LogOperation(logger, "table_count_verification",
+			slog.String("table", k),
+			slog.Int("count", v),
+			slog.Bool("matches_static", v == staticCounts[k]))
 	}
 
 	logging.LogOperation(logger, "updating_import_metadata",

--- a/internal/gtfs/gtfs_manager.go
+++ b/internal/gtfs/gtfs_manager.go
@@ -428,12 +428,16 @@ func (manager *Manager) GetAllTripUpdates() []gtfs.Trip {
 
 // IMPORTANT: Caller must hold manager.RLock() before calling this method.
 func (manager *Manager) PrintStatistics() {
-	fmt.Printf("Source: %s (Local File: %v)\n", manager.config.GtfsURL, manager.isLocalFile)
-	fmt.Printf("Last Updated: %s\n", manager.lastUpdated)
-	fmt.Println("Stops Count: ", len(manager.gtfsData.Stops))
-	fmt.Println("Routes Count: ", len(manager.gtfsData.Routes))
-	fmt.Println("Trips Count: ", len(manager.gtfsData.Trips))
-	fmt.Println("Agencies Count: ", len(manager.gtfsData.Agencies))
+	logger := slog.Default().With(slog.String("component", "gtfs_statistics"))
+	logger.Info("gtfs_statistics",
+		slog.String("source", manager.config.GtfsURL),
+		slog.Bool("is_local_file", manager.isLocalFile),
+		slog.String("last_updated", manager.lastUpdated.String()),
+		slog.Int("stops_count", len(manager.gtfsData.Stops)),
+		slog.Int("routes_count", len(manager.gtfsData.Routes)),
+		slog.Int("trips_count", len(manager.gtfsData.Trips)),
+		slog.Int("agencies_count", len(manager.gtfsData.Agencies)),
+	)
 }
 
 // IMPORTANT: Caller must hold manager.RLock() before calling this method.


### PR DESCRIPTION
## Summary
This PR improves observability by replacing `fmt.Printf` debug statements with 
structured logging using `slog`. This ensures all log output goes through the 
proper logging infrastructure for better monitoring and debugging.
Closes #318 
## The Problem
Previously, debug statements in GTFS import and statistics functions used
raw `fmt.Printf` calls that bypass the structured logging system.
**Scenario:** Debugging a failed GTFS import in production.
**Impact:** Debug logs are mixed with stdout, no structured fields for filtering.
**Result:** Difficult to query and analyze logs in observability tools (ELK, Datadog, Grafana).
```go
// Before: Unstructured output to stdout
fmt.Printf("Source: %s (Local File: %v)\n", manager.config.GtfsURL, manager.isLocalFile)
fmt.Printf("Last Updated: %s\n", manager.lastUpdated)
fmt.Printf("retrieved static data (warnings: %d)\n", len(staticData.Warnings))
fmt.Printf("%s: %d (Static matches? %v)\n", k, v, v == staticCounts[k])
```
The Solution
Replaced all fmt.Printf calls with structured slog logging:

Component Tagging: Added component field for easy log filtering
Structured Fields: All values are now queryable key-value pairs
Consistent Format: Uses existing logging.LogOperation helper
```go
// After: Structured logging with queryable fields
logger := slog.Default().With(slog.String("component", "gtfs_statistics"))
logger.Info("gtfs_statistics",
    slog.String("source", manager.config.GtfsURL),
    slog.Bool("is_local_file", manager.isLocalFile),
    slog.String("last_updated", manager.lastUpdated.String()),
    slog.Int("stops_count", len(manager.gtfsData.Stops)),
    slog.Int("routes_count", len(manager.gtfsData.Routes)),
    slog.Int("trips_count", len(manager.gtfsData.Trips)),
    slog.Int("agencies_count", len(manager.gtfsData.Agencies)),
)
logging.LogOperation(logger, "static_data_retrieved",
    slog.Int("warnings", len(staticData.Warnings)))
logging.LogOperation(logger, "table_count_verification",
    slog.String("table", k),
    slog.Int("count", v),
    slog.Bool("matches_static", v == staticCounts[k]))
```
Technical Changes
internal/gtfs/gtfs_manager.go
: Refactored 
PrintStatistics()
 to use slog
gtfsdb/helpers.go
: Replaced 5 fmt.Printf calls with structured logging
Performance Impact
No performance regression
Slightly better as slog can be configured for async/buffered writes
Verification & Testing
✅ Build: go build -tags "sqlite_fts5" ./... completes successfully ✅ Code Review: 2 files changed, 19 insertions(+), 12 deletions(-) ✅ Consistency: Matches existing logging patterns in the codebase