### PR TITLE
perf: Optimize `SELECT *` queries to project only necessary columns

### DIFF
--- a/gtfsdb/query.sql
+++ b/gtfsdb/query.sql
@@ -744,7 +744,7 @@ WHERE
 ORDER BY
     st.arrival_time LIMIT 50;
 -- name: GetTripsByServiceID :many
-SELECT *
+SELECT id, route_id, service_id, trip_headsign
 FROM trips
 WHERE service_id IN (sqlc.slice('service_ids'));
 
@@ -958,7 +958,8 @@ WHERE bte.block_trip_index_id IN (sqlc.slice('index_ids'))
 
 
 -- name: GetShapePointsByIDs :many
-SELECT * FROM shapes
+SELECT shape_id, lat, lon, shape_pt_sequence, shape_dist_traveled
+FROM shapes
 WHERE shape_id IN (sqlc.slice('shape_ids'))
 ORDER BY shape_id, shape_pt_sequence;
 


### PR DESCRIPTION
# Description
This PR improves database performance by replacing `SELECT *` with explicit column projections in key SQL queries. By limiting the retrieved columns to only what is required, the change reduces network transfer, memory usage, and query processing overhead while maintaining compatibility with existing application logic.

### closes  #415

---

## Code Changes

### 1. `GetTripsByServiceID`

**Before**
```sql
-- name: GetTripsByServiceID :many
SELECT * 
FROM trips
WHERE service_id IN (...);
```

**After**
```sql
-- name: GetTripsByServiceID :many
SELECT id, route_id, service_id, trip_headsign
FROM trips
WHERE service_id IN (...);
```


---

### 2. `GetShapePointsByIDs`

**Before**
```sql
-- name: GetShapePointsByIDs :many
SELECT * 
FROM shapes
WHERE shape_id IN (...);
```

**After**
```sql
-- name: GetShapePointsByIDs :many
SELECT shape_id, lat, lon, shape_pt_sequence, shape_dist_traveled
FROM shapes
WHERE shape_id IN (...);
```


---

## Summary of Changes
- Updated `gtfsdb/query.sql`:
  - Refactored `GetTripsByServiceID` to project only required columns.
  - Refactored `GetShapePointsByIDs` to eliminate unnecessary column transfers.
- Regenerated Go code using `sqlc` to reflect the updated queries.

---

## Impact Analysis
- **Database:** Lower I/O and reduced network overhead.
- **Application:** No functional changes required, generated structs remain compatible with existing usage.
- **Performance:** Faster deserialization and reduced memory consumption.

---

## Verification
- [x] Ran `make models` to regenerate SQLC code.
- [x] Ran `go build ./...` successfully.
- [x] Executed `go test -v -tags "sqlite_fts5" ./internal/...` and confirmed all tests pass.
