### PR TITLE
fix: use opentransitsoftwarefoundation namespace for Docker Hub

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -90,5 +90,5 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: |
-            onebusaway/maglev:${{ env.IMAGE_TAG }}
-            onebusaway/maglev:latest
+            opentransitsoftwarefoundation/maglev:${{ env.IMAGE_TAG }}
+            opentransitsoftwarefoundation/maglev:latest

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ else
     SET_ENV := CGO_ENABLED=1 CGO_CFLAGS="-DSQLITE_ENABLE_FTS5"
 endif
 
-DOCKER_IMAGE := onebusaway/maglev
+DOCKER_IMAGE := opentransitsoftwarefoundation/maglev
 
 .PHONY: build build-debug clean coverage test run lint watch fmt \
 	gtfstidy models check-golangci-lint \

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -3,7 +3,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.dev
-    image: onebusaway/maglev:dev
+    image: opentransitsoftwarefoundation/maglev:dev
     container_name: maglev-dev
     ports:
       - "4000:4000"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-    image: onebusaway/maglev:latest
+    image: opentransitsoftwarefoundation/maglev:latest
     container_name: maglev
     ports:
       - "4000:4000"


### PR DESCRIPTION
The Docker Hub org is opentransitsoftwarefoundation, not onebusaway. Update all Docker Hub image references accordingly. GHCR references remain ghcr.io/onebusaway/maglev since that matches the GitHub org.