### PR TITLE
Fix: Prevent goroutine leak in bulk insert operations

### DIFF
--- a/gtfsdb/helpers.go
+++ b/gtfsdb/helpers.go
@@ -631,10 +631,14 @@ func (c *Client) bulkInsertStopTimes(ctx context.Context, stopTimes []CreateStop
 
 	// Feed batch indices to workers
 	go func() {
+		defer close(batchChan)
 		for i := 0; i < numBatches; i++ {
-			batchChan <- i
+			select {
+			case <-ctx.Done():
+				return
+			case batchChan <- i:
+			}
 		}
-		close(batchChan)
 	}()
 
 	// Close results channel when all workers are done
@@ -784,10 +788,14 @@ func (c *Client) bulkInsertShapes(ctx context.Context, shapes []CreateShapeParam
 
 	// Feed batch indices to workers
 	go func() {
+		defer close(batchChan)
 		for i := 0; i < numBatches; i++ {
-			batchChan <- i
+			select {
+			case <-ctx.Done():
+				return
+			case batchChan <- i:
+			}
 		}
-		close(batchChan)
 	}()
 
 	// ===== PHASE 2: COLLECT PREPARED BATCHES =====


### PR DESCRIPTION
## Problem
The batch feeder goroutines in `gtfsdb/helpers.go` did not check for context cancellation, causing goroutine leaks when database import operations were cancelled or timed out.

When `ctx.Done()` was triggered, worker goroutines would exit early, but the feeder goroutine continued trying to send to `batchChan`, blocking forever since no one was receiving.

## Solution
Added context cancellation checks using `select` statements in the batch feeder goroutines:

```go
go func() {
    defer close(batchChan)
    for i := 0; i < numBatches; i++ {
        select {
        case <-ctx.Done():
            return
        case batchChan <- i:
        }
    }
}()
```

## Changes Made
1. **bulkInsertStopTimes()** (line ~633): Added context check in batch feeder
2. **bulkInsertShapes()** (line ~786): Added context check in batch feeder
3. Moved `close(batchChan)` to `defer` to ensure cleanup on early return

## Impact
- **Severity**: Medium-High
- **Type**: Resource leak fix
- **Affected Operations**: GTFS imports with timeouts, cancelled bulk inserts, hot-swap operations

## Testing
- Code compiles successfully
- Logic follows Go best practices for context cancellation
- Should be tested with context cancellation during bulk import

Fixes #391