### PR TITLE
refactor(api): use POST with JSON body for report endpoints

### DIFF
--- a/gtfsdb/helpers.go
+++ b/gtfsdb/helpers.go
@@ -172,7 +172,6 @@ func (c *Client) processAndStoreGTFSDataWithSource(b []byte, source string) erro
 		}
 
 		_, err := c.Queries.CreateRoute(ctx, route)
-
 		if err != nil {
 			return fmt.Errorf("unable to create route: %w", err)
 		}
@@ -494,6 +493,14 @@ func ParseNullBool(s string) sql.NullInt64 {
 		return sql.NullInt64{Int64: 1, Valid: true}
 	}
 	return sql.NullInt64{Int64: 0, Valid: true}
+}
+
+// Float64ToNull converts a *float64 to sql.NullFloat64 with nil values becoming NULL.
+func Float64ToNull(f *float64) sql.NullFloat64 {
+	if f == nil {
+		return sql.NullFloat64{Valid: false}
+	}
+	return sql.NullFloat64{Float64: *f, Valid: true}
 }
 
 func pickFirstAvailable(a, b string) string {

--- a/internal/restapi/caching_middleware_test.go
+++ b/internal/restapi/caching_middleware_test.go
@@ -1,6 +1,7 @@
 package restapi
 
 import (
+	"bytes"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -18,26 +19,33 @@ func TestCacheControlHeaders(t *testing.T) {
 
 	tests := []struct {
 		name           string
+		method         string
 		endpoint       string
+		body           []byte
 		expectedHeader string
 	}{
 		{
 			name:           "Static Data (Long Cache)",
+			method:         http.MethodGet,
 			endpoint:       "/api/where/agencies-with-coverage.json?key=TEST",
-			expectedHeader: "public, max-age=300", // 5 minutes
+			expectedHeader: "public, max-age=300",
 		},
 		{
 			name:           "Real-time Data (Short Cache)",
+			method:         http.MethodGet,
 			endpoint:       "/api/where/current-time.json?key=TEST",
-			expectedHeader: "public, max-age=30", // 30 seconds
+			expectedHeader: "public, max-age=30",
 		},
 		{
 			name:           "User Reports (No Cache)",
-			endpoint:       "/api/where/report-problem-with-stop/123.json?key=TEST",
-			expectedHeader: "no-cache, no-store, must-revalidate", // 0 seconds
+			method:         http.MethodPost,
+			endpoint:       "/api/where/report-problem-with-stop?key=TEST",
+			body:           []byte(`{"compositeID": "12345.json"}`),
+			expectedHeader: "no-cache, no-store, must-revalidate",
 		},
 		{
 			name:           "Error Response (No Cache on 404)",
+			method:         http.MethodGet,
 			endpoint:       "/api/where/stop/nonexistent_stop_id_123",
 			expectedHeader: "no-cache, no-store, must-revalidate",
 		},
@@ -45,9 +53,16 @@ func TestCacheControlHeaders(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			resp, err := http.Get(server.URL + tt.endpoint)
+			req, err := http.NewRequest(tt.method, server.URL+tt.endpoint, bytes.NewReader(tt.body))
 			assert.NoError(t, err)
-			defer func() { _ = resp.Body.Close() }()
+
+			if tt.method == http.MethodPost {
+				req.Header.Set("Content-Type", "application/json")
+			}
+
+			resp, err := http.DefaultClient.Do(req)
+			assert.NoError(t, err)
+			defer resp.Body.Close()
 
 			gotHeader := resp.Header.Get("Cache-Control")
 			assert.Equal(t, tt.expectedHeader, gotHeader, "Cache-Control header mismatch for %s", tt.endpoint)

--- a/internal/restapi/http_test.go
+++ b/internal/restapi/http_test.go
@@ -121,6 +121,35 @@ func serveApiAndRetrieveEndpoint(t testing.TB, api *RestAPI, endpoint string) (*
 	return resp, response
 }
 
+// serveApiAndRetrieveEndpointWithBody performs an HTTP request with a JSON body
+// against an existing API instance. Accepts testing.TB to support both *testing.T and *testing.B.
+func serveApiAndRetrieveEndpointWithBody(t testing.TB, api *RestAPI, method string, endpoint string, body []byte) (*http.Response, models.ResponseModel) {
+	mux := http.NewServeMux()
+	api.SetRoutes(mux)
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	req, err := http.NewRequest(method, server.URL+endpoint, bytes.NewReader(body))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+
+	respBody, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	var response models.ResponseModel
+	err = json.Unmarshal(respBody, &response)
+	if err != nil {
+		t.Fatalf("Failed to decode JSON. Body was: %s, Error: %v", string(respBody), err)
+	}
+	return resp, response
+}
+
 func TestCompressionMiddleware(t *testing.T) {
 	// Create a test handler that returns a large response
 	testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/restapi/report_problem_with_stop_handler.go
+++ b/internal/restapi/report_problem_with_stop_handler.go
@@ -1,6 +1,7 @@
 package restapi
 
 import (
+	"encoding/json"
 	"log/slog"
 	"net/http"
 
@@ -10,15 +11,33 @@ import (
 	"maglev.onebusaway.org/internal/utils"
 )
 
+// ReportProblemStop represents a stop-related issue report submitted by a user.
+type ReportProblemStop struct {
+	CompositeID          string   `json:"composite_id"`
+	Code                 string   `json:"code,omitempty"`
+	UserComment          string   `json:"user_comment,omitempty"`
+	UserLat              *float64 `json:"user_lat,omitempty"`
+	UserLon              *float64 `json:"user_lon,omitempty"`
+	UserLocationAccuracy *float64 `json:"user_location_accuracy,omitempty"`
+}
+
 func (api *RestAPI) reportProblemWithStopHandler(w http.ResponseWriter, r *http.Request) {
 	logger := api.Logger
 	if logger == nil {
 		logger = slog.Default()
 	}
 
-	compositeID := utils.ExtractIDFromParams(r)
+	dec := json.NewDecoder(r.Body)
+	dec.DisallowUnknownFields()
 
-	if err := utils.ValidateID(compositeID); err != nil {
+	var repProbStop ReportProblemStop
+	if err := dec.Decode(&repProbStop); err != nil {
+		logger.Error("report problem with stop failed: Error decoding json")
+		http.Error(w, `{"code":400, "text":"bad request"}`, http.StatusBadRequest)
+		return
+	}
+
+	if err := utils.ValidateID(repProbStop.CompositeID); err != nil {
 		fieldErrors := map[string][]string{
 			"id": {err.Error()},
 		}
@@ -27,10 +46,10 @@ func (api *RestAPI) reportProblemWithStopHandler(w http.ResponseWriter, r *http.
 	}
 
 	// Extract agency ID and stop ID from composite ID
-	_, stopID, err := utils.ExtractAgencyIDAndCodeID(compositeID)
+	_, stopID, err := utils.ExtractAgencyIDAndCodeID(repProbStop.CompositeID)
 	if err != nil {
 		logger.Warn("report problem with stop failed: invalid stopID format",
-			slog.String("stopID", compositeID),
+			slog.String("stopID", repProbStop.CompositeID),
 			slog.Any("error", err))
 		http.Error(w, `{"code":400, "text":"stopID is required"}`, http.StatusBadRequest)
 		return
@@ -43,32 +62,27 @@ func (api *RestAPI) reportProblemWithStopHandler(w http.ResponseWriter, r *http.
 		return
 	}
 
-	query := r.URL.Query()
-	code := query.Get("code")
-	userComment := utils.TruncateComment(query.Get("userComment"))
-	userLatStr := utils.ValidateNumericParam(query.Get("userLat"))
-	userLonStr := utils.ValidateNumericParam(query.Get("userLon"))
-	userLocationAccuracy := query.Get("userLocationAccuracy")
+	userComment := utils.TruncateComment(repProbStop.UserComment)
 
 	// Log the problem report for observability
 	logger = logging.FromContext(r.Context()).With(slog.String("component", "problem_reporting"))
 	logging.LogOperation(logger, "problem_report_received_for_stop",
 		slog.String("stop_id", stopID),
-		slog.String("code", code),
+		slog.String("code", repProbStop.Code),
 		slog.String("user_comment", userComment),
-		slog.String("user_lat", userLatStr),
-		slog.String("user_lon", userLonStr),
-		slog.String("user_location_accuracy", userLocationAccuracy))
+		slog.Any("user_lat", repProbStop.UserLat),
+		slog.Any("user_lon", repProbStop.UserLon),
+		slog.Any("user_location_accuracy", repProbStop.UserLocationAccuracy))
 
 	// Store the problem report in the database
 	now := api.Clock.Now().UnixMilli()
 	params := gtfsdb.CreateProblemReportStopParams{
 		StopID:               stopID,
-		Code:                 gtfsdb.ToNullString(code),
+		Code:                 gtfsdb.ToNullString(repProbStop.Code),
 		UserComment:          gtfsdb.ToNullString(userComment),
-		UserLat:              gtfsdb.ParseNullFloat(userLatStr),
-		UserLon:              gtfsdb.ParseNullFloat(userLonStr),
-		UserLocationAccuracy: gtfsdb.ParseNullFloat(userLocationAccuracy),
+		UserLat:              gtfsdb.Float64ToNull(repProbStop.UserLat),
+		UserLon:              gtfsdb.Float64ToNull(repProbStop.UserLon),
+		UserLocationAccuracy: gtfsdb.Float64ToNull(repProbStop.UserLocationAccuracy),
 		CreatedAt:            now,
 		SubmittedAt:          now,
 	}

--- a/internal/restapi/report_problem_with_stop_handler_test.go
+++ b/internal/restapi/report_problem_with_stop_handler_test.go
@@ -1,8 +1,9 @@
 package restapi
 
 import (
-	"fmt"
+	"encoding/json"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -10,7 +11,20 @@ import (
 )
 
 func TestReportProblemWithStopRequiresValidApiKey(t *testing.T) {
-	_, resp, model := serveAndRetrieveEndpoint(t, "/api/where/report-problem-with-stop/12345.json?key=invalid")
+	api := createTestApi(t)
+	defer api.Shutdown()
+
+	payload := ReportProblemStop{CompositeID: "12345.json"}
+	body, _ := json.Marshal(payload)
+
+	resp, model := serveApiAndRetrieveEndpointWithBody(
+		t,
+		api,
+		http.MethodPost,
+		"/api/where/report-problem-with-stop?key=invalid",
+		body,
+	)
+
 	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
 	assert.Equal(t, http.StatusUnauthorized, model.Code)
 	assert.Equal(t, "permission denied", model.Text)
@@ -20,39 +34,48 @@ func TestReportProblemWithStopEndToEnd(t *testing.T) {
 	api := createTestApi(t)
 	defer api.Shutdown()
 
-	stopId := "1_75403"
+	lat, lon, acc := 47.6097, -122.3331, 10.0
+	stopId := "1_75403.json"
 
-	url := fmt.Sprintf("/api/where/report-problem-with-stop/%s.json?key=TEST&code=stop_name_wrong&userComment=Test+comment&userLat=47.6097&userLon=-122.3331&userLocationAccuracy=10", stopId)
+	payload := ReportProblemStop{
+		CompositeID:          stopId,
+		Code:                 "stop_name_wrong",
+		UserComment:          "Test comment",
+		UserLat:              &lat,
+		UserLon:              &lon,
+		UserLocationAccuracy: &acc,
+	}
 
-	resp, model := serveApiAndRetrieveEndpoint(t, api, url)
+	body, _ := json.Marshal(payload)
+	resp, model := serveApiAndRetrieveEndpointWithBody(t, api, http.MethodPost, "/api/where/report-problem-with-stop?key=TEST", body)
 
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, 200, model.Code)
 	assert.Equal(t, "OK", model.Text)
 
 	data, ok := model.Data.(map[string]interface{})
-	require.True(t, ok, "Data should be a map")
+	require.True(t, ok)
+	assert.Empty(t, data)
 
-	assert.Empty(t, data, "Data should be an empty object")
+	payload.CompositeID = ""
+	bodyEmpty, _ := json.Marshal(payload)
+	respErr, modelErr := serveApiAndRetrieveEndpointWithBody(t, api, http.MethodPost, "/api/where/report-problem-with-stop?key=TEST", bodyEmpty)
 
-	nullURL := "/api/where/report-problem-with-stop/.json?key=TEST&code=stop_name_wrong"
-	nullResp, nullModel := serveApiAndRetrieveEndpoint(t, api, nullURL)
-
-	assert.Equal(t, http.StatusBadRequest, nullResp.StatusCode, "Should return 400 when ID is missing")
-	assert.Equal(t, 400, nullModel.Code)
-	assert.Equal(t, "id cannot be empty", nullModel.Text)
+	assert.Equal(t, http.StatusBadRequest, respErr.StatusCode)
+	assert.Equal(t, "id cannot be empty", modelErr.Text)
 }
 
 func TestReportProblemWithStop_MinimalParams(t *testing.T) {
 	api := createTestApi(t)
 	defer api.Shutdown()
 
-	// Test with only stop_id (no optional params)
-	stopID := "1_75403"
+	payload := ReportProblemStop{
+		CompositeID: "1_12345.json",
+	}
 
-	url := fmt.Sprintf("/api/where/report-problem-with-stop/%s.json?key=TEST", stopID)
+	body, _ := json.Marshal(payload)
+	resp, model := serveApiAndRetrieveEndpointWithBody(t, api, http.MethodPost, "/api/where/report-problem-with-stop?key=TEST", body)
 
-	resp, model := serveApiAndRetrieveEndpoint(t, api, url)
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 	require.Equal(t, 200, model.Code)
 }
@@ -61,23 +84,20 @@ func TestReportProblemWithStopSanitization(t *testing.T) {
 	api := createTestApi(t)
 	defer api.Shutdown()
 
-	stopId := "1_75403"
-	urlInvalidGeo := fmt.Sprintf("/api/where/report-problem-with-stop/%s.json?key=TEST&code=stop_name_wrong&userLat=invalid&userLon=not_a_number", stopId)
+	invalidJSON := []byte(`{"composite_id": "1_75403.json", "user_lat": "invalid"}`)
+	resp, _ := serveApiAndRetrieveEndpointWithBody(t, api, http.MethodPost, "/api/where/report-problem-with-stop?key=TEST", invalidJSON)
 
-	resp, model := serveApiAndRetrieveEndpoint(t, api, urlInvalidGeo)
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode, "Should return 400 for invalid types in JSON")
 
-	assert.Equal(t, http.StatusOK, resp.StatusCode, "Should handle invalid userLat/userLon gracefully without 500 error")
-	assert.Equal(t, 200, model.Code)
-	assert.Equal(t, "OK", model.Text)
-
-	longComment := make([]byte, 1000)
-	for i := range longComment {
-		longComment[i] = 'a'
+	longComment := strings.Repeat("a", 1000)
+	payload := ReportProblemStop{
+		CompositeID: "1_12345.json",
+		UserComment: longComment,
 	}
-	urlLongComment := fmt.Sprintf("/api/where/report-problem-with-stop/%s.json?key=TEST&code=stop_name_wrong&userComment=%s", stopId, string(longComment))
 
-	respLong, modelLong := serveApiAndRetrieveEndpoint(t, api, urlLongComment)
+	body, _ := json.Marshal(payload)
+	respLong, modelLong := serveApiAndRetrieveEndpointWithBody(t, api, http.MethodPost, "/api/where/report-problem-with-stop?key=TEST", body)
 
-	assert.Equal(t, http.StatusOK, respLong.StatusCode, "Should handle massive user comments gracefully")
+	assert.Equal(t, http.StatusOK, respLong.StatusCode)
 	assert.Equal(t, 200, modelLong.Code)
 }

--- a/internal/restapi/report_problem_with_trip_handler.go
+++ b/internal/restapi/report_problem_with_trip_handler.go
@@ -1,6 +1,7 @@
 package restapi
 
 import (
+	"encoding/json"
 	"log/slog"
 	"net/http"
 
@@ -10,15 +11,38 @@ import (
 	"maglev.onebusaway.org/internal/utils"
 )
 
+// ReportProblemTrip represents a trip-related issue report submitted by a user.
+type ReportProblemTrip struct {
+	CompositeID          string   `json:"composite_id"`
+	ServiceDate          string   `json:"service_date,omitempty"`
+	VehicleID            string   `json:"vehicle_id,omitempty"`
+	StopID               string   `json:"stop_id,omitempty"`
+	Code                 string   `json:"code,omitempty"`
+	UserComment          string   `json:"user_comment,omitempty"`
+	UserVehicleNumber    string   `json:"user_vehicle_number,omitempty"`
+	UserOnVehicle        string   `json:"user_on_vehicle,omitempty"`
+	UserLat              *float64 `json:"user_lat,omitempty"`
+	UserLon              *float64 `json:"user_lon,omitempty"`
+	UserLocationAccuracy *float64 `json:"user_location_accuracy,omitempty"`
+}
+
 func (api *RestAPI) reportProblemWithTripHandler(w http.ResponseWriter, r *http.Request) {
 	logger := api.Logger
 	if logger == nil {
 		logger = slog.Default()
 	}
 
-	compositeID := utils.ExtractIDFromParams(r)
+	dec := json.NewDecoder(r.Body)
+	dec.DisallowUnknownFields()
 
-	if err := utils.ValidateID(compositeID); err != nil {
+	var repProbTrip ReportProblemTrip
+	if err := dec.Decode(&repProbTrip); err != nil {
+		logger.Error("report problem with trip failed: Error decoding json")
+		http.Error(w, `{"code":400, "text":"bad request"}`, http.StatusBadRequest)
+		return
+	}
+
+	if err := utils.ValidateID(repProbTrip.CompositeID); err != nil {
 		fieldErrors := map[string][]string{
 			"id": {err.Error()},
 		}
@@ -27,10 +51,10 @@ func (api *RestAPI) reportProblemWithTripHandler(w http.ResponseWriter, r *http.
 	}
 
 	// Extract agency ID and trip ID from composite ID
-	_, tripID, err := utils.ExtractAgencyIDAndCodeID(compositeID)
+	_, tripID, err := utils.ExtractAgencyIDAndCodeID(repProbTrip.CompositeID)
 	if err != nil {
 		logger.Warn("report problem with trip failed: invalid tripID format",
-			slog.String("tripID", compositeID),
+			slog.String("tripID", repProbTrip.CompositeID),
 			slog.Any("error", err))
 		http.Error(w, `{"code":400, "text":"tripID is required"}`, http.StatusBadRequest)
 		return
@@ -43,49 +67,38 @@ func (api *RestAPI) reportProblemWithTripHandler(w http.ResponseWriter, r *http.
 		return
 	}
 
-	query := r.URL.Query()
-
-	serviceDate := query.Get("serviceDate")
-	vehicleID := query.Get("vehicleId")
-	stopID := query.Get("stopId")
-	code := query.Get("code")
-	userComment := utils.TruncateComment(query.Get("userComment"))
-	userOnVehicle := query.Get("userOnVehicle")
-	userVehicleNumber := query.Get("userVehicleNumber")
-	userLatStr := utils.ValidateNumericParam(query.Get("userLat"))
-	userLonStr := utils.ValidateNumericParam(query.Get("userLon"))
-
-	userLocationAccuracy := query.Get("userLocationAccuracy")
+	userComment := utils.TruncateComment(repProbTrip.UserComment)
 
 	// Log the problem report for observability
 	logger = logging.FromContext(r.Context()).With(slog.String("component", "problem_reporting"))
 	logging.LogOperation(logger, "problem_report_received_for_trip",
 		slog.String("trip_id", tripID),
-		slog.String("code", code),
-		slog.String("service_date", serviceDate),
-		slog.String("vehicle_id", vehicleID),
-		slog.String("stop_id", stopID),
+		slog.String("code", repProbTrip.Code),
+		slog.String("service_date", repProbTrip.ServiceDate),
+		slog.String("vehicle_id", repProbTrip.VehicleID),
+		slog.String("stop_id", repProbTrip.StopID),
 		slog.String("user_comment", userComment),
-		slog.String("user_on_vehicle", userOnVehicle),
-		slog.String("user_vehicle_number", userVehicleNumber),
-		slog.String("user_lat", userLatStr),
-		slog.String("user_lon", userLonStr),
-		slog.String("user_location_accuracy", userLocationAccuracy))
+		slog.String("user_vehicle_number", repProbTrip.UserVehicleNumber),
+
+		slog.Any("user_on_vehicle", repProbTrip.UserOnVehicle),
+		slog.Any("user_lat", repProbTrip.UserLat),
+		slog.Any("user_lon", repProbTrip.UserLon),
+		slog.Any("user_location_accuracy", repProbTrip.UserLocationAccuracy))
 
 	// Store the problem report in the database
 	now := api.Clock.Now().UnixMilli()
 	params := gtfsdb.CreateProblemReportTripParams{
 		TripID:               tripID,
-		ServiceDate:          gtfsdb.ToNullString(serviceDate),
-		VehicleID:            gtfsdb.ToNullString(vehicleID),
-		StopID:               gtfsdb.ToNullString(stopID),
-		Code:                 gtfsdb.ToNullString(code),
+		ServiceDate:          gtfsdb.ToNullString(repProbTrip.ServiceDate),
+		VehicleID:            gtfsdb.ToNullString(repProbTrip.VehicleID),
+		StopID:               gtfsdb.ToNullString(repProbTrip.StopID),
+		Code:                 gtfsdb.ToNullString(repProbTrip.Code),
 		UserComment:          gtfsdb.ToNullString(userComment),
-		UserLat:              gtfsdb.ParseNullFloat(userLatStr),
-		UserLon:              gtfsdb.ParseNullFloat(userLonStr),
-		UserLocationAccuracy: gtfsdb.ParseNullFloat(userLocationAccuracy),
-		UserOnVehicle:        gtfsdb.ParseNullBool(userOnVehicle),
-		UserVehicleNumber:    gtfsdb.ToNullString(userVehicleNumber),
+		UserLat:              gtfsdb.Float64ToNull(repProbTrip.UserLat),
+		UserLon:              gtfsdb.Float64ToNull(repProbTrip.UserLon),
+		UserLocationAccuracy: gtfsdb.Float64ToNull(repProbTrip.UserLocationAccuracy),
+		UserOnVehicle:        gtfsdb.ParseNullBool(repProbTrip.UserOnVehicle),
+		UserVehicleNumber:    gtfsdb.ToNullString(repProbTrip.UserVehicleNumber),
 		CreatedAt:            now,
 		SubmittedAt:          now,
 	}

--- a/internal/restapi/report_problem_with_trip_handler_test.go
+++ b/internal/restapi/report_problem_with_trip_handler_test.go
@@ -1,8 +1,9 @@
 package restapi
 
 import (
-	"fmt"
+	"encoding/json"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -10,7 +11,20 @@ import (
 )
 
 func TestReportProblemWithTripRequiresValidApiKey(t *testing.T) {
-	_, resp, model := serveAndRetrieveEndpoint(t, "/api/where/report-problem-with-trip/12345.json?key=invalid")
+	api := createTestApi(t)
+	defer api.Shutdown()
+
+	payload := ReportProblemTrip{CompositeID: "1_12345.json"}
+	body, _ := json.Marshal(payload)
+
+	resp, model := serveApiAndRetrieveEndpointWithBody(
+		t,
+		api,
+		http.MethodPost,
+		"/api/where/report-problem-with-trip?key=invalid",
+		body,
+	)
+
 	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
 	assert.Equal(t, http.StatusUnauthorized, model.Code)
 	assert.Equal(t, "permission denied", model.Text)
@@ -20,38 +34,47 @@ func TestReportProblemWithTripEndToEnd(t *testing.T) {
 	api := createTestApi(t)
 	defer api.Shutdown()
 
-	tripId := "1_12345"
+	lat, lon, acc := 47.6097, -122.3331, 10.0
 
-	url := fmt.Sprintf("/api/where/report-problem-with-trip/%s.json?key=TEST&serviceDate=1291536000000&vehicleId=1_3521&stopId=1_75403&code=vehicle_never_came&userComment=Test&userOnVehicle=true&userVehicleNumber=1234&userLat=47.6097&userLon=-122.3331&userLocationAccuracy=10", tripId)
+	payload := ReportProblemTrip{
+		CompositeID:          "1_12345.json",
+		ServiceDate:          "1291536000000",
+		VehicleID:            "1_3521",
+		StopID:               "1_75403",
+		Code:                 "vehicle_never_came",
+		UserComment:          "Test",
+		UserOnVehicle:        "true",
+		UserVehicleNumber:    "1234",
+		UserLat:              &lat,
+		UserLon:              &lon,
+		UserLocationAccuracy: &acc,
+	}
 
-	resp, model := serveApiAndRetrieveEndpoint(t, api, url)
+	body, _ := json.Marshal(payload)
+	resp, model := serveApiAndRetrieveEndpointWithBody(t, api, http.MethodPost, "/api/where/report-problem-with-trip?key=TEST", body)
 
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, 200, model.Code)
-	assert.Equal(t, "OK", model.Text)
 
-	data, ok := model.Data.(map[string]interface{})
-	require.True(t, ok, "Data should be a map")
+	payload.CompositeID = ""
+	bodyEmptyID, _ := json.Marshal(payload)
+	resp400, model400 := serveApiAndRetrieveEndpointWithBody(t, api, http.MethodPost, "/api/where/report-problem-with-trip?key=TEST", bodyEmptyID)
 
-	assert.Empty(t, data, "Data should be an empty object")
-
-	nullURL := "/api/where/report-problem-with-trip/.json?key=TEST&code=vehicle_never_came"
-	nullResp, nullModel := serveApiAndRetrieveEndpoint(t, api, nullURL)
-
-	assert.Equal(t, http.StatusBadRequest, nullResp.StatusCode, "Should return 400 when ID is missing")
-	assert.Equal(t, 400, nullModel.Code)
-	assert.Equal(t, "id cannot be empty", nullModel.Text)
+	assert.Equal(t, http.StatusBadRequest, resp400.StatusCode)
+	assert.Equal(t, "id cannot be empty", model400.Text)
 }
 
 func TestReportProblemWithTrip_MinimalParams(t *testing.T) {
 	api := createTestApi(t)
 	defer api.Shutdown()
 
-	tripID := "1_12345"
+	payload := ReportProblemTrip{
+		CompositeID: "1_12345.json",
+	}
 
-	url := fmt.Sprintf("/api/where/report-problem-with-trip/%s.json?key=TEST", tripID)
+	body, _ := json.Marshal(payload)
+	resp, model := serveApiAndRetrieveEndpointWithBody(t, api, http.MethodPost, "/api/where/report-problem-with-trip?key=TEST", body)
 
-	resp, model := serveApiAndRetrieveEndpoint(t, api, url)
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 	require.Equal(t, 200, model.Code)
 }
@@ -60,24 +83,20 @@ func TestReportProblemWithTripSanitization(t *testing.T) {
 	api := createTestApi(t)
 	defer api.Shutdown()
 
-	tripId := "1_12345"
+	invalidJSON := []byte(`{"composite_id": "1_12345.json", "user_lat": "invalid"}`)
+	resp, _ := serveApiAndRetrieveEndpointWithBody(t, api, http.MethodPost, "/api/where/report-problem-with-trip?key=TEST", invalidJSON)
 
-	urlInvalidGeo := fmt.Sprintf("/api/where/report-problem-with-trip/%s.json?key=TEST&code=vehicle_never_came&userLat=invalid&userLon=not_a_number", tripId)
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode, "Invalid JSON types should return 400")
 
-	resp, model := serveApiAndRetrieveEndpoint(t, api, urlInvalidGeo)
-
-	assert.Equal(t, http.StatusOK, resp.StatusCode, "Should handle invalid userLat/userLon gracefully without 500 error")
-	assert.Equal(t, 200, model.Code)
-	assert.Equal(t, "OK", model.Text)
-
-	longComment := make([]byte, 1000)
-	for i := range longComment {
-		longComment[i] = 'a'
+	longComment := strings.Repeat("a", 1000)
+	payload := ReportProblemTrip{
+		CompositeID: "1_12345.json",
+		UserComment: longComment,
 	}
-	urlLongComment := fmt.Sprintf("/api/where/report-problem-with-trip/%s.json?key=TEST&code=vehicle_never_came&userComment=%s", tripId, string(longComment))
 
-	respLong, modelLong := serveApiAndRetrieveEndpoint(t, api, urlLongComment)
+	body, _ := json.Marshal(payload)
+	respLong, modelLong := serveApiAndRetrieveEndpointWithBody(t, api, http.MethodPost, "/api/where/report-problem-with-trip?key=TEST", body)
 
-	assert.Equal(t, http.StatusOK, respLong.StatusCode, "Should handle massive user comments gracefully")
+	assert.Equal(t, http.StatusOK, respLong.StatusCode)
 	assert.Equal(t, 200, modelLong.Code)
 }

--- a/internal/restapi/routes.go
+++ b/internal/restapi/routes.go
@@ -80,8 +80,8 @@ func (api *RestAPI) SetRoutes(mux *http.ServeMux) {
 	mux.Handle("GET /api/where/arrival-and-departure-for-stop/{id}", CacheControlMiddleware(models.CacheDurationShort, rateLimitAndValidateAPIKey(api, api.arrivalAndDepartureForStopHandler)))
 	mux.Handle("GET /api/where/trips-for-route/{id}", CacheControlMiddleware(models.CacheDurationShort, rateLimitAndValidateAPIKey(api, api.tripsForRouteHandler)))
 	mux.Handle("GET /api/where/arrivals-and-departures-for-stop/{id}", CacheControlMiddleware(models.CacheDurationShort, rateLimitAndValidateAPIKey(api, api.arrivalsAndDeparturesForStopHandler)))
-	mux.Handle("GET /api/where/report-problem-with-trip/{id}", CacheControlMiddleware(models.CacheDurationNone, rateLimitAndValidateAPIKey(api, api.reportProblemWithTripHandler)))
-	mux.Handle("GET /api/where/report-problem-with-stop/{id}", CacheControlMiddleware(models.CacheDurationNone, rateLimitAndValidateAPIKey(api, api.reportProblemWithStopHandler)))
+	mux.Handle("POST /api/where/report-problem-with-trip", CacheControlMiddleware(models.CacheDurationNone, rateLimitAndValidateAPIKey(api, api.reportProblemWithTripHandler)))
+	mux.Handle("POST /api/where/report-problem-with-stop", CacheControlMiddleware(models.CacheDurationNone, rateLimitAndValidateAPIKey(api, api.reportProblemWithStopHandler)))
 }
 
 // SetupAPIRoutes creates and configures the API router with all middleware applied globally


### PR DESCRIPTION
## Description

This PR updates the `report-problem-with-trip` and `report-problem-with-stop` endpoints to use **POST** with a JSON request body instead of **GET** with query parameters.

These endpoints create new problem reports and therefore mutate application state. Using GET for this operation violates HTTP semantics (GET should be safe and non-mutating), even though strict `Cache-Control` headers were previously applied.

This change aligns the API with proper REST semantics and makes the mutation explicit in the contract.

Closes #440 

## Changes Made

- Switched both report endpoints from **GET** to **POST**
- Replaced query parameter parsing with structured JSON body decoding
- Updated route registration in `internal/restapi/routes.go`
- Updated handlers:
  - `internal/restapi/report_problem_with_stop_handler.go`
  - `internal/restapi/report_problem_with_trip_handler.go`
- Updated tests:
  - `internal/restapi/report_problem_with_stop_handler_test.go`
  - `internal/restapi/report_problem_with_trip_handler_test.go`
  - `internal/restapi/caching_middleware_test.go`
  - `internal/restapi/http_test.go`
- Added helper logic in `gtfsdb/helpers.go`.

All tests pass locally with the updated request structure.

---

## Impact

- Correct HTTP method semantics (state-changing operations use POST)
- Prevents unintended replay or prefetch risks associated with GET
- Cleaner request structure via JSON payloads
- Improves long-term API maintainability and clarity of intent
