### PR TITLE
fix: resolve flaky stops_for_route test by sorting trips

### DIFF
--- a/internal/restapi/stops_for_route_handler.go
+++ b/internal/restapi/stops_for_route_handler.go
@@ -335,6 +335,12 @@ func processTripGroups(
 
 	for _, key := range keys {
 		tripsInGroup := tripGroups[key]
+
+		// Sort trips by ID to ensure we always pick the same representative trip
+		sort.Slice(tripsInGroup, func(i, j int) bool {
+			return tripsInGroup[i].ID < tripsInGroup[j].ID
+		})
+
 		representativeTrip := tripsInGroup[0]
 		stopsList, err := api.GtfsManager.GtfsDB.Queries.GetOrderedStopIDsForTrip(ctx, representativeTrip.ID)
 		if err != nil {

--- a/internal/restapi/stops_for_route_handler_test.go
+++ b/internal/restapi/stops_for_route_handler_test.go
@@ -75,9 +75,8 @@ func TestStopsForRouteHandlerEndToEnd(t *testing.T) {
 	inboundStopIds, ok := inboundGroup["stopIds"].([]interface{})
 	require.True(t, ok)
 
-	// TODO: why is this varying between 21 and 22 depending on the test run?
-	either21Or22 := len(inboundStopIds) == 21 || len(inboundStopIds) == 22
-	assert.True(t, either21Or22, "Expected 21 or 22 stop IDs, got %d", len(inboundStopIds))
+	// With deterministic sorting, checks should be consistent
+	assert.Equal(t, 21, len(inboundStopIds))
 
 	inboundPolylines, ok := inboundGroup["polylines"].([]interface{})
 	require.True(t, ok)
@@ -95,9 +94,8 @@ func TestStopsForRouteHandlerEndToEnd(t *testing.T) {
 
 	outboundStopIds, ok := outboundGroup["stopIds"].([]interface{})
 	require.True(t, ok)
-	// TODO: why is this varying between 21 and 22 depending on the test run?
-	either21Or22 = len(outboundStopIds) == 21 || len(outboundStopIds) == 22
-	assert.True(t, either21Or22, "Expected 21 or 22 stop IDs, got %d", len(outboundStopIds))
+	// With deterministic sorting, checks should be consistent
+	assert.Equal(t, 22, len(outboundStopIds))
 
 	// Verify references
 	refs, ok := data["references"].(map[string]interface{})


### PR DESCRIPTION
## Summary
This PR fixes a known flaky test in `TestStopsForRouteHandlerEndToEnd` where the number of returned stops would fluctuate between 21 and 22 depending on execution order.

### closes #336 

## Changes Made

### `internal/restapi/stops_for_route_handler.go`
* **Fix:** Added `sort.Slice` to sort the `tripsInGroup` slice by `Trip.ID` before selecting the representative trip.
* **Impact:** This ensures that the `representativeTrip` selection is deterministic. The same trip is now always chosen to represent the group, resulting in a consistent list of stops every time.

### `internal/restapi/stops_for_route_handler_test.go`
* **Update:** Removed the conditional assertion that accepted either 21 or 22 stops.
* **Update:** Hardcoded strict expectations:
    * Inbound: Expect exactly **21** stops.
    * Outbound: Expect exactly **22** stops.

## Verification
Ran the test 10 times locally to ensure flakiness is resolved.

```bash
go test -v -count=10 -tags sqlite_fts5 ./internal/restapi/... -run TestStopsForRouteHandlerEndToEnd