### PR TITLE
Fix nullsafe shortname fallback

### DIFF
--- a/internal/gtfs/shapes_test.go
+++ b/internal/gtfs/shapes_test.go
@@ -80,7 +80,7 @@ func TestGetRegionBounds(t *testing.T) {
 			expectedLonSpan: 0.0,
 		},
 		{
-			name: "Fallback to Stops",
+			name:   "Fallback to Stops",
 			shapes: []gtfs.Shape{},
 			stops: []gtfs.Stop{
 				{Latitude: fptr(47.0), Longitude: fptr(-122.0)},

--- a/internal/models/routes.go
+++ b/internal/models/routes.go
@@ -15,7 +15,12 @@ type Route struct {
 	URL               string    `json:"url"`
 }
 
-func NewRoute(id, agencyID, shortName, longName, description string, routeType RouteType, url, color, textColor, nullSafeShortName string) Route {
+func NewRoute(id, agencyID, shortName, longName, description string, routeType RouteType, url, color, textColor string) Route {
+	nullSafeShortName := shortName
+	if nullSafeShortName == "" {
+		nullSafeShortName = longName
+	}
+
 	return Route{
 		AgencyID:          agencyID,
 		Color:             color,

--- a/internal/models/routes_test.go
+++ b/internal/models/routes_test.go
@@ -2,8 +2,9 @@ package models
 
 import (
 	"encoding/json"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestRouteCreation(t *testing.T) {
@@ -16,12 +17,10 @@ func TestRouteCreation(t *testing.T) {
 	url := "https://transit.org/routes/1"
 	color := "FF0000"
 	textColor := "FFFFFF"
-	nullSafeShortName := "A"
 
 	route := NewRoute(
 		id, agencyID, shortName, longName, description,
-		routeType, url, color, textColor, nullSafeShortName,
-	)
+		routeType, url, color, textColor)
 
 	assert.Equal(t, id, route.ID)
 	assert.Equal(t, agencyID, route.AgencyID)
@@ -32,7 +31,7 @@ func TestRouteCreation(t *testing.T) {
 	assert.Equal(t, url, route.URL)
 	assert.Equal(t, color, route.Color)
 	assert.Equal(t, textColor, route.TextColor)
-	assert.Equal(t, nullSafeShortName, route.NullSafeShortName)
+	assert.Equal(t, "A", route.NullSafeShortName)
 }
 
 func TestRouteJSON(t *testing.T) {
@@ -69,7 +68,7 @@ func TestRouteJSON(t *testing.T) {
 }
 
 func TestRouteWithEmptyValues(t *testing.T) {
-	route := NewRoute("", "", "", "", "", 0, "", "", "", "")
+	route := NewRoute("", "", "", "", "", 0, "", "", "")
 
 	assert.Equal(t, "", route.ID)
 	assert.Equal(t, "", route.AgencyID)
@@ -101,8 +100,8 @@ func TestRouteWithNilValuesJSON(t *testing.T) {
 }
 
 func TestRouteDataJSON(t *testing.T) {
-	route1 := NewRoute("1", "agency-1", "A", "Route A", "Description A", 3, "url-a", "FF0000", "FFFFFF", "A")
-	route2 := NewRoute("2", "agency-1", "B", "Route B", "Description B", 2, "url-b", "00FF00", "000000", "B")
+	route1 := NewRoute("1", "agency-1", "A", "Route A", "Description A", 3, "url-a", "FF0000", "FFFFFF")
+	route2 := NewRoute("2", "agency-1", "B", "Route B", "Description B", 2, "url-b", "00FF00", "000000")
 
 	routeData := RouteData{
 		LimitExceeded: false,
@@ -124,7 +123,7 @@ func TestRouteDataJSON(t *testing.T) {
 }
 
 func TestRouteResponseJSON(t *testing.T) {
-	route := NewRoute("1", "agency-1", "A", "Route A", "Description A", 3, "url-a", "FF0000", "FFFFFF", "A")
+	route := NewRoute("1", "agency-1", "A", "Route A", "Description A", 3, "url-a", "FF0000", "FFFFFF")
 
 	references := ReferencesModel{
 		Agencies: []AgencyReference{
@@ -169,4 +168,15 @@ func TestRouteResponseJSON(t *testing.T) {
 
 	assert.Len(t, unmarshaledResponse.Data.References.Agencies, 1)
 	assert.Equal(t, "agency-1", unmarshaledResponse.Data.References.Agencies[0].ID)
+}
+
+func TestRouteNullSafeShortNameFallback(t *testing.T) {
+	// When shortName is empty, NullSafeShortName should fall back to longName
+	route := NewRoute("1", "agency-1", "", "Downtown Express", "", 3, "", "", "")
+	assert.Equal(t, "Downtown Express", route.NullSafeShortName)
+	assert.Equal(t, "", route.ShortName) // ShortName itself stays empty
+
+	// When shortName is present, NullSafeShortName should use it
+	route2 := NewRoute("2", "agency-1", "DX", "Downtown Express", "", 3, "", "", "")
+	assert.Equal(t, "DX", route2.NullSafeShortName)
 }

--- a/internal/restapi/arrival_and_departure_for_stop_handler.go
+++ b/internal/restapi/arrival_and_departure_for_stop_handler.go
@@ -468,9 +468,8 @@ func (api *RestAPI) arrivalAndDepartureForStopHandler(w http.ResponseWriter, r *
 			models.RouteType(route.Type),
 			route.Url.String,
 			route.Color.String,
-			route.TextColor.String,
-			route.ShortName.String,
-		)
+			route.TextColor.String)
+
 		references.Routes = append(references.Routes, routeRef)
 	}
 

--- a/internal/restapi/arrivals_and_departure_for_stop.go
+++ b/internal/restapi/arrivals_and_departure_for_stop.go
@@ -508,9 +508,8 @@ func (api *RestAPI) arrivalsAndDeparturesForStopHandler(w http.ResponseWriter, r
 			models.RouteType(route.Type),
 			route.Url.String,
 			route.Color.String,
-			route.TextColor.String,
-			route.ShortName.String,
-		)
+			route.TextColor.String)
+
 		references.Routes = append(references.Routes, routeRef)
 	}
 

--- a/internal/restapi/route_handler.go
+++ b/internal/restapi/route_handler.go
@@ -32,9 +32,7 @@ func (api *RestAPI) routeHandler(w http.ResponseWriter, r *http.Request) {
 		models.RouteType(route.Type),
 		route.Url.String,
 		route.Color.String,
-		route.TextColor.String,
-		utils.NullStringOrEmpty(route.ShortName),
-	)
+		route.TextColor.String)
 
 	references := models.NewEmptyReferences()
 

--- a/internal/restapi/route_search_handler.go
+++ b/internal/restapi/route_search_handler.go
@@ -108,9 +108,7 @@ func (api *RestAPI) routeSearchHandler(w http.ResponseWriter, r *http.Request) {
 			models.RouteType(routeRow.Type),
 			url,
 			color,
-			textColor,
-			shortName,
-		))
+			textColor))
 	}
 
 	agencies := utils.FilterAgencies(api.GtfsManager.GetAgencies(), agencyIDs)

--- a/internal/restapi/routes_for_agency_handler.go
+++ b/internal/restapi/routes_for_agency_handler.go
@@ -32,8 +32,7 @@ func (api *RestAPI) routesForAgencyHandler(w http.ResponseWriter, r *http.Reques
 		routesList = append(routesList, models.NewRoute(
 			utils.FormCombinedID(route.Agency.Id, route.Id), route.Agency.Id, route.ShortName, route.LongName,
 			route.Description, models.RouteType(route.Type),
-			route.Url, route.Color, route.TextColor, route.ShortName,
-		))
+			route.Url, route.Color, route.TextColor))
 	}
 
 	references := models.ReferencesModel{

--- a/internal/restapi/routes_for_location_handler.go
+++ b/internal/restapi/routes_for_location_handler.go
@@ -120,9 +120,7 @@ func (api *RestAPI) routesForLocationHandler(w http.ResponseWriter, r *http.Requ
 				models.RouteType(routeRow.Type),
 				routeRow.Url.String,
 				routeRow.Color.String,
-				routeRow.TextColor.String,
-				routeRow.ShortName.String,
-			))
+				routeRow.TextColor.String))
 		}
 		routeIDs[combinedRouteID] = true
 		if len(results) >= maxCount {

--- a/internal/restapi/schedule_for_route_handler.go
+++ b/internal/restapi/schedule_for_route_handler.go
@@ -107,9 +107,8 @@ func (api *RestAPI) scheduleForRouteHandler(w http.ResponseWriter, r *http.Reque
 		models.RouteType(route.Type),
 		route.Url.String,
 		route.Color.String,
-		route.TextColor.String,
-		route.ShortName.String,
-	)
+		route.TextColor.String)
+
 	routeRefs[utils.FormCombinedID(agencyID, route.ID)] = routeModel
 
 	type tripGroupKey struct {

--- a/internal/restapi/schedule_for_stop_handler.go
+++ b/internal/restapi/schedule_for_stop_handler.go
@@ -178,9 +178,8 @@ func (api *RestAPI) scheduleForStopHandler(w http.ResponseWriter, r *http.Reques
 					models.RouteType(route.Type),
 					route.Url.String,
 					route.Color.String,
-					route.TextColor.String,
-					route.ShortName.String,
-				)
+					route.TextColor.String)
+
 				routeRefs[combinedRouteID] = routeModel
 			}
 		}

