### PR TITLE
perf: Optimize RoutesForAgencyID lookup to O(1) and fix concurrency issues

### DIFF
--- a/internal/gtfs/gtfs_manager.go
+++ b/internal/gtfs/gtfs_manager.go
@@ -32,6 +32,7 @@ type RegionBounds struct {
 type Manager struct {
 	gtfsData                       *gtfs.Static
 	GtfsDB                         *gtfsdb.Client
+	routesByAgencyID               map[string][]*gtfs.Route
 	lastUpdated                    time.Time
 	isLocalFile                    bool
 	realTimeTrips                  []gtfs.Trip
@@ -187,15 +188,11 @@ func (manager *Manager) GetRoutes() []gtfs.Route {
 // RoutesForAgencyID retrieves all routes associated with the specified agency ID from the GTFS data.
 // IMPORTANT: Caller must hold manager.RLock() before calling this method.
 func (manager *Manager) RoutesForAgencyID(agencyID string) []*gtfs.Route {
-	var agencyRoutes []*gtfs.Route
-
-	for i := range manager.gtfsData.Routes {
-		if manager.gtfsData.Routes[i].Agency.Id == agencyID {
-			agencyRoutes = append(agencyRoutes, &manager.gtfsData.Routes[i])
-		}
+	if routes, ok := manager.routesByAgencyID[agencyID]; ok {
+		return routes
 	}
 
-	return agencyRoutes
+	return []*gtfs.Route{}
 }
 
 type stopWithDistance struct {

--- a/internal/models/test_helpers.go
+++ b/internal/models/test_helpers.go
@@ -6,7 +6,7 @@ import (
 )
 
 // GetFixturePath returns the absolute path to a fixture file in the "testdata" directory relative to the project's root.
-func GetFixturePath(t *testing.T, fixturePath string) string {
+func GetFixturePath(t testing.TB, fixturePath string) string {
 	t.Helper()
 
 	absPath, err := filepath.Abs(filepath.Join("..", "..", "testdata", fixturePath))


### PR DESCRIPTION
## Description

This PR optimizes the `RoutesForAgencyID` method in the GTFS Manager. Previously, this method performed a linear O(N) scan over all routes in the system to filter by agency ID. This created a performance bottleneck for large regional feeds and high-traffic endpoints.

Additionally, this PR fixes a data race condition discovered in the `AdvancedDirectionCalculator` during testing.

closes #371

## Changes

### Performance Optimization

* **`internal/gtfs/gtfs_manager.go`**:
* Added `routesByAgencyID` map to the `Manager` struct for O(1) lookups.
* Refactored `RoutesForAgencyID` to look up routes directly from the map instead of iterating.


* **`internal/gtfs/static.go`**:
* Implemented `buildRouteIndex` helper to pre-compute the route map.
* Updated `setStaticGTFS` (initialization) and `ForceUpdate` (hot-swap) to ensure the index is rebuilt whenever GTFS data changes.



### Bug Fixes

* **`internal/gtfs/advanced_direction_calculator.go`**:
* Added a `sync.RWMutex` to protect the internal `contextCache`.
* Fixed a data race where `SetContextCache` (write) and `computeFromShapes` (read) could occur simultaneously.



### Testing

* **`internal/gtfs/gtfs_manager_test.go`**:
* Added `TestRoutesForAgencyID_MapOptimization` to verify correct map initialization.
* Added `TestRoutesForAgencyID_ConcurrentAccess` to ensure thread safety.



## Checklist

* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] Verified that data hot-swaps (`ForceUpdate`) maintain data integrity.