### PR TITLE
perf: implement ETag conditional caching for static endpoints

### DIFF
--- a/internal/restapi/caching_middleware.go
+++ b/internal/restapi/caching_middleware.go
@@ -3,6 +3,7 @@ package restapi
 import (
 	"fmt"
 	"net/http"
+	"strings"
 )
 
 // CacheControlMiddleware adds Cache-Control headers based on the tier
@@ -32,7 +33,8 @@ type cacheControlWriter struct {
 func (w *cacheControlWriter) WriteHeader(code int) {
 	if !w.headerWritten {
 		w.headerWritten = true
-		if code >= 200 && code < 300 {
+		// 304 Not Modified must preserve cache headers
+		if (code >= 200 && code < 300) || code == http.StatusNotModified {
 			w.ResponseWriter.Header().Set("Cache-Control", w.headerValue)
 		} else {
 			w.ResponseWriter.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate")
@@ -46,4 +48,38 @@ func (w *cacheControlWriter) Write(b []byte) (int, error) {
 		w.WriteHeader(http.StatusOK)
 	}
 	return w.ResponseWriter.Write(b)
+}
+
+// ETagMiddleware handles Conditional HTTP requests by comparing the incoming
+// If-None-Match header against the current system ETag.
+func ETagMiddleware(getETag func() string) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			etag := getETag()
+			if etag != "" {
+				inm := r.Header.Get("If-None-Match")
+				// Check for wildcard or iterate through parsed comma-separated parts
+				if inm != "" {
+					if inm == "*" {
+						w.Header().Set("ETag", etag)
+						w.WriteHeader(http.StatusNotModified)
+						return
+					}
+
+					parts := strings.Split(inm, ",")
+					for _, part := range parts {
+						if strings.TrimSpace(part) == etag {
+							// RFC 7232: 304 response MUST include the ETag header
+							w.Header().Set("ETag", etag)
+							w.WriteHeader(http.StatusNotModified)
+							return
+						}
+					}
+				}
+				// Otherwise, attach the ETag to the response and proceed normally
+				w.Header().Set("ETag", etag)
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
 }


### PR DESCRIPTION
### Description

This PR implements **Conditional HTTP Requests (`ETag` / `304 Not Modified`)** for static GTFS endpoints. It allows returning clients to skip downloading multi-megabyte JSON payloads when the underlying GTFS dataset hasn't changed.

While building this, I also fixed a latent bug in the caching middleware that was incorrectly overwriting cache headers on `304` responses.

closes #445 

### Changes Made

* **Zero-cost Hashing:** Added `SystemETag` to the `gtfs.Manager`. It automatically populates using the existing SHA-256 `FileHash` generated during database import, avoiding any runtime hashing overhead.
* **Middleware Bug Fix:** Updated `cacheControlWriter` in `caching_middleware.go` to preserve `Cache-Control` headers for `304 Not Modified` responses.
* **New Middleware:** Added `ETagMiddleware` to intercept `If-None-Match` headers. If the hashes match, it short-circuits the request and returns a `304` with an empty body.
* **Targeted Application:** Created the `etagStatic` helper in `routes.go` and applied it **strictly to static endpoints** (agencies, routes, stops, shapes, etc.). Real-time endpoints were deliberately excluded so vehicle data is never served stale.

### Impact

* **Bandwidth:** Drops payload size from several Megabytes to ~200 bytes for returning clients.
* **CPU:** Bypasses routing, database queries, and JSON serialization entirely on cache hits.
* **Stability:** Ensures clients actually cache `304` responses by fixing the middleware conflict.