### PR TITLE
Fix: index.html and marketing assets not served in Docker deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -28,8 +28,7 @@ coverage.out
 *~
 .DS_Store
 
-# Documentation and marketing (not needed in container)
-marketing/
+# Documentation (not needed in container)
 *.md
 !README.markdown
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -72,6 +72,8 @@ RUN mkdir -p /app/data && chown -R maglev:maglev /app
 COPY --from=builder /build/maglev .
 # Copy example config (users should mount their own config.json)
 COPY --from=builder /build/config.example.json ./config.example.json
+COPY --from=builder /build/index.html ./index.html
+COPY --from=builder /build/marketing/ ./marketing/
 
 # Set ownership
 RUN chown -R maglev:maglev /app


### PR DESCRIPTION
## Description

Fixes an issue where `GET /` returned **404 Not Found** when running Maglev via Docker.

The issue was caused by:
- `marketing` being excluded in `.dockerignore`, preventing static assets from being included in the build context.
- `Dockerfile` not copying `index.html` and `marketing` into the runtime image.

## Changes

- Removed `marketing` from `.dockerignore`
- Added COPY instructions in the runtime stage to include:
  - `index.html`
  - `marketing/` directory

Fixes #466 