### PR TITLE
improve test coverage for cmd/api 40.5 -> 81

### DIFF
--- a/cmd/api/app.go
+++ b/cmd/api/app.go
@@ -23,6 +23,25 @@ import (
 	"maglev.onebusaway.org/internal/webui"
 )
 
+func gtfsConfigFromData(gtfsCfgData appconf.GtfsConfigData) gtfs.Config {
+	gtfsCfg := gtfs.Config{
+		GtfsURL:                 gtfsCfgData.GtfsURL,
+		StaticAuthHeaderKey:     gtfsCfgData.StaticAuthHeaderKey,
+		StaticAuthHeaderValue:   gtfsCfgData.StaticAuthHeaderValue,
+		TripUpdatesURL:          gtfsCfgData.TripUpdatesURL,
+		VehiclePositionsURL:     gtfsCfgData.VehiclePositionsURL,
+		ServiceAlertsURL:        gtfsCfgData.ServiceAlertsURL,
+		RealTimeAuthHeaderKey:   gtfsCfgData.RealTimeAuthHeaderKey,
+		RealTimeAuthHeaderValue: gtfsCfgData.RealTimeAuthHeaderValue,
+		GTFSDataPath:            gtfsCfgData.GTFSDataPath,
+		Env:                     gtfsCfgData.Env,
+		Verbose:                 gtfsCfgData.Verbose,
+		EnableGTFSTidy:          gtfsCfgData.EnableGTFSTidy,
+	}
+
+	return gtfsCfg
+}
+
 // ParseAPIKeys splits a comma-separated string of API keys and trims whitespace from each key.
 // Returns an empty slice if the input is empty.
 func ParseAPIKeys(apiKeysFlag string) []string {

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -64,20 +64,8 @@ func main() {
 
 		// Convert to GTFS config
 		gtfsCfgData := jsonConfig.ToGtfsConfigData()
-		gtfsCfg = gtfs.Config{
-			GtfsURL:                 gtfsCfgData.GtfsURL,
-			StaticAuthHeaderKey:     gtfsCfgData.StaticAuthHeaderKey,
-			StaticAuthHeaderValue:   gtfsCfgData.StaticAuthHeaderValue,
-			TripUpdatesURL:          gtfsCfgData.TripUpdatesURL,
-			VehiclePositionsURL:     gtfsCfgData.VehiclePositionsURL,
-			ServiceAlertsURL:        gtfsCfgData.ServiceAlertsURL,
-			RealTimeAuthHeaderKey:   gtfsCfgData.RealTimeAuthHeaderKey,
-			RealTimeAuthHeaderValue: gtfsCfgData.RealTimeAuthHeaderValue,
-			GTFSDataPath:            gtfsCfgData.GTFSDataPath,
-			Env:                     gtfsCfgData.Env,
-			Verbose:                 gtfsCfgData.Verbose,
-			EnableGTFSTidy:          gtfsCfgData.EnableGTFSTidy,
-		}
+		gtfsCfg = gtfsConfigFromData(gtfsCfgData)
+
 	} else {
 		// Use command-line flags for configuration
 		// Set verbosity flags


### PR DESCRIPTION
Add tests for cmd/api to include tests to cover the jsonDumps function and check graceful shutdown as well
