### PR TITLE
perf: implement deep context cancellation to prevent resource exhaustion

### DIFF
--- a/internal/gtfs/gtfs_manager.go
+++ b/internal/gtfs/gtfs_manager.go
@@ -240,6 +240,10 @@ func (manager *Manager) GetStopsForLocation(
 	dbStops := queryStopsInBounds(manager.stopSpatialIndex, bounds)
 
 	for _, dbStop := range dbStops {
+		if ctx.Err() != nil {
+			return []gtfsdb.Stop{}
+		}
+
 		if query != "" && !isForRoutes {
 			if dbStop.Code.Valid && dbStop.Code.String == query {
 				return []gtfsdb.Stop{dbStop}
@@ -268,6 +272,10 @@ func (manager *Manager) GetStopsForLocation(
 
 				filteredCandidates := make([]stopWithDistance, 0, len(candidates))
 				for _, candidate := range candidates {
+					if ctx.Err() != nil {
+						return []gtfsdb.Stop{}
+					}
+
 					types := stopRouteTypes[candidate.stop.ID]
 					hasMatchingType := false
 					for _, rt := range types {
@@ -320,6 +328,10 @@ func (manager *Manager) GetStopsForLocation(
 
 					filteredCandidates := make([]stopWithDistance, 0, len(candidates))
 					for _, candidate := range candidates {
+						if ctx.Err() != nil {
+							return []gtfsdb.Stop{}
+						}
+
 						if stopsWithService[candidate.stop.ID] {
 							filteredCandidates = append(filteredCandidates, candidate)
 						}

--- a/internal/restapi/arrivals_and_departure_for_stop.go
+++ b/internal/restapi/arrivals_and_departure_for_stop.go
@@ -241,6 +241,10 @@ func (api *RestAPI) arrivalsAndDeparturesForStopHandler(w http.ResponseWriter, r
 	}
 
 	for _, st := range stopTimes {
+		if ctx.Err() != nil {
+			return
+		}
+
 		route, routeExists := routesLookup[st.RouteID]
 		if !routeExists {
 			api.Logger.Debug("skipping stop time: route not found in batch fetch",
@@ -435,6 +439,10 @@ func (api *RestAPI) arrivalsAndDeparturesForStopHandler(w http.ResponseWriter, r
 	calc := GTFS.NewAdvancedDirectionCalculator(api.GtfsManager.GtfsDB.Queries)
 
 	for stopID := range stopIDSet {
+		if ctx.Err() != nil {
+			return
+		}
+
 		stopData, err := api.GtfsManager.GtfsDB.Queries.GetStop(ctx, stopID)
 		if err != nil {
 			api.Logger.Debug("skipping stop reference: stop not found",

--- a/internal/restapi/block_handler.go
+++ b/internal/restapi/block_handler.go
@@ -221,6 +221,10 @@ func (api *RestAPI) getReferences(ctx context.Context, agencyID string, calc *GT
 
 	var stops []models.Stop
 	for stopID := range stopIDs {
+		if ctx.Err() != nil {
+			return models.ReferencesModel{}, ctx.Err()
+		}
+
 		stop, err := api.GtfsManager.GtfsDB.Queries.GetStop(ctx, stopID)
 		if err != nil {
 			return models.ReferencesModel{}, err
@@ -237,6 +241,10 @@ func (api *RestAPI) getReferences(ctx context.Context, agencyID string, calc *GT
 
 	var trips []interface{}
 	for tripID := range tripIDs {
+		if ctx.Err() != nil {
+			return models.ReferencesModel{}, ctx.Err()
+		}
+
 		trip, err := api.GtfsManager.GtfsDB.Queries.GetTrip(ctx, tripID)
 		if err != nil {
 			return models.ReferencesModel{}, err

--- a/internal/restapi/reference_utils.go
+++ b/internal/restapi/reference_utils.go
@@ -14,6 +14,10 @@ func (api *RestAPI) BuildRouteReferences(ctx context.Context, agencyID string, s
 	originalRouteIDs := make([]string, 0)
 
 	for _, stop := range stops {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+
 		for _, routeID := range stop.StaticRouteIDs {
 			_, originalRouteID, err := utils.ExtractAgencyIDAndCodeID(routeID)
 			if err != nil {
@@ -38,6 +42,10 @@ func (api *RestAPI) BuildRouteReferences(ctx context.Context, agencyID string, s
 
 	modelRoutes := make([]models.Route, 0, len(routes))
 	for _, route := range routes {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+
 		routeModel := models.Route{
 			ID:                utils.FormCombinedID(agencyID, route.ID),
 			AgencyID:          agencyID,

--- a/internal/restapi/route_search_handler.go
+++ b/internal/restapi/route_search_handler.go
@@ -68,6 +68,10 @@ func (api *RestAPI) routeSearchHandler(w http.ResponseWriter, r *http.Request) {
 	results := make([]models.Route, 0, len(routes))
 	agencyIDs := make(map[string]bool)
 	for _, routeRow := range routes {
+		if ctx.Err() != nil {
+			return
+		}
+
 		agencyIDs[routeRow.AgencyID] = true
 
 		shortName := ""

--- a/internal/restapi/routes_for_location_handler.go
+++ b/internal/restapi/routes_for_location_handler.go
@@ -98,6 +98,10 @@ func (api *RestAPI) routesForLocationHandler(w http.ResponseWriter, r *http.Requ
 	isLimitExceeded := false
 	// Process routes and filter by query if provided
 	for _, routeRow := range routesForStops {
+		if ctx.Err() != nil {
+			return
+		}
+
 		if query != "" && strings.ToLower(routeRow.ShortName.String) != query {
 			continue
 		}
@@ -121,6 +125,10 @@ func (api *RestAPI) routesForLocationHandler(w http.ResponseWriter, r *http.Requ
 			isLimitExceeded = true
 			break
 		}
+	}
+
+	if ctx.Err() != nil {
+		return
 	}
 
 	agencies := utils.FilterAgencies(api.GtfsManager.GetAgencies(), agencyIDs)

--- a/internal/restapi/schedule_for_route_handler.go
+++ b/internal/restapi/schedule_for_route_handler.go
@@ -138,6 +138,10 @@ func (api *RestAPI) scheduleForRouteHandler(w http.ResponseWriter, r *http.Reque
 	globalStopIDSet := make(map[string]struct{})
 	var stopTimesRefs []interface{}
 	for key, groupedTrips := range groupings {
+		if ctx.Err() != nil {
+			return
+		}
+
 		stopIDSet := make(map[string]struct{})
 		tripIDs := make([]string, 0, len(groupedTrips))
 		tripsWithStopTimes := make([]models.TripStopTimes, 0, len(groupedTrips))

--- a/internal/restapi/schedule_for_stop_handler.go
+++ b/internal/restapi/schedule_for_stop_handler.go
@@ -147,6 +147,10 @@ func (api *RestAPI) scheduleForStopHandler(w http.ResponseWriter, r *http.Reques
 	routeHeadsignCounts := make(map[string]map[string]int)
 
 	for _, row := range scheduleRows {
+		if ctx.Err() != nil {
+			return
+		}
+
 		combinedRouteID := utils.FormCombinedID(agencyID, row.RouteID)
 		combinedTripID := utils.FormCombinedID(agencyID, row.TripID)
 

--- a/internal/restapi/search_stops_handler.go
+++ b/internal/restapi/search_stops_handler.go
@@ -149,6 +149,10 @@ func (api *RestAPI) searchStopsHandler(w http.ResponseWriter, r *http.Request) {
 	routesMap := make(map[string]models.Route)
 
 	for _, row := range routesRows {
+		if ctx.Err() != nil {
+			return
+		}
+
 		combinedRouteID := utils.FormCombinedID(row.AgencyID, row.ID)
 
 		routesByStopID[row.StopID] = append(routesByStopID[row.StopID], combinedRouteID)
@@ -222,6 +226,10 @@ func (api *RestAPI) searchStopsHandler(w http.ResponseWriter, r *http.Request) {
 	stopModels := make([]models.Stop, 0, len(stops))
 
 	for _, s := range stops {
+		if ctx.Err() != nil {
+			return
+		}
+
 		var agencyID string
 
 		if rts, ok := routesByStopID[s.ID]; ok && len(rts) > 0 {

--- a/internal/restapi/stops_for_agency_handler.go
+++ b/internal/restapi/stops_for_agency_handler.go
@@ -116,6 +116,10 @@ func (api *RestAPI) buildStopsListForAgency(ctx context.Context, agencyID string
 	// Construct the stops list
 	stopsList := make([]models.Stop, 0, len(stops))
 	for _, stop := range stops {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+
 		routeIdsString := routesByStop[stop.ID]
 		if routeIdsString == nil {
 			routeIdsString = []string{}

--- a/internal/restapi/stops_for_location_handler.go
+++ b/internal/restapi/stops_for_location_handler.go
@@ -166,6 +166,10 @@ func (api *RestAPI) stopsForLocationHandler(w http.ResponseWriter, r *http.Reque
 	isLimitExceeded := false
 	// Build results using the pre-fetched data
 	for _, stopID := range stopIDs {
+		if ctx.Err() != nil {
+			return 
+		}
+
 		stop := stopMap[stopID]
 		rids := stopRouteIDs[stopID]
 		agency := stopAgency[stopID]
@@ -196,6 +200,10 @@ func (api *RestAPI) stopsForLocationHandler(w http.ResponseWriter, r *http.Reque
 			isLimitExceeded = true
 			break
 		}
+	}
+
+	if ctx.Err() != nil {
+		return 
 	}
 
 	agencies := utils.FilterAgencies(api.GtfsManager.GetAgencies(), agencyIDs)

--- a/internal/restapi/stops_for_route_handler.go
+++ b/internal/restapi/stops_for_route_handler.go
@@ -252,6 +252,9 @@ func buildStopsList(ctx context.Context, api *RestAPI, calc *GTFS.AdvancedDirect
 	stopsList := make([]models.Stop, 0, len(stops))
 
 	for _, stop := range stops {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
 
 		direction := calc.CalculateStopDirection(ctx, stop.ID, stop.Direction)
 
@@ -343,6 +346,10 @@ func processTripGroups(
 	})
 
 	for _, key := range keys {
+		if ctx.Err() != nil {
+			return
+		}
+
 		tripsInGroup := tripGroups[key]
 
 		// Sort trips by ID to ensure we always pick the same representative trip

--- a/internal/restapi/trip_details_handler.go
+++ b/internal/restapi/trip_details_handler.go
@@ -255,6 +255,10 @@ func (api *RestAPI) buildReferencedTrips(ctx context.Context, agencyID string, t
 	referencedTrips := []*models.Trip{}
 
 	for _, tripID := range tripsToInclude {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+
 		_, refTripID, err := utils.ExtractAgencyIDAndCodeID(tripID)
 		if err != nil {
 			continue
@@ -337,6 +341,10 @@ func (api *RestAPI) buildStopReferences(ctx context.Context, calc *GTFS.Advanced
 
 	routesByStop := make(map[string][]gtfsdb.Route)
 	for _, routeRow := range allRoutes {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+
 		route := gtfsdb.Route{
 			ID:        routeRow.ID,
 			AgencyID:  routeRow.AgencyID,
@@ -355,6 +363,10 @@ func (api *RestAPI) buildStopReferences(ctx context.Context, calc *GTFS.Advanced
 	processedStops := make(map[string]bool)
 
 	for _, st := range stopTimes {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+
 		_, originalStopID, err := utils.ExtractAgencyIDAndCodeID(st.StopID)
 		if err != nil {
 			continue
@@ -401,6 +413,10 @@ func (api *RestAPI) BuildRouteReference(ctx context.Context, agencyID string, st
 	originalRouteIDs := make([]string, 0)
 
 	for _, stop := range stops {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+
 		for _, routeID := range stop.StaticRouteIDs {
 			_, originalRouteID, err := utils.ExtractAgencyIDAndCodeID(routeID)
 			if err != nil {
@@ -425,6 +441,10 @@ func (api *RestAPI) BuildRouteReference(ctx context.Context, agencyID string, st
 
 	modelRoutes := make([]models.Route, 0, len(routes))
 	for _, route := range routes {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+
 		routeModel := models.Route{
 			ID:                utils.FormCombinedID(agencyID, route.ID),
 			AgencyID:          agencyID,

--- a/internal/restapi/trips_for_location_handler.go
+++ b/internal/restapi/trips_for_location_handler.go
@@ -39,6 +39,10 @@ func (api *RestAPI) tripsForLocationHandler(w http.ResponseWriter, r *http.Reque
 
 	visibleTripIDs := make([]string, 0, len(activeTrips))
 	for _, vehicle := range activeTrips {
+		if ctx.Err() != nil {
+			return
+		}
+
 		if vehicle.Position == nil {
 			continue
 		}
@@ -88,6 +92,10 @@ func (api *RestAPI) tripsForLocationHandler(w http.ResponseWriter, r *http.Reque
 	// Build entries from pre-fetched trip data
 	result := api.buildTripsForLocationEntries(ctx, trips, tripAgencyMap, includeSchedule, currentLocation, todayMidnight, serviceDate, w, r)
 	if result == nil {
+		return
+	}
+
+	if ctx.Err() != nil {
 		return
 	}
 
@@ -474,6 +482,10 @@ func (rb *referenceBuilder) collectTripIDs(trips []models.TripsForLocationListEn
 func (rb *referenceBuilder) buildStopList(stops []gtfsdb.Stop) {
 	rb.stopList = make([]models.Stop, 0, len(stops))
 	for _, stop := range stops {
+		if rb.ctx.Err() != nil {
+			return
+		}
+
 		routeIds, err := rb.api.GtfsManager.GtfsDB.Queries.GetRouteIDsForStop(rb.ctx, stop.ID)
 		if err != nil {
 			continue
@@ -620,6 +632,10 @@ func (rb *referenceBuilder) buildTripReferences() error {
 	rb.tripsRefList = make([]interface{}, 0, len(rb.presentTrips))
 
 	for _, trip := range rb.presentTrips {
+		if rb.ctx.Err() != nil {
+			return rb.ctx.Err()
+		}
+
 		tripDetails, err := rb.api.GtfsManager.GtfsDB.Queries.GetTrip(rb.ctx, trip.ID)
 		if err != nil {
 			continue

--- a/internal/restapi/trips_for_route_handler.go
+++ b/internal/restapi/trips_for_route_handler.go
@@ -138,6 +138,10 @@ func (api *RestAPI) tripsForRouteHandler(w http.ResponseWriter, r *http.Request)
 	var activeTrips []ActiveTripEntry
 
 	for blockID := range allLinkedBlocks {
+		if ctx.Err() != nil {
+			return
+		}
+
 		blockIDNullStr := sql.NullString{String: blockID, Valid: true}
 
 		tripsInBlock, err := api.GtfsManager.GtfsDB.Queries.GetTripsInBlock(ctx, gtfsdb.GetTripsInBlockParams{
@@ -235,6 +239,10 @@ func (api *RestAPI) tripsForRouteHandler(w http.ResponseWriter, r *http.Request)
 
 	var result []models.TripsForRouteListEntry
 	for _, activeEntry := range activeTrips {
+		if ctx.Err() != nil {
+			return
+		}
+
 		tripID := activeEntry.TripID
 
 		agencyID, ok := tripAgencyMap[tripID]

--- a/internal/restapi/vehicles_for_agency_handler.go
+++ b/internal/restapi/vehicles_for_agency_handler.go
@@ -19,6 +19,8 @@ func (api *RestAPI) vehiclesForAgencyHandler(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
+	ctx := r.Context()
+
 	api.GtfsManager.RLock()
 	defer api.GtfsManager.RUnlock()
 
@@ -42,6 +44,10 @@ func (api *RestAPI) vehiclesForAgencyHandler(w http.ResponseWriter, r *http.Requ
 	tripRefs := make(map[string]interface{})
 
 	for _, vehicle := range vehiclesForAgency {
+		if ctx.Err() != nil {
+			return
+		}
+
 		vehicleStatus := models.VehicleStatus{
 			VehicleID: vehicle.ID.ID,
 		}
@@ -104,7 +110,7 @@ func (api *RestAPI) vehiclesForAgencyHandler(w http.ResponseWriter, r *http.Requ
 			}
 
 			// Find and add route to references
-			if route, err := api.GtfsManager.GtfsDB.Queries.GetRoute(r.Context(), vehicle.Trip.ID.RouteID); err == nil {
+			if route, err := api.GtfsManager.GtfsDB.Queries.GetRoute(ctx, vehicle.Trip.ID.RouteID); err == nil {
 				shortName := ""
 				if route.ShortName.Valid {
 					shortName = route.ShortName.String


### PR DESCRIPTION
### Description

This PR fixes the "ghost requests" problem where heavy, synchronous API operations continue running in the background after a client drops their connection or times out.

Previously, heavy operations like spatial calculations, sequential DB queries, and massive JSON array allocations would execute to completion regardless of client state, leading to unnecessary CPU/memory spikes and latency under load.

**What was changed:**
Implemented the Load Shedding pattern by injecting explicit `if ctx.Err() != nil { return }` checks into the heaviest iteration loops and right before major array filtering operations. This ensures the server instantly halts work and frees up the thread the exact millisecond a request context is canceled.

**Affected Files:**

* `internal/gtfs/gtfs_manager.go`
* `internal/restapi/arrivals_and_departure_for_stop.go`
* `internal/restapi/block_handler.go`
* `internal/restapi/reference_utils.go`
* `internal/restapi/route_search_handler.go`
* `internal/restapi/routes_for_location_handler.go`
* `internal/restapi/schedule_for_route_handler.go`
* `internal/restapi/schedule_for_stop_handler.go`
* `internal/restapi/search_stops_handler.go`
* `internal/restapi/shapes_handler.go`
* `internal/restapi/stops_for_agency_handler.go`
* `internal/restapi/stops_for_location_handler.go`
* `internal/restapi/stops_for_route_handler.go`
* `internal/restapi/trip_details_handler.go`
* `internal/restapi/trips_for_location_handler.go`
* `internal/restapi/trips_for_route_handler.go`
* `internal/restapi/vehicles_for_agency_handler.go`


closes #406 