### PR TITLE
feat: achieve parity with Java OBA for stops-for-location endpoint

### DIFF
--- a/gtfsdb/db.go
+++ b/gtfsdb/db.go
@@ -90,6 +90,9 @@ func Prepare(ctx context.Context, db DBTX) (*Queries, error) {
 	if q.createTripStmt, err = db.PrepareContext(ctx, createTrip); err != nil {
 		return nil, fmt.Errorf("error preparing query CreateTrip: %w", err)
 	}
+	if q.getActiveRouteIDsForStopsOnDateStmt, err = db.PrepareContext(ctx, getActiveRouteIDsForStopsOnDate); err != nil {
+		return nil, fmt.Errorf("error preparing query GetActiveRouteIDsForStopsOnDate: %w", err)
+	}
 	if q.getActiveServiceIDsForDateStmt, err = db.PrepareContext(ctx, getActiveServiceIDsForDate); err != nil {
 		return nil, fmt.Errorf("error preparing query GetActiveServiceIDsForDate: %w", err)
 	}
@@ -410,6 +413,11 @@ func (q *Queries) Close() error {
 	if q.createTripStmt != nil {
 		if cerr := q.createTripStmt.Close(); cerr != nil {
 			err = fmt.Errorf("error closing createTripStmt: %w", cerr)
+		}
+	}
+	if q.getActiveRouteIDsForStopsOnDateStmt != nil {
+		if cerr := q.getActiveRouteIDsForStopsOnDateStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing getActiveRouteIDsForStopsOnDateStmt: %w", cerr)
 		}
 	}
 	if q.getActiveServiceIDsForDateStmt != nil {
@@ -818,6 +826,7 @@ type Queries struct {
 	createStopStmt                            *sql.Stmt
 	createStopTimeStmt                        *sql.Stmt
 	createTripStmt                            *sql.Stmt
+	getActiveRouteIDsForStopsOnDateStmt       *sql.Stmt
 	getActiveServiceIDsForDateStmt            *sql.Stmt
 	getActiveStopsStmt                        *sql.Stmt
 	getActiveTripForRouteAtTimeStmt           *sql.Stmt
@@ -915,6 +924,7 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		createStopStmt:                            q.createStopStmt,
 		createStopTimeStmt:                        q.createStopTimeStmt,
 		createTripStmt:                            q.createTripStmt,
+		getActiveRouteIDsForStopsOnDateStmt:       q.getActiveRouteIDsForStopsOnDateStmt,
 		getActiveServiceIDsForDateStmt:            q.getActiveServiceIDsForDateStmt,
 		getActiveStopsStmt:                        q.getActiveStopsStmt,
 		getActiveTripForRouteAtTimeStmt:           q.getActiveTripForRouteAtTimeStmt,

--- a/gtfsdb/query.sql
+++ b/gtfsdb/query.sql
@@ -521,6 +521,18 @@ FROM
 WHERE
     stop_times.stop_id IN (sqlc.slice('stop_ids'));
 
+-- name: GetActiveRouteIDsForStopsOnDate :many
+SELECT DISTINCT
+    routes.agency_id || '_' || routes.id AS route_id,
+    stop_times.stop_id
+FROM
+    stop_times
+    JOIN trips ON stop_times.trip_id = trips.id
+    JOIN routes ON trips.route_id = routes.id
+WHERE
+    stop_times.stop_id IN (sqlc.slice('stop_ids'))
+    AND trips.service_id IN (sqlc.slice('service_ids'));
+
 -- name: GetAgenciesForStops :many
 SELECT DISTINCT
     a.id,


### PR DESCRIPTION
## Description
This PR addresses Issue #33 by achieving full logic parity with the original Java OBA `stops-for-location` endpoint. 

### Key Changes:
* **Active Route Filtering**: 
   - Added a new `sqlc` query (`GetActiveRouteIDsForStopsOnDate`) to filter route IDs based on currently active `service_ids` for the requested date, solving the issue of historical/inactive routes being returned.
* **Dynamic Direction Calculation**: 
   - Implemented `GetDirectionForStop` in the GTFS Manager. It dynamically calculates the compass direction (N, S, E, W, etc.) of a stop by analyzing the coordinates of the "next stops" across all trips passing through it using `math.Atan2`.
* **Robust Testing**: 
   - Updated existing integration tests to use a `MockClock` injected with a fixed date corresponding to the `raba.zip` test data.
   - Added `TestStopsForLocationActiveRoutesOnly` to verify that stops with no active routes are gracefully omitted or returned empty.
   - Added a dedicated test suite (`direction_test.go`) utilizing table-driven tests for the compass angle logic and DB-backed tests for the GTFS manager direction extraction.

<img width="1917" height="488" alt="image" src="https://github.com/user-attachments/assets/42e277ed-063f-4c6d-af10-1f08d295e495" />

@aaronbrethorst 
fixes : #33 