### PR TITLE
Refactor: Centralize ID validation and parsing logic with middleware

### DIFF
--- a/internal/restapi/agency_handler.go
+++ b/internal/restapi/agency_handler.go
@@ -8,19 +8,11 @@ import (
 )
 
 func (api *RestAPI) agencyHandler(w http.ResponseWriter, r *http.Request) {
-	id := utils.ExtractIDFromParams(r)
+	// We can ignore the bool return because middleware guarantees presence
+	id, _ := utils.GetIDFromContext(r.Context())
 
 	api.GtfsManager.RLock()
 	defer api.GtfsManager.RUnlock()
-
-	// Validate ID
-	if err := utils.ValidateID(id); err != nil {
-		fieldErrors := map[string][]string{
-			"id": {err.Error()},
-		}
-		api.validationErrorResponse(w, r, fieldErrors)
-		return
-	}
 
 	agency := api.GtfsManager.FindAgency(id)
 

--- a/internal/restapi/arrival_and_departure_for_stop_handler.go
+++ b/internal/restapi/arrival_and_departure_for_stop_handler.go
@@ -100,24 +100,10 @@ func (api *RestAPI) parseArrivalAndDepartureParams(r *http.Request) (ArrivalAndD
 }
 
 func (api *RestAPI) arrivalAndDepartureForStopHandler(w http.ResponseWriter, r *http.Request) {
-	stopID := utils.ExtractIDFromParams(r)
-
-	if err := utils.ValidateID(stopID); err != nil {
-		fieldErrors := map[string][]string{
-			"id": {err.Error()},
-		}
-		api.validationErrorResponse(w, r, fieldErrors)
-		return
-	}
-
-	agencyID, stopCode, err := utils.ExtractAgencyIDAndCodeID(stopID)
-	if err != nil {
-		fieldErrors := map[string][]string{
-			"id": {err.Error()},
-		}
-		api.validationErrorResponse(w, r, fieldErrors)
-		return
-	}
+	parsed, _ := utils.GetParsedIDFromContext(r.Context())
+	agencyID := parsed.AgencyID
+	stopCode := parsed.CodeID
+	stopID := parsed.CombinedID
 
 	ctx := r.Context()
 

--- a/internal/restapi/arrivals_and_departure_for_stop.go
+++ b/internal/restapi/arrivals_and_departure_for_stop.go
@@ -82,24 +82,10 @@ func (api *RestAPI) parseArrivalsAndDeparturesParams(r *http.Request) (ArrivalsS
 }
 
 func (api *RestAPI) arrivalsAndDeparturesForStopHandler(w http.ResponseWriter, r *http.Request) {
-	stopID := utils.ExtractIDFromParams(r)
-
-	if err := utils.ValidateID(stopID); err != nil {
-		fieldErrors := map[string][]string{
-			"id": {err.Error()},
-		}
-		api.validationErrorResponse(w, r, fieldErrors)
-		return
-	}
-
-	agencyID, stopCode, err := utils.ExtractAgencyIDAndCodeID(stopID)
-	if err != nil {
-		fieldErrors := map[string][]string{
-			"id": {err.Error()},
-		}
-		api.validationErrorResponse(w, r, fieldErrors)
-		return
-	}
+	parsed, _ := utils.GetParsedIDFromContext(r.Context())
+	agencyID := parsed.AgencyID
+	stopCode := parsed.CodeID
+	stopID := parsed.CombinedID
 
 	ctx := r.Context()
 

--- a/internal/restapi/block_handler.go
+++ b/internal/restapi/block_handler.go
@@ -19,21 +19,13 @@ func (api *RestAPI) blockHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	id := utils.ExtractIDFromParams(r)
-
-	if err := utils.ValidateID(id); err != nil {
-		fieldErrors := map[string][]string{
-			"id": {err.Error()},
-		}
-		api.validationErrorResponse(w, r, fieldErrors)
-		return
-	}
-
-	agencyID, blockID, err := utils.ExtractAgencyIDAndCodeID(id)
+	parsed, _ := utils.GetParsedIDFromContext(r.Context())
+	agencyID := parsed.AgencyID
+	blockID := parsed.CodeID
 
 	//  Return JSON 400 response for invalid block IDs
 	// We use an explicit struct here to ensure the text is exactly "invalid block id"
-	if err != nil || blockID == "" {
+	if blockID == "" {
 		api.sendError(w, r, http.StatusBadRequest, "invalid block id")
 		return
 	}

--- a/internal/restapi/id_middleware.go
+++ b/internal/restapi/id_middleware.go
@@ -1,0 +1,66 @@
+package restapi
+
+import (
+	"net/http"
+
+	"maglev.onebusaway.org/internal/utils"
+)
+
+// ValidateIDMiddleware extracts the {id} param, validates it against safety rules,
+// and injects it into the context. If validation fails, it returns 400.
+func (api *RestAPI) ValidateIDMiddleware(next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		id := utils.ExtractIDFromParams(r)
+
+		if err := utils.ValidateID(id); err != nil {
+			fieldErrors := map[string][]string{
+				"id": {err.Error()},
+			}
+			api.validationErrorResponse(w, r, fieldErrors)
+			return
+		}
+
+		ctx := utils.WithValidatedID(r.Context(), id)
+		next(w, r.WithContext(ctx))
+	}
+}
+
+// ValidateCombinedIDMiddleware enforces that the ID is in "agency_code" format.
+// It injects both the raw ID and the ParsedID struct into the context.
+func (api *RestAPI) ValidateCombinedIDMiddleware(next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		id := utils.ExtractIDFromParams(r)
+
+		// Basic Validation
+		if err := utils.ValidateID(id); err != nil {
+			fieldErrors := map[string][]string{
+				"id": {err.Error()},
+			}
+			api.validationErrorResponse(w, r, fieldErrors)
+			return
+		}
+
+		// Parse Split
+		agencyID, codeID, err := utils.ExtractAgencyIDAndCodeID(id)
+		if err != nil {
+			fieldErrors := map[string][]string{
+				"id": {err.Error()},
+			}
+			api.validationErrorResponse(w, r, fieldErrors)
+			return
+		}
+
+		// Inject into Context
+		parsed := utils.ParsedID{
+			CombinedID: id,
+			AgencyID:   agencyID,
+			CodeID:     codeID,
+		}
+		ctx := utils.WithParsedID(r.Context(), parsed)
+
+		// Also add the raw ID for convenience
+		ctx = utils.WithValidatedID(ctx, id)
+
+		next(w, r.WithContext(ctx))
+	}
+}

--- a/internal/restapi/id_middleware_test.go
+++ b/internal/restapi/id_middleware_test.go
@@ -1,0 +1,105 @@
+package restapi
+
+import (
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"maglev.onebusaway.org/internal/app"
+	"maglev.onebusaway.org/internal/clock"
+	"maglev.onebusaway.org/internal/utils"
+)
+
+func TestValidateIDMiddleware(t *testing.T) {
+	// Properly initialize the embedded Application struct
+	api := &RestAPI{
+		Application: &app.Application{
+			Logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+			Clock:  clock.NewMockClock(time.Now()),
+		},
+	}
+
+	nextHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		id, ok := utils.GetIDFromContext(r.Context())
+		if !ok || id != "valid_id" {
+			t.Errorf("Expected 'valid_id' in context, got %v", id)
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler := api.ValidateIDMiddleware(nextHandler)
+
+	t.Run("Valid ID", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/where/agency/valid_id", nil)
+		req.SetPathValue("id", "valid_id")
+		rr := httptest.NewRecorder()
+
+		handler.ServeHTTP(rr, req)
+
+		if rr.Code != http.StatusOK {
+			t.Errorf("Expected 200 OK, got %d", rr.Code)
+		}
+	})
+
+	t.Run("Invalid ID Format", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/where/agency/", nil)
+		req.SetPathValue("id", "") // Empty ID should fail basic validation
+		rr := httptest.NewRecorder()
+
+		handler.ServeHTTP(rr, req)
+
+		if rr.Code != http.StatusBadRequest {
+			t.Errorf("Expected 400 Bad Request for empty ID, got %d", rr.Code)
+		}
+	})
+}
+
+func TestValidateCombinedIDMiddleware(t *testing.T) {
+	// Properly initialize the embedded Application struct
+	api := &RestAPI{
+		Application: &app.Application{
+			Logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+			Clock:  clock.NewMockClock(time.Now()),
+		},
+	}
+
+	nextHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		parsed, ok := utils.GetParsedIDFromContext(r.Context())
+		if !ok {
+			t.Errorf("Expected ParsedID in context")
+		}
+		if parsed.AgencyID != "1" || parsed.CodeID != "stop123" {
+			t.Errorf("Expected AgencyID=1, CodeID=stop123, got %v", parsed)
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler := api.ValidateCombinedIDMiddleware(nextHandler)
+
+	t.Run("Valid Combined ID", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/where/stop/1_stop123", nil)
+		req.SetPathValue("id", "1_stop123")
+		rr := httptest.NewRecorder()
+
+		handler.ServeHTTP(rr, req)
+
+		if rr.Code != http.StatusOK {
+			t.Errorf("Expected 200 OK, got %d", rr.Code)
+		}
+	})
+
+	t.Run("Invalid Combined ID (No Underscore)", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/where/stop/1stop123", nil)
+		req.SetPathValue("id", "1stop123") // Missing underscore
+		rr := httptest.NewRecorder()
+
+		handler.ServeHTTP(rr, req)
+
+		if rr.Code != http.StatusBadRequest {
+			t.Errorf("Expected 400 Bad Request for missing underscore, got %d", rr.Code)
+		}
+	})
+}

