### PR TITLE
fix(restapi): add missing RLock in routesForAgencyHandler

### DIFF
--- a/internal/restapi/routes_for_agency_handler.go
+++ b/internal/restapi/routes_for_agency_handler.go
@@ -10,6 +10,9 @@ import (
 func (api *RestAPI) routesForAgencyHandler(w http.ResponseWriter, r *http.Request) {
 	id, _ := utils.GetIDFromContext(r.Context())
 
+	api.GtfsManager.RLock()
+	defer api.GtfsManager.RUnlock()
+
 	agency := api.GtfsManager.FindAgency(id)
 
 	if agency == nil {


### PR DESCRIPTION
**Description:**
This PR resolves a data race condition in `routesForAgencyHandler` that occurs when a `ForceUpdate` is in progress.

Currently, `FindAgency()` and `RoutesForAgencyID()` are called without acquiring the required read lock, violating the documented contract. This fix adds `api.GtfsManager.RLock()` and `defer api.GtfsManager.RUnlock()` prior to accessing the manager, matching the thread-safe pattern used in `vehiclesForAgencyHandler`.

**Related Issue:**
Closes #455 

The test are passing perfectly

<img width="838" height="322" alt="image" src="https://github.com/user-attachments/assets/b1c15112-75e1-4732-9831-df43c8daebb0" />