--- a/internal/restapi/search_stops_handler.go
+++ b/internal/restapi/search_stops_handler.go
@@ -198,9 +198,8 @@ func (api *RestAPI) searchStopsHandler(w http.ResponseWriter, r *http.Request) {
 				models.RouteType(row.Type),
 				url,
 				color,
-				textColor,
-				shortName,
-			)
+				textColor)
+
 		}
 	}
 

--- a/internal/restapi/stop_handler.go
+++ b/internal/restapi/stop_handler.go
@@ -66,9 +66,8 @@ func (api *RestAPI) stopHandler(w http.ResponseWriter, r *http.Request) {
 			models.RouteType(route.Type),
 			route.Url.String,
 			route.Color.String,
-			route.TextColor.String,
-			route.ShortName.String,
-		)
+			route.TextColor.String)
+
 		references.Routes = append(references.Routes, routeModel)
 		uniqueAgencyIDs[route.AgencyID] = true
 	}

--- a/internal/restapi/trip_for_vehicle_handler.go
+++ b/internal/restapi/trip_for_vehicle_handler.go
@@ -260,9 +260,8 @@ func (api *RestAPI) tripForVehicleHandler(w http.ResponseWriter, r *http.Request
 			models.RouteType(route.Type),
 			route.Url.String,
 			route.Color.String,
-			route.TextColor.String,
-			route.ShortName.String,
-		)
+			route.TextColor.String)
+
 		references.Routes = append(references.Routes, routeModel)
 	}
 

