### PR TITLE
chore: implement review suggestions for request ID middleware

### DIFF
--- a/internal/restapi/request_id_middleware.go
+++ b/internal/restapi/request_id_middleware.go
@@ -29,3 +29,11 @@ func RequestIDMiddleware(next http.Handler) http.Handler {
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})
 }
+
+// GetRequestID allows other packages to retrieve the ID without importing restapi.
+func GetRequestID(ctx context.Context) string {
+	if id, ok := ctx.Value(RequestIDKey).(string); ok {
+		return id
+	}
+	return ""
+}

--- a/internal/restapi/request_id_middleware_test.go
+++ b/internal/restapi/request_id_middleware_test.go
@@ -1,6 +1,8 @@
 package restapi
 
 import (
+	"bytes"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -31,6 +33,26 @@ func TestRequestIDMiddleware(t *testing.T) {
 
 	t.Run("should preserve existing valid request ID", func(t *testing.T) {
 		existingID := "my-custom-trace-id-123"
+
+		nextHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			reqID, ok := r.Context().Value(RequestIDKey).(string)
+			assert.True(t, ok)
+			assert.Equal(t, existingID, reqID)
+		})
+
+		handlerToTest := RequestIDMiddleware(nextHandler)
+
+		req := httptest.NewRequest("GET", "http://example.com/foo", nil)
+		req.Header.Set("X-Request-ID", existingID)
+		rec := httptest.NewRecorder()
+
+		handlerToTest.ServeHTTP(rec, req)
+
+		assert.Equal(t, existingID, rec.Header().Get("X-Request-ID"))
+	})
+
+	t.Run("should preserve exactly 128 character request ID (boundary)", func(t *testing.T) {
+		existingID := strings.Repeat("a", 128)
 
 		nextHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			reqID, ok := r.Context().Value(RequestIDKey).(string)
@@ -83,4 +105,28 @@ func TestRequestIDMiddleware(t *testing.T) {
 			})
 		}
 	})
+}
+
+func TestRequestIDLoggingIntegration(t *testing.T) {
+	var logBuf bytes.Buffer
+
+	testLogger := slog.New(slog.NewJSONHandler(&logBuf, nil))
+
+	finalHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	loggingMiddleware := NewRequestLoggingMiddleware(testLogger)(finalHandler)
+	handlerToTest := RequestIDMiddleware(loggingMiddleware)
+
+	expectedReqID := "integration-test-id-999"
+	req := httptest.NewRequest("GET", "http://example.com/test", nil)
+	req.Header.Set("X-Request-ID", expectedReqID)
+	rec := httptest.NewRecorder()
+
+	handlerToTest.ServeHTTP(rec, req)
+
+	logOutput := logBuf.String()
+	assert.Contains(t, logOutput, expectedReqID, "Log output should contain the request ID")
+	assert.Contains(t, logOutput, "request_id", "Log output should contain the request_id key")
 }


### PR DESCRIPTION
### Description
This is a follow-up to the previously merged Request ID #370 PR to implement the non-blocking suggestions 

### Changes Made
* **Helper Function:** Added `GetRequestID(ctx)` in `request_id_middleware.go` to allow other packages (like `logging` or `webui`) to easily retrieve the request ID from the context without importing `restapi`.
* **Boundary Test:** Added a test case in `request_id_middleware_test.go` to explicitly verify that a request ID of exactly 128 characters is accepted.
* **Integration Test:** Added `TestRequestIDLoggingIntegration` to verify that composing `RequestIDMiddleware` with `NewRequestLoggingMiddleware` correctly produces the `"request_id":"..."` key-value pair in the log output.

<img width="1919" height="496" alt="image" src="https://github.com/user-attachments/assets/04a55922-38c5-4580-ad16-7adf3077dde9" />

@aaronbrethorst 
Ready for review!