### PR TITLE
Fix race condition in calculateBlockTripSequence

### DIFF
--- a/internal/restapi/calculate_block_trip_sequence_test.go
+++ b/internal/restapi/calculate_block_trip_sequence_test.go
@@ -1,0 +1,66 @@
+package restapi
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCalculateBlockTripSequence tests the block trip sequence calculation
+func TestCalculateBlockTripSequence(t *testing.T) {
+	api := createTestApi(t)
+	defer api.Shutdown()
+	ctx := context.Background()
+
+	// Get a trip with a valid block ID
+	trips := api.GtfsManager.GetTrips()
+	require.NotEmpty(t, trips, "Should have test trips")
+
+	var testTripID string
+	var testServiceDate time.Time
+	
+	// Find a trip with a block ID
+	for _, trip := range trips {
+		tripRow, err := api.GtfsManager.GtfsDB.Queries.GetTrip(ctx, trip.ID)
+		if err != nil {
+			continue
+		}
+		
+		if tripRow.BlockID.Valid && tripRow.BlockID.String != "" {
+			testTripID = trip.ID
+			// Use a service date for testing
+			testServiceDate = time.Now()
+			break
+		}
+	}
+	
+	if testTripID == "" {
+		t.Skip("No trips with block IDs found in test data")
+	}
+
+	t.Run("Valid trip with block ID", func(t *testing.T) {
+		sequence := api.calculateBlockTripSequence(ctx, testTripID, testServiceDate)
+		
+		// Sequence should be non-negative
+		assert.GreaterOrEqual(t, sequence, 0, "Sequence should be >= 0")
+	})
+
+	t.Run("Invalid trip ID", func(t *testing.T) {
+		sequence := api.calculateBlockTripSequence(ctx, "invalid-trip-id", testServiceDate)
+		
+		// Should return 0 for invalid trip
+		assert.Equal(t, 0, sequence, "Should return 0 for invalid trip")
+	})
+	
+	t.Run("Transaction consistency", func(t *testing.T) {
+		// Call the function multiple times to ensure transaction handling works
+		sequence1 := api.calculateBlockTripSequence(ctx, testTripID, testServiceDate)
+		sequence2 := api.calculateBlockTripSequence(ctx, testTripID, testServiceDate)
+		
+		// Should return the same result consistently
+		assert.Equal(t, sequence1, sequence2, "Should return consistent results")
+	})
+}


### PR DESCRIPTION
### Fix race condition in `calculateBlockTripSequence`

**Issue**  
`calculateBlockTripSequence` was making multiple database queries without a consistent view of the data.  
During a GTFS hot-swap, these queries could hit different database versions, causing trips to be returned in the wrong order.

**Fix**  
Wrapped all related DB calls in a **read-only transaction**, ensuring every query reads from the same snapshot of data.

**Tests**  
Added basic test coverage for `calculateBlockTripSequence` to guard against regressions.

**Fixes**  
Closes #362
