### PR TITLE
chore: validate userLocationAccuracy parameter for consistency

### DIFF
--- a/internal/restapi/report_problem_with_stop_handler.go
+++ b/internal/restapi/report_problem_with_stop_handler.go
@@ -48,7 +48,7 @@ func (api *RestAPI) reportProblemWithStopHandler(w http.ResponseWriter, r *http.
 	userComment := utils.TruncateComment(query.Get("userComment"))
 	userLatStr := utils.ValidateNumericParam(query.Get("userLat"))
 	userLonStr := utils.ValidateNumericParam(query.Get("userLon"))
-	userLocationAccuracy := query.Get("userLocationAccuracy")
+	userLocationAccuracy := utils.ValidateNumericParam(query.Get("userLocationAccuracy"))
 
 	// Log the problem report for observability
 	logger = logging.FromContext(r.Context()).With(slog.String("component", "problem_reporting"))

--- a/internal/restapi/report_problem_with_trip_handler.go
+++ b/internal/restapi/report_problem_with_trip_handler.go
@@ -54,8 +54,7 @@ func (api *RestAPI) reportProblemWithTripHandler(w http.ResponseWriter, r *http.
 	userVehicleNumber := query.Get("userVehicleNumber")
 	userLatStr := utils.ValidateNumericParam(query.Get("userLat"))
 	userLonStr := utils.ValidateNumericParam(query.Get("userLon"))
-
-	userLocationAccuracy := query.Get("userLocationAccuracy")
+	userLocationAccuracy := utils.ValidateNumericParam(query.Get("userLocationAccuracy"))
 
 	// Log the problem report for observability
 	logger = logging.FromContext(r.Context()).With(slog.String("component", "problem_reporting"))


### PR DESCRIPTION
## Description
This is a follow-up to address a non-blocking consistency suggestion from my merged PR #366 

### Changes Made
- Wrapped the `userLocationAccuracy` query parameter parsing with `utils.ValidateNumericParam` in both `reportProblemWithStopHandler` and `reportProblemWithTripHandler`. 
- This ensures it is validated exactly the same way as `userLat` and `userLon`, bringing consistency to how all numeric location-based inputs are handled across the problem reporting endpoints.

@aaronbrethorst 
Ready for merge!