### PR TITLE
refactor(gtfs): optimize situation IDs fetch by eliminating duplicate DB queries

### DIFF
--- a/internal/gtfs/realtime.go
+++ b/internal/gtfs/realtime.go
@@ -105,7 +105,6 @@ func (manager *Manager) GetAlertsForRoute(routeID string) []gtfs.Alert {
 	return alerts
 }
 
-// IMPORTANT: Caller must hold manager.RLock() before calling this method.
 func (manager *Manager) GetAlertsByIDs(tripID, routeID, agencyID string) []gtfs.Alert {
 	manager.realTimeMutex.RLock()
 	defer manager.realTimeMutex.RUnlock()
@@ -135,6 +134,7 @@ func (manager *Manager) GetAlertsByIDs(tripID, routeID, agencyID string) []gtfs.
 }
 
 // GetAlertsForTrip returns alerts matching the trip, its route, or agency.
+// IMPORTANT: Caller must hold manager.RLock() before calling this method.
 func (manager *Manager) GetAlertsForTrip(ctx context.Context, tripID string) []gtfs.Alert {
 	var routeID string
 	var agencyID string

--- a/internal/restapi/trips_helper.go
+++ b/internal/restapi/trips_helper.go
@@ -786,7 +786,14 @@ func (api *RestAPI) GetSituationIDsForTrip(ctx context.Context, tripID string) [
 
 	situationIDs := []string{}
 	for _, alert := range alerts {
-		situationIDs = append(situationIDs, alert.ID)
+		if alert.ID == "" {
+			continue
+		}
+		if agencyID != "" {
+			situationIDs = append(situationIDs, utils.FormCombinedID(agencyID, alert.ID))
+		} else {
+			situationIDs = append(situationIDs, alert.ID)
+		}
 	}
 
 	return situationIDs


### PR DESCRIPTION
### Context
This Pr was identified that `GetSituationIDsForTrip` was performing redundant database work:
* It queried the database for Trip and Route details to get the `AgencyID`.
* It then called `GetAlertsForTrip`, which performed the exact same database queries internally.

### Changes
- **Refactor:** Extracted the alert filtering logic into a new method `GetAlertsByIDs` in `internal/gtfs/realtime.go`. This method accepts pre-fetched IDs, avoiding the need for internal DB lookups.
- **Optimization:** Updated `GetSituationIDsForTrip` in `internal/restapi/trips_helper.go` to fetch the Trip/Route/Agency data once and pass it to `GetAlertsByIDs`.
- **Fix:** Updated `BuildTripStatus` to explicitly initialize `SituationIDs` as an empty slice `[]` (instead of `nil`) when no alerts are found. This ensures the JSON response remains consistent (`"situationIds": []` instead of `null`), preventing test failures in `TestTripsForLocationHandler`.

### Impact
Reduces database load by eliminating duplicate queries per trip status request while maintaining API contract stability.

<img width="1920" height="485" alt="Screenshot From 2026-02-11 23-45-51" src="https://github.com/user-attachments/assets/84c49cf2-4ee9-4f0a-b022-7f3d86b27be2" />


@aaronbrethorst 
#fixes : #394