### PR TITLE
Replace fmt.Printf with structured logging using slog

### DIFF
--- a/gtfsdb/helpers.go
+++ b/gtfsdb/helpers.go
@@ -117,11 +117,11 @@ func (c *Client) processAndStoreGTFSDataWithSource(b []byte, source string) erro
 		return err
 	}
 
-	logger.Info("retrieved static data", slog.Int("warnings", len(staticData.Warnings)))
+	logging.LogOperation(logger, "retrieved_static_data", slog.Int("warnings", len(staticData.Warnings)))
 
 	staticCounts = c.staticDataCounts(staticData)
 	for k, v := range staticCounts {
-		logger.Info("static data count", slog.String("entity_type", k), slog.Int("count", v))
+		logging.LogOperation(logger, "static_data_count", slog.String("entity_type", k), slog.Int("count", v))
 	}
 
 	logging.LogOperation(logger, "starting_database_import")
@@ -327,7 +327,7 @@ func (c *Client) processAndStoreGTFSDataWithSource(b []byte, source string) erro
 		return fmt.Errorf("failed to get table counts: %w", err)
 	}
 	for k, v := range counts {
-		logger.Info("table count", slog.String("table", k), slog.Int("count", v), slog.Bool("static_matches", v == staticCounts[k]))
+		logging.LogOperation(logger, "table_count", slog.String("table", k), slog.Int("count", v), slog.Bool("static_matches", v == staticCounts[k]))
 	}
 
 	logging.LogOperation(logger, "updating_import_metadata",

--- a/internal/gtfs/gtfs_manager.go
+++ b/internal/gtfs/gtfs_manager.go
@@ -469,7 +469,7 @@ func (manager *Manager) GetAllTripUpdates() []gtfs.Trip {
 // IMPORTANT: Caller must hold manager.RLock() before calling this method.
 func (manager *Manager) PrintStatistics() {
 	logger := slog.Default().With(slog.String("component", "gtfs_manager"))
-	logger.Info("GTFS statistics",
+	logging.LogOperation(logger, "gtfs_statistics",
 		slog.String("source", manager.config.GtfsURL),
 		slog.Bool("local_file", manager.isLocalFile),
 		slog.Time("last_updated", manager.lastUpdated),


### PR DESCRIPTION
This PR replaces fmt.Printf debug statements with structured logging using slog.

Changes:
- Updated logging in gtfs_manager.go (PrintStatistics)
- Updated logging in gtfsdb/helpers.go
- Replaced fmt.Printf / fmt.Println with slog.Info and structured fields
- Removed unnecessary separator prints
- Avoided fmt.Sprintf in logging

This improves log consistency and makes logs easier to process in production environments.