### PR TITLE
docker: Fix SQLITE error for docker dev.

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -19,7 +19,7 @@ RUN go install github.com/go-delve/delve/cmd/dlv@latest
 
 # Create app directory and set ownership
 # Critical Fix: chown -R /go ensures the maglev user can access the Go module cache volume
-RUN mkdir -p /app && \
+RUN mkdir -p /app/data && \
     addgroup -g ${GROUP_ID} maglev && \
     adduser -u ${USER_ID} -G maglev -s /bin/sh -D maglev && \
     chown -R maglev:maglev /app && \


### PR DESCRIPTION
Fixes #463

When running docker in dev move (e.g., using `make docker-compose-dev`) SQLITE throws the following error:
```shell
ERROR failed to set SQLite pragma component=sqlite_performance 
error="unable to open database file: no such file or directory" pragma="Set cache size to 64MB"
``` 
## Cause
Permission misconfiguration inside `Dockerfile.dev`:

Unlike `Dockerfile`,  `Dockerfile.dev` creates `/app` folder and recursively changes ownership to maglev user, **BUT** this happens before `app/data/` folder is created. As a result, `/data` is left with root permission while SQLite attempts to write to it as maglev user.

## Fix

Simply create `/app/data` early while keeping the `-p` flag so the parent dir `/app` is created if it didn't exist