### PR TITLE
perf(gtfs): optimize agency and route lookups to O(1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -301,7 +301,8 @@ The GTFS Manager (`internal/gtfs/gtfs_manager.go`) maintains:
 ### GTFS Manager vs Database Access
 
 **In-Memory Data** (from `manager.gtfsData`):
-- `FindAgency(id)` - Direct agency lookup
+- `FindAgency(id)` - Direct O(1) agency lookup
+- `FindRoute(id)` - Direct O(1) route lookup
 - `RoutesForAgencyID(id)` - Routes for an agency
 - `VehiclesForAgencyID(id)` - Real-time vehicle data
 - `GetVehicleForTrip(tripID)` - Vehicle for a trip (checks block)
@@ -313,7 +314,6 @@ The GTFS Manager (`internal/gtfs/gtfs_manager.go`) maintains:
 - `GetRoute(ctx, id)` - Single route by ID
 - `GetAgency(ctx, id)` - Single agency by ID
 - Access via: `api.GtfsManager.GtfsDB.Queries.GetRoute()`, etc.
-- **Important**: No `FindRoute()` method exists - use database queries for route lookups
 
 ### Working with sqlc Models
 

--- a/internal/gtfs/gtfs_manager.go
+++ b/internal/gtfs/gtfs_manager.go
@@ -33,6 +33,8 @@ type Manager struct {
 	realTimeTripLookup             map[string]int
 	realTimeVehicleLookupByTrip    map[string]int
 	realTimeVehicleLookupByVehicle map[string]int
+	agenciesMap                    map[string]*gtfs.Agency
+	routesMap                      map[string]*gtfs.Route
 	staticUpdateMutex              sync.Mutex   // Protects against concurrent ForceUpdate calls
 	staticMutex                    sync.RWMutex // Protects gtfsData and lastUpdated
 	config                         Config
@@ -145,11 +147,16 @@ func (manager *Manager) GetBlockLayoverIndicesForRoute(routeID string) []*BlockL
 
 // IMPORTANT: Caller must hold manager.RLock() before calling this method.
 func (manager *Manager) FindAgency(id string) *gtfs.Agency {
-	for _, agency := range manager.gtfsData.Agencies {
-		if agency.Id == id {
-			agencyCopy := agency
-			return &agencyCopy
-		}
+	if agency, ok := manager.agenciesMap[id]; ok {
+		return agency
+	}
+	return nil
+}
+
+// IMPORTANT: Caller must hold manager.RLock() before calling this method.
+func (manager *Manager) FindRoute(id string) *gtfs.Route {
+	if route, ok := manager.routesMap[id]; ok {
+		return route
 	}
 	return nil
 }


### PR DESCRIPTION
### Summary
This PR optimizes the internal GTFS data lookups for Agencies and Routes, significantly improving performance by replacing linear searches with constant-time hash map lookups.

### Performance Improvements
* **Before:** `FindAgency` used a linear search loop over a slice ($O(N)$), which degrades as the number of agencies increases. `FindRoute` did not exist in-memory, forcing slower database queries.
* **After:** Implemented `map[string]*Agency` and `map[string]*Route` indices.
    * **Agency Lookup:** Now **$O(1)$** (Constant time).
    * **Route Lookup:** Added `FindRoute(id)` with **$O(1)$** access.

### Key Changes
* **`gtfs_manager.go`:**
    * Added `agenciesMap` and `routesMap` to the `Manager` struct.
    * Refactored `FindAgency` to use the map index.
    * Implemented the missing `FindRoute` method.
* **`static.go`:**
    * Created `buildLookupMaps` helper to index data during initial load (`setStaticGTFS`) and hot-swaps (`ForceUpdate`).
* **`CLAUDE.md`:** Updated documentation to reflect the availability and speed of `FindRoute`.

### Testing
* Added `TestBuildLookupMaps` to verify index creation.
* Added `TestManager_FindAgency_UsesMap` and `TestManager_FindRoute_UsesMap` to verify $O(1)$ logic (tested against empty slices to ensure map usage).
* Verification
<img width="1914" height="431" alt="image" src="https://github.com/user-attachments/assets/f9df4937-026b-474c-9c8b-57837c0042d1" />

@aaronbrethorst 
fixes : #411
