### PR TITLE
fix: Correct route agency ID generation in arrival-and-departure-for-stop handler

### DIFF
--- a/internal/restapi/arrival_and_departure_for_stop_handler.go
+++ b/internal/restapi/arrival_and_departure_for_stop_handler.go
@@ -101,7 +101,7 @@ func (api *RestAPI) parseArrivalAndDepartureParams(r *http.Request) (ArrivalAndD
 
 func (api *RestAPI) arrivalAndDepartureForStopHandler(w http.ResponseWriter, r *http.Request) {
 	parsed, _ := utils.GetParsedIDFromContext(r.Context())
-	agencyID := parsed.AgencyID
+	stopAgencyID := parsed.AgencyID
 	stopCode := parsed.CodeID
 	stopID := parsed.CombinedID
 
@@ -148,7 +148,7 @@ func (api *RestAPI) arrivalAndDepartureForStopHandler(w http.ResponseWriter, r *
 		return
 	}
 
-	agency, err := api.GtfsManager.GtfsDB.Queries.GetAgency(ctx, agencyID)
+	stopAgency, err := api.GtfsManager.GtfsDB.Queries.GetAgency(ctx, stopAgencyID)
 	if err != nil {
 		api.serverErrorResponse(w, r, err)
 		return
@@ -206,7 +206,7 @@ func (api *RestAPI) arrivalAndDepartureForStopHandler(w http.ResponseWriter, r *
 
 	// Set current time
 	var currentTime time.Time
-	loc := utils.LoadLocationWithUTCFallBack(agency.Timezone, agency.ID)
+	loc := utils.LoadLocationWithUTCFallBack(stopAgency.Timezone, stopAgency.ID)
 	if params.Time != nil {
 		currentTime = params.Time.In(loc)
 	} else {
@@ -274,7 +274,7 @@ func (api *RestAPI) arrivalAndDepartureForStopHandler(w http.ResponseWriter, r *
 		predicted = true
 	}
 
-	status, _ := api.BuildTripStatus(ctx, agencyID, tripID, serviceDate, currentTime)
+	status, _ := api.BuildTripStatus(ctx, route.AgencyID, tripID, serviceDate, currentTime)
 	if status != nil {
 		tripStatus = status
 
@@ -312,59 +312,81 @@ func (api *RestAPI) arrivalAndDepartureForStopHandler(w http.ResponseWriter, r *
 	situationIDs := api.GetSituationIDsForTrip(r.Context(), tripID)
 
 	arrival := models.NewArrivalAndDeparture(
-		utils.FormCombinedID(agencyID, route.ID),
-		route.ShortName.String,
-		route.LongName.String,
-		utils.FormCombinedID(agencyID, tripID),
-		trip.TripHeadsign.String,
-		stopID,
-		vehicleID,
-		serviceDateMillis,
-		scheduledArrivalTimeMs,
-		scheduledDepartureTimeMs,
-		predictedArrivalTime,
-		predictedDepartureTime,
-		lastUpdateTime,
-		predicted,
-		true,                               // arrivalEnabled
-		true,                               // departureEnabled
-		int(targetStopTime.StopSequence)-1, // Zero-based index
-		totalStopsInTrip,
-		numberOfStopsAway,
-		blockTripSequence,
-		distanceFromStop,
-		"default", // status
-		"",        // occupancyStatus
-		"",        // predictedOccupancy
-		"",        // historicalOccupancy
-		tripStatus,
-		situationIDs,
+		utils.FormCombinedID(route.AgencyID, route.ID), // routeID
+		route.ShortName.String,                         // routeShortName
+		route.LongName.String,                          // routeLongName
+		utils.FormCombinedID(route.AgencyID, tripID),   // tripID
+		trip.TripHeadsign.String,                       // tripHeadsign
+		stopID,                                         // stopID
+		vehicleID,                                      // vehicleID
+		serviceDateMillis,                              // serviceDate
+		scheduledArrivalTimeMs,                         // scheduledArrivalTime
+		scheduledDepartureTimeMs,                       // scheduledDepartureTime
+		predictedArrivalTime,                           // predictedArrivalTime
+		predictedDepartureTime,                         // predictedDepartureTime
+		lastUpdateTime,                                 // lastUpdateTime
+		predicted,                                      // predicted
+		true,                                           // arrivalEnabled
+		true,                                           // departureEnabled
+		int(targetStopTime.StopSequence)-1,             // stopSequence (Zero-based index)
+		totalStopsInTrip,                               // totalStopsInTrip
+		numberOfStopsAway,                              // numberOfStopsAway
+		blockTripSequence,                              // blockTripSequence
+		distanceFromStop,                               // distanceFromStop
+		"default",                                      // status
+		"",                                             // occupancyStatus
+		"",                                             // predictedOccupancy
+		"",                                             // historicalOccupancy
+		tripStatus,                                     // tripStatus
+		situationIDs,                                   // situationIds
 	)
 
 	references := models.NewEmptyReferences()
 
+	// Add Stop Agency Reference
 	references.Agencies = append(references.Agencies, models.NewAgencyReference(
-		agency.ID,
-		agency.Name,
-		agency.Url,
-		agency.Timezone,
-		agency.Lang.String,
-		agency.Phone.String,
-		agency.Email.String,
-		agency.FareUrl.String,
+		stopAgency.ID,
+		stopAgency.Name,
+		stopAgency.Url,
+		stopAgency.Timezone,
+		stopAgency.Lang.String,
+		stopAgency.Phone.String,
+		stopAgency.Email.String,
+		stopAgency.FareUrl.String,
 		"",
 		false,
 	))
 
+	// Add Route Agency Reference if different from Stop Agency
+	if route.AgencyID != stopAgency.ID {
+		routeAgency, err := api.GtfsManager.GtfsDB.Queries.GetAgency(ctx, route.AgencyID)
+		if err == nil {
+			references.Agencies = append(references.Agencies, models.NewAgencyReference(
+				routeAgency.ID,
+				routeAgency.Name,
+				routeAgency.Url,
+				routeAgency.Timezone,
+				routeAgency.Lang.String,
+				routeAgency.Phone.String,
+				routeAgency.Email.String,
+				routeAgency.FareUrl.String,
+				"",
+				false,
+			))
+		} else {
+			api.Logger.Warn("failed to fetch route agency for reference", "agencyID", route.AgencyID, "error", err)
+		}
+	}
+
 	tripRef := models.NewTripReference(
-		utils.FormCombinedID(agencyID, tripID),
-		utils.FormCombinedID(agencyID, trip.RouteID),
-		utils.FormCombinedID(agencyID, trip.ServiceID),
+		utils.FormCombinedID(route.AgencyID, tripID),
+		utils.FormCombinedID(route.AgencyID, trip.RouteID),
+		utils.FormCombinedID(route.AgencyID, trip.ServiceID),
 		trip.TripHeadsign.String,
 		"", // trip short name
 		trip.DirectionID.Int64,
-		utils.FormCombinedID(agencyID, trip.BlockID.String),
-		utils.FormCombinedID(agencyID, trip.ShapeID.String),
+		utils.FormCombinedID(route.AgencyID, trip.BlockID.String),
+		utils.FormCombinedID(route.AgencyID, trip.ShapeID.String),
 	)
 	references.Trips = append(references.Trips, tripRef)
 
@@ -374,17 +396,22 @@ func (api *RestAPI) arrivalAndDepartureForStopHandler(w http.ResponseWriter, r *
 		if err == nil && activeTripID != tripID {
 			activeTrip, err := api.GtfsManager.GtfsDB.Queries.GetTrip(ctx, activeTripID)
 			if err == nil {
-				activeTripRef := models.NewTripReference(
-					utils.FormCombinedID(agencyID, activeTripID),
-					utils.FormCombinedID(agencyID, activeTrip.RouteID),
-					utils.FormCombinedID(agencyID, activeTrip.ServiceID),
-					activeTrip.TripHeadsign.String,
-					"", // trip short name
-					activeTrip.DirectionID.Int64,
-					utils.FormCombinedID(agencyID, activeTrip.BlockID.String),
-					utils.FormCombinedID(agencyID, activeTrip.ShapeID.String),
-				)
-				references.Trips = append(references.Trips, activeTripRef)
+				activeRoute, err := api.GtfsManager.GtfsDB.Queries.GetRoute(ctx, activeTrip.RouteID)
+				if err != nil {
+					api.Logger.Warn("failed to fetch route for active trip reference", "tripID", activeTripID, "error", err)
+				} else {
+					activeTripRef := models.NewTripReference(
+						utils.FormCombinedID(activeRoute.AgencyID, activeTripID),
+						utils.FormCombinedID(activeRoute.AgencyID, activeTrip.RouteID),
+						utils.FormCombinedID(activeRoute.AgencyID, activeTrip.ServiceID),
+						activeTrip.TripHeadsign.String,
+						"", // trip short name
+						activeTrip.DirectionID.Int64,
+						utils.FormCombinedID(activeRoute.AgencyID, activeTrip.BlockID.String),
+						utils.FormCombinedID(activeRoute.AgencyID, activeTrip.ShapeID.String),
+					)
+					references.Trips = append(references.Trips, activeTripRef)
+				}
 			}
 		}
 	}
@@ -424,10 +451,15 @@ func (api *RestAPI) arrivalAndDepartureForStopHandler(w http.ResponseWriter, r *
 			continue
 		}
 
-		routesForThisStop, _ := api.GtfsManager.GtfsDB.Queries.GetRoutesForStops(ctx, []string{stopID})
+		routesForThisStop, err := api.GtfsManager.GtfsDB.Queries.GetRoutesForStops(ctx, []string{stopID})
+		if err != nil {
+			api.Logger.Warn("failed to fetch routes for stop", "stopID", stopID, "error", err)
+			continue
+		}
+
 		combinedRouteIDs := make([]string, len(routesForThisStop))
 		for i, route := range routesForThisStop {
-			combinedRouteIDs[i] = utils.FormCombinedID(agencyID, route.ID)
+			combinedRouteIDs[i] = utils.FormCombinedID(route.AgencyID, route.ID)
 			routeCopy := gtfsdb.Route{
 				ID:        route.ID,
 				AgencyID:  route.AgencyID,
@@ -443,7 +475,7 @@ func (api *RestAPI) arrivalAndDepartureForStopHandler(w http.ResponseWriter, r *
 		}
 
 		stopRef := models.Stop{
-			ID:                 utils.FormCombinedID(agencyID, stopData.ID),
+			ID:                 utils.FormCombinedID(stopAgencyID, stopData.ID),
 			Name:               stopData.Name.String,
 			Lat:                stopData.Lat,
 			Lon:                stopData.Lon,
@@ -460,8 +492,8 @@ func (api *RestAPI) arrivalAndDepartureForStopHandler(w http.ResponseWriter, r *
 	// Build routes references
 	for _, route := range routeIDSet {
 		routeRef := models.NewRoute(
-			utils.FormCombinedID(agencyID, route.ID),
-			agencyID,
+			utils.FormCombinedID(route.AgencyID, route.ID),
+			route.AgencyID,
 			route.ShortName.String,
 			route.LongName.String,
 			route.Desc.String,
@@ -476,7 +508,7 @@ func (api *RestAPI) arrivalAndDepartureForStopHandler(w http.ResponseWriter, r *
 	if len(situationIDs) > 0 {
 		alerts := api.GtfsManager.GetAlertsForTrip(r.Context(), tripID)
 		if len(alerts) > 0 {
-			situations := api.BuildSituationReferences(alerts, agencyID)
+			situations := api.BuildSituationReferences(alerts, route.AgencyID)
 			for _, situation := range situations {
 				references.Situations = append(references.Situations, situation)
 			}

--- a/internal/restapi/arrival_and_departure_for_stop_handler_test.go
+++ b/internal/restapi/arrival_and_departure_for_stop_handler_test.go
@@ -2,6 +2,7 @@ package restapi
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -13,6 +14,7 @@ import (
 	"github.com/OneBusAway/go-gtfs"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"maglev.onebusaway.org/gtfsdb"
 	"maglev.onebusaway.org/internal/models"
 	"maglev.onebusaway.org/internal/utils"
 )
@@ -666,6 +668,143 @@ func TestArrivalsAndDeparturesForStopHandlerInvalidTime(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 }
 
+func TestArrivalAndDepartureForStopHandler_MultiAgency_Regression(t *testing.T) {
+	api := createTestApi(t)
+	defer api.Shutdown()
+
+	ctx := context.Background()
+	queries := api.GtfsManager.GtfsDB.Queries
+
+	// 1. Setup: Agency A owns the stop
+	agencyA := "AgencyA"
+	stopID := "MultiAgencyStop"
+	_, err := queries.CreateAgency(ctx, gtfsdb.CreateAgencyParams{
+		ID:       agencyA,
+		Name:     "Transit Agency A",
+		Url:      "http://agency-a.com",
+		Timezone: "America/Los_Angeles",
+	})
+	require.NoError(t, err)
+
+	_, err = queries.CreateStop(ctx, gtfsdb.CreateStopParams{
+		ID:   stopID,
+		Name: sql.NullString{String: "Shared Transit Center", Valid: true},
+		Lat:  47.6062,
+		Lon:  -122.3321,
+	})
+	require.NoError(t, err)
+
+	// 2. Setup: Agency B owns the route
+	agencyB := "AgencyB"
+	routeB_ID := "RouteB"
+	_, err = queries.CreateAgency(ctx, gtfsdb.CreateAgencyParams{
+		ID:       agencyB,
+		Name:     "Transit Agency B",
+		Url:      "http://agency-b.com",
+		Timezone: "America/Los_Angeles",
+	})
+	require.NoError(t, err)
+
+	_, err = queries.CreateRoute(ctx, gtfsdb.CreateRouteParams{
+		ID:        routeB_ID,
+		AgencyID:  agencyB,
+		ShortName: sql.NullString{String: "B-Line", Valid: true},
+		LongName:  sql.NullString{String: "Agency B Express", Valid: true},
+		Type:      3, // Bus
+	})
+	require.NoError(t, err)
+
+	// 3. Setup: Create a service
+	_, err = queries.CreateCalendar(ctx, gtfsdb.CreateCalendarParams{
+		ID:        "service1",
+		Monday:    1,
+		Tuesday:   1,
+		Wednesday: 1,
+		Thursday:  1,
+		Friday:    1,
+		Saturday:  1,
+		Sunday:    1,
+		StartDate: "20200101",
+		EndDate:   "20301231",
+	})
+	require.NoError(t, err)
+
+	// 4. Setup: Trip from Agency B's route serving Agency A's stop
+	tripB_ID := "TripB"
+	_, err = queries.CreateTrip(ctx, gtfsdb.CreateTripParams{
+		ID:           tripB_ID,
+		RouteID:      routeB_ID,
+		ServiceID:    "service1",
+		TripHeadsign: sql.NullString{String: "Downtown", Valid: true},
+	})
+	require.NoError(t, err)
+
+	_, err = queries.CreateStopTime(ctx, gtfsdb.CreateStopTimeParams{
+		TripID:        tripB_ID,
+		StopID:        stopID,
+		StopSequence:  1,
+		ArrivalTime:   28800 * 1e9, // 08:00:00 converted to nanoseconds
+		DepartureTime: 29100 * 1e9, // 08:05:00 converted to nanoseconds
+	})
+	require.NoError(t, err)
+
+	// 5. Execution: Request arrival/departure using Agency A's stop prefix
+	combinedStopID := utils.FormCombinedID(agencyA, stopID)
+	combinedTripID := utils.FormCombinedID(agencyB, tripB_ID)
+	serviceDate := time.Now().Unix() * 1000
+
+	resp, model := serveApiAndRetrieveEndpoint(t, api,
+		"/api/where/arrival-and-departure-for-stop/"+combinedStopID+".json?key=TEST&tripId="+combinedTripID+
+			"&serviceDate="+fmt.Sprintf("%d", serviceDate))
+	// 6. Assertions
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, http.StatusOK, model.Code)
+
+	data, ok := model.Data.(map[string]interface{})
+	require.True(t, ok)
+
+	entry, ok := data["entry"].(map[string]interface{})
+	require.True(t, ok)
+
+	// CRITICAL: Verify routeId uses Agency B prefix (not Agency A)
+	routeID, ok := entry["routeId"].(string)
+	require.True(t, ok)
+	expectedRouteID := utils.FormCombinedID(agencyB, routeB_ID)
+	assert.Equal(t, expectedRouteID, routeID,
+		"routeId should use the route's agency (AgencyB), not the stop's agency (AgencyA)")
+
+	// Verify references contain both agencies
+	references, ok := data["references"].(map[string]interface{})
+	require.True(t, ok)
+
+	agencies, ok := references["agencies"].([]interface{})
+	require.True(t, ok)
+
+	agencyIDs := make(map[string]bool)
+	for _, ag := range agencies {
+		agencyMap := ag.(map[string]interface{})
+		agencyIDs[agencyMap["id"].(string)] = true
+	}
+
+	assert.True(t, agencyIDs[agencyA], "references.agencies should contain Agency A")
+	assert.True(t, agencyIDs[agencyB], "references.agencies should contain Agency B")
+
+	// Verify route is correctly prefixed
+	routes, ok := references["routes"].([]interface{})
+	require.True(t, ok)
+	require.NotEmpty(t, routes)
+
+	foundCorrectRoute := false
+	for _, r := range routes {
+		routeMap := r.(map[string]interface{})
+		if routeMap["id"].(string) == expectedRouteID {
+			foundCorrectRoute = true
+			assert.Equal(t, agencyB, routeMap["agencyId"], "route's agencyId should be AgencyB")
+			break
+		}
+	}
+	assert.True(t, foundCorrectRoute, "references.routes should contain the correctly prefixed route")
+}
 func TestGetPredictedTimes_DelayPropagationLogic(t *testing.T) {
 	api := createTestApi(t)
 	defer api.Shutdown()

--- a/internal/restapi/arrivals_and_departures_for_stop_handler_test.go
+++ b/internal/restapi/arrivals_and_departures_for_stop_handler_test.go
@@ -1,6 +1,8 @@
 package restapi
 
 import (
+	"context"
+	"database/sql"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
@@ -8,6 +10,8 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"maglev.onebusaway.org/gtfsdb"
 	"maglev.onebusaway.org/internal/clock"
 	"maglev.onebusaway.org/internal/utils"
 )
@@ -446,6 +450,149 @@ func TestArrivalsAndDeparturesForStopHandlerWithInvalidParams(t *testing.T) {
 	endpoint = "/api/where/arrivals-and-departures-for-stop/" + stopID + ".json?key=TEST&minutesAfter=invalid"
 	resp, _ = serveApiAndRetrieveEndpoint(t, api, endpoint)
 	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+}
+
+func TestArrivalsAndDeparturesForStopHandler_MultiAgency_Regression(t *testing.T) {
+	// Use a MockClock within the service window so the plural handler finds the trip
+	loc, err := time.LoadLocation("America/Los_Angeles")
+	require.NoError(t, err)
+	mockClock := clock.NewMockClock(time.Date(2010, 1, 1, 8, 2, 0, 0, loc))
+
+	api := createTestApiWithClock(t, mockClock)
+	defer api.Shutdown()
+
+	ctx := context.Background()
+	queries := api.GtfsManager.GtfsDB.Queries
+
+	agencyA := "AgencyA"
+	stopID := "MultiAgencyStop"
+	_, err = queries.CreateAgency(ctx, gtfsdb.CreateAgencyParams{
+		ID:       agencyA,
+		Name:     "Transit Agency A",
+		Url:      "http://agency-a.com",
+		Timezone: "America/Los_Angeles",
+	})
+	require.NoError(t, err)
+
+	_, err = queries.CreateStop(ctx, gtfsdb.CreateStopParams{
+		ID:   stopID,
+		Name: sql.NullString{String: "Shared Transit Center", Valid: true},
+		Lat:  47.6062,
+		Lon:  -122.3321,
+	})
+	require.NoError(t, err)
+
+	agencyB := "AgencyB"
+	routeB_ID := "RouteB"
+	_, err = queries.CreateAgency(ctx, gtfsdb.CreateAgencyParams{
+		ID:       agencyB,
+		Name:     "Transit Agency B",
+		Url:      "http://agency-b.com",
+		Timezone: "America/Los_Angeles",
+	})
+	require.NoError(t, err)
+
+	_, err = queries.CreateRoute(ctx, gtfsdb.CreateRouteParams{
+		ID:        routeB_ID,
+		AgencyID:  agencyB,
+		ShortName: sql.NullString{String: "B-Line", Valid: true},
+		LongName:  sql.NullString{String: "Agency B Express", Valid: true},
+		Type:      3,
+	})
+	require.NoError(t, err)
+
+	_, err = queries.CreateCalendar(ctx, gtfsdb.CreateCalendarParams{
+		ID:        "service1",
+		Monday:    1,
+		Tuesday:   1,
+		Wednesday: 1,
+		Thursday:  1,
+		Friday:    1,
+		Saturday:  1,
+		Sunday:    1,
+		StartDate: "20000101",
+		EndDate:   "20301231",
+	})
+	require.NoError(t, err)
+
+	tripB_ID := "TripB"
+	_, err = queries.CreateTrip(ctx, gtfsdb.CreateTripParams{
+		ID:           tripB_ID,
+		RouteID:      routeB_ID,
+		ServiceID:    "service1",
+		TripHeadsign: sql.NullString{String: "Downtown", Valid: true},
+	})
+	require.NoError(t, err)
+
+	_, err = queries.CreateStopTime(ctx, gtfsdb.CreateStopTimeParams{
+		TripID:        tripB_ID,
+		StopID:        stopID,
+		StopSequence:  1,
+		ArrivalTime:   28800 * 1e9, // 08:00:00 converted to nanoseconds
+		DepartureTime: 29100 * 1e9, // 08:05:00 converted to nanoseconds
+	})
+	require.NoError(t, err)
+
+	combinedStopID := utils.FormCombinedID(agencyA, stopID)
+
+	resp, model := serveApiAndRetrieveEndpoint(t, api,
+		"/api/where/arrivals-and-departures-for-stop/"+combinedStopID+".json?key=TEST")
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, http.StatusOK, model.Code)
+
+	data, ok := model.Data.(map[string]interface{})
+	require.True(t, ok)
+
+	entry, ok := data["entry"].(map[string]interface{})
+	require.True(t, ok)
+
+	// Verify arrivalsAndDepartures array
+	arrivalsAndDepartures, ok := entry["arrivalsAndDepartures"].([]interface{})
+	require.True(t, ok)
+
+	// Fail loudly if no data is returned
+	require.NotEmpty(t, arrivalsAndDepartures, "expected arrivals for multi-agency stop")
+
+	firstArrival := arrivalsAndDepartures[0].(map[string]interface{})
+
+	routeID, ok := firstArrival["routeId"].(string)
+	require.True(t, ok)
+	expectedRouteID := utils.FormCombinedID(agencyB, routeB_ID)
+	assert.Equal(t, expectedRouteID, routeID,
+		"routeId should use the route's agency (AgencyB), not the stop's agency (AgencyA)")
+
+	// Verify references contain both agencies
+	references, ok := data["references"].(map[string]interface{})
+	require.True(t, ok)
+
+	agencies, ok := references["agencies"].([]interface{})
+	require.True(t, ok)
+
+	agencyIDs := make(map[string]bool)
+	for _, ag := range agencies {
+		agencyMap := ag.(map[string]interface{})
+		agencyIDs[agencyMap["id"].(string)] = true
+	}
+
+	assert.True(t, agencyIDs[agencyA], "references.agencies should contain Agency A")
+	assert.True(t, agencyIDs[agencyB], "references.agencies should contain Agency B")
+
+	// Verify route is correctly prefixed
+	routes, ok := references["routes"].([]interface{})
+	require.True(t, ok)
+	require.NotEmpty(t, routes, "references.routes should not be empty")
+
+	foundCorrectRoute := false
+	for _, r := range routes {
+		routeMap := r.(map[string]interface{})
+		if routeMap["id"].(string) == expectedRouteID {
+			foundCorrectRoute = true
+			assert.Equal(t, agencyB, routeMap["agencyId"], "route's agencyId should be AgencyB")
+			break
+		}
+	}
+	assert.True(t, foundCorrectRoute, "references.routes should contain the correctly prefixed route")
 }
 
 func TestArrivalsAndDeparturesReturnsResultsNearMidnight(t *testing.T) {


### PR DESCRIPTION
**New Title**
fix: Correct route agency ID generation in arrival/departure handlers

**Problem**
The `arrival-and-departure-for-stop` (singular) and `arrivals-and-departures-for-stop` (plural) handlers incorrectly assume that a Route's Agency ID always matches the Stop's Agency ID.

In multi-agency setups (e.g., Agency B route serving Agency A stop), this results in:

closes #349

1. **Invalid Route IDs:** The `routeId` is prefixed with the stop's agency (e.g., `AgencyA_RouteID`) instead of the route's actual agency (`AgencyB_RouteID`), causing broken links.
2. **Missing Metadata:** The `references` response fails to include agency metadata for the route if it differs from the stop.

**Solution**

* Updated `arrivalAndDepartureForStopHandler` and `arrivalsAndDeparturesForStopHandler` to explicitly use `route.AgencyID` when generating combined Route IDs and Trip References.
* Added logic to both handlers to inject the Route's Agency metadata into the `references.agencies` list if it differs from the Stop's Agency.
* Ensured active trips (real-time) also fetch and register their route metadata correctly in the plural handler.

**Testing**

* Added regression test `TestArrivalAndDepartureForStopHandler_MultiAgency_Regression` to `arrival_and_departure_for_stop_handler_test.go`.
* Added regression test `TestArrivalsAndDeparturesForStopHandler_MultiAgency_Regression` to `arrivals_and_departures_for_stop_handler_test.go`.
* Both tests verify that the returned `routeId` is prefixed with the correct agency and that the corresponding agency metadata is present in the references.