--- a/internal/restapi/trip_handler.go
+++ b/internal/restapi/trip_handler.go
@@ -76,9 +76,7 @@ func (api *RestAPI) tripHandler(w http.ResponseWriter, r *http.Request) {
 		models.RouteType(route.Type),
 		route.Url.String,
 		route.Color.String,
-		route.TextColor.String,
-		route.ShortName.String,
-	))
+		route.TextColor.String))
 
 	references.Agencies = append(references.Agencies, models.NewAgencyReference(
 		agency.ID,

--- a/internal/restapi/trips_for_location_handler.go
+++ b/internal/restapi/trips_for_location_handler.go
@@ -602,9 +602,8 @@ func (rb *referenceBuilder) createRoute(route gtfsdb.Route) models.Route {
 		models.RouteType(route.Type),
 		route.Url.String,
 		route.Color.String,
-		route.TextColor.String,
-		route.ShortName.String,
-	)
+		route.TextColor.String)
+
 }
 
 func (rb *referenceBuilder) addAgency(agencyID string) error {

--- a/internal/restapi/trips_for_route_handler.go
+++ b/internal/restapi/trips_for_route_handler.go
@@ -393,9 +393,8 @@ func buildTripReferences[T interface{ GetTripId() string }](
 				models.RouteType(route.Type),
 				route.Url.String,
 				route.Color.String,
-				route.TextColor.String,
-				route.ShortName.String,
-			)
+				route.TextColor.String)
+
 			// Identify Agency IDs needed
 			if _, exists := presentAgencies[route.AgencyID]; !exists {
 				currentAgency, err := api.GtfsManager.GtfsDB.Queries.GetAgency(ctx, route.AgencyID)

--- a/internal/restapi/vehicles_for_agency_handler.go
+++ b/internal/restapi/vehicles_for_agency_handler.go
@@ -131,8 +131,8 @@ func (api *RestAPI) vehiclesForAgencyHandler(w http.ResponseWriter, r *http.Requ
 				routeRefs[route.ID] = models.NewRoute(
 					route.ID, route.AgencyID, shortName, longName,
 					desc, models.RouteType(route.Type),
-					url, color, textColor, shortName,
-				)
+					url, color, textColor)
+
 			}
 		}
 

--- a/internal/utils/filters.go
+++ b/internal/utils/filters.go
@@ -35,8 +35,7 @@ func FilterRoutes(q *gtfsdb.Queries, ctx context.Context, present map[string]boo
 			refs = append(refs, models.NewRoute(
 				routeIDStr, r.AgencyID, r.ShortName.String, r.LongName.String,
 				r.Desc.String, models.RouteType(r.Type), r.Url.String,
-				r.Color.String, r.TextColor.String, r.ShortName.String,
-			))
+				r.Color.String, r.TextColor.String))
 		}
 	}
 	return refs
@@ -52,8 +51,7 @@ func GetAllRoutesRefs(q *gtfsdb.Queries, ctx context.Context) []interface{} {
 		refs = append(refs, models.NewRoute(
 			FormCombinedID(r.AgencyID, r.ID), r.AgencyID, r.ShortName.String, r.LongName.String,
 			r.Desc.String, models.RouteType(r.Type), r.Url.String,
-			r.Color.String, r.TextColor.String, r.ShortName.String,
-		))
+			r.Color.String, r.TextColor.String))
 	}
 	return refs
 }


### PR DESCRIPTION
fixes #451 

Updated the signature of `models.NewRoute()` to completely drop the nullSafeShortName parameter (now it correctly expects 9 arguments instead of 10).
Centralized the fallback logic exclusively within the `models.NewRoute` constructor:
```go
nullSafeShortName := shortName
if nullSafeShortName == "" {
    nullSafeShortName = longName
}
```