--- a/internal/restapi/route_handler.go
+++ b/internal/restapi/route_handler.go
@@ -8,25 +8,9 @@ import (
 )
 
 func (api *RestAPI) routeHandler(w http.ResponseWriter, r *http.Request) {
-	queryParamID := utils.ExtractIDFromParams(r)
-
-	// Validate ID
-	if err := utils.ValidateID(queryParamID); err != nil {
-		fieldErrors := map[string][]string{
-			"id": {err.Error()},
-		}
-		api.validationErrorResponse(w, r, fieldErrors)
-		return
-	}
-
-	agencyID, routeID, err := utils.ExtractAgencyIDAndCodeID(queryParamID)
-	if err != nil {
-		fieldErrors := map[string][]string{
-			"id": {err.Error()},
-		}
-		api.validationErrorResponse(w, r, fieldErrors)
-		return
-	}
+	parsed, _ := utils.GetParsedIDFromContext(r.Context())
+	agencyID := parsed.AgencyID
+	routeID := parsed.CodeID // The raw GTFS route ID
 
 	api.GtfsManager.RLock()
 	defer api.GtfsManager.RUnlock()

--- a/internal/restapi/route_ids_for_agency_handler.go
+++ b/internal/restapi/route_ids_for_agency_handler.go
@@ -8,15 +8,7 @@ import (
 )
 
 func (api *RestAPI) routeIDsForAgencyHandler(w http.ResponseWriter, r *http.Request) {
-	id := utils.ExtractIDFromParams(r)
-
-	if err := utils.ValidateID(id); err != nil {
-		fieldErrors := map[string][]string{
-			"id": {err.Error()},
-		}
-		api.validationErrorResponse(w, r, fieldErrors)
-		return
-	}
+	id, _ := utils.GetIDFromContext(r.Context())
 
 	api.GtfsManager.RLock()
 	defer api.GtfsManager.RUnlock()

--- a/internal/restapi/routes_for_agency_handler.go
+++ b/internal/restapi/routes_for_agency_handler.go
@@ -8,15 +8,7 @@ import (
 )
 
 func (api *RestAPI) routesForAgencyHandler(w http.ResponseWriter, r *http.Request) {
-	id := utils.ExtractIDFromParams(r)
-
-	if err := utils.ValidateID(id); err != nil {
-		fieldErrors := map[string][]string{
-			"id": {err.Error()},
-		}
-		api.validationErrorResponse(w, r, fieldErrors)
-		return
-	}
+	id, _ := utils.GetIDFromContext(r.Context())
 
 	agency := api.GtfsManager.FindAgency(id)
 

--- a/internal/restapi/schedule_for_route_handler.go
+++ b/internal/restapi/schedule_for_route_handler.go
@@ -11,22 +11,10 @@ import (
 )
 
 func (api *RestAPI) scheduleForRouteHandler(w http.ResponseWriter, r *http.Request) {
-	queryParamID := utils.ExtractIDFromParams(r)
-	if err := utils.ValidateID(queryParamID); err != nil {
-		fieldErrors := map[string][]string{
-			"id": {err.Error()},
-		}
-		api.validationErrorResponse(w, r, fieldErrors)
-		return
-	}
-	agencyID, routeID, err := utils.ExtractAgencyIDAndCodeID(queryParamID)
-	if err != nil {
-		fieldErrors := map[string][]string{
-			"id": {err.Error()},
-		}
-		api.validationErrorResponse(w, r, fieldErrors)
-		return
-	}
+	parsed, _ := utils.GetParsedIDFromContext(r.Context())
+	agencyID := parsed.AgencyID
+	routeID := parsed.CodeID
+
 	dateParam := r.URL.Query().Get("date")
 	if err := utils.ValidateDate(dateParam); err != nil {
 		fieldErrors := map[string][]string{

--- a/internal/restapi/schedule_for_stop_handler.go
+++ b/internal/restapi/schedule_for_stop_handler.go
@@ -11,25 +11,9 @@ import (
 )
 
 func (api *RestAPI) scheduleForStopHandler(w http.ResponseWriter, r *http.Request) {
-	queryParamID := utils.ExtractIDFromParams(r)
-
-	// Validate ID
-	if err := utils.ValidateID(queryParamID); err != nil {
-		fieldErrors := map[string][]string{
-			"id": {err.Error()},
-		}
-		api.validationErrorResponse(w, r, fieldErrors)
-		return
-	}
-
-	agencyID, stopID, err := utils.ExtractAgencyIDAndCodeID(queryParamID)
-	if err != nil {
-		fieldErrors := map[string][]string{
-			"id": {err.Error()},
-		}
-		api.validationErrorResponse(w, r, fieldErrors)
-		return
-	}
+	parsed, _ := utils.GetParsedIDFromContext(r.Context())
+	agencyID := parsed.AgencyID
+	stopID := parsed.CodeID
 
 	ctx := r.Context()
 

--- a/internal/restapi/shapes_handler.go
+++ b/internal/restapi/shapes_handler.go
@@ -9,30 +9,17 @@ import (
 )
 
 func (api *RestAPI) shapesHandler(w http.ResponseWriter, r *http.Request) {
-	id := utils.ExtractIDFromParams(r)
-	if err := utils.ValidateID(id); err != nil {
-		fieldErrors := map[string][]string{
-			"id": {err.Error()},
-		}
-		api.validationErrorResponse(w, r, fieldErrors)
-		return
-	}
-
-	agencyID, shapeID, err := utils.ExtractAgencyIDAndCodeID(id)
-	if err != nil {
-		fieldErrors := map[string][]string{
-			"id": {err.Error()},
-		}
-		api.validationErrorResponse(w, r, fieldErrors)
-		return
-	}
+	parsed, _ := utils.GetParsedIDFromContext(r.Context())
+	agencyID := parsed.AgencyID
+	shapeID := parsed.CodeID
 
 	ctx := r.Context()
 
 	api.GtfsManager.RLock()
 	defer api.GtfsManager.RUnlock()
 
-	_, err = api.GtfsManager.GtfsDB.Queries.GetAgency(ctx, agencyID)
+	_, err := api.GtfsManager.GtfsDB.Queries.GetAgency(ctx, agencyID)
+
 	if err != nil {
 		api.sendNotFound(w, r)
 		return

--- a/internal/restapi/stop-ids-for-agency_handler.go
+++ b/internal/restapi/stop-ids-for-agency_handler.go
@@ -9,15 +9,7 @@ import (
 
 func (api *RestAPI) stopIDsForAgencyHandler(w http.ResponseWriter, r *http.Request) {
 
-	id := utils.ExtractIDFromParams(r)
-
-	if err := utils.ValidateID(id); err != nil {
-		fieldErrors := map[string][]string{
-			"id": {err.Error()},
-		}
-		api.validationErrorResponse(w, r, fieldErrors)
-		return
-	}
+	id, _ := utils.GetIDFromContext(r.Context())
 
 	api.GtfsManager.RLock()
 	defer api.GtfsManager.RUnlock()

--- a/internal/restapi/stop_handler.go
+++ b/internal/restapi/stop_handler.go
@@ -8,27 +8,12 @@ import (
 )
 
 func (api *RestAPI) stopHandler(w http.ResponseWriter, r *http.Request) {
-	queryParamID := utils.ExtractIDFromParams(r)
-
-	// Validate ID
-	if err := utils.ValidateID(queryParamID); err != nil {
-		fieldErrors := map[string][]string{
-			"id": {err.Error()},
-		}
-		api.validationErrorResponse(w, r, fieldErrors)
-		return
-	}
+	parsed, _ := utils.GetParsedIDFromContext(r.Context())
+	stopID := parsed.CodeID // The raw GTFS stop ID
 
 	// agencyID here is specifically the *Stop's* agency.
 	// Routes serving this stop might belong to different agencies.
-	agencyID, stopID, err := utils.ExtractAgencyIDAndCodeID(queryParamID)
-	if err != nil {
-		fieldErrors := map[string][]string{
-			"id": {err.Error()},
-		}
-		api.validationErrorResponse(w, r, fieldErrors)
-		return
-	}
+	agencyID := parsed.AgencyID
 
 	api.GtfsManager.RLock()
 	defer api.GtfsManager.RUnlock()

--- a/internal/restapi/stops_for_agency_handler.go
+++ b/internal/restapi/stops_for_agency_handler.go
@@ -20,15 +20,7 @@ func (api *RestAPI) stopsForAgencyHandler(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	id := utils.ExtractIDFromParams(r)
-
-	if err := utils.ValidateID(id); err != nil {
-		fieldErrors := map[string][]string{
-			"id": {err.Error()},
-		}
-		api.validationErrorResponse(w, r, fieldErrors)
-		return
-	}
+	id, _ := utils.GetIDFromContext(r.Context())
 
 	// Validate agency exists
 	agency := api.GtfsManager.FindAgency(id)

--- a/internal/restapi/stops_for_route_handler.go
+++ b/internal/restapi/stops_for_route_handler.go
@@ -50,24 +50,10 @@ func (api *RestAPI) stopsForRouteHandler(w http.ResponseWriter, r *http.Request)
 		api.serverErrorResponse(w, r, ctx.Err())
 		return
 	}
-	id := utils.ExtractIDFromParams(r)
 
-	if err := utils.ValidateID(id); err != nil {
-		fieldErrors := map[string][]string{
-			"id": {err.Error()},
-		}
-		api.validationErrorResponse(w, r, fieldErrors)
-		return
-	}
-
-	agencyID, routeID, err := utils.ExtractAgencyIDAndCodeID(id)
-	if err != nil {
-		fieldErrors := map[string][]string{
-			"id": {err.Error()},
-		}
-		api.validationErrorResponse(w, r, fieldErrors)
-		return
-	}
+	parsed, _ := utils.GetParsedIDFromContext(r.Context())
+	agencyID := parsed.AgencyID
+	routeID := parsed.CodeID
 
 	params := api.parseStopsForRouteParams(r)
 
@@ -174,6 +160,7 @@ func (api *RestAPI) stopsForRouteHandler(w http.ResponseWriter, r *http.Request)
 
 	api.buildAndSendResponse(w, r, ctx, result, stopsList, currentAgency)
 }
+
 func (api *RestAPI) processRouteStops(ctx context.Context, agencyID string, routeID string, serviceIDs []string, includePolylines bool, adc *GTFS.AdvancedDirectionCalculator) (models.RouteEntry, []models.Stop, error) {
 	allStops := make(map[string]bool)
 	allPolylines := make([]models.Polyline, 0, 100)

--- a/internal/restapi/trip_details_handler.go
+++ b/internal/restapi/trip_details_handler.go
@@ -82,24 +82,9 @@ func (api *RestAPI) parseTripIdDetailsParams(r *http.Request) (TripDetailsParams
 }
 
 func (api *RestAPI) tripDetailsHandler(w http.ResponseWriter, r *http.Request) {
-	queryParamID := utils.ExtractIDFromParams(r)
-
-	if err := utils.ValidateID(queryParamID); err != nil {
-		fieldErrors := map[string][]string{
-			"id": {err.Error()},
-		}
-		api.validationErrorResponse(w, r, fieldErrors)
-		return
-	}
-
-	agencyID, tripID, err := utils.ExtractAgencyIDAndCodeID(queryParamID)
-	if err != nil {
-		fieldErrors := map[string][]string{
-			"id": {err.Error()},
-		}
-		api.validationErrorResponse(w, r, fieldErrors)
-		return
-	}
+	parsed, _ := utils.GetParsedIDFromContext(r.Context())
+	agencyID := parsed.AgencyID
+	tripID := parsed.CodeID
 
 	ctx := r.Context()
 

--- a/internal/restapi/trip_for_vehicle_handler.go
+++ b/internal/restapi/trip_for_vehicle_handler.go
@@ -84,25 +84,9 @@ func (api *RestAPI) parseTripForVehicleParams(r *http.Request) (TripForVehiclePa
 }
 
 func (api *RestAPI) tripForVehicleHandler(w http.ResponseWriter, r *http.Request) {
-	queryParamID := utils.ExtractIDFromParams(r)
-
-	if err := utils.ValidateID(queryParamID); err != nil {
-		fieldErrors := map[string][]string{
-			"id": {err.Error()},
-		}
-		api.validationErrorResponse(w, r, fieldErrors)
-		return
-	}
-
-	agencyID, vehicleID, err := utils.ExtractAgencyIDAndCodeID(queryParamID)
-
-	if err != nil {
-		fieldErrors := map[string][]string{
-			"id": {err.Error()},
-		}
-		api.validationErrorResponse(w, r, fieldErrors)
-		return
-	}
+	parsed, _ := utils.GetParsedIDFromContext(r.Context())
+	agencyID := parsed.AgencyID
+	vehicleID := parsed.CodeID
 
 	api.GtfsManager.RLock()
 	defer api.GtfsManager.RUnlock()

--- a/internal/restapi/trip_handler.go
+++ b/internal/restapi/trip_handler.go
@@ -8,25 +8,9 @@ import (
 )
 
 func (api *RestAPI) tripHandler(w http.ResponseWriter, r *http.Request) {
-	queryParamID := utils.ExtractIDFromParams(r)
-
-	// Validate ID
-	if err := utils.ValidateID(queryParamID); err != nil {
-		fieldErrors := map[string][]string{
-			"id": {err.Error()},
-		}
-		api.validationErrorResponse(w, r, fieldErrors)
-		return
-	}
-
-	agencyID, id, err := utils.ExtractAgencyIDAndCodeID(queryParamID)
-	if err != nil {
-		fieldErrors := map[string][]string{
-			"id": {err.Error()},
-		}
-		api.validationErrorResponse(w, r, fieldErrors)
-		return
-	}
+	parsed, _ := utils.GetParsedIDFromContext(r.Context())
+	agencyID := parsed.AgencyID
+	id := parsed.CodeID // The raw GTFS trip ID
 
 	api.GtfsManager.RLock()
 	defer api.GtfsManager.RUnlock()

--- a/internal/restapi/trips_for_route_handler.go
+++ b/internal/restapi/trips_for_route_handler.go
@@ -19,24 +19,9 @@ func (api *RestAPI) tripsForRouteHandler(w http.ResponseWriter, r *http.Request)
 	api.GtfsManager.RLock()
 	defer api.GtfsManager.RUnlock()
 
-	id := utils.ExtractIDFromParams(r)
-
-	if err := utils.ValidateID(id); err != nil {
-		fieldErrors := map[string][]string{
-			"id": {err.Error()},
-		}
-		api.validationErrorResponse(w, r, fieldErrors)
-		return
-	}
-
-	agencyID, routeID, err := utils.ExtractAgencyIDAndCodeID(id)
-	if err != nil {
-		fieldErrors := map[string][]string{
-			"id": {err.Error()},
-		}
-		api.validationErrorResponse(w, r, fieldErrors)
-		return
-	}
+	parsed, _ := utils.GetParsedIDFromContext(r.Context())
+	agencyID := parsed.AgencyID
+	routeID := parsed.CodeID
 
 	includeSchedule := r.URL.Query().Get("includeSchedule") != "false"
 	includeStatus := r.URL.Query().Get("includeStatus") != "false"

--- a/internal/restapi/vehicles_for_agency_handler.go
+++ b/internal/restapi/vehicles_for_agency_handler.go
@@ -9,15 +9,7 @@ import (
 )
 
 func (api *RestAPI) vehiclesForAgencyHandler(w http.ResponseWriter, r *http.Request) {
-	id := utils.ExtractIDFromParams(r)
-
-	if err := utils.ValidateID(id); err != nil {
-		fieldErrors := map[string][]string{
-			"id": {err.Error()},
-		}
-		api.validationErrorResponse(w, r, fieldErrors)
-		return
-	}
+	id, _ := utils.GetIDFromContext(r.Context())
 
 	api.GtfsManager.RLock()
 	defer api.GtfsManager.RUnlock()


### PR DESCRIPTION
**Summary**
This PR refactors the API's ID validation and parsing logic by moving it from individual handlers into reusable middleware. Previously, nearly every handler (e.g., `agency_handler`, `stop_handler`) contained repetitive boilerplate code to extract IDs, validate them, and parse combined IDs (like `agency_id`). This logic is now centralized, improving code maintainability, consistency, and readability.

**Motivation**

* **DRY Principle:** Removed approximately 200+ lines of redundant error handling and parsing code across ~20 files.
* **Consistency:** Ensures that every endpoint enforces the exact same validation rules and returns identical `400 Bad Request` responses for invalid inputs.
* **Safety:** Handlers can now safely assume that if they are executing, the IDs in the context are valid and parsed.

### Key Changes

1. **New Middleware (`internal/restapi/id_middleware.go`)**:
* `ValidateIDMiddleware`: Validates simple IDs.
* `ValidateCombinedIDMiddleware`: Validates and parses "combined" IDs (format: `agency_id`).
* These middlewares handle the error response flow immediately if validation fails.


2. **Context Helpers (`internal/utils/api.go`)**:
* Added `WithValidatedID` / `GetIDFromContext`.
* Added `WithParsedID` / `GetParsedIDFromContext` to store and retrieve the parsed `AgencyID` and `CodeID`.


3. **Router Update (`internal/restapi/routes.go`)**:
* Updated `SetRoutes` to wrap relevant endpoints with the new middleware using `withID()` and `withCombinedID()` helpers.


4. **Handler Refactor**:
* Cleaned up handlers (e.g., `agency_handler.go`, `trip_handler.go`, `stop_handler.go`, `schedule_for_stop_handler.go`, etc.) by removing manual extraction logic.
* Handlers now retrieve clean data directly from the request context.

### Checklist:

* [x] My code follows the style guidelines of this project.
* [x] I have performed a self-review of my own code.
* [x] I have removed commented-out code and unnecessary logging.
* [x] My changes generate no new warnings.

closes #400 