### PR TITLE
fix: propagate context to GetVehicleForTrip to prevent db connection leaks

### DIFF
--- a/internal/gtfs/gtfs_manager.go
+++ b/internal/gtfs/gtfs_manager.go
@@ -413,8 +413,9 @@ func (manager *Manager) VehiclesForAgencyID(agencyID string) []gtfs.Vehicle {
 // for that trip. Note we depend on getting the vehicle that may not match the trip ID exactly,
 // but is part of the same block.
 // IMPORTANT: Caller must hold manager.RLock() before calling this method.
-func (manager *Manager) GetVehicleForTrip(tripID string) *gtfs.Vehicle {
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+func (manager *Manager) GetVehicleForTrip(ctx context.Context, tripID string) *gtfs.Vehicle {
+
+	ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
 	defer cancel()
 
 	logger := slog.Default().With(slog.String("component", "gtfs_manager"))

--- a/internal/gtfs/gtfs_manager_test.go
+++ b/internal/gtfs/gtfs_manager_test.go
@@ -353,7 +353,7 @@ func TestManager_GetVehicleForTrip(t *testing.T) {
 
 	manager.rebuildMergedRealtimeLocked()
 
-	vehicle := manager.GetVehicleForTrip("5735633")
+	vehicle := manager.GetVehicleForTrip(context.Background(), "5735633")
 	if vehicle != nil {
 		assert.NotNil(t, vehicle)
 		assert.Equal(t, "vehicle1", vehicle.ID.ID)

--- a/internal/restapi/arrival_and_departure_for_stop_handler.go
+++ b/internal/restapi/arrival_and_departure_for_stop_handler.go
@@ -266,7 +266,7 @@ func (api *RestAPI) arrivalAndDepartureForStopHandler(w http.ResponseWriter, r *
 		}
 	} else {
 		// If vehicleId is not provided, get the vehicle for the trip
-		vehicle = api.GtfsManager.GetVehicleForTrip(tripID)
+		vehicle = api.GtfsManager.GetVehicleForTrip(ctx, tripID)
 	}
 
 	if vehicle != nil && vehicle.Trip != nil {

--- a/internal/restapi/arrivals_and_departure_for_stop.go
+++ b/internal/restapi/arrivals_and_departure_for_stop.go
@@ -292,7 +292,7 @@ func (api *RestAPI) arrivalsAndDeparturesForStopHandler(w http.ResponseWriter, r
 		)
 
 		// Get real-time updates from GTFS-RT
-		vehicle := api.GtfsManager.GetVehicleForTrip(st.TripID)
+		vehicle := api.GtfsManager.GetVehicleForTrip(ctx, st.TripID)
 		if vehicle != nil && vehicle.Trip != nil {
 			vehicleID = vehicle.ID.ID
 

--- a/internal/restapi/trips_helper.go
+++ b/internal/restapi/trips_helper.go
@@ -24,7 +24,7 @@ func (api *RestAPI) BuildTripStatus(
 	currentTime time.Time,
 
 ) (*models.TripStatusForTripDetails, error) {
-	vehicle := api.GtfsManager.GetVehicleForTrip(tripID)
+	vehicle := api.GtfsManager.GetVehicleForTrip(ctx, tripID)
 
 	var occupancyStatus string
 	var vehicleID string


### PR DESCRIPTION
## Description
This PR resolves a stability issue where orphaned database queries were not properly cancelled when HTTP clients disconnected early. `GetVehicleForTrip` previously spun up an isolated `context.Background()` with a hardcoded timeout, leading to potential database connection pool exhaustion under heavy load or client disconnects. 

## Changes Made
- [x] Modified `internal/gtfs/gtfs_manager.go`: `GetVehicleForTrip` now accepts and wraps the HTTP request context.
- [x] Updated downstream API handlers (e.g., `arrival_and_departure_for_stop_handler.go` and `arrivals_and_departure_for_stop.go`) to properly pass `r.Context()` to `GetVehicleForTrip`.
- [x] Updated `gtfs_manager_test.go` to provide a context in test cases.
- [x] Ensured proper `defer cancel()` execution to prevent memory leaks on the context tree.
- [x] Verified that downstream SQLite `GtfsDB.Queries` successfully inherit the propagated context.
- [x] Ran `make fmt`, `make lint`, and `make test` successfully.

Closes #472