### PR TITLE
Fix: Return a Copy of Vehicle in GetVehicleByID to Prevent Unsafe Pointer Usage

### DIFF
--- a/internal/gtfs/gtfs_manager.go
+++ b/internal/gtfs/gtfs_manager.go
@@ -374,7 +374,8 @@ func (manager *Manager) GetVehicleForTrip(tripID string) *gtfs.Vehicle {
 	// match against any trip in the block, not a specific trip ID.
 	for _, v := range manager.realTimeVehicles {
 		if v.Trip != nil && v.Trip.ID.ID != "" && blockTripIDs[v.Trip.ID.ID] {
-			return &v
+			vehicle := v
+			return &vehicle
 		}
 	}
 	return nil
@@ -386,7 +387,8 @@ func (manager *Manager) GetVehicleByID(vehicleID string) (*gtfs.Vehicle, error) 
 	defer manager.realTimeMutex.RUnlock()
 
 	if index, exists := manager.realTimeVehicleLookupByVehicle[vehicleID]; exists {
-		return &manager.realTimeVehicles[index], nil
+		vehicle := manager.realTimeVehicles[index]
+		return &vehicle, nil
 	}
 
 	return nil, fmt.Errorf("vehicle with ID %s not found", vehicleID)
@@ -416,7 +418,8 @@ func (manager *Manager) GetTripUpdateByID(tripID string) (*gtfs.Trip, error) {
 	manager.realTimeMutex.RLock()
 	defer manager.realTimeMutex.RUnlock()
 	if index, exists := manager.realTimeTripLookup[tripID]; exists {
-		return &manager.realTimeTrips[index], nil
+		trip := manager.realTimeTrips[index]
+		return &trip, nil
 	}
 	return nil, fmt.Errorf("trip with ID %s not found", tripID)
 }


### PR DESCRIPTION
## Problem

`GetVehicleByID`, `GetTripUpdateByID`, and `GetVehicleForTrip` were returning pointers directly to internal slice elements protected by `realTimeMutex`.

Once the lock was released, callers could hold pointers to data that might be replaced by the background real-time update goroutine (runs every 30 seconds), leading to unsafe access and potential data races.

---

## Solution

Updated these functions to return pointers to **copies** instead of pointers to internal slice elements.

This follows the same safe pattern already used in `FindAgency`.

---

## Changes

- **GetVehicleByID**  
  - Copy vehicle before returning the pointer

- **GetTripUpdateByID**  
  - Copy trip update before returning the pointer

- **GetVehicleForTrip**  
  - Make copy explicit for consistency

---

## Testing

-  All existing tests pass  
-  Linting passes  
-  No API changes — callers are unaffected since returned data is identical

---

## Fixes

Fixes #329

