### PR TITLE
refactor: replace hardcoded exemptions with config flag

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -14,6 +14,7 @@ func main() {
 	var cfg appconf.Config
 	var gtfsCfg gtfs.Config
 	var apiKeysFlag string
+	var exemptApiKeysFlag string
 	var envFlag string
 	var configFile string
 	var dumpConfig bool
@@ -24,6 +25,7 @@ func main() {
 	flag.IntVar(&cfg.Port, "port", 4000, "API server port")
 	flag.StringVar(&envFlag, "env", "development", "Environment (development|test|production)")
 	flag.StringVar(&apiKeysFlag, "api-keys", "test", "Comma Separated API Keys (test, etc)")
+	flag.StringVar(&exemptApiKeysFlag, "exempt-api-keys", "org.onebusaway.iphone", "Comma separated list of API keys exempt from rate limiting")
 	flag.IntVar(&cfg.RateLimit, "rate-limit", 100, "Requests per second per API key for rate limiting")
 	flag.StringVar(&gtfsCfg.GtfsURL, "gtfs-url", "https://www.soundtransit.org/GTFS-rail/40_gtfs.zip", "URL for a static GTFS zip file")
 	flag.StringVar(&gtfsCfg.StaticAuthHeaderKey, "gtfs-static-auth-header-name", "", "Optional header name for static GTFS feed auth")
@@ -84,6 +86,11 @@ func main() {
 
 		// Parse API keys
 		cfg.ApiKeys = ParseAPIKeys(apiKeysFlag)
+
+		// Parse Exempt API Keys
+		if exemptApiKeysFlag != "" {
+			cfg.ExemptApiKeys = ParseAPIKeys(exemptApiKeysFlag)
+		}
 
 		// Convert environment flag to enum
 		cfg.Env = appconf.EnvFlagToEnvironment(envFlag)

--- a/config.docker.example.json
+++ b/config.docker.example.json
@@ -3,6 +3,7 @@
   "port": 4000,
   "env": "production",
   "api-keys": ["test"],
+  "exempt-api-keys": ["org.onebusaway.iphone"],
   "_comment": "WARNING: Change 'api-keys' before deploying to production! The default 'test' key is for development only.",
   "rate-limit": 100,
   "gtfs-static-feed": {

--- a/config.example.json
+++ b/config.example.json
@@ -3,6 +3,7 @@
   "port": 4000,
   "env": "development",
   "api-keys": ["test"],
+  "exempt-api-keys": ["org.onebusaway.iphone"],
   "rate-limit": 100,
   "gtfs-static-feed": {
     "url": "https://www.soundtransit.org/GTFS-rail/40_gtfs.zip",

--- a/config.schema.json
+++ b/config.schema.json
@@ -29,6 +29,16 @@
       "uniqueItems": true,
       "minItems": 1
     },
+    "exempt-api-keys": {
+      "type": "array",
+      "description": "API keys that are exempt from rate limiting",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "default": ["org.onebusaway.iphone"],
+      "uniqueItems": true
+    },
     "rate-limit": {
       "type": "integer",
       "description": "Requests per second per API key for rate limiting",

--- a/internal/appconf/config.go
+++ b/internal/appconf/config.go
@@ -6,11 +6,12 @@ package appconf
 // Application (development, staging, production, etc.). We will read in these
 // configuration settings from command-line flags when the Application starts.
 type Config struct {
-	Port      int
-	Env       Environment
-	ApiKeys   []string
-	Verbose   bool
-	RateLimit int // Requests per second per API key for rate limiting
+	Port          int
+	Env           Environment
+	ApiKeys       []string
+	ExemptApiKeys []string
+	Verbose       bool
+	RateLimit     int // Requests per second per API key for rate limiting
 }
 
 // Environment is an enumerated type representing various stages or configurations in the system's lifecycle.

--- a/internal/appconf/json_config.go
+++ b/internal/appconf/json_config.go
@@ -31,6 +31,7 @@ type JSONConfig struct {
 	Port           int            `json:"port"`
 	Env            string         `json:"env"`
 	ApiKeys        []string       `json:"api-keys"`
+	ExemptApiKeys  []string       `json:"exempt-api-keys"`
 	RateLimit      int            `json:"rate-limit"`
 	GtfsStaticFeed GtfsStaticFeed `json:"gtfs-static-feed"`
 	GtfsRtFeeds    []GtfsRtFeed   `json:"gtfs-rt-feeds"`
@@ -47,6 +48,9 @@ func (j *JSONConfig) setDefaults() {
 	}
 	if len(j.ApiKeys) == 0 {
 		j.ApiKeys = []string{"test"}
+	}
+	if len(j.ExemptApiKeys) == 0 {
+		j.ExemptApiKeys = []string{"org.onebusaway.iphone"}
 	}
 	if j.RateLimit == 0 {
 		j.RateLimit = 100
@@ -166,11 +170,12 @@ func validatePath(path, fieldName string) error {
 // ToAppConfig converts JSONConfig to appconf.Config
 func (j *JSONConfig) ToAppConfig() Config {
 	return Config{
-		Port:      j.Port,
-		Env:       EnvFlagToEnvironment(j.Env),
-		ApiKeys:   j.ApiKeys,
-		Verbose:   true, // Always set to true like in main.go
-		RateLimit: j.RateLimit,
+		Port:          j.Port,
+		Env:           EnvFlagToEnvironment(j.Env),
+		ApiKeys:       j.ApiKeys,
+		ExemptApiKeys: j.ExemptApiKeys,
+		Verbose:       true, // Always set to true like in main.go
+		RateLimit:     j.RateLimit,
 	}
 }
 

--- a/internal/appconf/json_config_test.go
+++ b/internal/appconf/json_config_test.go
@@ -158,10 +158,11 @@ func TestValidate_DuplicateApiKeys(t *testing.T) {
 
 func TestToAppConfig(t *testing.T) {
 	jsonConfig := &JSONConfig{
-		Port:      8080,
-		Env:       "production",
-		ApiKeys:   []string{"key1", "key2"},
-		RateLimit: 50,
+		Port:          8080,
+		Env:           "production",
+		ApiKeys:       []string{"key1", "key2"},
+		RateLimit:     50,
+		ExemptApiKeys: []string{"exempt-key-1"},
 	}
 
 	appConfig := jsonConfig.ToAppConfig()
@@ -171,6 +172,7 @@ func TestToAppConfig(t *testing.T) {
 	assert.Equal(t, []string{"key1", "key2"}, appConfig.ApiKeys)
 	assert.Equal(t, 50, appConfig.RateLimit)
 	assert.True(t, appConfig.Verbose)
+	assert.Equal(t, []string{"exempt-key-1"}, appConfig.ExemptApiKeys)
 }
 
 func TestToAppConfig_EnvironmentConversion(t *testing.T) {
@@ -274,6 +276,7 @@ func TestSetDefaults(t *testing.T) {
 	assert.Equal(t, "./gtfs.db", config.DataPath)
 	assert.Len(t, config.GtfsRtFeeds, 1)
 	assert.Equal(t, "https://api.pugetsound.onebusaway.org/api/gtfs_realtime/trip-updates-for-agency/40.pb?key=org.onebusaway.iphone", config.GtfsRtFeeds[0].TripUpdatesURL)
+	assert.Equal(t, []string{"org.onebusaway.iphone"}, config.ExemptApiKeys)
 }
 
 func TestSetDefaults_PartialConfig(t *testing.T) {

--- a/internal/restapi/http_test.go
+++ b/internal/restapi/http_test.go
@@ -68,9 +68,10 @@ func createTestApiWithClock(t testing.TB, c clock.Clock) *RestAPI {
 
 	application := &app.Application{
 		Config: appconf.Config{
-			Env:       appconf.EnvFlagToEnvironment("test"),
-			ApiKeys:   []string{"TEST", "test", "test-rate-limit", "test-headers", "test-refill", "test-error-format", "org.onebusaway.iphone"},
-			RateLimit: 5, // Low rate limit for testing
+			Env:           appconf.EnvFlagToEnvironment("test"),
+			ApiKeys:       []string{"TEST", "test", "test-rate-limit", "test-headers", "test-refill", "test-error-format", "org.onebusaway.iphone"},
+			RateLimit:     5, // Low rate limit for testing
+			ExemptApiKeys: []string{"org.onebusaway.iphone"},
 		},
 		GtfsConfig:  gtfsConfig,
 		GtfsManager: testGtfsManager,

--- a/internal/restapi/rate_limit_cleanup_test.go
+++ b/internal/restapi/rate_limit_cleanup_test.go
@@ -15,7 +15,7 @@ import (
 // TestRateLimitMiddleware_CleanupKeepsActiveClients verifies active users are not deleted.
 func TestRateLimitMiddleware_CleanupKeepsActiveClients(t *testing.T) {
 	mockClock := clock.NewMockClock(time.Now())
-	middleware := NewRateLimitMiddleware(10, time.Second, mockClock)
+	middleware := NewRateLimitMiddleware(10, time.Second, nil, mockClock)
 	defer middleware.Stop()
 
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -71,7 +71,7 @@ func TestRateLimitMiddleware_CleanupKeepsActiveClients(t *testing.T) {
 // TestRateLimitMiddleware_CleanupRemovesInactiveClients verifies inactive users are deleted after threshold.
 func TestRateLimitMiddleware_CleanupRemovesInactiveClients(t *testing.T) {
 	mockClock := clock.NewMockClock(time.Now())
-	middleware := NewRateLimitMiddleware(10, time.Second, mockClock)
+	middleware := NewRateLimitMiddleware(10, time.Second, nil, mockClock)
 	defer middleware.Stop()
 
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -117,7 +117,7 @@ func TestRateLimitMiddleware_CleanupRemovesInactiveClients(t *testing.T) {
 // TestRateLimitMiddleware_CleanupHandlesExhaustedLimiters verifies exhausted limiters are deleted based on time, not token count.
 func TestRateLimitMiddleware_CleanupHandlesExhaustedLimiters(t *testing.T) {
 	mockClock := clock.NewMockClock(time.Now())
-	middleware := NewRateLimitMiddleware(3, time.Second, mockClock)
+	middleware := NewRateLimitMiddleware(3, time.Second, nil, mockClock)
 	defer middleware.Stop()
 
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -172,7 +172,7 @@ func TestRateLimitMiddleware_CleanupHandlesExhaustedLimiters(t *testing.T) {
 // TestRateLimitMiddleware_CleanupMemoryLeakPrevention verifies cleanup prevents memory leaks from attack scenarios.
 func TestRateLimitMiddleware_CleanupMemoryLeakPrevention(t *testing.T) {
 	mockClock := clock.NewMockClock(time.Now())
-	middleware := NewRateLimitMiddleware(5, time.Second, mockClock)
+	middleware := NewRateLimitMiddleware(5, time.Second, nil, mockClock)
 	defer middleware.Stop()
 
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -226,7 +226,7 @@ func TestRateLimitMiddleware_CleanupMemoryLeakPrevention(t *testing.T) {
 // TestRateLimitMiddleware_CleanupPreservesExemptedKeys verifies exempted keys are never deleted.
 func TestRateLimitMiddleware_CleanupPreservesExemptedKeys(t *testing.T) {
 	mockClock := clock.NewMockClock(time.Now())
-	middleware := NewRateLimitMiddleware(10, time.Second, mockClock)
+	middleware := NewRateLimitMiddleware(10, time.Second, []string{"org.onebusaway.iphone"}, mockClock)
 	defer middleware.Stop()
 
 	// Manually add an exempted key to the limiters map
@@ -263,7 +263,7 @@ func TestRateLimitMiddleware_CleanupPreservesExemptedKeys(t *testing.T) {
 // TestRateLimitMiddleware_LastSeenUpdateOnEveryRequest verifies lastSeen timestamp is updated on each request.
 func TestRateLimitMiddleware_LastSeenUpdateOnEveryRequest(t *testing.T) {
 	mockClock := clock.NewMockClock(time.Now())
-	middleware := NewRateLimitMiddleware(10, time.Second, mockClock)
+	middleware := NewRateLimitMiddleware(10, time.Second, nil, mockClock)
 	defer middleware.Stop()
 
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/restapi/rate_limit_shutdown_test.go
+++ b/internal/restapi/rate_limit_shutdown_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestRateLimitMiddleware_Shutdown(t *testing.T) {
-	middleware := NewRateLimitMiddleware(10, time.Second, clock.RealClock{})
+	middleware := NewRateLimitMiddleware(10, time.Second, nil, clock.RealClock{})
 
 	assert.NotNil(t, middleware)
 	assert.NotNil(t, middleware.Handler())
@@ -29,7 +29,7 @@ func TestRateLimitMiddleware_Shutdown(t *testing.T) {
 }
 
 func TestRateLimitMiddleware_ShutdownIdempotent(t *testing.T) {
-	middleware := NewRateLimitMiddleware(10, time.Second, clock.RealClock{})
+	middleware := NewRateLimitMiddleware(10, time.Second, nil, clock.RealClock{})
 
 	middleware.Stop()
 	middleware.Stop()
@@ -69,7 +69,7 @@ func TestRateLimitMiddleware_GoroutineActuallyExits(t *testing.T) {
 	// Get baseline goroutine count
 	initial := runtime.NumGoroutine()
 
-	middleware := NewRateLimitMiddleware(10, time.Second, clock.RealClock{})
+	middleware := NewRateLimitMiddleware(10, time.Second, nil, clock.RealClock{})
 	time.Sleep(50 * time.Millisecond) // Give goroutine time to start
 
 	afterCreate := runtime.NumGoroutine()

--- a/internal/restapi/rest_api.go
+++ b/internal/restapi/rest_api.go
@@ -15,7 +15,7 @@ type RestAPI struct {
 func NewRestAPI(app *app.Application) *RestAPI {
 	return &RestAPI{
 		Application: app,
-		rateLimiter: NewRateLimitMiddleware(app.Config.RateLimit, time.Second, app.Clock),
+		rateLimiter: NewRateLimitMiddleware(app.Config.RateLimit, time.Second, app.Config.ExemptApiKeys, app.Clock),
 	}
 }
 


### PR DESCRIPTION
### Description
This PR addresses the issue raised in #343 regarding the hardcoded rate-limit exemptions.

It refactors the `RateLimitMiddleware` to move exemption logic from a hardcoded string literal into the application configuration, enabling dynamic runtime configuration via a new CLI flag.

### Changes
1.  **Configuration:** Added `ExemptApiKeys` to `appconf.Config`.
2.  **CLI Interface:** Introduced a new flag `--exempt-api-keys` (comma-separated list) to `cmd/api/main.go`.
3.  **Middleware Logic:**
    * Refactored `NewRateLimitMiddleware` to accept a list of exempted keys.
    * Optimized exemption lookup from $O(n)$ slice iteration to $O(1)$ map lookup.
4.  **Testing:** Updated unit and integration tests to inject the exempted keys properly via the new configuration structure.

### Backward Compatibility 
* **Default Behavior Preserved:** The default value for the `--exempt-api-keys` flag is set to `org.onebusaway.iphone`.

### Testing
<img width="1920" height="449" alt="Screenshot From 2026-02-08 16-37-47" src="https://github.com/user-attachments/assets/9bcb0b63-8e03-4ee5-8703-a541a654ce07" />

@aaronbrethorst 
fixes : #343