### PR TITLE
fix: clear calendar_dates table on GTFS data import

### DIFF
--- a/gtfsdb/conditional_import_test.go
+++ b/gtfsdb/conditional_import_test.go
@@ -273,6 +273,12 @@ func TestClearAllGTFSData(t *testing.T) {
 	require.NoError(t, err, "Should be able to retrieve agencies")
 	assert.Greater(t, len(agencies), 0, "Should have agencies before clear")
 
+	// Verify calendar_dates exist before clear
+	var countBefore int
+	err = client.DB.QueryRowContext(ctx, "SELECT COUNT(*) FROM calendar_dates").Scan(&countBefore)
+	require.NoError(t, err, "Should be able to count calendar_dates before clear")
+	assert.Greater(t, countBefore, 0, "Should have calendar_dates before clear")
+
 	// Clear all data
 	err = client.clearAllGTFSData(ctx)
 	require.NoError(t, err, "Should be able to clear all GTFS data")
@@ -285,6 +291,12 @@ func TestClearAllGTFSData(t *testing.T) {
 	routesAfter, err := client.Queries.ListRoutes(ctx)
 	require.NoError(t, err, "Should be able to query routes after clear")
 	assert.Equal(t, 0, len(routesAfter), "Should have no routes after clear")
+
+	// Verify calendar_dates are cleared
+	var countAfter int
+	err = client.DB.QueryRowContext(ctx, "SELECT COUNT(*) FROM calendar_dates").Scan(&countAfter)
+	require.NoError(t, err, "Should be able to count calendar_dates after clear")
+	assert.Equal(t, 0, countAfter, "Should have no calendar_dates after clear")
 
 	// Note: Import metadata should NOT be cleared by clearAllGTFSData
 	metadata, err := client.Queries.GetImportMetadata(ctx)

--- a/gtfsdb/db.go
+++ b/gtfsdb/db.go
@@ -36,6 +36,9 @@ func Prepare(ctx context.Context, db DBTX) (*Queries, error) {
 	if q.clearCalendarStmt, err = db.PrepareContext(ctx, clearCalendar); err != nil {
 		return nil, fmt.Errorf("error preparing query ClearCalendar: %w", err)
 	}
+	if q.clearCalendarDatesStmt, err = db.PrepareContext(ctx, clearCalendarDates); err != nil {
+		return nil, fmt.Errorf("error preparing query ClearCalendarDates: %w", err)
+	}
 	if q.clearRoutesStmt, err = db.PrepareContext(ctx, clearRoutes); err != nil {
 		return nil, fmt.Errorf("error preparing query ClearRoutes: %w", err)
 	}
@@ -317,6 +320,11 @@ func (q *Queries) Close() error {
 	if q.clearCalendarStmt != nil {
 		if cerr := q.clearCalendarStmt.Close(); cerr != nil {
 			err = fmt.Errorf("error closing clearCalendarStmt: %w", cerr)
+		}
+	}
+	if q.clearCalendarDatesStmt != nil {
+		if cerr := q.clearCalendarDatesStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing clearCalendarDatesStmt: %w", cerr)
 		}
 	}
 	if q.clearRoutesStmt != nil {
@@ -792,6 +800,7 @@ type Queries struct {
 	clearBlockTripEntriesStmt                 *sql.Stmt
 	clearBlockTripIndicesStmt                 *sql.Stmt
 	clearCalendarStmt                         *sql.Stmt
+	clearCalendarDatesStmt                    *sql.Stmt
 	clearRoutesStmt                           *sql.Stmt
 	clearShapesStmt                           *sql.Stmt
 	clearStopTimesStmt                        *sql.Stmt
@@ -888,6 +897,7 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		clearBlockTripEntriesStmt:                 q.clearBlockTripEntriesStmt,
 		clearBlockTripIndicesStmt:                 q.clearBlockTripIndicesStmt,
 		clearCalendarStmt:                         q.clearCalendarStmt,
+		clearCalendarDatesStmt:                    q.clearCalendarDatesStmt,
 		clearRoutesStmt:                           q.clearRoutesStmt,
 		clearShapesStmt:                           q.clearShapesStmt,
 		clearStopTimesStmt:                        q.clearStopTimesStmt,

--- a/gtfsdb/helpers.go
+++ b/gtfsdb/helpers.go
@@ -412,6 +412,9 @@ func (c *Client) clearAllGTFSData(ctx context.Context) error {
 	if err := c.Queries.ClearTrips(ctx); err != nil {
 		return fmt.Errorf("error clearing trips: %w", err)
 	}
+	if err := c.Queries.ClearCalendarDates(ctx); err != nil {
+		return fmt.Errorf("error clearing calendar dates: %w", err)
+	}
 	if err := c.Queries.ClearCalendar(ctx); err != nil {
 		return fmt.Errorf("error clearing calendar: %w", err)
 	}

--- a/gtfsdb/query.sql
+++ b/gtfsdb/query.sql
@@ -485,6 +485,9 @@ DELETE FROM trips;
 -- name: ClearCalendar :exec
 DELETE FROM calendar;
 
+-- name: ClearCalendarDates :exec
+DELETE FROM calendar_dates;
+
 -- name: ClearStops :exec
 DELETE FROM stops;
 

--- a/gtfsdb/query.sql.go
+++ b/gtfsdb/query.sql.go
@@ -47,6 +47,15 @@ func (q *Queries) ClearCalendar(ctx context.Context) error {
 	return err
 }
 
+const clearCalendarDates = `-- name: ClearCalendarDates :exec
+DELETE FROM calendar_dates
+`
+
+func (q *Queries) ClearCalendarDates(ctx context.Context) error {
+	_, err := q.exec(ctx, q.clearCalendarDatesStmt, clearCalendarDates)
+	return err
+}
+
 const clearRoutes = `-- name: ClearRoutes :exec
 DELETE FROM routes
 `


### PR DESCRIPTION
## Description
This PR addresses Issue #81 where stale `service_ids` accumulated in the database across multiple GTFS imports because the `calendar_dates` table was never cleared.

### Key Changes:
* **Database Query**: Added `-- name: ClearCalendarDates :exec` to `gtfsdb/query.sql` to explicitly delete records from the `calendar_dates` table. Generated the corresponding sqlc models.
* **Import Cleanup Logic**: Updated `clearAllGTFSData` in `gtfsdb/helper.go` to invoke `ClearCalendarDates` during the data purge process. Placed it specifically *before* clearing the `calendar` table to strictly respect SQLite foreign key constraints.
* **Test Coverage**: Updated `TestClearAllGTFSData` in `gtfsdb/client_test.go` to explicitly verify that `calendar_dates` records exist prior to the clear operation and are completely wiped out afterward, preventing future regressions.

<img width="1917" height="488" alt="image" src="https://github.com/user-attachments/assets/a745424e-65c3-4709-a332-96a8d823f396" />

@aaronbrethorst 
fixes : #81 