### PR TITLE
Optimize `stop_times` lookups with composite index

### DIFF
--- a/gtfsdb/schema.sql
+++ b/gtfsdb/schema.sql
@@ -330,7 +330,10 @@ CREATE INDEX IF NOT EXISTS idx_trips_service_id ON trips (service_id);
 CREATE INDEX IF NOT EXISTS idx_stop_times_trip_id ON stop_times (trip_id);
 
 -- migrate
-CREATE INDEX IF NOT EXISTS idx_stop_times_stop_id ON stop_times (stop_id);
+DROP INDEX IF EXISTS idx_stop_times_stop_id;
+
+-- migrate
+CREATE INDEX IF NOT EXISTS idx_stop_times_stop_arrival ON stop_times (stop_id, arrival_time);
 
 -- migrate
 CREATE INDEX IF NOT EXISTS idx_stop_times_stop_id_trip_id ON stop_times (stop_id, trip_id);


### PR DESCRIPTION
**Description:**
This PR optimizes database performance for schedule-related queries.

closes #355 

Currently, queries like `GetStopTimesForStopInWindow` and `GetArrivalsAndDeparturesForStop` use an index on `stop_id` but must perform an expensive scan and sort operation to order results by time.

**Changes:**

* Replaced the single-column index `idx_stop_times_stop_id` with a composite index `idx_stop_times_stop_arrival` on `(stop_id, arrival_time)`.
* Ran `make models` to update schema artifacts.

**Impact:**

* Significantly reduces CPU usage and latency for high-traffic stop schedule endpoints by allowing SQLite to retrieve pre-sorted rows directly from the index.
* The new index still satisfies pure `stop_id` lookups, making the old index redundant.

**Verification:**

* Verified via `sqlite_master` that the new composite index is created and the old redundant index is removed.
* Existing queries automatically utilize the new index structure without modification.