### PR TITLE
Fix Docker workflow failure emails on cancelled builds

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -17,18 +17,28 @@ jobs:
     runs-on: ubuntu-latest
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
-      cancel-in-progress: true
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+      - name: Check if build is needed
+        id: check
+        run: |
+          LATEST_SHA=$(git ls-remote origin refs/heads/main | awk '{print $1}')
+          if [ "${{ github.sha }}" != "$LATEST_SHA" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::Build skipped — commit ${{ github.sha }} has been superseded by ${LATEST_SHA}."
+          fi
       - name: Set up QEMU
+        if: steps.check.outputs.skip != 'true'
         uses: docker/setup-qemu-action@v3
         with:
           platforms: linux/amd64,linux/arm64
       - name: Set up Docker Buildx
+        if: steps.check.outputs.skip != 'true'
         id: buildx
         uses: docker/setup-buildx-action@v3
       - name: Inspect builder
+        if: steps.check.outputs.skip != 'true'
         run: |
           echo "Name:      ${{ steps.buildx.outputs.name }}"
           echo "Endpoint:  ${{ steps.buildx.outputs.endpoint }}"
@@ -36,12 +46,14 @@ jobs:
           echo "Flags:     ${{ steps.buildx.outputs.flags }}"
           echo "Platforms: ${{ steps.buildx.outputs.platforms }}"
       - name: Login to GitHub Container Registry
+        if: steps.check.outputs.skip != 'true'
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push images
+        if: steps.check.outputs.skip != 'true'
         uses: docker/build-push-action@v5
         with:
           context: .


### PR DESCRIPTION
## Summary
- When multiple PRs are merged in quick succession, the Docker workflow's `cancel-in-progress: true` setting forcefully cancels in-progress builds. GitHub treats cancelled runs as failures and sends email notifications for each one.
- This replaces `cancel-in-progress: true` with a "check if build is needed" step that compares the current commit against the latest on `main`. Superseded runs skip the expensive Docker build and exit with **success** status — no more spurious failure emails.
- The concurrency group is preserved (without `cancel-in-progress`) so builds still run one at a time.

## Test plan
- [ ] Merge this PR and then merge another PR shortly after — verify no failure email is received
- [ ] Verify the latest commit's Docker image is still built and pushed to GHCR
- [ ] Check that the superseded run shows a "Build skipped" notice annotation instead of a cancelled status