### PR TITLE
fix: include exempt-api-keys in dump-config output

### DIFF
--- a/cmd/api/app.go
+++ b/cmd/api/app.go
@@ -221,6 +221,7 @@ func dumpConfigJSON(cfg appconf.Config, gtfsCfg gtfs.Config) {
 		"port":             cfg.Port,
 		"env":              envStr,
 		"api-keys":         cfg.ApiKeys,
+		"exempt-api-keys":  cfg.ExemptApiKeys,
 		"rate-limit":       cfg.RateLimit,
 		"gtfs-static-feed": staticFeed,
 		"data-path":        gtfsCfg.GTFSDataPath,


### PR DESCRIPTION
### Summary
This is a follow-up to this #344 pr. As noted in the review, the `exempt-api-keys` field was missing from the `--dump-config` debug output.

### Changes
* **`cmd/api/app.go`**: Added `exempt-api-keys` to the `dumpConfigJSON` map map to ensure full visibility into the runtime configuration.

@aaronbrethorst 