### PR TITLE
fix: allow colon in ID pattern validation to support GTFS IDs

### DIFF
--- a/internal/utils/validation.go
+++ b/internal/utils/validation.go
@@ -9,8 +9,8 @@ import (
 
 // Compiled regular expressions for validation
 var (
-	// Allow alphanumeric, underscore, hyphen, dot - common in transit IDs
-	validIDPattern = regexp.MustCompile(`^[a-zA-Z0-9_.-]+$`)
+	// Allow alphanumeric, underscore, hyphen, dot, colon - common in transit IDs
+	validIDPattern = regexp.MustCompile(`^[a-zA-Z0-9_.:-]+$`)
 
 	// Detect potentially dangerous characters - more focused on injection patterns
 	dangerousPattern = regexp.MustCompile(`[<>]|--|\/\*|\*\/|;.*--`)

--- a/internal/utils/validation_test.go
+++ b/internal/utils/validation_test.go
@@ -64,6 +64,11 @@ func TestValidateID(t *testing.T) {
 			id:      "agency.123_stop.456",
 			wantErr: false,
 		},
+		{
+			name:    "valid ID with colon",
+			id:      "agency_shp_654:456",
+			wantErr: false,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
### Description
This PR addresses the input ID validation regex logic which incorrectly rejects IDs containing colons (:).

### Changes
- Allow colon in `validIDPattern` to support GTFS agencies that use colons in their IDs (e.g., agency_N23:S01)
- The colon poses no SQL injection or XSS risk

Fix: #438 
