### PR TITLE
feat: Implement GET /api/where/alerts.json endpoint

### DIFF
--- a/internal/gtfs/realtime.go
+++ b/internal/gtfs/realtime.go
@@ -26,6 +26,17 @@ func (manager *Manager) GetRealTimeVehicles() []gtfs.Vehicle {
 	return manager.realTimeVehicles
 }
 
+// GetAllAlerts returns all active service alerts safely
+func (manager *Manager) GetAllAlerts() []gtfs.Alert {
+	manager.realTimeMutex.RLock()
+	defer manager.realTimeMutex.RUnlock()
+
+	alerts := make([]gtfs.Alert, len(manager.realTimeAlerts))
+	copy(alerts, manager.realTimeAlerts)
+
+	return alerts
+}
+
 func loadRealtimeData(ctx context.Context, source string, headers map[string]string) (*gtfs.Realtime, error) {
 	req, err := http.NewRequestWithContext(ctx, "GET", source, nil)
 	if err != nil {

--- a/internal/restapi/alerts_handler.go
+++ b/internal/restapi/alerts_handler.go
@@ -1,0 +1,51 @@
+package restapi
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/OneBusAway/go-gtfs"
+	"maglev.onebusaway.org/internal/models"
+)
+
+func (api *RestAPI) handleAlerts(w http.ResponseWriter, r *http.Request) {
+	query := r.URL.Query()
+	routeID := query.Get("routeId")
+	stopID := query.Get("stopId")
+	agencyID := query.Get("agencyId")
+
+	var alerts []gtfs.Alert
+
+	if routeID != "" {
+		alerts = api.GtfsManager.GetAlertsForRoute(routeID)
+	} else if stopID != "" {
+		alerts = api.GtfsManager.GetAlertsForStop(stopID)
+	} else {
+		alerts = api.GtfsManager.GetAllAlerts()
+	}
+
+	if agencyID != "" {
+		filtered := make([]gtfs.Alert, 0)
+		for _, alert := range alerts {
+			for _, entity := range alert.InformedEntities {
+				if entity.AgencyID != nil && *entity.AgencyID == agencyID {
+					filtered = append(filtered, alert)
+					break
+				}
+			}
+		}
+		alerts = filtered
+	}
+
+	situations := api.BuildSituationReferences(alerts, agencyID)
+
+	references := models.NewEmptyReferences()
+
+	resp := models.NewEntryResponse(situations, references, api.Clock)
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	if err := json.NewEncoder(w).Encode(resp); err != nil {
+		http.Error(w, "Failed to encode response", http.StatusInternalServerError)
+	}
+}

--- a/internal/restapi/alerts_handler_test.go
+++ b/internal/restapi/alerts_handler_test.go
@@ -1,0 +1,51 @@
+package restapi
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"maglev.onebusaway.org/internal/app"
+	"maglev.onebusaway.org/internal/clock"
+	"maglev.onebusaway.org/internal/gtfs"
+	"maglev.onebusaway.org/internal/models"
+)
+
+func TestHandleAlerts(t *testing.T) {
+	mockClock := clock.NewMockClock(time.Date(2023, 1, 1, 12, 0, 0, 0, time.UTC))
+
+	testApp := &app.Application{
+		GtfsManager: &gtfs.Manager{},
+		Clock:       mockClock,
+	}
+
+	api := &RestAPI{
+		Application: testApp,
+	}
+
+	req := httptest.NewRequest("GET", "/api/where/alerts.json?key=TEST", nil)
+	w := httptest.NewRecorder()
+
+	api.handleAlerts(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("Expected status code 200, got %d", w.Code)
+	}
+
+	if contentType := w.Header().Get("Content-Type"); contentType != "application/json" {
+		t.Errorf("Expected Content-Type application/json, got %s", contentType)
+	}
+
+	var resp models.ResponseModel
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("Failed to decode response: %v", err)
+	}
+
+	if resp.Code != 200 {
+		t.Errorf("Expected response code 200, got %d", resp.Code)
+	}
+
+	t.Log("TestHandleAlerts passed successfully!")
+}

--- a/internal/restapi/routes.go
+++ b/internal/restapi/routes.go
@@ -78,6 +78,7 @@ func (api *RestAPI) SetRoutes(mux *http.ServeMux) {
 	mux.Handle("GET /api/where/arrivals-and-departures-for-stop/{id}", rateLimitAndValidateAPIKey(api, api.arrivalsAndDeparturesForStopHandler))
 	mux.Handle("GET /api/where/search/stop.json", rateLimitAndValidateAPIKey(api, api.searchStopsHandler))
 	mux.Handle("GET /api/where/search/route.json", rateLimitAndValidateAPIKey(api, api.routeSearchHandler))
+	mux.Handle("GET /api/where/alerts.json", rateLimitAndValidateAPIKey(api, api.handleAlerts))
 }
 
 // SetupAPIRoutes creates and configures the API router with all middleware applied globally


### PR DESCRIPTION
### Summary
This PR implements the `/api/where/alerts.json` endpoint, allowing clients to retrieve GTFS-Realtime service alerts. This brings the API closer to the standard OneBusAway API specification.

### Changes
- **API Handler:** Added `alerts_handler.go` to handle requests and support filtering by `routeId`, `stopId`, or `agencyId`.
- **Data Layer:** Added `GetAllAlerts()` method in `internal/gtfs/realtime.go` to fetch system-wide alerts safely.
- **Routing:** Registered the new endpoint in `routes.go`.

### Design Decisions (Performance Optimization)
- **Empty References:** The `references` object is intentionally left empty to **minimize payload size and reduce database load**.
    - Since clients (mobile/web) typically cache static data (Agencies, Routes, Stops) from other endpoints, sending this duplicate data with every alerts request is redundant.
    - This approach avoids unnecessary N+1 queries to resolve entities, ensuring the endpoint remains lightweight and fast.

### Testing & Verification
<img width="1920" height="462" alt="Screenshot From 2026-02-07 16-27-16" src="https://github.com/user-attachments/assets/972760bd-65c8-4526-a95d-17d32eb26593" />

@aaronbrethorst 
closes : #333 