### PR TITLE
fix: Add missing service calendar in TestStopHandlerMultiAgencyScenario

### DIFF
--- a/internal/restapi/stop_handler_test.go
+++ b/internal/restapi/stop_handler_test.go
@@ -203,6 +203,20 @@ func TestStopHandlerMultiAgencyScenario(t *testing.T) {
 	})
 	require.NoError(t, err)
 
+	_, err = queries.CreateCalendar(ctx, gtfsdb.CreateCalendarParams{
+		ID:        "service1",
+		Monday:    1,
+		Tuesday:   1,
+		Wednesday: 1,
+		Thursday:  1,
+		Friday:    1,
+		Saturday:  1,
+		Sunday:    1,
+		StartDate: "20250101",
+		EndDate:   "20251231",
+	})
+	require.NoError(t, err)
+
 	// 4. Link them: Create Trips and StopTimes for both agencies at the shared stop
 	// Trip for Agency B (Arriving at 08:00:00 -> 28800 seconds)
 	tripB_ID := "TripB"


### PR DESCRIPTION
## Description

Fixes a `FOREIGN KEY constraint failed` error in `TestStopHandlerMultiAgencyScenario` by adding the missing calendar/service entry that trips reference.

## Problem

The test creates trips with `ServiceID: "service1"` but never creates the corresponding calendar entry in the database, causing the test to fail with:
```
FOREIGN KEY constraint failed
Error Trace: /internal/restapi/stop_handler_test.go:214
```

## Solution

Added `CreateCalendar` call to create the `service1` calendar entry before creating trips that reference it.

## Changes
- Added calendar creation in `TestStopHandlerMultiAgencyScenario` (line ~205)
- Ensures foreign key constraint `trips.service_id` → `calendar.id` is satisfied

## Testing
```bash
go test -v ./internal/restapi -run TestStopHandlerMultiAgencyScenario
```

✅ Test now passes

## Related
- Discovered while investigating CI failures in PR #350
- This is a pre-existing test infrastructure bug, unrelated to any feature changes