### PR TITLE
Refactor: Centralize Global Cache & Fix Test Dependency Injection

### DIFF
--- a/cmd/api/app.go
+++ b/cmd/api/app.go
@@ -78,6 +78,11 @@ func BuildApplication(cfg appconf.Config, gtfsCfg gtfs.Config) (*app.Application
 	var directionCalculator *gtfs.AdvancedDirectionCalculator
 	if gtfsManager != nil {
 		directionCalculator = gtfs.NewAdvancedDirectionCalculator(gtfsManager.GtfsDB.Queries)
+
+		err = gtfs.InitializeGlobalCache(context.Background(), gtfsManager.GtfsDB.Queries, directionCalculator)
+		if err != nil {
+			return nil, fmt.Errorf("failed to initialize global cache: %w", err)
+		}
 	}
 
 	// Select clock implementation based on environment

--- a/gtfsdb/db.go
+++ b/gtfsdb/db.go
@@ -117,6 +117,9 @@ func Prepare(ctx context.Context, db DBTX) (*Queries, error) {
 	if q.getAllShapesStmt, err = db.PrepareContext(ctx, getAllShapes); err != nil {
 		return nil, fmt.Errorf("error preparing query GetAllShapes: %w", err)
 	}
+	if q.getAllStopIDsStmt, err = db.PrepareContext(ctx, getAllStopIDs); err != nil {
+		return nil, fmt.Errorf("error preparing query GetAllStopIDs: %w", err)
+	}
 	if q.getAllTripsForRouteStmt, err = db.PrepareContext(ctx, getAllTripsForRoute); err != nil {
 		return nil, fmt.Errorf("error preparing query GetAllTripsForRoute: %w", err)
 	}
@@ -458,6 +461,11 @@ func (q *Queries) Close() error {
 	if q.getAllShapesStmt != nil {
 		if cerr := q.getAllShapesStmt.Close(); cerr != nil {
 			err = fmt.Errorf("error closing getAllShapesStmt: %w", cerr)
+		}
+	}
+	if q.getAllStopIDsStmt != nil {
+		if cerr := q.getAllStopIDsStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing getAllStopIDsStmt: %w", cerr)
 		}
 	}
 	if q.getAllTripsForRouteStmt != nil {
@@ -835,6 +843,7 @@ type Queries struct {
 	getAgencyStmt                             *sql.Stmt
 	getAgencyForStopStmt                      *sql.Stmt
 	getAllShapesStmt                          *sql.Stmt
+	getAllStopIDsStmt                         *sql.Stmt
 	getAllTripsForRouteStmt                   *sql.Stmt
 	getArrivalsAndDeparturesForStopStmt       *sql.Stmt
 	getBlockDetailsStmt                       *sql.Stmt
@@ -933,6 +942,7 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		getAgencyStmt:                             q.getAgencyStmt,
 		getAgencyForStopStmt:                      q.getAgencyForStopStmt,
 		getAllShapesStmt:                          q.getAllShapesStmt,
+		getAllStopIDsStmt:                         q.getAllStopIDsStmt,
 		getAllTripsForRouteStmt:                   q.getAllTripsForRouteStmt,
 		getArrivalsAndDeparturesForStopStmt:       q.getArrivalsAndDeparturesForStopStmt,
 		getBlockDetailsStmt:                       q.getBlockDetailsStmt,

--- a/gtfsdb/query.sql
+++ b/gtfsdb/query.sql
@@ -194,6 +194,12 @@ ORDER BY
 LIMIT
     1;
 
+-- name: GetAllStopIDs :many
+SELECT
+    id
+FROM
+    stops;    
+
 -- name: GetStopIDsForAgency :many
 SELECT DISTINCT
     s.id

--- a/gtfsdb/query.sql.go
+++ b/gtfsdb/query.sql.go
@@ -1136,6 +1136,36 @@ func (q *Queries) GetAllShapes(ctx context.Context) ([]Shape, error) {
 	return items, nil
 }
 
+const getAllStopIDs = `-- name: GetAllStopIDs :many
+SELECT
+    id
+FROM
+    stops
+`
+
+func (q *Queries) GetAllStopIDs(ctx context.Context) ([]string, error) {
+	rows, err := q.query(ctx, q.getAllStopIDsStmt, getAllStopIDs)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		items = append(items, id)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const getAllTripsForRoute = `-- name: GetAllTripsForRoute :many
 SELECT DISTINCT id, route_id, service_id, trip_headsign, trip_short_name, direction_id, block_id, shape_id, wheelchair_accessible, bikes_allowed
 FROM trips t

--- a/internal/gtfs/advanced_direction_calculator_test.go
+++ b/internal/gtfs/advanced_direction_calculator_test.go
@@ -4,12 +4,52 @@ import (
 	"context"
 	"database/sql"
 	"math"
+	"os"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"maglev.onebusaway.org/gtfsdb"
 	"maglev.onebusaway.org/internal/models"
 )
+
+// This uses a Singleton pattern to load the DB and Warm the Cache exactly ONCE
+// for this test file. This prevents re-loading the ZIP file 15+ times.
+
+var (
+	sharedManager *Manager
+	sharedCalc    *AdvancedDirectionCalculator
+	setupOnce     sync.Once
+)
+
+// Helper function to get the shared instances.
+func getSharedTestComponents(t *testing.T) (*Manager, *AdvancedDirectionCalculator) {
+	setupOnce.Do(func() {
+		// Initialize the DB (In-Memory)
+		gtfsConfig := Config{
+			GtfsURL:      models.GetFixturePath(t, "raba.zip"),
+			GTFSDataPath: ":memory:",
+		}
+
+		var err error
+		sharedManager, err = InitGTFSManager(gtfsConfig)
+		if err != nil {
+			panic("Failed to init shared GTFS manager: " + err.Error())
+		}
+
+		// Create the Calculator
+		sharedCalc = NewAdvancedDirectionCalculator(sharedManager.GtfsDB.Queries)
+
+		// Warm the Global Cache (The heavy operation)
+		// We do this only once per test suite execution.
+		err = InitializeGlobalCache(context.Background(), sharedManager.GtfsDB.Queries, sharedCalc)
+		if err != nil {
+			panic("Failed to warm global cache: " + err.Error())
+		}
+	})
+
+	return sharedManager, sharedCalc
+}
 
 func TestTranslateGtfsDirection(t *testing.T) {
 	calc := &AdvancedDirectionCalculator{}
@@ -41,7 +81,6 @@ func TestTranslateGtfsDirection(t *testing.T) {
 		{"225 degrees", "225", "SW"},
 		{"270 degrees", "270", "W"},
 		{"315 degrees", "315", "NW"},
-
 		// Invalid
 		{"invalid text", "invalid", ""},
 		{"empty string", "", ""},
@@ -158,7 +197,6 @@ func TestStatisticalFunctions(t *testing.T) {
 
 func TestStandardDeviationThreshold(t *testing.T) {
 	calc := NewAdvancedDirectionCalculator(nil)
-
 	// Test default threshold
 	assert.Equal(t, defaultStandardDeviationThreshold, calc.standardDeviationThreshold)
 
@@ -168,63 +206,33 @@ func TestStandardDeviationThreshold(t *testing.T) {
 }
 
 func TestCalculateStopDirection_WithShapeData(t *testing.T) {
-	gtfsConfig := Config{
-		GtfsURL:      models.GetFixturePath(t, "raba.zip"),
-		GTFSDataPath: ":memory:",
-	}
-	manager, err := InitGTFSManager(gtfsConfig)
-	assert.Nil(t, err)
-	defer manager.Shutdown()
+	// Optimization: Reuse shared DB and Cache
+	_, calc := getSharedTestComponents(t)
 
-	calc := NewAdvancedDirectionCalculator(manager.GtfsDB.Queries)
-
-	// Test with a real stop from RABA data
 	direction := calc.CalculateStopDirection(context.Background(), "7000", sql.NullString{Valid: false})
-	// Should return a valid direction or empty string
 	assert.True(t, direction == "" || len(direction) <= 2)
 }
 
 func TestComputeFromShapes_NoShapeData(t *testing.T) {
-	gtfsConfig := Config{
-		GtfsURL:      models.GetFixturePath(t, "raba.zip"),
-		GTFSDataPath: ":memory:",
-	}
-	manager, err := InitGTFSManager(gtfsConfig)
-	assert.Nil(t, err)
-	defer manager.Shutdown()
+	// Optimization: Reuse shared DB and Cache
+	_, calc := getSharedTestComponents(t)
 
-	calc := NewAdvancedDirectionCalculator(manager.GtfsDB.Queries)
-
-	// Test with a non-existent stop
 	direction := calc.computeFromShapes(context.Background(), "nonexistent")
 	assert.Equal(t, "", direction)
 }
 
 func TestComputeFromShapes_SingleOrientation(t *testing.T) {
-	gtfsConfig := Config{
-		GtfsURL:      models.GetFixturePath(t, "raba.zip"),
-		GTFSDataPath: ":memory:",
-	}
-	manager, err := InitGTFSManager(gtfsConfig)
-	assert.Nil(t, err)
-	defer manager.Shutdown()
+	// Optimization: Reuse shared DB and Cache
+	_, calc := getSharedTestComponents(t)
 
-	calc := NewAdvancedDirectionCalculator(manager.GtfsDB.Queries)
-
-	// Test with actual stop data - single orientation path will be taken if only one trip
 	direction := calc.computeFromShapes(context.Background(), "7000")
-	// Direction should be valid or empty
 	assert.True(t, direction == "" || len(direction) <= 2)
 }
 
 func TestComputeFromShapes_StandardDeviationThreshold(t *testing.T) {
-	gtfsConfig := Config{
-		GtfsURL:      models.GetFixturePath(t, "raba.zip"),
-		GTFSDataPath: ":memory:",
-	}
-	manager, err := InitGTFSManager(gtfsConfig)
-	assert.Nil(t, err)
-	defer manager.Shutdown()
+	// Note: We reuse the Shared Manager (DB) but create a NEW Calculator.
+	// This is because we modify the variance threshold and don't want to break other tests.
+	manager, _ := getSharedTestComponents(t)
 
 	calc := NewAdvancedDirectionCalculator(manager.GtfsDB.Queries)
 
@@ -238,15 +246,7 @@ func TestComputeFromShapes_StandardDeviationThreshold(t *testing.T) {
 }
 
 func TestCalculateOrientationAtStop_WithDistanceTraveled(t *testing.T) {
-	gtfsConfig := Config{
-		GtfsURL:      models.GetFixturePath(t, "raba.zip"),
-		GTFSDataPath: ":memory:",
-	}
-	manager, err := InitGTFSManager(gtfsConfig)
-	assert.Nil(t, err)
-	defer manager.Shutdown()
-
-	calc := NewAdvancedDirectionCalculator(manager.GtfsDB.Queries)
+	manager, calc := getSharedTestComponents(t)
 
 	// Get a shape ID from the database
 	shapes, err := manager.GtfsDB.Queries.GetShapePointsWithDistance(context.Background(), "19_0_1")
@@ -263,15 +263,7 @@ func TestCalculateOrientationAtStop_WithDistanceTraveled(t *testing.T) {
 }
 
 func TestCalculateOrientationAtStop_GeographicMatching(t *testing.T) {
-	gtfsConfig := Config{
-		GtfsURL:      models.GetFixturePath(t, "raba.zip"),
-		GTFSDataPath: ":memory:",
-	}
-	manager, err := InitGTFSManager(gtfsConfig)
-	assert.Nil(t, err)
-	defer manager.Shutdown()
-
-	calc := NewAdvancedDirectionCalculator(manager.GtfsDB.Queries)
+	manager, calc := getSharedTestComponents(t)
 
 	// Get a shape ID from the database
 	shapes, err := manager.GtfsDB.Queries.GetShapePointsWithDistance(context.Background(), "19_0_1")
@@ -290,15 +282,7 @@ func TestCalculateOrientationAtStop_GeographicMatching(t *testing.T) {
 }
 
 func TestCalculateOrientationAtStop_NoShapePoints(t *testing.T) {
-	gtfsConfig := Config{
-		GtfsURL:      models.GetFixturePath(t, "raba.zip"),
-		GTFSDataPath: ":memory:",
-	}
-	manager, err := InitGTFSManager(gtfsConfig)
-	assert.Nil(t, err)
-	defer manager.Shutdown()
-
-	calc := NewAdvancedDirectionCalculator(manager.GtfsDB.Queries)
+	_, calc := getSharedTestComponents(t)
 
 	// Test with non-existent shape - should return error or 0 orientation
 	orientation, err := calc.calculateOrientationAtStop(context.Background(), "nonexistent", 0, 0, 0)
@@ -307,22 +291,13 @@ func TestCalculateOrientationAtStop_NoShapePoints(t *testing.T) {
 }
 
 func TestCalculateOrientationAtStop_EdgeCases(t *testing.T) {
-	gtfsConfig := Config{
-		GtfsURL:      models.GetFixturePath(t, "raba.zip"),
-		GTFSDataPath: ":memory:",
-	}
-	manager, err := InitGTFSManager(gtfsConfig)
-	assert.Nil(t, err)
-	defer manager.Shutdown()
-
-	calc := NewAdvancedDirectionCalculator(manager.GtfsDB.Queries)
+	manager, calc := getSharedTestComponents(t)
 
 	// Test with shape that has points at the boundaries
 	shapes, err := manager.GtfsDB.Queries.GetShapePointsWithDistance(context.Background(), "19_0_1")
 	if err != nil || len(shapes) < 2 {
 		t.Skip("No shape data available for testing")
 	}
-
 	// Test at the very beginning of the shape
 	if len(shapes) > 0 && shapes[0].ShapeDistTraveled.Valid {
 		orientation, err := calc.calculateOrientationAtStop(context.Background(), "19_0_1", shapes[0].ShapeDistTraveled.Float64, 0, 0)
@@ -430,18 +405,7 @@ func TestSetContextCache_PanicAfterInit(t *testing.T) {
 }
 
 func TestCalculateStopDirection_VariadicSignature(t *testing.T) {
-
-	// Setup in-memory DB so the calculator has a valid query interface
-	gtfsConfig := Config{
-		GtfsURL:      models.GetFixturePath(t, "raba.zip"),
-		GTFSDataPath: ":memory:",
-	}
-	manager, err := InitGTFSManager(gtfsConfig)
-	assert.Nil(t, err)
-	defer manager.Shutdown()
-
-	// Create the calculator using the VALID queries object
-	calc := NewAdvancedDirectionCalculator(manager.GtfsDB.Queries)
+	_, calc := getSharedTestComponents(t)
 
 	// Case 1: Caller provides the optimized direction (should be used instantly)
 	// We pass "North", expect "N"
@@ -456,15 +420,8 @@ func TestCalculateStopDirection_VariadicSignature(t *testing.T) {
 }
 
 func TestSetContextCache_ConcurrentAccess(t *testing.T) {
-	// Setup
-	gtfsConfig := Config{
-		GtfsURL:      models.GetFixturePath(t, "raba.zip"),
-		GTFSDataPath: ":memory:",
-	}
-	manager, err := InitGTFSManager(gtfsConfig)
-	assert.Nil(t, err)
-	defer manager.Shutdown()
-
+	manager, _ := getSharedTestComponents(t)
+	// We use shared DB, but MUST use a fresh Calculator to test the race condition specifically on that instance.
 	calc := NewAdvancedDirectionCalculator(manager.GtfsDB.Queries)
 
 	// Create dummy cache
@@ -505,22 +462,10 @@ func TestSetContextCache_ConcurrentAccess(t *testing.T) {
 
 // TestBulkQuery_GetStopsWithShapeContextByIDs verifies the bulk optimization
 func TestBulkQuery_GetStopsWithShapeContextByIDs(t *testing.T) {
-	// Setup
-	gtfsConfig := Config{
-		GtfsURL:      models.GetFixturePath(t, "raba.zip"),
-		GTFSDataPath: ":memory:",
-	}
-	manager, err := InitGTFSManager(gtfsConfig)
-	if err != nil {
-		t.Fatalf("Failed to init manager: %v", err)
-	}
-	defer manager.Shutdown()
-
+	manager, _ := getSharedTestComponents(t)
 	ctx := context.Background()
-
 	// DYNAMICALLY fetch valid Stop IDs
 	rows, err := manager.GtfsDB.DB.QueryContext(ctx, "SELECT id FROM stops LIMIT 5")
-
 	if err != nil {
 		t.Fatalf("Failed to query stops: %v", err)
 	}
@@ -563,22 +508,12 @@ func TestBulkQuery_GetStopsWithShapeContextByIDs(t *testing.T) {
 
 // TestBulkQuery_GetShapePointsByIDs verifies fetching shape points in bulk.
 func TestBulkQuery_GetShapePointsByIDs(t *testing.T) {
-	// Setup
-	gtfsConfig := Config{
-		GtfsURL:      models.GetFixturePath(t, "raba.zip"),
-		GTFSDataPath: ":memory:",
-	}
-	manager, err := InitGTFSManager(gtfsConfig)
-	if err != nil {
-		t.Fatalf("Failed to init manager: %v", err)
-	}
-	defer manager.Shutdown()
-
+	manager, _ := getSharedTestComponents(t)
 	ctx := context.Background()
 
 	// DYNAMICALLY fetch a real Shape ID from the DB
 	var shapeID string
-	err = manager.GtfsDB.DB.QueryRowContext(ctx, "SELECT shape_id FROM shapes LIMIT 1").Scan(&shapeID)
+	err := manager.GtfsDB.DB.QueryRowContext(ctx, "SELECT shape_id FROM shapes LIMIT 1").Scan(&shapeID)
 
 	// Stop immediately on error
 	if err != nil {
@@ -605,4 +540,18 @@ func TestBulkQuery_GetShapePointsByIDs(t *testing.T) {
 		}
 	}
 	assert.True(t, isSorted, "Shape points should be returned in sequence order")
+}
+
+func TestMain(m *testing.M) {
+	// Run all tests
+	code := m.Run()
+
+	// Global Teardown
+	// If sharedManager was initialized during tests, shut it down now.
+	if sharedManager != nil {
+		sharedManager.Shutdown()
+	}
+
+	// Exit with the test result code
+	os.Exit(code)
 }

--- a/internal/gtfs/global_cache.go
+++ b/internal/gtfs/global_cache.go
@@ -1,0 +1,70 @@
+package gtfs
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"maglev.onebusaway.org/gtfsdb"
+)
+
+func InitializeGlobalCache(ctx context.Context, queries *gtfsdb.Queries, adc *AdvancedDirectionCalculator) error {
+	slog.Info("starting global cache warmup...")
+
+	allStopIDs, err := queries.GetAllStopIDs(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to fetch all stop IDs: %w", err)
+	}
+
+	contextRows, err := queries.GetStopsWithShapeContextByIDs(ctx, allStopIDs)
+	if err != nil {
+		return fmt.Errorf("failed to fetch stop context rows: %w", err)
+	}
+
+	contextCache := make(map[string][]gtfsdb.GetStopsWithShapeContextRow)
+	shapeIDMap := make(map[string]bool)
+	var uniqueShapeIDs []string
+
+	for _, row := range contextRows {
+		calcRow := gtfsdb.GetStopsWithShapeContextRow{
+			ID:                row.StopID,
+			ShapeID:           row.ShapeID,
+			Lat:               row.Lat,
+			Lon:               row.Lon,
+			ShapeDistTraveled: row.ShapeDistTraveled,
+		}
+		contextCache[row.StopID] = append(contextCache[row.StopID], calcRow)
+
+		if row.ShapeID.Valid && row.ShapeID.String != "" && !shapeIDMap[row.ShapeID.String] {
+			shapeIDMap[row.ShapeID.String] = true
+			uniqueShapeIDs = append(uniqueShapeIDs, row.ShapeID.String)
+		}
+	}
+
+	shapeCache := make(map[string][]gtfsdb.GetShapePointsWithDistanceRow)
+
+	if len(uniqueShapeIDs) > 0 {
+		shapePoints, err := queries.GetShapePointsByIDs(ctx, uniqueShapeIDs)
+		if err != nil {
+			return fmt.Errorf("failed to fetch shape points for global cache: %w", err)
+		}
+
+		for _, p := range shapePoints {
+			shapeCache[p.ShapeID] = append(shapeCache[p.ShapeID], gtfsdb.GetShapePointsWithDistanceRow{
+				Lat:               p.Lat,
+				Lon:               p.Lon,
+				ShapeDistTraveled: p.ShapeDistTraveled,
+				ShapePtSequence:   p.ShapePtSequence,
+			})
+		}
+	}
+
+	adc.SetShapeCache(shapeCache)
+	adc.SetContextCache(contextCache)
+
+	slog.Info("global cache warmup complete",
+		slog.Int("stops_cached", len(contextCache)),
+		slog.Int("shapes_cached", len(shapeCache)))
+
+	return nil
+}

--- a/internal/gtfs/global_cache_test.go
+++ b/internal/gtfs/global_cache_test.go
@@ -1,0 +1,177 @@
+package gtfs
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"maglev.onebusaway.org/gtfsdb"
+	"maglev.onebusaway.org/internal/appconf"
+	"maglev.onebusaway.org/internal/models"
+)
+
+// wipeDatabase clears all tables in the correct order to respect Foreign Keys.
+// We delete dependent ("child") tables before independent ("parent") tables.
+func wipeDatabase(t *testing.T, client *gtfsdb.Client) {
+	ctx := context.Background()
+	// Order is critical to satisfy Foreign Key constraints:
+	// 1. block_trip_entry (depends on trips AND block_trip_index)
+	// 2. stop_times (depends on trips AND stops)
+	// 3. trips (depends on routes, shapes, calendar)
+	// 4. block_trip_index (referenced by block_trip_entry)
+	// 5. calendar_dates (depends on service_id)
+	// 6. calendar, shapes, stops, routes (now safe to delete)
+	// 7. agencies (root)
+	queries := []string{
+		"DELETE FROM block_trip_entry;",
+		"DELETE FROM stop_times;",
+		"DELETE FROM trips;",
+		"DELETE FROM block_trip_index;",
+		"DELETE FROM calendar_dates;",
+		"DELETE FROM calendar;",
+		"DELETE FROM shapes;",
+		"DELETE FROM stops;",
+		"DELETE FROM routes;",
+		"DELETE FROM agencies;",
+	}
+
+	for _, q := range queries {
+		_, err := client.DB.ExecContext(ctx, q)
+		if err != nil {
+			t.Fatalf("Failed to execute cleanup query %q: %v", q, err)
+		}
+	}
+}
+
+// HAPPY PATH: Uses the Shared DB (Fast, Standard Data)
+func TestInitializeGlobalCache_HappyPath(t *testing.T) {
+	manager, _ := getSharedTestComponents(t)
+
+	calc := NewAdvancedDirectionCalculator(manager.GtfsDB.Queries)
+
+	err := InitializeGlobalCache(context.Background(), manager.GtfsDB.Queries, calc)
+	assert.NoError(t, err)
+
+	// Verify real data from raba.zip
+	assert.Greater(t, len(calc.contextCache), 0, "Context cache should be populated")
+	assert.Greater(t, len(calc.shapeCache), 0, "Shape cache should be populated")
+
+	// Dynamic check: Pick any ID to verify
+	var sampleID string
+	for id := range calc.contextCache {
+		sampleID = id
+		break
+	}
+	assert.NotEmpty(t, sampleID)
+
+	stops := calc.contextCache[sampleID]
+	assert.NotEmpty(t, stops)
+	assert.Equal(t, sampleID, stops[0].ID)
+}
+
+// EDGE CASE: Empty Database
+func TestInitializeGlobalCache_EmptyDatabase(t *testing.T) {
+	gtfsConfig := Config{
+		GtfsURL:      models.GetFixturePath(t, "raba.zip"),
+		GTFSDataPath: ":memory:",
+		Env:          appconf.Test,
+	}
+	manager, err := InitGTFSManager(gtfsConfig)
+	if err != nil {
+		t.Fatalf("Failed to init manager: %v", err)
+	}
+	defer manager.Shutdown()
+
+	wipeDatabase(t, manager.GtfsDB)
+
+	calc := NewAdvancedDirectionCalculator(manager.GtfsDB.Queries)
+	err = InitializeGlobalCache(context.Background(), manager.GtfsDB.Queries, calc)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 0, len(calc.contextCache))
+	assert.Equal(t, 0, len(calc.shapeCache))
+}
+
+// FAILURE CASE: Database Error
+func TestInitializeGlobalCache_DatabaseError(t *testing.T) {
+	gtfsConfig := Config{
+		GtfsURL:      models.GetFixturePath(t, "raba.zip"),
+		GTFSDataPath: ":memory:",
+		Env:          appconf.Test,
+	}
+	manager, err := InitGTFSManager(gtfsConfig)
+	if err != nil {
+		t.Fatalf("Failed to init manager: %v", err)
+	}
+	// Important: Defer shutdown to clean up background routines
+	defer manager.Shutdown()
+
+	// SABOTAGE: Close DB to force errors
+	_ = manager.GtfsDB.DB.Close()
+
+	calc := NewAdvancedDirectionCalculator(manager.GtfsDB.Queries)
+	err = InitializeGlobalCache(context.Background(), manager.GtfsDB.Queries, calc)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to fetch")
+}
+
+// EDGE CASE: Stops without Shapes
+// Tests that the calculator handles active stops gracefully when the associated
+// trip lacks shape geometry (e.g., shape_id is NULL).
+func TestInitializeGlobalCache_StopsWithoutShapes(t *testing.T) {
+	gtfsConfig := Config{
+		GtfsURL:      models.GetFixturePath(t, "raba.zip"),
+		GTFSDataPath: ":memory:",
+		Env:          appconf.Test,
+	}
+	manager, err := InitGTFSManager(gtfsConfig)
+	if err != nil {
+		t.Fatalf("Failed to init manager: %v", err)
+	}
+	defer manager.Shutdown()
+
+	// Clear any existing data
+	wipeDatabase(t, manager.GtfsDB)
+
+	ctx := context.Background()
+
+	// Setup: Create a "Valid" Stop (Active, but no Shape)
+	// Link the stop to a trip, otherwise the cache loader will correctly
+	// ignore it as "unused/ghost" data.
+	queries := []string{
+		// Hierarchy: Agency -> Route -> Calendar -> Trip
+		`INSERT INTO agencies (id, name, url, timezone) VALUES ('agency_1', 'Test Agency', 'http://example.com', 'UTC');`,
+		`INSERT INTO routes (id, agency_id, type) VALUES ('route_1', 'agency_1', 3);`,
+		`INSERT INTO calendar (id, monday, tuesday, wednesday, thursday, friday, saturday, sunday, start_date, end_date) 
+		 VALUES ('service_1', 1, 1, 1, 1, 1, 1, 1, '20240101', '20250101');`,
+
+		// CRITICAL: Trip has NULL shape_id
+		`INSERT INTO trips (id, route_id, service_id, shape_id) VALUES ('trip_1', 'route_1', 'service_1', NULL);`,
+
+		// The Stop itself
+		`INSERT INTO stops (id, code, name, lat, lon, location_type) VALUES ('orphan_stop', '999', 'Orphan Stop', 10.0, 20.0, 0);`,
+
+		// Link: Stop -> Trip (Makes the stop "Active")
+		`INSERT INTO stop_times (trip_id, arrival_time, departure_time, stop_id, stop_sequence) 
+		 VALUES ('trip_1', 0, 0, 'orphan_stop', 1);`,
+	}
+
+	for _, q := range queries {
+		_, err := manager.GtfsDB.DB.ExecContext(ctx, q)
+		assert.NoError(t, err, "Failed to execute setup query")
+	}
+
+	// Run the Test
+	calc := NewAdvancedDirectionCalculator(manager.GtfsDB.Queries)
+	err = InitializeGlobalCache(ctx, manager.GtfsDB.Queries, calc)
+
+	// Verify
+	assert.NoError(t, err)
+
+	// Should be 1 because the stop is now active (linked to trip_1)
+	assert.Equal(t, 1, len(calc.contextCache), "Active stop should be cached")
+
+	// Should be 0 because we explicitly set shape_id to NULL
+	assert.Equal(t, 0, len(calc.shapeCache), "No shapes should be cached")
+}

--- a/internal/gtfs/gtfs_manager_test.go
+++ b/internal/gtfs/gtfs_manager_test.go
@@ -15,81 +15,41 @@ import (
 )
 
 func TestManager_GetAgencies(t *testing.T) {
-	testCases := []struct {
-		name     string
-		dataPath string
-	}{
-		{
-			name:     "FromLocalFile",
-			dataPath: models.GetFixturePath(t, "raba.zip"),
-		},
-	}
+	// Use shared component to avoid reloading DB
+	manager, _ := getSharedTestComponents(t)
+	assert.NotNil(t, manager)
 
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			gtfsConfig := Config{
-				GtfsURL:      tc.dataPath,
-				Env:          appconf.Test,
-				GTFSDataPath: ":memory:",
-			}
-			manager, err := InitGTFSManager(gtfsConfig)
-			assert.Nil(t, err)
-			defer manager.Shutdown()
+	agencies := manager.GetAgencies()
+	assert.Equal(t, 1, len(agencies))
 
-			agencies := manager.GetAgencies()
-			assert.Equal(t, 1, len(agencies))
-
-			agency := agencies[0]
-			assert.Equal(t, "25", agency.Id)
-			assert.Equal(t, "Redding Area Bus Authority", agency.Name)
-			assert.Equal(t, "http://www.rabaride.com/", agency.Url)
-			assert.Equal(t, "America/Los_Angeles", agency.Timezone)
-			assert.Equal(t, "en", agency.Language)
-			assert.Equal(t, "530-241-2877", agency.Phone)
-			assert.Equal(t, "", agency.FareUrl)
-			assert.Equal(t, "", agency.Email)
-		})
-	}
+	agency := agencies[0]
+	assert.Equal(t, "25", agency.Id)
+	assert.Equal(t, "Redding Area Bus Authority", agency.Name)
+	assert.Equal(t, "http://www.rabaride.com/", agency.Url)
+	assert.Equal(t, "America/Los_Angeles", agency.Timezone)
+	assert.Equal(t, "en", agency.Language)
+	assert.Equal(t, "530-241-2877", agency.Phone)
+	assert.Equal(t, "", agency.FareUrl)
+	assert.Equal(t, "", agency.Email)
 }
 
 func TestManager_RoutesForAgencyID(t *testing.T) {
-	testCases := []struct {
-		name     string
-		dataPath string
-	}{
-		{
-			name:     "FromLocalFile",
-			dataPath: models.GetFixturePath(t, "raba.zip"),
-		},
-	}
+	manager, _ := getSharedTestComponents(t)
+	assert.NotNil(t, manager)
 
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			gtfsConfig := Config{
-				GtfsURL:      tc.dataPath,
-				GTFSDataPath: ":memory:",
-				Env:          appconf.Test,
-			}
-			manager, err := InitGTFSManager(gtfsConfig)
-			assert.Nil(t, err)
-			defer manager.Shutdown()
+	manager.RLock()
+	routes := manager.RoutesForAgencyID("25")
+	manager.RUnlock()
+	assert.Equal(t, 13, len(routes))
 
-			manager.RLock()
-			routes := manager.RoutesForAgencyID("25")
-			manager.RUnlock()
-			assert.Equal(t, 13, len(routes))
-
-			route := routes[0]
-			assert.Equal(t, "1", route.ShortName)
-			assert.Equal(t, "25", route.Agency.Id)
-		})
-	}
+	route := routes[0]
+	assert.Equal(t, "1", route.ShortName)
+	assert.Equal(t, "25", route.Agency.Id)
 }
 
 func TestManager_GetStopsForLocation_UsesSpatialIndex(t *testing.T) {
 	testCases := []struct {
 		name          string
-		dataPath      string
 		lat           float64
 		lon           float64
 		radius        float64
@@ -97,7 +57,6 @@ func TestManager_GetStopsForLocation_UsesSpatialIndex(t *testing.T) {
 	}{
 		{
 			name:          "FindStopsWithinRadius",
-			dataPath:      models.GetFixturePath(t, "raba.zip"),
 			lat:           40.589123, // Near Redding, CA
 			lon:           -122.390830,
 			radius:        2000, // 2km radius
@@ -105,7 +64,6 @@ func TestManager_GetStopsForLocation_UsesSpatialIndex(t *testing.T) {
 		},
 		{
 			name:          "FindStopsWithinRadius",
-			dataPath:      models.GetFixturePath(t, "raba.zip"),
 			lat:           47.589123, // West Seattle
 			lon:           -122.390830,
 			radius:        2000, // 2km radius
@@ -115,14 +73,8 @@ func TestManager_GetStopsForLocation_UsesSpatialIndex(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			gtfsConfig := Config{
-				GtfsURL:      tc.dataPath,
-				GTFSDataPath: ":memory:",
-				Env:          appconf.Test,
-			}
-			manager, err := InitGTFSManager(gtfsConfig)
-			assert.Nil(t, err)
-			defer manager.Shutdown()
+			manager, _ := getSharedTestComponents(t)
+			assert.NotNil(t, manager)
 
 			// Get stops using the manager method
 			stops := manager.GetStopsForLocation(context.Background(), tc.lat, tc.lon, tc.radius, 0, 0, "", 100, false, nil, time.Time{})
@@ -142,14 +94,8 @@ func TestManager_GetStopsForLocation_UsesSpatialIndex(t *testing.T) {
 }
 
 func TestManager_GetTrips(t *testing.T) {
-	gtfsConfig := Config{
-		GtfsURL:      models.GetFixturePath(t, "raba.zip"),
-		GTFSDataPath: ":memory:",
-		Env:          appconf.Test,
-	}
-	manager, err := InitGTFSManager(gtfsConfig)
-	assert.Nil(t, err)
-	defer manager.Shutdown()
+	manager, _ := getSharedTestComponents(t)
+	assert.NotNil(t, manager)
 
 	trips := manager.GetTrips()
 	assert.NotEmpty(t, trips)
@@ -157,14 +103,7 @@ func TestManager_GetTrips(t *testing.T) {
 }
 
 func TestManager_FindAgency(t *testing.T) {
-	gtfsConfig := Config{
-		GtfsURL:      models.GetFixturePath(t, "raba.zip"),
-		GTFSDataPath: ":memory:",
-		Env:          appconf.Test,
-	}
-	manager, err := InitGTFSManager(gtfsConfig)
-	assert.Nil(t, err)
-	defer manager.Shutdown()
+	manager, _ := getSharedTestComponents(t)
 
 	agency := manager.FindAgency("25")
 	assert.NotNil(t, agency)
@@ -260,14 +199,7 @@ func TestManager_GetTripUpdateByID(t *testing.T) {
 }
 
 func TestManager_IsServiceActiveOnDate(t *testing.T) {
-	gtfsConfig := Config{
-		GtfsURL:      models.GetFixturePath(t, "raba.zip"),
-		GTFSDataPath: ":memory:",
-		Env:          appconf.Test,
-	}
-	manager, err := InitGTFSManager(gtfsConfig)
-	assert.Nil(t, err)
-	defer manager.Shutdown()
+	manager, _ := getSharedTestComponents(t)
 
 	// Get a trip to find a valid service ID
 	trips := manager.GetTrips()
@@ -335,6 +267,7 @@ func TestManager_GetVehicleForTrip(t *testing.T) {
 		GTFSDataPath: ":memory:",
 		Env:          appconf.Test,
 	}
+	// We use isolated GTFSManager here instead of shared test components because we want to control the real-time vehicles for this test.
 	manager, err := InitGTFSManager(gtfsConfig)
 	assert.Nil(t, err)
 	defer manager.Shutdown()
@@ -358,6 +291,10 @@ func TestManager_GetVehicleForTrip(t *testing.T) {
 		assert.NotNil(t, vehicle)
 		assert.Equal(t, "vehicle1", vehicle.ID.ID)
 	}
+
+	// Test Not Found
+	nilVehicle := manager.GetVehicleForTrip(t.Context(), "nonexistent")
+	assert.Nil(t, nilVehicle)
 }
 
 func TestBuildLookupMaps(t *testing.T) {
@@ -389,7 +326,6 @@ func TestManager_FindAgency_UsesMap(t *testing.T) {
 	// This test proves we are using the Map, not the Slice.
 	// We populate the Map, but leave the Slice empty.
 	// If the code was still looping over the slice, this would fail.
-
 	manager := &Manager{
 		agenciesMap: map[string]*gtfs.Agency{
 			"A1": {Id: "A1", Name: "Fast Agency"},
@@ -409,7 +345,6 @@ func TestManager_FindAgency_UsesMap(t *testing.T) {
 }
 
 func TestManager_FindRoute_UsesMap(t *testing.T) {
-
 	manager := &Manager{
 		routesMap: map[string]*gtfs.Route{
 			"R1": {Id: "R1", LongName: "Express Route"},

--- a/internal/restapi/arrival_and_departure_for_stop_handler.go
+++ b/internal/restapi/arrival_and_departure_for_stop_handler.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/OneBusAway/go-gtfs"
 	"maglev.onebusaway.org/gtfsdb"
-	GTFS "maglev.onebusaway.org/internal/gtfs"
 	"maglev.onebusaway.org/internal/models"
 	"maglev.onebusaway.org/internal/utils"
 )
@@ -444,7 +443,6 @@ func (api *RestAPI) arrivalAndDepartureForStopHandler(w http.ResponseWriter, r *
 			stopIDSet[closestStopID] = true
 		}
 	}
-	calc := GTFS.NewAdvancedDirectionCalculator(api.GtfsManager.GtfsDB.Queries)
 	for stopID := range stopIDSet {
 		stopData, err := api.GtfsManager.GtfsDB.Queries.GetStop(ctx, stopID)
 		if err != nil {
@@ -480,7 +478,7 @@ func (api *RestAPI) arrivalAndDepartureForStopHandler(w http.ResponseWriter, r *
 			Lat:                stopData.Lat,
 			Lon:                stopData.Lon,
 			Code:               stopData.Code.String,
-			Direction:          calc.CalculateStopDirection(r.Context(), stopData.ID, stopData.Direction),
+			Direction:          api.DirectionCalculator.CalculateStopDirection(r.Context(), stopData.ID, stopData.Direction),
 			LocationType:       int(stopData.LocationType.Int64),
 			WheelchairBoarding: utils.MapWheelchairBoarding(utils.NullWheelchairBoardingOrUnknown(stopData.WheelchairBoarding)),
 			RouteIDs:           combinedRouteIDs,

--- a/internal/restapi/arrivals_and_departure_for_stop.go
+++ b/internal/restapi/arrivals_and_departure_for_stop.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"maglev.onebusaway.org/gtfsdb"
-	GTFS "maglev.onebusaway.org/internal/gtfs"
 	"maglev.onebusaway.org/internal/models"
 	"maglev.onebusaway.org/internal/utils"
 )
@@ -478,8 +477,6 @@ func (api *RestAPI) arrivalsAndDeparturesForStopHandler(w http.ResponseWriter, r
 		references.Trips = append(references.Trips, tripRef)
 	}
 
-	calc := GTFS.NewAdvancedDirectionCalculator(api.GtfsManager.GtfsDB.Queries)
-
 	for stopID := range stopIDSet {
 		if ctx.Err() != nil {
 			return
@@ -527,7 +524,7 @@ func (api *RestAPI) arrivalsAndDeparturesForStopHandler(w http.ResponseWriter, r
 			Lat:                stopData.Lat,
 			Lon:                stopData.Lon,
 			Code:               stopData.Code.String,
-			Direction:          calc.CalculateStopDirection(ctx, stopData.ID, stopData.Direction),
+			Direction:          api.DirectionCalculator.CalculateStopDirection(ctx, stopData.ID, stopData.Direction),
 			LocationType:       int(stopData.LocationType.Int64),
 			WheelchairBoarding: utils.MapWheelchairBoarding(utils.NullWheelchairBoardingOrUnknown(stopData.WheelchairBoarding)),
 			RouteIDs:           combinedRouteIDs,

--- a/internal/restapi/block_handler.go
+++ b/internal/restapi/block_handler.go
@@ -7,7 +7,6 @@ import (
 	"sort"
 
 	"maglev.onebusaway.org/gtfsdb"
-	GTFS "maglev.onebusaway.org/internal/gtfs"
 	"maglev.onebusaway.org/internal/models"
 	"maglev.onebusaway.org/internal/utils"
 )
@@ -57,8 +56,7 @@ func (api *RestAPI) blockHandler(w http.ResponseWriter, r *http.Request) {
 		Data: blockData,
 	}
 
-	calc := GTFS.NewAdvancedDirectionCalculator(api.GtfsManager.GtfsDB.Queries)
-	references, err := api.getReferences(ctx, agencyID, calc, block)
+	references, err := api.getReferences(ctx, agencyID, block)
 	if err != nil {
 		api.serverErrorResponse(w, r, err)
 		return
@@ -167,7 +165,7 @@ func transformBlockToEntry(block []gtfsdb.GetBlockDetailsRow, blockID, agencyID 
 }
 
 // IMPORTANT: Caller must hold manager.RLock() before calling this method.
-func (api *RestAPI) getReferences(ctx context.Context, agencyID string, calc *GTFS.AdvancedDirectionCalculator, block []gtfsdb.GetBlockDetailsRow) (models.ReferencesModel, error) {
+func (api *RestAPI) getReferences(ctx context.Context, agencyID string, block []gtfsdb.GetBlockDetailsRow) (models.ReferencesModel, error) {
 	routeIDs := make(map[string]struct{})
 	stopIDs := make(map[string]struct{})
 	tripIDs := make(map[string]struct{})
@@ -227,7 +225,7 @@ func (api *RestAPI) getReferences(ctx context.Context, agencyID string, calc *GT
 			Code:      stop.Code.String,
 			Lat:       stop.Lat,
 			Lon:       stop.Lon,
-			Direction: calc.CalculateStopDirection(ctx, stop.ID, stop.Direction),
+			Direction: api.DirectionCalculator.CalculateStopDirection(ctx, stop.ID, stop.Direction),
 		})
 	}
 

--- a/internal/restapi/http_test.go
+++ b/internal/restapi/http_test.go
@@ -3,6 +3,7 @@ package restapi
 import (
 	"bytes"
 	"compress/gzip"
+	"context"
 	"encoding/json"
 	"io"
 	"log/slog"
@@ -26,9 +27,10 @@ import (
 
 // Shared test database setup
 var (
-	testGtfsManager *gtfs.Manager
-	testDbSetupOnce sync.Once
-	testDbPath      = filepath.Join("../../testdata", "raba-test.db")
+	testGtfsManager         *gtfs.Manager
+	testDirectionCalculator *gtfs.AdvancedDirectionCalculator
+	testDbSetupOnce         sync.Once
+	testDbPath              = filepath.Join("../../testdata", "raba-test.db")
 )
 
 // TestMain handles setup and cleanup for all tests in this package
@@ -59,6 +61,13 @@ func createTestApiWithClock(t testing.TB, c clock.Clock) *RestAPI {
 		if err != nil {
 			t.Fatalf("Failed to initialize shared test GTFS manager: %v", err)
 		}
+
+		// Create the DirectionCalculator using the shared manager's queries
+		testDirectionCalculator = gtfs.NewAdvancedDirectionCalculator(testGtfsManager.GtfsDB.Queries)
+
+		// Warm up the cache with test data
+		err = gtfs.InitializeGlobalCache(context.Background(), testGtfsManager.GtfsDB.Queries, testDirectionCalculator)
+		require.NoError(t, err, "Failed to initialize global cache for tests")
 	})
 
 	gtfsConfig := gtfs.Config{
@@ -73,9 +82,10 @@ func createTestApiWithClock(t testing.TB, c clock.Clock) *RestAPI {
 			RateLimit:     5, // Low rate limit for testing
 			ExemptApiKeys: []string{"org.onebusaway.iphone"},
 		},
-		GtfsConfig:  gtfsConfig,
-		GtfsManager: testGtfsManager,
-		Clock:       c,
+		GtfsConfig:          gtfsConfig,
+		GtfsManager:         testGtfsManager,
+		DirectionCalculator: testDirectionCalculator,
+		Clock:               c,
 	}
 
 	api := NewRestAPI(application)

--- a/internal/restapi/schedule_for_route_handler.go
+++ b/internal/restapi/schedule_for_route_handler.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"maglev.onebusaway.org/gtfsdb"
-	"maglev.onebusaway.org/internal/gtfs"
 	"maglev.onebusaway.org/internal/models"
 	"maglev.onebusaway.org/internal/utils"
 )
@@ -155,6 +154,7 @@ func (api *RestAPI) scheduleForRouteHandler(w http.ResponseWriter, r *http.Reque
 			}
 			stopIDs, err := api.GtfsManager.GtfsDB.Queries.GetOrderedStopIDsForTrip(ctx, trip.ID)
 			if err != nil {
+				api.Logger.Warn("failed to fetch stop IDs for trip", "trip_id", trip.ID, "error", err)
 				continue
 			}
 			for _, stopID := range stopIDs {
@@ -163,6 +163,7 @@ func (api *RestAPI) scheduleForRouteHandler(w http.ResponseWriter, r *http.Reque
 			}
 			stopTimes, err := api.GtfsManager.GtfsDB.Queries.GetStopTimesForTrip(ctx, trip.ID)
 			if err != nil {
+				api.Logger.Warn("failed to fetch stop times for trip", "trip_id", trip.ID, "error", err)
 				continue
 			}
 			stopTimesList := make([]models.RouteStopTime, 0, len(stopTimes))
@@ -228,37 +229,39 @@ func (api *RestAPI) scheduleForRouteHandler(w http.ResponseWriter, r *http.Reque
 	}
 	if len(tripIDs) > 0 {
 		tripRows, err := api.GtfsManager.GtfsDB.Queries.GetTripsByIDs(ctx, tripIDs)
-		if err == nil {
-			for _, t := range tripRows {
-				combinedTripID := utils.FormCombinedID(agencyID, t.ID)
-				tripRef := models.NewTripReference(
-					combinedTripID,
-					t.RouteID,
-					t.ServiceID,
-					t.TripHeadsign.String,
-					t.TripShortName.String,
-					t.DirectionID.Int64,
-					utils.FormCombinedID(agencyID, t.BlockID.String),
-					utils.FormCombinedID(agencyID, t.ShapeID.String),
-				)
-				references.Trips = append(references.Trips, tripRef)
-			}
+		if err != nil {
+			api.serverErrorResponse(w, r, err)
+			return
+		}
+
+		for _, t := range tripRows {
+			combinedTripID := utils.FormCombinedID(agencyID, t.ID)
+			tripRef := models.NewTripReference(
+				combinedTripID,
+				t.RouteID,
+				t.ServiceID,
+				t.TripHeadsign.String,
+				t.TripShortName.String,
+				t.DirectionID.Int64,
+				utils.FormCombinedID(agencyID, t.BlockID.String),
+				utils.FormCombinedID(agencyID, t.ShapeID.String),
+			)
+			references.Trips = append(references.Trips, tripRef)
 		}
 	}
-
-	// Create a local calculator to ensure thread safety
-	calc := gtfs.NewAdvancedDirectionCalculator(api.GtfsManager.GtfsDB.Queries)
 
 	uniqueStopIDs := make([]string, 0, len(globalStopIDSet))
 	for sid := range globalStopIDSet {
 		uniqueStopIDs = append(uniqueStopIDs, sid)
 	}
 	if len(uniqueStopIDs) > 0 {
-		// Pass the local calculator
-		modelStops, _, err := BuildStopReferencesAndRouteIDsForStops(api, ctx, agencyID, uniqueStopIDs, calc)
-		if err == nil {
-			references.Stops = append(references.Stops, modelStops...)
+
+		modelStops, _, err := BuildStopReferencesAndRouteIDsForStops(api, ctx, agencyID, uniqueStopIDs)
+		if err != nil {
+			api.serverErrorResponse(w, r, err)
+			return
 		}
+		references.Stops = append(references.Stops, modelStops...)
 	}
 
 	for _, sref := range stopTimesRefs {

--- a/internal/restapi/stops_for_location_handler.go
+++ b/internal/restapi/stops_for_location_handler.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"maglev.onebusaway.org/gtfsdb"
-	"maglev.onebusaway.org/internal/gtfs"
 	"maglev.onebusaway.org/internal/models"
 	"maglev.onebusaway.org/internal/utils"
 )
@@ -200,8 +199,6 @@ func (api *RestAPI) stopsForLocationHandler(w http.ResponseWriter, r *http.Reque
 
 	isLimitExceeded := false
 
-	calc := gtfs.NewAdvancedDirectionCalculator(api.GtfsManager.GtfsDB.Queries)
-
 	// Build results using the pre-fetched data
 	for _, stopID := range stopIDs {
 		if ctx.Err() != nil {
@@ -216,7 +213,7 @@ func (api *RestAPI) stopsForLocationHandler(w http.ResponseWriter, r *http.Reque
 			continue
 		}
 
-		direction := calc.CalculateStopDirection(ctx, stop.ID, stop.Direction)
+		direction := api.DirectionCalculator.CalculateStopDirection(ctx, stop.ID, stop.Direction)
 
 		results = append(results, models.NewStop(
 			utils.NullStringOrEmpty(stop.Code),

--- a/internal/restapi/stops_for_route_handler.go
+++ b/internal/restapi/stops_for_route_handler.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/twpayne/go-polyline"
 	"maglev.onebusaway.org/gtfsdb"
-	GTFS "maglev.onebusaway.org/internal/gtfs"
 	"maglev.onebusaway.org/internal/models"
 	"maglev.onebusaway.org/internal/utils"
 )
@@ -92,67 +91,7 @@ func (api *RestAPI) stopsForRouteHandler(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	// This prevents nil pointer panics and ensures thread-safety.
-	adc := GTFS.NewAdvancedDirectionCalculator(api.GtfsManager.GtfsDB.Queries)
-
-	// Get Stop IDs for the route to drive the bulk-loading caches
-	stopIDs, err := api.GtfsManager.GtfsDB.Queries.GetStopIDsForRoute(ctx, routeID)
-	if err == nil && len(stopIDs) > 0 {
-
-		contextRows, err := api.GtfsManager.GtfsDB.Queries.GetStopsWithShapeContextByIDs(ctx, stopIDs)
-		if err != nil {
-			// Log error when bulk context load fails
-			slog.Warn("bulk context cache load failed, falling back to per-stop queries",
-				slog.String("routeID", routeID),
-				slog.String("error", err.Error()))
-		} else {
-			contextCache := make(map[string][]gtfsdb.GetStopsWithShapeContextRow)
-			shapeIDMap := make(map[string]bool)
-			var uniqueShapeIDs []string
-
-			for _, row := range contextRows {
-				calcRow := gtfsdb.GetStopsWithShapeContextRow{
-					ID:                row.StopID,
-					ShapeID:           row.ShapeID,
-					Lat:               row.Lat,
-					Lon:               row.Lon,
-					ShapeDistTraveled: row.ShapeDistTraveled,
-				}
-				contextCache[row.StopID] = append(contextCache[row.StopID], calcRow)
-
-				if row.ShapeID.Valid && row.ShapeID.String != "" && !shapeIDMap[row.ShapeID.String] {
-					shapeIDMap[row.ShapeID.String] = true
-					uniqueShapeIDs = append(uniqueShapeIDs, row.ShapeID.String)
-				}
-			}
-
-			// Fetch Shape Points in bulk to populate the local cache
-			if len(uniqueShapeIDs) > 0 {
-				shapePoints, err := api.GtfsManager.GtfsDB.Queries.GetShapePointsByIDs(ctx, uniqueShapeIDs)
-				if err != nil {
-					// Log error when bulk shape load fails
-					slog.Warn("bulk shape cache load failed, falling back to per-stop queries",
-						slog.String("routeID", routeID),
-						slog.String("error", err.Error()))
-				} else {
-					shapeCache := make(map[string][]gtfsdb.GetShapePointsWithDistanceRow)
-					for _, p := range shapePoints {
-						shapeCache[p.ShapeID] = append(shapeCache[p.ShapeID], gtfsdb.GetShapePointsWithDistanceRow{
-							Lat:               p.Lat,
-							Lon:               p.Lon,
-							ShapeDistTraveled: p.ShapeDistTraveled,
-						})
-					}
-
-					// Inject caches into the LOCAL instance.
-					adc.SetShapeCache(shapeCache)
-					adc.SetContextCache(contextCache)
-				}
-			}
-		}
-	}
-
-	result, stopsList, err := api.processRouteStops(ctx, agencyID, routeID, serviceIDs, params.IncludePolylines, adc)
+	result, stopsList, err := api.processRouteStops(ctx, agencyID, routeID, serviceIDs, params.IncludePolylines)
 	if err != nil {
 		api.serverErrorResponse(w, r, err)
 		return
@@ -161,7 +100,7 @@ func (api *RestAPI) stopsForRouteHandler(w http.ResponseWriter, r *http.Request)
 	api.buildAndSendResponse(w, r, ctx, result, stopsList, currentAgency)
 }
 
-func (api *RestAPI) processRouteStops(ctx context.Context, agencyID string, routeID string, serviceIDs []string, includePolylines bool, adc *GTFS.AdvancedDirectionCalculator) (models.RouteEntry, []models.Stop, error) {
+func (api *RestAPI) processRouteStops(ctx context.Context, agencyID string, routeID string, serviceIDs []string, includePolylines bool) (models.RouteEntry, []models.Stop, error) {
 	allStops := make(map[string]bool)
 	allPolylines := make([]models.Polyline, 0, 100)
 	var stopGroupings []models.StopGrouping
@@ -193,7 +132,7 @@ func (api *RestAPI) processRouteStops(ctx context.Context, agencyID string, rout
 	}
 
 	allStopsIds := formatStopIDs(agencyID, allStops)
-	stopsList, err := buildStopsList(ctx, api, adc, agencyID, allStops)
+	stopsList, err := buildStopsList(ctx, api, agencyID, allStops)
 	if err != nil {
 		return models.RouteEntry{}, nil, err
 	}
@@ -208,7 +147,7 @@ func (api *RestAPI) processRouteStops(ctx context.Context, agencyID string, rout
 	return result, stopsList, nil
 }
 
-func buildStopsList(ctx context.Context, api *RestAPI, calc *GTFS.AdvancedDirectionCalculator, agencyID string, allStops map[string]bool) ([]models.Stop, error) {
+func buildStopsList(ctx context.Context, api *RestAPI, agencyID string, allStops map[string]bool) ([]models.Stop, error) {
 
 	stopIDs := make([]string, 0, len(allStops))
 	for stopID := range allStops {
@@ -243,7 +182,7 @@ func buildStopsList(ctx context.Context, api *RestAPI, calc *GTFS.AdvancedDirect
 			return nil, ctx.Err()
 		}
 
-		direction := calc.CalculateStopDirection(ctx, stop.ID, stop.Direction)
+		direction := api.DirectionCalculator.CalculateStopDirection(ctx, stop.ID, stop.Direction)
 
 		routeIdsString := append([]string(nil), routesMap[stop.ID]...)
 
@@ -347,6 +286,7 @@ func processTripGroups(
 		representativeTrip := tripsInGroup[0]
 		stopsList, err := api.GtfsManager.GtfsDB.Queries.GetOrderedStopIDsForTrip(ctx, representativeTrip.ID)
 		if err != nil {
+			api.Logger.Warn("failed to fetch stop IDs for representative trip", "trip_id", representativeTrip.ID, "error", err)
 			continue
 		}
 
@@ -362,6 +302,7 @@ func processTripGroups(
 				TripHeadsign: representativeTrip.TripHeadsign,
 			})
 		if err != nil {
+			api.Logger.Warn("failed to fetch shapes for trip group", "route_id", routeID, "headsign", representativeTrip.TripHeadsign.String, "error", err)
 			continue
 		}
 

--- a/internal/restapi/trip_details_handler.go
+++ b/internal/restapi/trip_details_handler.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"maglev.onebusaway.org/gtfsdb"
-	GTFS "maglev.onebusaway.org/internal/gtfs"
 	"maglev.onebusaway.org/internal/models"
 	"maglev.onebusaway.org/internal/utils"
 )
@@ -206,8 +205,6 @@ func (api *RestAPI) tripDetailsHandler(w http.ResponseWriter, r *http.Request) {
 		references.Trips = referencedTripsIface
 	}
 
-	calc := GTFS.NewAdvancedDirectionCalculator(api.GtfsManager.GtfsDB.Queries)
-
 	agencyModel := models.NewAgencyReference(
 		agency.ID,
 		agency.Name,
@@ -233,7 +230,7 @@ func (api *RestAPI) tripDetailsHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if params.IncludeSchedule && schedule != nil {
-		stops, err := api.buildStopReferences(ctx, calc, agencyID, schedule.StopTimes)
+		stops, err := api.buildStopReferences(ctx, agencyID, schedule.StopTimes)
 		if err != nil {
 			api.serverErrorResponse(w, r, err)
 			return
@@ -311,7 +308,7 @@ func (api *RestAPI) buildReferencedTrips(ctx context.Context, agencyID string, t
 }
 
 // IMPORTANT: Caller must hold manager.RLock() before calling this method.
-func (api *RestAPI) buildStopReferences(ctx context.Context, calc *GTFS.AdvancedDirectionCalculator, agencyID string, stopTimes []models.StopTime) ([]models.Stop, error) {
+func (api *RestAPI) buildStopReferences(ctx context.Context, agencyID string, stopTimes []models.StopTime) ([]models.Stop, error) {
 	stopIDSet := make(map[string]bool)
 	originalStopIDs := make([]string, 0, len(stopTimes))
 
@@ -401,7 +398,7 @@ func (api *RestAPI) buildStopReferences(ctx context.Context, calc *GTFS.Advanced
 			Lat:                stop.Lat,
 			Lon:                stop.Lon,
 			Code:               stop.Code.String,
-			Direction:          calc.CalculateStopDirection(ctx, stop.ID, stop.Direction),
+			Direction:          api.DirectionCalculator.CalculateStopDirection(ctx, stop.ID, stop.Direction),
 			LocationType:       int(stop.LocationType.Int64),
 			WheelchairBoarding: utils.MapWheelchairBoarding(utils.NullWheelchairBoardingOrUnknown(stop.WheelchairBoarding)),
 			RouteIDs:           combinedRouteIDs,

--- a/internal/restapi/trip_for_vehicle_handler.go
+++ b/internal/restapi/trip_for_vehicle_handler.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"maglev.onebusaway.org/gtfsdb"
-	"maglev.onebusaway.org/internal/gtfs"
 	"maglev.onebusaway.org/internal/models"
 	"maglev.onebusaway.org/internal/utils"
 )
@@ -140,7 +139,6 @@ func (api *RestAPI) tripForVehicleHandler(w http.ResponseWriter, r *http.Request
 	)
 
 	stopIDs := []string{}
-	calc := gtfs.NewAdvancedDirectionCalculator(api.GtfsManager.GtfsDB.Queries)
 
 	if status != nil {
 		if status.ClosestStop != "" {
@@ -160,7 +158,7 @@ func (api *RestAPI) tripForVehicleHandler(w http.ResponseWriter, r *http.Request
 			stopIDs = append(stopIDs, nextStopID)
 		}
 	}
-	stops, uniqueRouteMap, err := BuildStopReferencesAndRouteIDsForStops(api, ctx, agencyID, stopIDs, calc)
+	stops, uniqueRouteMap, err := BuildStopReferencesAndRouteIDsForStops(api, ctx, agencyID, stopIDs)
 	if err != nil {
 		api.serverErrorResponse(w, r, err)
 		return
@@ -205,7 +203,7 @@ func (api *RestAPI) tripForVehicleHandler(w http.ResponseWriter, r *http.Request
 
 // BuildStopReferencesAndRouteIDsForStops builds stop references and collects unique routes for the given stop IDs.
 // IMPORTANT: Caller must hold manager.RLock() before calling this method.
-func BuildStopReferencesAndRouteIDsForStops(api *RestAPI, ctx context.Context, agencyID string, stopIDs []string, calc *gtfs.AdvancedDirectionCalculator) ([]models.Stop, map[string]gtfsdb.GetRoutesForStopsRow, error) {
+func BuildStopReferencesAndRouteIDsForStops(api *RestAPI, ctx context.Context, agencyID string, stopIDs []string) ([]models.Stop, map[string]gtfsdb.GetRoutesForStopsRow, error) {
 	if len(stopIDs) == 0 {
 		return []models.Stop{}, map[string]gtfsdb.GetRoutesForStopsRow{}, nil
 	}
@@ -269,7 +267,7 @@ func BuildStopReferencesAndRouteIDsForStops(api *RestAPI, ctx context.Context, a
 			Lat:                stop.Lat,
 			Lon:                stop.Lon,
 			Code:               stop.Code.String,
-			Direction:          calc.CalculateStopDirection(ctx, stop.ID, stop.Direction),
+			Direction:          api.DirectionCalculator.CalculateStopDirection(ctx, stop.ID, stop.Direction),
 			LocationType:       int(stop.LocationType.Int64),
 			WheelchairBoarding: utils.MapWheelchairBoarding(utils.NullWheelchairBoardingOrUnknown(stop.WheelchairBoarding)),
 			RouteIDs:           combinedRouteIDs,

--- a/internal/restapi/vehicles_for_agency_handler_test.go
+++ b/internal/restapi/vehicles_for_agency_handler_test.go
@@ -1,6 +1,7 @@
 package restapi
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -347,15 +348,20 @@ func createTestApiWithRealTimeData(t *testing.T) (*RestAPI, func()) {
 	gtfsManager, err := gtfs.InitGTFSManager(gtfsConfig)
 	require.NoError(t, err)
 
+	dirCalc := gtfs.NewAdvancedDirectionCalculator(gtfsManager.GtfsDB.Queries)
+	err = gtfs.InitializeGlobalCache(context.Background(), gtfsManager.GtfsDB.Queries, dirCalc)
+	require.NoError(t, err)
+
 	application := &app.Application{
 		Config: appconf.Config{
 			Env:       appconf.EnvFlagToEnvironment("test"),
 			ApiKeys:   []string{"TEST"},
 			RateLimit: 100, // Higher rate limit for this test
 		},
-		GtfsConfig:  gtfsConfig,
-		GtfsManager: gtfsManager,
-		Clock:       clock.RealClock{},
+		GtfsConfig:          gtfsConfig,
+		GtfsManager:         gtfsManager,
+		DirectionCalculator: dirCalc,
+		Clock:               clock.RealClock{},
 	}
 
 	api := NewRestAPI(application)


### PR DESCRIPTION
This pull request introduces a global cache warmup for GTFS data and refactors how the direction calculator is used throughout the codebase. It also adds a new query for retrieving all stop IDs, updates the GTFS database query preparation and teardown logic, and makes minor improvements to the GTFS models. The most significant changes are grouped below.

**Global Cache Initialization and Direction Calculator Refactor:**

* Added a new `InitializeGlobalCache` function in `internal/gtfs/global_cache.go` to preload stop and shape data into memory at application startup, improving performance for direction calculations. The application now calls this function during initialization and sets up the advanced direction calculator with pre-cached data.
* Refactored REST API handlers to use the application's shared `DirectionCalculator` instance instead of creating new instances, ensuring cache utilization and consistency. 

**GTFS Database Query Enhancements:**

* Added a new `GetAllStopIDs` query and its associated statement preparation, closing, and struct wiring in `gtfsdb/db.go`, `gtfsdb/query.sql`, and generated code, enabling efficient retrieval of all stop IDs for cache warmup. 
* Fixed the ordering of statement preparation and closing for `searchRoutesByFullTextStmt` to ensure correct resource management. 

**Other Improvements:**

* Updated the `RoutesFt` struct in `gtfsdb/models.go` to better represent full-text search results on routes.
* Minor import cleanups and test improvements.

**Known Issues:**

-  SQLite FTS5 & SQLC Conflict There is a known conflict between sqlc validation and SQLite runtime behavior regarding the Full Text Search (FTS5) virtual table:

- The Issue: sqlc requires the column routes_fts to be explicitly defined in the schema to validate MATCH queries. However, explicitly defining this column causes SQLite to crash at runtime with "vtable constructor failed" (as routes_fts is a reserved shadow table name).

- Current State: The schema is currently set to the Runtime Safe version (the explicit column is removed).

- Impact: The application runs correctly and tests pass (with -tags sqlite_fts5), but running make models will fail.

- Workaround: To regenerate models, temporarily add the column to the schema, run make models, and then revert the change before running the app.

Please let me know if any improvements or corrections are required and what should be done regarding the SQLC & FTS5 conflict.