### PR TITLE
feat: refactor GTFS realtime data storage to use a `FeedData` struct per feed with granular locking

### DIFF
--- a/internal/gtfs/agency_filter_test.go
+++ b/internal/gtfs/agency_filter_test.go
@@ -383,12 +383,8 @@ func TestAgencyFilterFeedAgencyFilterPopulation(t *testing.T) {
 		realTimeTripLookup:             make(map[string]int),
 		realTimeVehicleLookupByTrip:    make(map[string]int),
 		realTimeVehicleLookupByVehicle: make(map[string]int),
-		feedTrips:                      make(map[string][]gtfs.Trip),
-		feedVehicles:                   make(map[string][]gtfs.Vehicle),
-		feedAlerts:                     make(map[string][]gtfs.Alert),
+		feedData:                       make(map[string]*FeedData),
 		feedAgencyFilter:               make(map[string]map[string]bool),
-		feedVehicleLastSeen:            make(map[string]map[string]time.Time),
-		feedVehicleTimestamp:           make(map[string]uint64),
 	}
 
 	// Simulate what InitGTFSManager does for populating feedAgencyFilter
@@ -570,11 +566,11 @@ func TestAgencyFilterMultipleFeedsIntegration(t *testing.T) {
 	filteredA := manager.filterTripsByAgency(tripsA, filterA)
 	filteredB := manager.filterTripsByAgency(tripsB, filterB)
 
-	manager.realTimeMutex.Lock()
-	manager.feedTrips["feed-a"] = filteredA
-	manager.feedTrips["feed-b"] = filteredB
-	manager.rebuildMergedRealtimeLocked()
-	manager.realTimeMutex.Unlock()
+	manager.feedMapMutex.Lock()
+	manager.feedData["feed-a"] = &FeedData{Trips: filteredA, VehicleLastSeen: make(map[string]time.Time)}
+	manager.feedData["feed-b"] = &FeedData{Trips: filteredB, VehicleLastSeen: make(map[string]time.Time)}
+	manager.feedMapMutex.Unlock()
+	manager.buildMergedRealtime()
 
 	allTrips := manager.GetRealTimeTrips()
 	assert.Len(t, allTrips, 2, "merged view should have T1 (agency-A from feed-a) and T5 (agency-B from feed-b)")
@@ -717,15 +713,17 @@ func TestFeedVehicleRetentionWithAgencyFilter(t *testing.T) {
 	ts := now.Add(-1 * time.Minute)
 
 	// Seed initial vehicle data
-	manager.realTimeMutex.Lock()
-	manager.feedVehicles["feed"] = []gtfs.Vehicle{
-		{ID: vid, Trip: &gtfs.Trip{ID: gtfs.TripID{RouteID: "R1"}}, Timestamp: &ts},
+	manager.feedMapMutex.Lock()
+	manager.feedData["feed"] = &FeedData{
+		Vehicles: []gtfs.Vehicle{
+			{ID: vid, Trip: &gtfs.Trip{ID: gtfs.TripID{RouteID: "R1"}}, Timestamp: &ts},
+		},
+		VehicleLastSeen: map[string]time.Time{
+			"V1": now,
+		},
 	}
-	manager.feedVehicleLastSeen["feed"] = map[string]time.Time{
-		"V1": now,
-	}
-	manager.rebuildMergedRealtimeLocked()
-	manager.realTimeMutex.Unlock()
+	manager.feedMapMutex.Unlock()
+	manager.buildMergedRealtime()
 
 	vehicles := manager.GetRealTimeVehicles()
 	assert.Len(t, vehicles, 1, "seeded vehicle should be present")

--- a/internal/gtfs/gtfs_manager.go
+++ b/internal/gtfs/gtfs_manager.go
@@ -73,18 +73,15 @@ type Manager struct {
 
 	feedExpiresAt time.Time // Holds the max valid service date for the static feed
 
-	feedTrips    map[string][]gtfs.Trip
-	feedVehicles map[string][]gtfs.Vehicle
-	feedAlerts   map[string][]gtfs.Alert
+	feedMapMutex sync.RWMutex
+	feedData     map[string]*FeedData
+
+	mergeMutex sync.Mutex
+
 	// Per-feed agency filter: feedID -> set of allowed agency IDs.
 	// Populated once during InitGTFSManager before goroutines start; read-only thereafter.
 	// No lock is required for reads.
 	feedAgencyFilter map[string]map[string]bool
-	// Per-feed, per-vehicle last-seen timestamps for stale vehicle expiry
-	feedVehicleLastSeen map[string]map[string]time.Time // feedID -> vehicleID -> lastSeen
-
-	// Per-feed last successfully applied vehicle feed timestamp
-	feedVehicleTimestamp map[string]uint64 // feedID -> timestamp
 
 	// Exported metrics client dependency
 	Metrics *metrics.Metrics
@@ -107,21 +104,37 @@ type Manager struct {
 	cacheEpoch atomic.Uint64
 }
 
+// FeedData holds real-time data for a specific feed
+type FeedData struct {
+	mu               sync.RWMutex
+	Trips            []gtfs.Trip
+	Vehicles         []gtfs.Vehicle
+	Alerts           []gtfs.Alert
+	VehicleLastSeen  map[string]time.Time
+	VehicleTimestamp uint64 // last successfully applied vehicle feed timestamp
+}
+
 // clearFeedData removes stale data for a specific feed when the staleness threshold is crossed
 func (manager *Manager) clearFeedData(feedID string) {
-	manager.realTimeMutex.Lock()
-	defer manager.realTimeMutex.Unlock()
+	manager.feedMapMutex.RLock()
+	feed := manager.feedData[feedID]
+	manager.feedMapMutex.RUnlock()
 
-	manager.feedTrips[feedID] = nil
-	manager.feedVehicles[feedID] = nil
-	manager.feedAlerts[feedID] = nil
+	if feed == nil {
+		return
+	}
 
-	delete(manager.feedVehicleTimestamp, feedID)
-	delete(manager.feedVehicleLastSeen, feedID)
+	feed.mu.Lock()
+	feed.Trips = nil
+	feed.Vehicles = nil
+	feed.Alerts = nil
+	feed.VehicleTimestamp = 0
+	feed.VehicleLastSeen = make(map[string]time.Time)
+	feed.mu.Unlock()
 
 	delete(manager.feedLastUpdate, feedID)
 
-	manager.rebuildMergedRealtimeLocked()
+	manager.buildMergedRealtime()
 }
 
 // IsReady returns true if the GTFS data is fully initialized and indexed.
@@ -260,13 +273,9 @@ func InitGTFSManager(ctx context.Context, config Config) (*Manager, error) {
 		realTimeVehicleLookupByTrip:    make(map[string]int),
 		realTimeVehicleLookupByVehicle: make(map[string]int),
 		duplicatedVehicleByRoute:       make(map[string][]gtfs.Vehicle),
-		feedTrips:                      make(map[string][]gtfs.Trip),
-		feedVehicles:                   make(map[string][]gtfs.Vehicle),
-		feedAlerts:                     make(map[string][]gtfs.Alert),
+		feedData:                       make(map[string]*FeedData),
 		feedLastUpdate:                 make(map[string]time.Time),
 		feedAgencyFilter:               make(map[string]map[string]bool),
-		feedVehicleLastSeen:            make(map[string]map[string]time.Time),
-		feedVehicleTimestamp:           make(map[string]uint64),
 		frequencyTripIDs:               make(map[string]struct{}),
 		activeServiceIDsCache:          make(map[string][]string),
 		Metrics:                        config.Metrics,
@@ -385,6 +394,9 @@ func (manager *Manager) SetGtfsURL(url string) {
 
 // Shutdown gracefully shuts down the manager and its background goroutines
 func (manager *Manager) Shutdown() {
+	if manager == nil {
+		return
+	}
 	manager.shutdownOnce.Do(func() {
 		close(manager.shutdownChan)
 		manager.wg.Wait()
@@ -933,14 +945,24 @@ func (manager *Manager) SetFeedExpiresAt(t time.Time) {
 
 // SetRealTimeTripsForTest manually sets realtime trips for testing purposes.
 // It stores the trips under the synthetic feed ID "_test" so that a subsequent
-// call to rebuildMergedRealtimeLocked (e.g. from a real feed update) does not
+// call to buildMergedRealtime (e.g. from a real feed update) does not
 // silently discard the injected data.
 func (manager *Manager) SetRealTimeTripsForTest(trips []gtfs.Trip) {
-	manager.realTimeMutex.Lock()
-	defer manager.realTimeMutex.Unlock()
+	manager.feedMapMutex.Lock()
+	feed := manager.feedData["_test"]
+	if feed == nil {
+		feed = &FeedData{
+			VehicleLastSeen: make(map[string]time.Time),
+		}
+		manager.feedData["_test"] = feed
+	}
+	manager.feedMapMutex.Unlock()
 
-	manager.feedTrips["_test"] = trips
-	manager.rebuildMergedRealtimeLocked()
+	feed.mu.Lock()
+	feed.Trips = trips
+	feed.mu.Unlock()
+
+	manager.buildMergedRealtime()
 }
 
 // GetStaticLastUpdated returns the timestamp when static GTFS data was last loaded lock-free.
@@ -989,12 +1011,19 @@ func (manager *Manager) SetStaticLastUpdatedForTest(t time.Time) {
 
 // AddTestAlert is a helper method used ONLY for testing to inject mock alerts safely.
 func (m *Manager) AddTestAlert(alert gtfs.Alert) {
-	m.realTimeMutex.Lock()
-	defer m.realTimeMutex.Unlock()
-	// Initialize the map if it doesn't exist
-	if m.feedAlerts == nil {
-		m.feedAlerts = make(map[string][]gtfs.Alert)
+	m.feedMapMutex.Lock()
+	feed := m.feedData["_test"]
+	if feed == nil {
+		feed = &FeedData{
+			VehicleLastSeen: make(map[string]time.Time),
+		}
+		m.feedData["_test"] = feed
 	}
-	m.feedAlerts["_test"] = append(m.feedAlerts["_test"], alert)
-	m.rebuildMergedRealtimeLocked()
+	m.feedMapMutex.Unlock()
+
+	feed.mu.Lock()
+	feed.Alerts = append(feed.Alerts, alert)
+	feed.mu.Unlock()
+
+	m.buildMergedRealtime()
 }

--- a/internal/gtfs/gtfs_manager.go
+++ b/internal/gtfs/gtfs_manager.go
@@ -104,7 +104,13 @@ type Manager struct {
 	cacheEpoch atomic.Uint64
 }
 
-// FeedData holds real-time data for a specific feed
+// FeedData holds real-time data for a specific feed.
+//
+// Concurrency: All exported fields are protected by mu. Callers must hold
+// mu.RLock() for reads and mu.Lock() for writes. Direct field access without
+// the lock is a data race. Within the Manager, production code acquires mu
+// after releasing feedMapMutex (see updateFeedRealtime and clearFeedData for
+// the canonical pattern).
 type FeedData struct {
 	mu               sync.RWMutex
 	Trips            []gtfs.Trip
@@ -132,7 +138,9 @@ func (manager *Manager) clearFeedData(feedID string) {
 	feed.VehicleLastSeen = make(map[string]time.Time)
 	feed.mu.Unlock()
 
+	manager.realTimeMutex.Lock()
 	delete(manager.feedLastUpdate, feedID)
+	manager.realTimeMutex.Unlock()
 
 	manager.buildMergedRealtime()
 }

--- a/internal/gtfs/gtfs_manager_mock.go
+++ b/internal/gtfs/gtfs_manager_mock.go
@@ -144,14 +144,21 @@ func (m *Manager) MockAddTripUpdate(tripID string, delay *time.Duration, stopTim
 }
 
 func (m *Manager) MockAddAlert(feedID string, alert gtfs.Alert) {
-	m.realTimeMutex.Lock()
-	defer m.realTimeMutex.Unlock()
-
-	if m.feedAlerts == nil {
-		m.feedAlerts = make(map[string][]gtfs.Alert)
+	m.feedMapMutex.Lock()
+	if m.feedData == nil {
+		m.feedData = make(map[string]*FeedData)
 	}
-	m.feedAlerts[feedID] = append(m.feedAlerts[feedID], alert)
-	m.rebuildMergedRealtimeLocked()
+	feed := m.feedData[feedID]
+	if feed == nil {
+		feed = &FeedData{}
+		m.feedData[feedID] = feed
+	}
+	feed.mu.Lock()
+	feed.Alerts = append(feed.Alerts, alert)
+	feed.mu.Unlock()
+	m.feedMapMutex.Unlock()
+
+	m.buildMergedRealtime()
 }
 
 // MockResetRealTimeData clears all mock real-time vehicles and trip updates.

--- a/internal/gtfs/gtfs_manager_mock.go
+++ b/internal/gtfs/gtfs_manager_mock.go
@@ -6,6 +6,10 @@ import (
 	"github.com/OneBusAway/go-gtfs"
 )
 
+// mockTestFeedID is the synthetic feed key used by all Mock* helpers.
+// Using a fixed key ensures MockResetRealTimeData can clean up everything.
+const mockTestFeedID = "_test"
+
 func (m *Manager) MockAddAgency(id, name string) {
 	for _, a := range m.gtfsData.Agencies {
 		if a.Id == id {
@@ -30,17 +34,35 @@ func (m *Manager) MockAddRoute(id, agencyID, name string) {
 		ShortName: name,
 	})
 }
-func (m *Manager) MockAddVehicle(vehicleID, tripID, routeID string) {
-	m.realTimeMutex.Lock()
-	defer m.realTimeMutex.Unlock()
+// mockGetOrCreateTestFeed returns the FeedData for mockTestFeedID, creating it if needed.
+func (m *Manager) mockGetOrCreateTestFeed() *FeedData {
+	m.feedMapMutex.Lock()
+	if m.feedData == nil {
+		m.feedData = make(map[string]*FeedData)
+	}
+	feed := m.feedData[mockTestFeedID]
+	if feed == nil {
+		feed = &FeedData{
+			VehicleLastSeen: make(map[string]time.Time),
+		}
+		m.feedData[mockTestFeedID] = feed
+	}
+	m.feedMapMutex.Unlock()
+	return feed
+}
 
-	for _, v := range m.realTimeVehicles {
+func (m *Manager) MockAddVehicle(vehicleID, tripID, routeID string) {
+	feed := m.mockGetOrCreateTestFeed()
+
+	feed.mu.Lock()
+	for _, v := range feed.Vehicles {
 		if v.ID != nil && v.ID.ID == vehicleID {
+			feed.mu.Unlock()
 			return
 		}
 	}
 	now := time.Now()
-	m.realTimeVehicles = append(m.realTimeVehicles, gtfs.Vehicle{
+	feed.Vehicles = append(feed.Vehicles, gtfs.Vehicle{
 		ID:        &gtfs.VehicleID{ID: vehicleID},
 		Timestamp: &now,
 		Trip: &gtfs.Trip{
@@ -50,12 +72,9 @@ func (m *Manager) MockAddVehicle(vehicleID, tripID, routeID string) {
 			},
 		},
 	})
+	feed.mu.Unlock()
 
-	idx := len(m.realTimeVehicles) - 1
-	m.realTimeVehicleLookupByVehicle[vehicleID] = idx
-	if tripID != "" {
-		m.realTimeVehicleLookupByTrip[tripID] = idx
-	}
+	m.buildMergedRealtime()
 }
 
 type MockVehicleOptions struct {
@@ -69,11 +88,12 @@ type MockVehicleOptions struct {
 }
 
 func (m *Manager) MockAddVehicleWithOptions(vehicleID, tripID, routeID string, opts MockVehicleOptions) {
-	m.realTimeMutex.Lock()
-	defer m.realTimeMutex.Unlock()
+	feed := m.mockGetOrCreateTestFeed()
 
-	for _, v := range m.realTimeVehicles {
+	feed.mu.Lock()
+	for _, v := range feed.Vehicles {
 		if v.ID != nil && v.ID.ID == vehicleID {
+			feed.mu.Unlock()
 			return
 		}
 	}
@@ -104,15 +124,10 @@ func (m *Manager) MockAddVehicleWithOptions(vehicleID, tripID, routeID string, o
 		CurrentStatus:       opts.CurrentStatus,
 		OccupancyStatus:     opts.OccupancyStatus,
 	}
-	m.realTimeVehicles = append(m.realTimeVehicles, v)
+	feed.Vehicles = append(feed.Vehicles, v)
+	feed.mu.Unlock()
 
-	idx := len(m.realTimeVehicles) - 1
-	if vehicleID != "" && !opts.NoID {
-		m.realTimeVehicleLookupByVehicle[vehicleID] = idx
-	}
-	if tripID != "" && !opts.NoTrip {
-		m.realTimeVehicleLookupByTrip[tripID] = idx
-	}
+	m.buildMergedRealtime()
 }
 
 func (m *Manager) MockAddTrip(tripID, agencyID, routeID string) {
@@ -128,19 +143,17 @@ func (m *Manager) MockAddTrip(tripID, agencyID, routeID string) {
 }
 
 func (m *Manager) MockAddTripUpdate(tripID string, delay *time.Duration, stopTimeUpdates []gtfs.StopTimeUpdate) {
-	m.realTimeMutex.Lock()
-	defer m.realTimeMutex.Unlock()
+	feed := m.mockGetOrCreateTestFeed()
 
-	trip := gtfs.Trip{
+	feed.mu.Lock()
+	feed.Trips = append(feed.Trips, gtfs.Trip{
 		ID:              gtfs.TripID{ID: tripID},
 		Delay:           delay,
 		StopTimeUpdates: stopTimeUpdates,
-	}
-	m.realTimeTrips = append(m.realTimeTrips, trip)
-	if m.realTimeTripLookup == nil {
-		m.realTimeTripLookup = make(map[string]int)
-	}
-	m.realTimeTripLookup[tripID] = len(m.realTimeTrips) - 1
+	})
+	feed.mu.Unlock()
+
+	m.buildMergedRealtime()
 }
 
 func (m *Manager) MockAddAlert(feedID string, alert gtfs.Alert) {
@@ -150,28 +163,28 @@ func (m *Manager) MockAddAlert(feedID string, alert gtfs.Alert) {
 	}
 	feed := m.feedData[feedID]
 	if feed == nil {
-		feed = &FeedData{}
+		feed = &FeedData{
+			VehicleLastSeen: make(map[string]time.Time),
+		}
 		m.feedData[feedID] = feed
 	}
+	m.feedMapMutex.Unlock()
+
 	feed.mu.Lock()
 	feed.Alerts = append(feed.Alerts, alert)
 	feed.mu.Unlock()
-	m.feedMapMutex.Unlock()
 
 	m.buildMergedRealtime()
 }
 
-// MockResetRealTimeData clears all mock real-time vehicles and trip updates.
+// MockResetRealTimeData clears all mock real-time vehicles, trip updates, and alerts
+// from the test feed, then rebuilds the merged view.
 func (m *Manager) MockResetRealTimeData() {
-	m.realTimeMutex.Lock()
-	defer m.realTimeMutex.Unlock()
+	m.feedMapMutex.Lock()
+	delete(m.feedData, mockTestFeedID)
+	m.feedMapMutex.Unlock()
 
-	m.realTimeVehicles = nil
-	m.realTimeVehicleLookupByVehicle = make(map[string]int)
-	m.realTimeVehicleLookupByTrip = make(map[string]int)
-	m.duplicatedVehicleByRoute = make(map[string][]gtfs.Vehicle)
-	m.realTimeTrips = nil
-	m.realTimeTripLookup = make(map[string]int)
+	m.buildMergedRealtime()
 }
 
 // MockClearServiceIDsCache evicts all entries from the active-service-IDs cache.

--- a/internal/gtfs/gtfs_manager_test.go
+++ b/internal/gtfs/gtfs_manager_test.go
@@ -123,15 +123,17 @@ func TestManager_FindAgency(t *testing.T) {
 func TestManager_GetVehicleByID(t *testing.T) {
 	manager := &Manager{
 		realTimeMutex: sync.RWMutex{},
-		feedVehicles: map[string][]gtfs.Vehicle{
+		feedData: map[string]*FeedData{
 			"feed-0": {
-				{
-					ID: &gtfs.VehicleID{ID: "vehicle1"},
+				Vehicles: []gtfs.Vehicle{
+					{
+						ID: &gtfs.VehicleID{ID: "vehicle1"},
+					},
 				},
 			},
 		},
 	}
-	manager.rebuildMergedRealtimeLocked()
+	manager.buildMergedRealtime()
 
 	vehicle, err := manager.GetVehicleByID("vehicle1")
 	assert.Nil(t, err)
@@ -149,16 +151,18 @@ func TestGetVehicleForTrip_DirectTripIDLookup(t *testing.T) {
 
 	manager := &Manager{
 		realTimeMutex: sync.RWMutex{},
-		feedVehicles: map[string][]gtfs.Vehicle{
+		feedData: map[string]*FeedData{
 			"feed-0": {
-				{
-					ID:   &gtfs.VehicleID{ID: vehicleID},
-					Trip: &gtfs.Trip{ID: gtfs.TripID{ID: tripID}},
+				Vehicles: []gtfs.Vehicle{
+					{
+						ID:   &gtfs.VehicleID{ID: vehicleID},
+						Trip: &gtfs.Trip{ID: gtfs.TripID{ID: tripID}},
+					},
 				},
 			},
 		},
 	}
-	manager.rebuildMergedRealtimeLocked()
+	manager.buildMergedRealtime()
 
 	ctx := context.Background()
 	got := manager.GetVehicleForTrip(ctx, tripID)
@@ -211,15 +215,17 @@ func TestManager_GetVehicleLastUpdateTime(t *testing.T) {
 func TestManager_GetTripUpdateByID(t *testing.T) {
 	manager := &Manager{
 		realTimeMutex: sync.RWMutex{},
-		feedTrips: map[string][]gtfs.Trip{
+		feedData: map[string]*FeedData{
 			"feed-0": {
-				{
-					ID: gtfs.TripID{ID: "trip1"},
+				Trips: []gtfs.Trip{
+					{
+						ID: gtfs.TripID{ID: "trip1"},
+					},
 				},
 			},
 		},
 	}
-	manager.rebuildMergedRealtimeLocked()
+	manager.buildMergedRealtime()
 
 	trip, err := manager.GetTripUpdateByID("trip1")
 	assert.Nil(t, err)
@@ -310,16 +316,18 @@ func TestManager_GetVehicleForTrip(t *testing.T) {
 	trip := &gtfs.Trip{
 		ID: gtfs.TripID{ID: "5735633"},
 	}
-	manager.feedVehicles = map[string][]gtfs.Vehicle{
+	manager.feedData = map[string]*FeedData{
 		"feed-0": {
-			{
-				ID:   &gtfs.VehicleID{ID: "vehicle1"},
-				Trip: trip,
+			Vehicles: []gtfs.Vehicle{
+				{
+					ID:   &gtfs.VehicleID{ID: "vehicle1"},
+					Trip: trip,
+				},
 			},
 		},
 	}
 
-	manager.rebuildMergedRealtimeLocked()
+	manager.buildMergedRealtime()
 
 	vehicle := manager.GetVehicleForTrip(context.Background(), "5735633")
 	if vehicle != nil {

--- a/internal/gtfs/multi_feed_test.go
+++ b/internal/gtfs/multi_feed_test.go
@@ -9,11 +9,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/OneBusAway/go-gtfs"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-// TestMultiFeedDataMerging verifies that rebuildMergedRealtimeLocked correctly
+// TestMultiFeedDataMerging verifies that buildMergedRealtime correctly
 // concatenates vehicles from distinct feeds and that per-feed lookup maps work.
 // Feed A uses RABA vehicle positions; feed B uses Unitrans vehicle positions so
 // that each feed contributes genuinely different vehicle IDs.
@@ -53,8 +54,16 @@ func TestMultiFeedDataMerging(t *testing.T) {
 	manager.updateFeedRealtime(ctx, feedA)
 	manager.updateFeedRealtime(ctx, feedB)
 
-	feedAVehicles := manager.feedVehicles["feed-a"]
-	feedBVehicles := manager.feedVehicles["feed-b"]
+	manager.feedData["feed-a"].mu.RLock()
+	feedAVehicles := make([]gtfs.Vehicle, len(manager.feedData["feed-a"].Vehicles))
+	copy(feedAVehicles, manager.feedData["feed-a"].Vehicles)
+	manager.feedData["feed-a"].mu.RUnlock()
+
+	manager.feedData["feed-b"].mu.RLock()
+	feedBVehicles := make([]gtfs.Vehicle, len(manager.feedData["feed-b"].Vehicles))
+	copy(feedBVehicles, manager.feedData["feed-b"].Vehicles)
+	manager.feedData["feed-b"].mu.RUnlock()
+
 	require.NotEmpty(t, feedAVehicles, "Feed A should have vehicles")
 	require.NotEmpty(t, feedBVehicles, "Feed B should have vehicles")
 
@@ -110,35 +119,35 @@ func TestStaleVehicleExpiry(t *testing.T) {
 
 	// Wind last-seen back to 5 minutes ago so vehicles appear to have disappeared
 	// but are still within the 15-min retention window.
-	manager.realTimeMutex.Lock()
-	for vid := range manager.feedVehicleLastSeen["expiry-test"] {
-		manager.feedVehicleLastSeen["expiry-test"][vid] = time.Now().Add(-5 * time.Minute)
+	manager.feedData["expiry-test"].mu.Lock()
+	for vid := range manager.feedData["expiry-test"].VehicleLastSeen {
+		manager.feedData["expiry-test"].VehicleLastSeen[vid] = time.Now().Add(-5 * time.Minute)
 	}
-	manager.realTimeMutex.Unlock()
+	manager.feedData["expiry-test"].mu.Unlock()
 
 	// Call cleanupExpiredVehicles directly to verify the 5-minute vehicles are preserved
-	manager.realTimeMutex.Lock()
-	manager.cleanupExpiredVehicles("expiry-test")
-	manager.rebuildMergedRealtimeLocked()
-	manager.realTimeMutex.Unlock()
+	manager.feedData["expiry-test"].mu.Lock()
+	manager.cleanupExpiredVehicles(manager.feedData["expiry-test"])
+	manager.feedData["expiry-test"].mu.Unlock()
+	manager.buildMergedRealtime()
 
 	afterCleanup := manager.GetRealTimeVehicles()
 	assert.Equal(t, initialCount, len(afterCleanup),
 		"vehicles should be retained when last-seen is within 15-min window")
 
 	// Wind last-seen back to 20 minutes ago (beyond the 15-min window).
-	manager.realTimeMutex.Lock()
-	for vid := range manager.feedVehicleLastSeen["expiry-test"] {
-		manager.feedVehicleLastSeen["expiry-test"][vid] = time.Now().Add(-20 * time.Minute)
+	manager.feedData["expiry-test"].mu.Lock()
+	for vid := range manager.feedData["expiry-test"].VehicleLastSeen {
+		manager.feedData["expiry-test"].VehicleLastSeen[vid] = time.Now().Add(-20 * time.Minute)
 	}
-	manager.realTimeMutex.Unlock()
+	manager.feedData["expiry-test"].mu.Unlock()
 
 	// Call cleanupExpiredVehicles again — stale vehicles beyond the 15-min window
 	// should now be evicted.
-	manager.realTimeMutex.Lock()
-	manager.cleanupExpiredVehicles("expiry-test")
-	manager.rebuildMergedRealtimeLocked()
-	manager.realTimeMutex.Unlock()
+	manager.feedData["expiry-test"].mu.Lock()
+	manager.cleanupExpiredVehicles(manager.feedData["expiry-test"])
+	manager.feedData["expiry-test"].mu.Unlock()
+	manager.buildMergedRealtime()
 
 	afterExpiry := manager.GetRealTimeVehicles()
 	assert.Empty(t, afterExpiry,
@@ -168,7 +177,7 @@ func TestFeedIsolation(t *testing.T) {
 	}
 	manager.updateFeedRealtime(ctx, feedB)
 
-	feedBCount := len(manager.feedVehicles["feed-b"])
+	feedBCount := len(manager.feedData["feed-b"].Vehicles)
 	require.Positive(t, feedBCount, "Feed B should have vehicles loaded")
 
 	// Now update feed-A with a failing URL (no vehicles)
@@ -186,13 +195,13 @@ func TestFeedIsolation(t *testing.T) {
 		"Merged vehicles should still contain all feed-B vehicles after feed-A update failure")
 
 	// Verify feed-B sub-map is unchanged
-	assert.Equal(t, feedBCount, len(manager.feedVehicles["feed-b"]),
+	assert.Equal(t, feedBCount, len(manager.feedData["feed-b"].Vehicles),
 		"Feed-B sub-map should be unaffected by feed-A update")
 }
 
 // TestConcurrentFeedUpdates verifies data isolation when two feeds update
 // simultaneously. Both goroutines race to write their per-feed sub-maps and
-// trigger rebuildMergedRealtimeLocked; the final merged view must contain
+// trigger buildMergedRealtime; the final merged view must contain
 // vehicles from both feeds with no data corruption.
 func TestConcurrentFeedUpdates(t *testing.T) {
 	mux := http.NewServeMux()
@@ -241,7 +250,7 @@ func TestConcurrentFeedUpdates(t *testing.T) {
 	// After all goroutines have finished, both per-feed sub-maps must be
 	// populated and the merged view must be non-empty. The -race detector
 	// validates that no unsynchronised access occurred during the updates.
-	assert.NotEmpty(t, manager.feedVehicles["feed-a"], "feed-a should have vehicles after concurrent updates")
-	assert.NotEmpty(t, manager.feedVehicles["feed-b"], "feed-b should have vehicles after concurrent updates")
+	assert.NotEmpty(t, manager.feedData["feed-a"].Vehicles, "feed-a should have vehicles after concurrent updates")
+	assert.NotEmpty(t, manager.feedData["feed-b"].Vehicles, "feed-b should have vehicles after concurrent updates")
 	assert.NotEmpty(t, manager.GetRealTimeVehicles(), "merged view should be non-empty after concurrent updates")
 }

--- a/internal/gtfs/parallel_realtime_test.go
+++ b/internal/gtfs/parallel_realtime_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/OneBusAway/go-gtfs"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -203,11 +202,7 @@ func newTestManager() *Manager {
 		realTimeTripLookup:             make(map[string]int),
 		realTimeVehicleLookupByTrip:    make(map[string]int),
 		realTimeVehicleLookupByVehicle: make(map[string]int),
-		feedTrips:                      make(map[string][]gtfs.Trip),
-		feedVehicles:                   make(map[string][]gtfs.Vehicle),
-		feedAlerts:                     make(map[string][]gtfs.Alert),
+		feedData:                       make(map[string]*FeedData),
 		feedAgencyFilter:               make(map[string]map[string]bool),
-		feedVehicleLastSeen:            make(map[string]map[string]time.Time),
-		feedVehicleTimestamp:           make(map[string]uint64),
 	}
 }

--- a/internal/gtfs/realtime.go
+++ b/internal/gtfs/realtime.go
@@ -489,12 +489,9 @@ func (manager *Manager) updateFeedRealtime(ctx context.Context, feedCfg RTFeedCo
 
 	manager.buildMergedRealtime()
 
-	// Update timestamp within the same lock
+	// Update timestamp safely
 	if hasNewData {
-		if manager.feedLastUpdate == nil {
-			manager.feedLastUpdate = make(map[string]time.Time)
-		}
-		manager.feedLastUpdate[feedID] = time.Now()
+		manager.SetFeedUpdateTime(feedID, time.Now())
 	}
 
 	return hasNewData

--- a/internal/gtfs/realtime.go
+++ b/internal/gtfs/realtime.go
@@ -616,8 +616,8 @@ func (manager *Manager) buildMergedRealtime() {
 	manager.mergeMutex.Lock()
 	defer manager.mergeMutex.Unlock()
 
-	// Snapshot feed pointers once under a single read lock — the pointers
-	// in the map are never overwritten, only appended, so this is safe.
+	// Snapshot feed pointers under feedMapMutex.RLock; writers use
+	// feedMapMutex.Lock when inserting new entries.
 	manager.feedMapMutex.RLock()
 	feedIDs := make([]string, 0, len(manager.feedData))
 	for id := range manager.feedData {

--- a/internal/gtfs/realtime.go
+++ b/internal/gtfs/realtime.go
@@ -73,40 +73,6 @@ func isVehicleStale(existing, incoming gtfs.Vehicle) bool {
 	return incoming.Timestamp.Before(*existing.Timestamp)
 }
 
-// cleanupExpiredVehicles removes vehicles from both the lastSeenMap and feedVehicles
-// that have exceeded the staleVehicleTimeout threshold since they were last seen.
-// This ensures a consistent retention window across feed updates.
-func (manager *Manager) cleanupExpiredVehicles(feedID string) {
-	if manager.feedVehicleLastSeen[feedID] == nil {
-		return
-	}
-
-	now := time.Now()
-	lastSeenMap := manager.feedVehicleLastSeen[feedID]
-
-	// First, delete expired entries from lastSeenMap
-	for vid, lastSeen := range lastSeenMap {
-		if now.Sub(lastSeen) > staleVehicleTimeout {
-			delete(lastSeenMap, vid)
-		}
-	}
-
-	// Then, rebuild feedVehicles to only include vehicles that are still in lastSeenMap
-	// (i.e., within the retention window)
-	currentVehicles := manager.feedVehicles[feedID]
-	validVehicles := make([]gtfs.Vehicle, 0, len(currentVehicles))
-	for _, v := range currentVehicles {
-		if v.ID == nil {
-			continue
-		}
-		// Keep the vehicle if it's still in the retention window
-		if _, ok := lastSeenMap[v.ID.ID]; ok {
-			validVehicles = append(validVehicles, v)
-		}
-	}
-	manager.feedVehicles[feedID] = validVehicles
-}
-
 func (manager *Manager) GetRealTimeTrips() []gtfs.Trip {
 	manager.realTimeMutex.RLock()
 	defer manager.realTimeMutex.RUnlock()
@@ -239,7 +205,7 @@ func loadRealtimeData(ctx context.Context, source string, headers map[string]str
 }
 
 // updateFeedRealtime fetches and processes realtime data for a single feed.
-// It updates the per-feed sub-maps and then calls rebuildMergedRealtimeLocked.
+// It updates the per-feed FeedData and then calls buildMergedRealtime.
 // Returns true if new data was successfully fetched and processed.
 func (manager *Manager) updateFeedRealtime(ctx context.Context, feedCfg RTFeedConfig) bool {
 	logger := logging.FromContext(ctx).With(slog.String("component", "gtfs_realtime"))
@@ -297,7 +263,7 @@ func (manager *Manager) updateFeedRealtime(ctx context.Context, feedCfg RTFeedCo
 	}
 
 	// Apply agency-based filtering if configured for this feed.
-	// This runs before acquiring realTimeMutex to keep the critical section short.
+	// This runs before acquiring feed lock to keep the critical section short.
 	agencyFilter := manager.feedAgencyFilter[feedID]
 	if len(agencyFilter) > 0 {
 		if tripData != nil && tripErr == nil {
@@ -311,11 +277,22 @@ func (manager *Manager) updateFeedRealtime(ctx context.Context, feedCfg RTFeedCo
 		}
 	}
 
-	manager.realTimeMutex.Lock()
-	defer manager.realTimeMutex.Unlock()
+	manager.feedMapMutex.Lock()
+	feed := manager.feedData[feedID]
+	if feed == nil {
+		feed = &FeedData{
+			VehicleLastSeen: make(map[string]time.Time),
+		}
+		manager.feedData[feedID] = feed
+	}
+	manager.feedMapMutex.Unlock()
+
+	feed.mu.Lock()
+
+	hadDataBefore := len(feed.Trips) > 0 || len(feed.Vehicles) > 0 || len(feed.Alerts) > 0
 
 	if tripData != nil && tripErr == nil {
-		manager.feedTrips[feedID] = tripData.Trips
+		feed.Trips = tripData.Trips
 	}
 
 	if vehicleData != nil && vehicleErr == nil {
@@ -329,24 +306,24 @@ func (manager *Manager) updateFeedRealtime(ctx context.Context, feedCfg RTFeedCo
 			applyVehicleUpdate = true
 		} else {
 			feedTimestamp := uint64(vehicleData.CreatedAt.UnixNano())
-			if feedTimestamp <= manager.feedVehicleTimestamp[feedID] {
+			if feedTimestamp <= feed.VehicleTimestamp {
 				logging.LogOperation(
 					logger,
 					"skipping_stale_vehicle_realtime_feed",
 					slog.String("feed", feedID),
 					slog.Uint64("feed_timestamp", feedTimestamp),
-					slog.Uint64("last_applied_timestamp", manager.feedVehicleTimestamp[feedID]),
+					slog.Uint64("last_applied_timestamp", feed.VehicleTimestamp),
 				)
 				// Skip applying vehicle updates, but still run cleanup
 				applyVehicleUpdate = false
 			} else {
 				// Record the latest applied vehicle feed timestamp
-				manager.feedVehicleTimestamp[feedID] = feedTimestamp
+				feed.VehicleTimestamp = feedTimestamp
 			}
 		}
 
 		if applyVehicleUpdate {
-			prevVehicles := manager.feedVehicles[feedID]
+			prevVehicles := feed.Vehicles
 			prevByID := make(map[string]gtfs.Vehicle, len(prevVehicles))
 			for _, pv := range prevVehicles {
 				if pv.ID != nil {
@@ -378,10 +355,7 @@ func (manager *Manager) updateFeedRealtime(ctx context.Context, feedCfg RTFeedCo
 			}
 
 			now := time.Now()
-			if manager.feedVehicleLastSeen[feedID] == nil {
-				manager.feedVehicleLastSeen[feedID] = make(map[string]time.Time)
-			}
-			lastSeenMap := manager.feedVehicleLastSeen[feedID]
+			lastSeenMap := feed.VehicleLastSeen
 
 			currentVehicleIDs := make(map[string]struct{}, len(validVehicles))
 			for _, v := range validVehicles {
@@ -399,7 +373,7 @@ func (manager *Manager) updateFeedRealtime(ctx context.Context, feedCfg RTFeedCo
 			}
 
 			// Retain recently-disappeared vehicles whose last-seen time hasn't expired
-			prevVehicles = manager.feedVehicles[feedID]
+			prevVehicles = feed.Vehicles
 			for _, pv := range prevVehicles {
 				if pv.ID == nil {
 					continue
@@ -411,16 +385,16 @@ func (manager *Manager) updateFeedRealtime(ctx context.Context, feedCfg RTFeedCo
 				}
 			}
 
-			manager.feedVehicles[feedID] = validVehicles
+			feed.Vehicles = validVehicles
 		} else {
 			// Even when skipping the vehicle update due to staleness, still clean up
 			// expired vehicles based on the last-seen timeout windows
-			manager.cleanupExpiredVehicles(feedID)
+			manager.cleanupExpiredVehicles(feed)
 		}
 	}
 
 	if alertData != nil && alertErr == nil {
-		manager.feedAlerts[feedID] = alertData.Alerts
+		feed.Alerts = alertData.Alerts
 	}
 
 	tripsUpdated := tripData != nil && tripErr == nil
@@ -454,6 +428,13 @@ func (manager *Manager) updateFeedRealtime(ctx context.Context, feedCfg RTFeedCo
 		hasNewData = false
 	}
 
+	// Capture count values for logging, then unlock early
+	tripCount := len(feed.Trips)
+	vehicleCount := len(feed.Vehicles)
+	alertCount := len(feed.Alerts)
+
+	feed.mu.Unlock()
+
 	// Logging based on partial vs total success
 	if hasNewData {
 		fullSuccess := true
@@ -470,9 +451,9 @@ func (manager *Manager) updateFeedRealtime(ctx context.Context, feedCfg RTFeedCo
 		if fullSuccess {
 			logger.Info("updated realtime feed successfully",
 				slog.String("feed", feedID),
-				slog.Int("trips", len(manager.feedTrips[feedID])),
-				slog.Int("vehicles", len(manager.feedVehicles[feedID])),
-				slog.Int("alerts", len(manager.feedAlerts[feedID])),
+				slog.Int("trips", tripCount),
+				slog.Int("vehicles", vehicleCount),
+				slog.Int("alerts", alertCount),
 			)
 		} else {
 			logger.Warn("realtime feed partially updated",
@@ -486,18 +467,27 @@ func (manager *Manager) updateFeedRealtime(ctx context.Context, feedCfg RTFeedCo
 			)
 		}
 	} else {
-		logger.Error("realtime feed update failed",
-			slog.String("feed", feedID),
-			slog.Bool("trip_updates_configured", feedCfg.TripUpdatesURL != ""),
-			slog.Bool("trip_updates_error", tripErr != nil),
-			slog.Bool("vehicle_positions_configured", feedCfg.VehiclePositionsURL != ""),
-			slog.Bool("vehicle_positions_error", vehicleErr != nil),
-			slog.Bool("service_alerts_configured", feedCfg.ServiceAlertsURL != ""),
-			slog.Bool("service_alerts_error", alertErr != nil),
-		)
+		if hadDataBefore {
+			logger.Warn("all realtime feed sources failed - retaining stale data",
+				slog.String("feed", feedID),
+				slog.Int("trips", tripCount),
+				slog.Int("vehicles", vehicleCount),
+				slog.Int("alerts", alertCount),
+			)
+		} else {
+			logger.Error("realtime feed update failed",
+				slog.String("feed", feedID),
+				slog.Bool("trip_updates_configured", feedCfg.TripUpdatesURL != ""),
+				slog.Bool("trip_updates_error", tripErr != nil),
+				slog.Bool("vehicle_positions_configured", feedCfg.VehiclePositionsURL != ""),
+				slog.Bool("vehicle_positions_error", vehicleErr != nil),
+				slog.Bool("service_alerts_configured", feedCfg.ServiceAlertsURL != ""),
+				slog.Bool("service_alerts_error", alertErr != nil),
+			)
+		}
 	}
 
-	manager.rebuildMergedRealtimeLocked()
+	manager.buildMergedRealtime()
 
 	// Update timestamp within the same lock
 	if hasNewData {
@@ -508,6 +498,41 @@ func (manager *Manager) updateFeedRealtime(ctx context.Context, feedCfg RTFeedCo
 	}
 
 	return hasNewData
+}
+
+// cleanupExpiredVehicles removes vehicles from both the lastSeenMap and feed Vehicles
+// that have exceeded the staleVehicleTimeout threshold since they were last seen.
+// This ensures a consistent retention window across feed updates.
+// Caller must hold feed.mu.Lock().
+func (manager *Manager) cleanupExpiredVehicles(feed *FeedData) {
+	if feed.VehicleLastSeen == nil {
+		return
+	}
+
+	now := time.Now()
+	lastSeenMap := feed.VehicleLastSeen
+
+	// First, delete expired entries from lastSeenMap
+	for vid, lastSeen := range lastSeenMap {
+		if now.Sub(lastSeen) > staleVehicleTimeout {
+			delete(lastSeenMap, vid)
+		}
+	}
+
+	// Then, rebuild feed Vehicles to only include vehicles that are still in lastSeenMap
+	// (i.e., within the retention window)
+	currentVehicles := feed.Vehicles
+	validVehicles := make([]gtfs.Vehicle, 0, len(currentVehicles))
+	for _, v := range currentVehicles {
+		if v.ID == nil {
+			continue
+		}
+		// Keep the vehicle if it's still in the retention window
+		if _, ok := lastSeenMap[v.ID.ID]; ok {
+			validVehicles = append(validVehicles, v)
+		}
+	}
+	feed.Vehicles = validVehicles
 }
 
 // filterTripsByAgency returns only the trips whose route belongs to one of the
@@ -590,38 +615,48 @@ func alertMatchesAgencyLocked(manager *Manager, alert gtfs.Alert, allowed map[st
 	return false
 }
 
-func (manager *Manager) rebuildMergedRealtimeLocked() {
-	feedIDs := make([]string, 0, len(manager.feedTrips))
-	totalTrips := 0
-	for id, trips := range manager.feedTrips {
+func (manager *Manager) buildMergedRealtime() {
+	manager.mergeMutex.Lock()
+	defer manager.mergeMutex.Unlock()
+
+	// Snapshot feed pointers once under a single read lock — the pointers
+	// in the map are never overwritten, only appended, so this is safe.
+	manager.feedMapMutex.RLock()
+	feedIDs := make([]string, 0, len(manager.feedData))
+	for id := range manager.feedData {
 		feedIDs = append(feedIDs, id)
-		totalTrips += len(trips)
 	}
+
+	// Sort feedIDs inside the read lock (very fast, usually < 10 feeds) to ensure deterministic merge order.
 	sort.Strings(feedIDs)
 
-	allTrips := make([]gtfs.Trip, 0, totalTrips)
-	for _, id := range feedIDs {
-		allTrips = append(allTrips, manager.feedTrips[id]...)
+	sortedFeeds := make([]*FeedData, len(feedIDs))
+	for i, id := range feedIDs {
+		sortedFeeds[i] = manager.feedData[id]
 	}
+	manager.feedMapMutex.RUnlock()
 
-	vehicleFeedIDs := make([]string, 0, len(manager.feedVehicles))
-	totalVehicles := 0
-	for id, vehicles := range manager.feedVehicles {
-		vehicleFeedIDs = append(vehicleFeedIDs, id)
-		totalVehicles += len(vehicles)
-	}
-	sort.Strings(vehicleFeedIDs)
+	// Pre-allocate capacities based on the current arrays to avoid expensive runtime growing during appends
+	manager.realTimeMutex.RLock()
+	tripCap := len(manager.realTimeTrips)
+	vehicleCap := len(manager.realTimeVehicles)
+	manager.realTimeMutex.RUnlock()
 
-	allVehicles := make([]gtfs.Vehicle, 0, totalVehicles)
-	for _, id := range vehicleFeedIDs {
-		allVehicles = append(allVehicles, manager.feedVehicles[id]...)
-	}
+	allTrips := make([]gtfs.Trip, 0, tripCap)
+	allVehicles := make([]gtfs.Vehicle, 0, vehicleCap)
+	var allAlerts []gtfs.Alert
 
-	alertFeedIDs := make([]string, 0, len(manager.feedAlerts))
-	for id := range manager.feedAlerts {
-		alertFeedIDs = append(alertFeedIDs, id)
+	for _, feed := range sortedFeeds {
+		if feed == nil {
+			continue
+		}
+
+		feed.mu.RLock()
+		allTrips = append(allTrips, feed.Trips...)
+		allVehicles = append(allVehicles, feed.Vehicles...)
+		allAlerts = append(allAlerts, feed.Alerts...)
+		feed.mu.RUnlock()
 	}
-	sort.Strings(alertFeedIDs)
 
 	tripLookup := make(map[string]int, len(allTrips))
 	for i, trip := range allTrips {
@@ -655,50 +690,52 @@ func (manager *Manager) rebuildMergedRealtimeLocked() {
 			duplicatedVehicleByRoute[routeID] = append(duplicatedVehicleByRoute[routeID], vehicle)
 		}
 	}
+
 	idx := alertIndex{
 		byTrip:   make(map[string][]gtfs.Alert),
 		byRoute:  make(map[string][]gtfs.Alert),
 		byAgency: make(map[string][]gtfs.Alert),
 		byStop:   make(map[string][]gtfs.Alert),
 	}
-	for _, id := range alertFeedIDs {
-		for _, alert := range manager.feedAlerts[id] {
-			if alert.InformedEntities == nil || alert.ID == "" {
-				continue
+	for _, alert := range allAlerts {
+		if alert.InformedEntities == nil || alert.ID == "" {
+			continue
+		}
+		// Per-alert per-bucket dedup: prevents the same alert from being appended
+		// to the same bucket more than once when it has multiple InformedEntities
+		// referencing the same key (e.g. two entities both pointing to stop "S1").
+		// Capacity is set to the entity count so the map never needs to grow.
+		n := len(alert.InformedEntities)
+		seenTrip := make(map[string]bool, n)
+		seenRoute := make(map[string]bool, n)
+		seenAgency := make(map[string]bool, n)
+		seenStop := make(map[string]bool, n)
+		for _, entity := range alert.InformedEntities {
+			if entity.TripID != nil && !seenTrip[entity.TripID.ID] {
+				seenTrip[entity.TripID.ID] = true
+				idx.byTrip[entity.TripID.ID] = append(idx.byTrip[entity.TripID.ID], alert)
 			}
-			// Per-alert per-bucket dedup: prevents the same alert from being appended
-			// to the same bucket more than once when it has multiple InformedEntities
-			// referencing the same key (e.g. two entities both pointing to stop "S1").
-			// Capacity is set to the entity count so the map never needs to grow.
-			n := len(alert.InformedEntities)
-			seenTrip := make(map[string]bool, n)
-			seenRoute := make(map[string]bool, n)
-			seenAgency := make(map[string]bool, n)
-			seenStop := make(map[string]bool, n)
-			for _, entity := range alert.InformedEntities {
-				if entity.TripID != nil && !seenTrip[entity.TripID.ID] {
-					seenTrip[entity.TripID.ID] = true
-					idx.byTrip[entity.TripID.ID] = append(idx.byTrip[entity.TripID.ID], alert)
-				}
-				// Only match route-level entities that have no stop or trip restriction.
-				// Entities with {routeId + stopId} are stop-specific alerts and are filed
-				// in byStop only (matching Java's inverted index bucket behaviour).
-				if entity.RouteID != nil && entity.StopID == nil && entity.TripID == nil && !seenRoute[*entity.RouteID] {
-					seenRoute[*entity.RouteID] = true
-					idx.byRoute[*entity.RouteID] = append(idx.byRoute[*entity.RouteID], alert)
-				}
-				// Only match agency-wide alerts: entity has agencyId but no route or trip restriction.
-				if entity.AgencyID != nil && entity.RouteID == nil && entity.TripID == nil && !seenAgency[*entity.AgencyID] {
-					seenAgency[*entity.AgencyID] = true
-					idx.byAgency[*entity.AgencyID] = append(idx.byAgency[*entity.AgencyID], alert)
-				}
-				if entity.StopID != nil && !seenStop[*entity.StopID] {
-					seenStop[*entity.StopID] = true
-					idx.byStop[*entity.StopID] = append(idx.byStop[*entity.StopID], alert)
-				}
+			// Only match route-level entities that have no stop or trip restriction.
+			// Entities with {routeId + stopId} are stop-specific alerts and are filed
+			// in byStop only (matching Java's inverted index bucket behaviour).
+			if entity.RouteID != nil && entity.StopID == nil && entity.TripID == nil && !seenRoute[*entity.RouteID] {
+				seenRoute[*entity.RouteID] = true
+				idx.byRoute[*entity.RouteID] = append(idx.byRoute[*entity.RouteID], alert)
+			}
+			// Only match agency-wide alerts: entity has agencyId but no route or trip restriction.
+			if entity.AgencyID != nil && entity.RouteID == nil && entity.TripID == nil && !seenAgency[*entity.AgencyID] {
+				seenAgency[*entity.AgencyID] = true
+				idx.byAgency[*entity.AgencyID] = append(idx.byAgency[*entity.AgencyID], alert)
+			}
+			if entity.StopID != nil && !seenStop[*entity.StopID] {
+				seenStop[*entity.StopID] = true
+				idx.byStop[*entity.StopID] = append(idx.byStop[*entity.StopID], alert)
 			}
 		}
 	}
+
+	manager.realTimeMutex.Lock()
+	defer manager.realTimeMutex.Unlock()
 
 	manager.realTimeTrips = allTrips
 	manager.realTimeVehicles = allVehicles

--- a/internal/gtfs/realtime_benchmark_test.go
+++ b/internal/gtfs/realtime_benchmark_test.go
@@ -13,7 +13,7 @@ import (
 func BenchmarkRebuildRealTimeTripLookup(b *testing.B) {
 	manager := &Manager{
 		realTimeMutex: sync.RWMutex{},
-		feedTrips:     make(map[string][]gtfs.Trip),
+		feedData:      make(map[string]*FeedData),
 	}
 
 	feedTrips := make([]gtfs.Trip, 1000)
@@ -22,18 +22,18 @@ func BenchmarkRebuildRealTimeTripLookup(b *testing.B) {
 			ID: gtfs.TripID{ID: fmt.Sprintf("trip_%d", i)},
 		}
 	}
-	manager.feedTrips["feed-0"] = feedTrips
+	manager.feedData["feed-0"] = &FeedData{Trips: feedTrips}
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		manager.rebuildMergedRealtimeLocked()
+		manager.buildMergedRealtime()
 	}
 }
 
 func BenchmarkRebuildRealTimeVehicleLookupByTrip(b *testing.B) {
 	manager := &Manager{
 		realTimeMutex: sync.RWMutex{},
-		feedVehicles:  make(map[string][]gtfs.Vehicle),
+		feedData:      make(map[string]*FeedData),
 	}
 
 	feedVehicles := make([]gtfs.Vehicle, 1000)
@@ -44,18 +44,18 @@ func BenchmarkRebuildRealTimeVehicleLookupByTrip(b *testing.B) {
 			},
 		}
 	}
-	manager.feedVehicles["feed-0"] = feedVehicles
+	manager.feedData["feed-0"] = &FeedData{Vehicles: feedVehicles}
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		manager.rebuildMergedRealtimeLocked()
+		manager.buildMergedRealtime()
 	}
 }
 
 func BenchmarkRebuildRealTimeVehicleLookupByVehicle(b *testing.B) {
 	manager := &Manager{
 		realTimeMutex: sync.RWMutex{},
-		feedVehicles:  make(map[string][]gtfs.Vehicle),
+		feedData:      make(map[string]*FeedData),
 	}
 
 	feedVehicles := make([]gtfs.Vehicle, 1000)
@@ -64,11 +64,11 @@ func BenchmarkRebuildRealTimeVehicleLookupByVehicle(b *testing.B) {
 			ID: &gtfs.VehicleID{ID: fmt.Sprintf("vehicle_%d", i)},
 		}
 	}
-	manager.feedVehicles["feed-0"] = feedVehicles
+	manager.feedData["feed-0"] = &FeedData{Vehicles: feedVehicles}
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		manager.rebuildMergedRealtimeLocked()
+		manager.buildMergedRealtime()
 	}
 }
 
@@ -77,14 +77,14 @@ func BenchmarkRebuildAlertIndex(b *testing.B) {
 	agencyID := "agency_0"
 	manager := &Manager{
 		realTimeMutex: sync.RWMutex{},
-		feedAlerts:    make(map[string][]gtfs.Alert),
+		feedData:      make(map[string]*FeedData),
 	}
 
-	feedAlerts := make([]gtfs.Alert, 1000)
+	alerts := make([]gtfs.Alert, 1000)
 	for i := 0; i < 1000; i++ {
 		tripID := gtfs.TripID{ID: fmt.Sprintf("trip_%d", i)}
 		stopID := fmt.Sprintf("stop_%d", i)
-		feedAlerts[i] = gtfs.Alert{
+		alerts[i] = gtfs.Alert{
 			ID: fmt.Sprintf("alert_%d", i),
 			InformedEntities: []gtfs.AlertInformedEntity{
 				{TripID: &tripID},
@@ -94,11 +94,11 @@ func BenchmarkRebuildAlertIndex(b *testing.B) {
 			},
 		}
 	}
-	manager.feedAlerts["feed-0"] = feedAlerts
+	manager.feedData["feed-0"] = &FeedData{Alerts: alerts}
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		manager.rebuildMergedRealtimeLocked()
+		manager.buildMergedRealtime()
 	}
 }
 
@@ -107,16 +107,16 @@ func BenchmarkGetAlertsByIDs(b *testing.B) {
 	// (~10 alerts/route, ~20 alerts/agency), each with a unique trip.
 	manager := &Manager{
 		realTimeMutex: sync.RWMutex{},
-		feedAlerts:    make(map[string][]gtfs.Alert),
+		feedData:      make(map[string]*FeedData),
 	}
 
-	feedAlerts := make([]gtfs.Alert, 1000)
+	alerts := make([]gtfs.Alert, 1000)
 	for i := 0; i < 1000; i++ {
 		tripID := gtfs.TripID{ID: fmt.Sprintf("trip_%d", i)}
 		routeID := fmt.Sprintf("route_%d", i%100)
 		agencyID := fmt.Sprintf("agency_%d", i%50)
 		stopID := fmt.Sprintf("stop_%d", i)
-		feedAlerts[i] = gtfs.Alert{
+		alerts[i] = gtfs.Alert{
 			ID: fmt.Sprintf("alert_%d", i),
 			InformedEntities: []gtfs.AlertInformedEntity{
 				{TripID: &tripID},
@@ -126,8 +126,8 @@ func BenchmarkGetAlertsByIDs(b *testing.B) {
 			},
 		}
 	}
-	manager.feedAlerts["feed-0"] = feedAlerts
-	manager.rebuildMergedRealtimeLocked()
+	manager.feedData["feed-0"] = &FeedData{Alerts: alerts}
+	manager.buildMergedRealtime()
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -143,21 +143,21 @@ func BenchmarkGetAlertsByIDs(b *testing.B) {
 func BenchmarkGetAlertsForStop(b *testing.B) {
 	manager := &Manager{
 		realTimeMutex: sync.RWMutex{},
-		feedAlerts:    make(map[string][]gtfs.Alert),
+		feedData:      make(map[string]*FeedData),
 	}
 
-	feedAlerts := make([]gtfs.Alert, 1000)
+	alerts := make([]gtfs.Alert, 1000)
 	for i := 0; i < 1000; i++ {
 		stopID := fmt.Sprintf("stop_%d", i)
-		feedAlerts[i] = gtfs.Alert{
+		alerts[i] = gtfs.Alert{
 			ID: fmt.Sprintf("alert_%d", i),
 			InformedEntities: []gtfs.AlertInformedEntity{
 				{StopID: &stopID},
 			},
 		}
 	}
-	manager.feedAlerts["feed-0"] = feedAlerts
-	manager.rebuildMergedRealtimeLocked()
+	manager.feedData["feed-0"] = &FeedData{Alerts: alerts}
+	manager.buildMergedRealtime()
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {

--- a/internal/gtfs/realtime_benchmark_test.go
+++ b/internal/gtfs/realtime_benchmark_test.go
@@ -168,8 +168,8 @@ func BenchmarkGetAlertsForStop(b *testing.B) {
 func BenchmarkRebuildDuplicatedVehicleByRoute(b *testing.B) {
 	manager := &Manager{
 		realTimeMutex: sync.RWMutex{},
-		feedTrips:     make(map[string][]gtfs.Trip),
-		feedVehicles:  make(map[string][]gtfs.Vehicle),
+		feedData:      make(map[string]*FeedData),
+		duplicatedVehicleByRoute: make(map[string][]gtfs.Vehicle),
 	}
 
 	feedTrips := make([]gtfs.Trip, 1000)
@@ -194,20 +194,19 @@ func BenchmarkRebuildDuplicatedVehicleByRoute(b *testing.B) {
 			},
 		}
 	}
-	manager.feedTrips["feed-0"] = feedTrips
-	manager.feedVehicles["feed-0"] = feedVehicles
+	manager.feedData["feed-0"] = &FeedData{Trips: feedTrips, Vehicles: feedVehicles}
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		manager.rebuildMergedRealtimeLocked()
+		manager.buildMergedRealtime()
 	}
 }
 
 func BenchmarkGetDuplicatedVehiclesForRoute(b *testing.B) {
 	manager := &Manager{
 		realTimeMutex: sync.RWMutex{},
-		feedTrips:     make(map[string][]gtfs.Trip),
-		feedVehicles:  make(map[string][]gtfs.Vehicle),
+		feedData:      make(map[string]*FeedData),
+		duplicatedVehicleByRoute: make(map[string][]gtfs.Vehicle),
 	}
 
 	feedTrips := make([]gtfs.Trip, 1000)
@@ -232,9 +231,8 @@ func BenchmarkGetDuplicatedVehiclesForRoute(b *testing.B) {
 			},
 		}
 	}
-	manager.feedTrips["feed-0"] = feedTrips
-	manager.feedVehicles["feed-0"] = feedVehicles
-	manager.rebuildMergedRealtimeLocked()
+	manager.feedData["feed-0"] = &FeedData{Trips: feedTrips, Vehicles: feedVehicles}
+	manager.buildMergedRealtime()
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {

--- a/internal/gtfs/realtime_test.go
+++ b/internal/gtfs/realtime_test.go
@@ -25,8 +25,8 @@ func TestGetAlertsForTrip(t *testing.T) {
 	tripID := gtfs.TripID{ID: "trip123"}
 	manager := &Manager{
 		realTimeMutex: sync.RWMutex{},
-		feedAlerts: map[string][]gtfs.Alert{
-			"feed-0": {
+		feedData: map[string]*FeedData{
+			"feed-0": &FeedData{Alerts: []gtfs.Alert{
 				{
 					ID: "alert1",
 					InformedEntities: []gtfs.AlertInformedEntity{
@@ -35,10 +35,10 @@ func TestGetAlertsForTrip(t *testing.T) {
 						},
 					},
 				},
-			},
+			}},
 		},
 	}
-	manager.rebuildMergedRealtimeLocked()
+	manager.buildMergedRealtime()
 
 	alerts := manager.GetAlertsForTrip(context.Background(), "trip123")
 
@@ -50,8 +50,8 @@ func TestGetAlertsForStop(t *testing.T) {
 	stopID := "stop123"
 	manager := &Manager{
 		realTimeMutex: sync.RWMutex{},
-		feedAlerts: map[string][]gtfs.Alert{
-			"feed-0": {
+		feedData: map[string]*FeedData{
+			"feed-0": &FeedData{Alerts: []gtfs.Alert{
 				{
 					ID: "alert1",
 					InformedEntities: []gtfs.AlertInformedEntity{
@@ -60,10 +60,10 @@ func TestGetAlertsForStop(t *testing.T) {
 						},
 					},
 				},
-			},
+			}},
 		},
 	}
-	manager.rebuildMergedRealtimeLocked()
+	manager.buildMergedRealtime()
 
 	alerts := manager.GetAlertsForStop("stop123")
 
@@ -74,19 +74,21 @@ func TestGetAlertsForStop(t *testing.T) {
 func TestRebuildRealTimeTripLookup(t *testing.T) {
 	manager := &Manager{
 		realTimeMutex: sync.RWMutex{},
-		feedTrips: map[string][]gtfs.Trip{
-			"feed-0": {
-				{
-					ID: gtfs.TripID{ID: "trip1"},
-				},
-				{
-					ID: gtfs.TripID{ID: "trip2"},
+		feedData: map[string]*FeedData{
+			"feed-0": &FeedData{
+				Trips: []gtfs.Trip{
+					{
+						ID: gtfs.TripID{ID: "trip1"},
+					},
+					{
+						ID: gtfs.TripID{ID: "trip2"},
+					},
 				},
 			},
 		},
 	}
 
-	manager.rebuildMergedRealtimeLocked()
+	manager.buildMergedRealtime()
 
 	assert.NotNil(t, manager.realTimeTripLookup)
 	assert.Len(t, manager.realTimeTripLookup, 2)
@@ -104,19 +106,21 @@ func TestRebuildRealTimeVehicleLookupByTrip(t *testing.T) {
 
 	manager := &Manager{
 		realTimeMutex: sync.RWMutex{},
-		feedVehicles: map[string][]gtfs.Vehicle{
-			"feed-0": {
-				{
-					Trip: trip1,
-				},
-				{
-					Trip: trip2,
+		feedData: map[string]*FeedData{
+			"feed-0": &FeedData{
+				Vehicles: []gtfs.Vehicle{
+					{
+						Trip: trip1,
+					},
+					{
+						Trip: trip2,
+					},
 				},
 			},
 		},
 	}
 
-	manager.rebuildMergedRealtimeLocked()
+	manager.buildMergedRealtime()
 
 	assert.NotNil(t, manager.realTimeVehicleLookupByTrip)
 	assert.Len(t, manager.realTimeVehicleLookupByTrip, 2)
@@ -130,19 +134,21 @@ func TestRebuildRealTimeVehicleLookupByVehicle(t *testing.T) {
 
 	manager := &Manager{
 		realTimeMutex: sync.RWMutex{},
-		feedVehicles: map[string][]gtfs.Vehicle{
-			"feed-0": {
-				{
-					ID: vehicleID1,
-				},
-				{
-					ID: vehicleID2,
+		feedData: map[string]*FeedData{
+			"feed-0": &FeedData{
+				Vehicles: []gtfs.Vehicle{
+					{
+						ID: vehicleID1,
+					},
+					{
+						ID: vehicleID2,
+					},
 				},
 			},
 		},
 	}
 
-	manager.rebuildMergedRealtimeLocked()
+	manager.buildMergedRealtime()
 
 	assert.NotNil(t, manager.realTimeVehicleLookupByVehicle)
 	assert.Len(t, manager.realTimeVehicleLookupByVehicle, 2)
@@ -153,25 +159,27 @@ func TestRebuildRealTimeVehicleLookupByVehicle(t *testing.T) {
 func TestRebuildRealTimeVehicleLookupByVehicle_WithInvalidIDs(t *testing.T) {
 	manager := &Manager{
 		realTimeMutex: sync.RWMutex{},
-		feedVehicles: map[string][]gtfs.Vehicle{
-			"feed-0": {
-				{
-					ID: &gtfs.VehicleID{ID: "vehicle1"},
-				},
-				{
-					ID: nil,
-				},
-				{
-					ID: &gtfs.VehicleID{ID: ""},
-				},
-				{
-					ID: &gtfs.VehicleID{ID: "vehicle3"},
+		feedData: map[string]*FeedData{
+			"feed-0": &FeedData{
+				Vehicles: []gtfs.Vehicle{
+					{
+						ID: &gtfs.VehicleID{ID: "vehicle1"},
+					},
+					{
+						ID: nil,
+					},
+					{
+						ID: &gtfs.VehicleID{ID: ""},
+					},
+					{
+						ID: &gtfs.VehicleID{ID: "vehicle3"},
+					},
 				},
 			},
 		},
 	}
 
-	manager.rebuildMergedRealtimeLocked()
+	manager.buildMergedRealtime()
 
 	assert.NotNil(t, manager.realTimeVehicleLookupByVehicle)
 	assert.Len(t, manager.realTimeVehicleLookupByVehicle, 2)
@@ -283,14 +291,13 @@ func TestEnabledFeeds(t *testing.T) {
 func TestClearFeedData(t *testing.T) {
 	manager := &Manager{
 		realTimeMutex: sync.RWMutex{},
-		feedTrips: map[string][]gtfs.Trip{
-			"test_feed": {{ID: gtfs.TripID{ID: "trip1"}}},
-		},
-		feedVehicles: map[string][]gtfs.Vehicle{
-			"test_feed": {{ID: &gtfs.VehicleID{ID: "veh1"}}},
-		},
-		feedAlerts: map[string][]gtfs.Alert{
-			"test_feed": {{ID: "alert1"}},
+		feedData: map[string]*FeedData{
+			"test_feed": {
+				Trips:           []gtfs.Trip{{ID: gtfs.TripID{ID: "trip1"}}},
+				Vehicles:        []gtfs.Vehicle{{ID: &gtfs.VehicleID{ID: "veh1"}}},
+				Alerts:          []gtfs.Alert{{ID: "alert1"}},
+				VehicleLastSeen: make(map[string]time.Time),
+			},
 		},
 		feedLastUpdate: map[string]time.Time{
 			"test_feed": time.Now(),
@@ -298,19 +305,83 @@ func TestClearFeedData(t *testing.T) {
 	}
 
 	// Warm up realTime lookup array cache
-	manager.rebuildMergedRealtimeLocked()
+	manager.buildMergedRealtime()
 	assert.Len(t, manager.GetRealTimeTrips(), 1, "Should have 1 trip initially")
 	assert.Contains(t, manager.feedLastUpdate, "test_feed", "feedLastUpdate should exist initially")
 
 	// Trigger the clearing mechanism
 	manager.clearFeedData("test_feed")
 
-	assert.Empty(t, manager.feedTrips["test_feed"], "feedTrips should be empty after clearing")
-	assert.Empty(t, manager.feedVehicles["test_feed"], "feedVehicles should be empty after clearing")
-	assert.Empty(t, manager.feedAlerts["test_feed"], "feedAlerts should be empty after clearing")
+	feed := manager.feedData["test_feed"]
+	assert.Empty(t, feed.Trips, "feedTrips should be empty after clearing")
+	assert.Empty(t, feed.Vehicles, "feedVehicles should be empty after clearing")
+	assert.Empty(t, feed.Alerts, "feedAlerts should be empty after clearing")
 	assert.NotContains(t, manager.feedLastUpdate, "test_feed", "feedLastUpdate should be removed after clearing")
 	assert.Len(t, manager.GetRealTimeTrips(), 0, "Global trip lookup should be empty")
 	assert.Len(t, manager.GetRealTimeVehicles(), 0, "Global vehicle lookup should be empty")
+}
+
+// A minimal valid GTFS-RT protobuf payload containing just a GTFS Realtime version header.
+// Parsed successfully as an empty feed.
+var emptyValidGTFSRTPayload = []byte{0x0a, 0x05, 0x0a, 0x03, 0x32, 0x2e, 0x30}
+
+func TestUpdateFeedRealtime_RetainsOldDataOnError(t *testing.T) {
+	// Setup a server that always returns 500 (causes error)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	manager := &Manager{
+		feedData:      make(map[string]*FeedData),
+		realTimeMutex: sync.RWMutex{},
+	}
+
+	oldTrips := []gtfs.Trip{{ID: gtfs.TripID{ID: "old-trip"}}}
+	manager.feedData["feed1"] = &FeedData{
+		Trips:           oldTrips,
+		VehicleLastSeen: make(map[string]time.Time),
+	}
+
+	feedCfg := RTFeedConfig{
+		ID:             "feed1",
+		TripUpdatesURL: server.URL,
+	}
+
+	manager.updateFeedRealtime(context.Background(), feedCfg)
+
+	feed := manager.feedData["feed1"]
+	assert.Len(t, feed.Trips, 1)
+	assert.Equal(t, "old-trip", feed.Trips[0].ID.ID, "Old data should be retained on error")
+}
+
+func TestUpdateFeedRealtime_SuccessReplacesOld(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(emptyValidGTFSRTPayload)
+	}))
+	defer server.Close()
+
+	manager := &Manager{
+		feedData:      make(map[string]*FeedData),
+		realTimeMutex: sync.RWMutex{},
+	}
+
+	oldTrips := []gtfs.Trip{{ID: gtfs.TripID{ID: "old-trip"}}}
+	manager.feedData["feed1"] = &FeedData{
+		Trips:           oldTrips,
+		VehicleLastSeen: make(map[string]time.Time),
+	}
+
+	feedCfg := RTFeedConfig{
+		ID:             "feed1",
+		TripUpdatesURL: server.URL, // Succeeds with empty payload
+	}
+
+	manager.updateFeedRealtime(context.Background(), feedCfg)
+
+	feed := manager.feedData["feed1"]
+	assert.Len(t, feed.Trips, 0, "Old data should be replaced by the empty feed on success")
 }
 
 func TestUpdateFeedRealtime_ReturnsFalseOnFailure(t *testing.T) {
@@ -321,12 +392,8 @@ func TestUpdateFeedRealtime_ReturnsFalseOnFailure(t *testing.T) {
 	defer server.Close()
 
 	manager := &Manager{
-		realTimeMutex:        sync.RWMutex{},
-		feedTrips:            make(map[string][]gtfs.Trip),
-		feedVehicles:         make(map[string][]gtfs.Vehicle),
-		feedAlerts:           make(map[string][]gtfs.Alert),
-		feedVehicleTimestamp: make(map[string]uint64),
-		feedVehicleLastSeen:  make(map[string]map[string]time.Time),
+		realTimeMutex: sync.RWMutex{},
+		feedData:      make(map[string]*FeedData),
 	}
 
 	cfg := RTFeedConfig{
@@ -375,16 +442,16 @@ func TestStaleFeedRejected(t *testing.T) {
 	// Verify the feed has a FeedHeader timestamp — this test
 	// exercises the freshness guard, which only applies to feeds
 	// with a non-zero CreatedAt.
-	manager.realTimeMutex.RLock()
-	require.NotZero(t, manager.feedVehicleTimestamp[feed.ID],
+	manager.feedData[feed.ID].mu.RLock()
+	require.NotZero(t, manager.feedData[feed.ID].VehicleTimestamp,
 		"RABA feed must have FeedHeader timestamp for this test to be meaningful")
-	manager.realTimeMutex.RUnlock()
+	manager.feedData[feed.ID].mu.RUnlock()
 
 	// Simulate a stale feed by manually setting the stored timestamp to a very
 	// large value (future timestamp), so the next update will be rejected.
-	manager.realTimeMutex.Lock()
-	manager.feedVehicleTimestamp[feed.ID] = uint64(time.Now().Add(1 * time.Hour).UnixNano())
-	manager.realTimeMutex.Unlock()
+	manager.feedData[feed.ID].mu.Lock()
+	manager.feedData[feed.ID].VehicleTimestamp = uint64(time.Now().Add(1 * time.Hour).UnixNano())
+	manager.feedData[feed.ID].mu.Unlock()
 
 	// Second poll: attempt to update with same feed URL (same data, same timestamp)
 	// This should be rejected because the stored timestamp is in the future
@@ -720,11 +787,11 @@ func TestGetAlertsByIDs_RouteScoping(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			manager := &Manager{
 				realTimeMutex: sync.RWMutex{},
-				feedAlerts: map[string][]gtfs.Alert{
-					"feed-0": {{ID: "alert1", InformedEntities: tt.entities}},
+				feedData: map[string]*FeedData{
+					"feed-0": &FeedData{Alerts: []gtfs.Alert{{ID: "alert1", InformedEntities: tt.entities}}},
 				},
 			}
-			manager.rebuildMergedRealtimeLocked()
+			manager.buildMergedRealtime()
 			alerts := manager.GetAlertsByIDs("", routeID, "")
 			if tt.expectMatch {
 				assert.Len(t, alerts, 1)
@@ -745,16 +812,16 @@ func TestAlertIndex_RouteTripEntityIndexedUnderByTrip(t *testing.T) {
 
 	manager := &Manager{
 		realTimeMutex: sync.RWMutex{},
-		feedAlerts: map[string][]gtfs.Alert{
-			"feed-0": {
+		feedData: map[string]*FeedData{
+			"feed-0": &FeedData{Alerts: []gtfs.Alert{
 				{
 					ID:               "alert1",
 					InformedEntities: []gtfs.AlertInformedEntity{{RouteID: &routeID, TripID: &tripID}},
 				},
-			},
+			}},
 		},
 	}
-	manager.rebuildMergedRealtimeLocked()
+	manager.buildMergedRealtime()
 
 	tripAlerts := manager.GetAlertsByIDs(tripID.ID, "", "")
 	assert.Len(t, tripAlerts, 1, "{routeID+tripID} entity should be indexed under byTrip")
@@ -804,11 +871,11 @@ func TestGetAlertsByIDs_AgencyScoping(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			manager := &Manager{
 				realTimeMutex: sync.RWMutex{},
-				feedAlerts: map[string][]gtfs.Alert{
-					"feed-0": {{ID: "alert1", InformedEntities: tt.entities}},
+				feedData: map[string]*FeedData{
+					"feed-0": &FeedData{Alerts: []gtfs.Alert{{ID: "alert1", InformedEntities: tt.entities}}},
 				},
 			}
-			manager.rebuildMergedRealtimeLocked()
+			manager.buildMergedRealtime()
 			alerts := manager.GetAlertsByIDs("", "", agencyID)
 			if tt.expectMatch {
 				assert.Len(t, alerts, 1)
@@ -823,16 +890,16 @@ func TestAlertIndex_ByTripID(t *testing.T) {
 	tripID := gtfs.TripID{ID: "trip1"}
 	manager := &Manager{
 		realTimeMutex: sync.RWMutex{},
-		feedAlerts: map[string][]gtfs.Alert{
-			"feed-0": {
+		feedData: map[string]*FeedData{
+			"feed-0": &FeedData{Alerts: []gtfs.Alert{
 				{
 					ID:               "alert1",
 					InformedEntities: []gtfs.AlertInformedEntity{{TripID: &tripID}},
 				},
-			},
+			}},
 		},
 	}
-	manager.rebuildMergedRealtimeLocked()
+	manager.buildMergedRealtime()
 
 	alerts := manager.GetAlertsByIDs("trip1", "", "")
 
@@ -844,16 +911,16 @@ func TestAlertIndex_ByRouteID(t *testing.T) {
 	routeID := "route1"
 	manager := &Manager{
 		realTimeMutex: sync.RWMutex{},
-		feedAlerts: map[string][]gtfs.Alert{
-			"feed-0": {
+		feedData: map[string]*FeedData{
+			"feed-0": &FeedData{Alerts: []gtfs.Alert{
 				{
 					ID:               "alert1",
 					InformedEntities: []gtfs.AlertInformedEntity{{RouteID: &routeID}},
 				},
-			},
+			}},
 		},
 	}
-	manager.rebuildMergedRealtimeLocked()
+	manager.buildMergedRealtime()
 
 	alerts := manager.GetAlertsByIDs("", "route1", "")
 
@@ -865,16 +932,16 @@ func TestAlertIndex_ByAgencyID(t *testing.T) {
 	agencyID := "agency1"
 	manager := &Manager{
 		realTimeMutex: sync.RWMutex{},
-		feedAlerts: map[string][]gtfs.Alert{
-			"feed-0": {
+		feedData: map[string]*FeedData{
+			"feed-0": &FeedData{Alerts: []gtfs.Alert{
 				{
 					ID:               "alert1",
 					InformedEntities: []gtfs.AlertInformedEntity{{AgencyID: &agencyID}},
 				},
-			},
+			}},
 		},
 	}
-	manager.rebuildMergedRealtimeLocked()
+	manager.buildMergedRealtime()
 
 	alerts := manager.GetAlertsByIDs("", "", "agency1")
 
@@ -886,16 +953,16 @@ func TestAlertIndex_ByStopID(t *testing.T) {
 	stopID := "stop1"
 	manager := &Manager{
 		realTimeMutex: sync.RWMutex{},
-		feedAlerts: map[string][]gtfs.Alert{
-			"feed-0": {
+		feedData: map[string]*FeedData{
+			"feed-0": &FeedData{Alerts: []gtfs.Alert{
 				{
 					ID:               "alert1",
 					InformedEntities: []gtfs.AlertInformedEntity{{StopID: &stopID}},
 				},
-			},
+			}},
 		},
 	}
-	manager.rebuildMergedRealtimeLocked()
+	manager.buildMergedRealtime()
 
 	alerts := manager.GetAlertsForStop("stop1")
 
@@ -908,8 +975,8 @@ func TestAlertIndex_Deduplication(t *testing.T) {
 	routeID := "route1"
 	manager := &Manager{
 		realTimeMutex: sync.RWMutex{},
-		feedAlerts: map[string][]gtfs.Alert{
-			"feed-0": {
+		feedData: map[string]*FeedData{
+			"feed-0": &FeedData{Alerts: []gtfs.Alert{
 				{
 					ID: "alert1",
 					InformedEntities: []gtfs.AlertInformedEntity{
@@ -917,10 +984,10 @@ func TestAlertIndex_Deduplication(t *testing.T) {
 						{RouteID: &routeID},
 					},
 				},
-			},
+			}},
 		},
 	}
-	manager.rebuildMergedRealtimeLocked()
+	manager.buildMergedRealtime()
 
 	// Querying by both trip and route should return the alert exactly once.
 	alerts := manager.GetAlertsByIDs("trip1", "route1", "")
@@ -932,9 +999,9 @@ func TestAlertIndex_Deduplication(t *testing.T) {
 func TestAlertIndex_EmptyAlerts(t *testing.T) {
 	manager := &Manager{
 		realTimeMutex: sync.RWMutex{},
-		feedAlerts:    map[string][]gtfs.Alert{},
+		feedData: map[string]*FeedData{},
 	}
-	manager.rebuildMergedRealtimeLocked()
+	manager.buildMergedRealtime()
 
 	assert.Empty(t, manager.GetAlertsByIDs("trip1", "route1", "agency1"))
 	assert.Empty(t, manager.GetAlertsForStop("stop1"))
@@ -948,8 +1015,8 @@ func TestAlertIndex_NoDuplicatesFromRepeatedEntityKeys(t *testing.T) {
 
 	manager := &Manager{
 		realTimeMutex: sync.RWMutex{},
-		feedAlerts: map[string][]gtfs.Alert{
-			"feed-0": {
+		feedData: map[string]*FeedData{
+			"feed-0": &FeedData{Alerts: []gtfs.Alert{
 				{
 					ID: "alert1",
 					InformedEntities: []gtfs.AlertInformedEntity{
@@ -963,10 +1030,10 @@ func TestAlertIndex_NoDuplicatesFromRepeatedEntityKeys(t *testing.T) {
 						{AgencyID: &agencyID},
 					},
 				},
-			},
+			}},
 		},
 	}
-	manager.rebuildMergedRealtimeLocked()
+	manager.buildMergedRealtime()
 
 	assert.Len(t, manager.GetAlertsForStop("stop1"), 1)
 	assert.Len(t, manager.GetAlertsByIDs("trip1", "route1", "agency1"), 1)
@@ -978,8 +1045,8 @@ func TestAlertIndex_EmptyIDAlertExcluded(t *testing.T) {
 
 	manager := &Manager{
 		realTimeMutex: sync.RWMutex{},
-		feedAlerts: map[string][]gtfs.Alert{
-			"feed-0": {
+		feedData: map[string]*FeedData{
+			"feed-0": &FeedData{Alerts: []gtfs.Alert{
 				{
 					ID:               "",
 					InformedEntities: []gtfs.AlertInformedEntity{{StopID: &stopID}, {TripID: &tripID}},
@@ -988,10 +1055,10 @@ func TestAlertIndex_EmptyIDAlertExcluded(t *testing.T) {
 					ID:               "alert-valid",
 					InformedEntities: []gtfs.AlertInformedEntity{{StopID: &stopID}},
 				},
-			},
+			}},
 		},
 	}
-	manager.rebuildMergedRealtimeLocked()
+	manager.buildMergedRealtime()
 
 	stopAlerts := manager.GetAlertsForStop("stop1")
 	require.Len(t, stopAlerts, 1)
@@ -1010,16 +1077,16 @@ func TestAlertIndex_AgencyStopEntityAlsoIndexedByStop(t *testing.T) {
 
 	manager := &Manager{
 		realTimeMutex: sync.RWMutex{},
-		feedAlerts: map[string][]gtfs.Alert{
-			"feed-0": {
+		feedData: map[string]*FeedData{
+			"feed-0": &FeedData{Alerts: []gtfs.Alert{
 				{
 					ID:               "alert1",
 					InformedEntities: []gtfs.AlertInformedEntity{{AgencyID: &agencyID, StopID: &stopID}},
 				},
-			},
+			}},
 		},
 	}
-	manager.rebuildMergedRealtimeLocked()
+	manager.buildMergedRealtime()
 
 	stopAlerts := manager.GetAlertsForStop(stopID)
 	assert.Len(t, stopAlerts, 1, "agency+stop entity should appear in byStop")
@@ -1065,13 +1132,13 @@ func TestAlertIndex_AllEmptyArgsReturnsNil(t *testing.T) {
 	stopID := "stop1"
 	manager := &Manager{
 		realTimeMutex: sync.RWMutex{},
-		feedAlerts: map[string][]gtfs.Alert{
-			"feed-0": {
+		feedData: map[string]*FeedData{
+			"feed-0": &FeedData{Alerts: []gtfs.Alert{
 				{ID: "alert1", InformedEntities: []gtfs.AlertInformedEntity{{StopID: &stopID}}},
-			},
+			}},
 		},
 	}
-	manager.rebuildMergedRealtimeLocked()
+	manager.buildMergedRealtime()
 
 	result := manager.GetAlertsByIDs("", "", "")
 	assert.Nil(t, result, "GetAlertsByIDs with all empty args should return nil")
@@ -1126,14 +1193,14 @@ func TestAlertIndex_NilInformedEntitiesExcludedFromAllBuckets(t *testing.T) {
 	// Both are tested here to guard against regressions in either branch.
 	manager := &Manager{
 		realTimeMutex: sync.RWMutex{},
-		feedAlerts: map[string][]gtfs.Alert{
-			"feed-0": {
+		feedData: map[string]*FeedData{
+			"feed-0": &FeedData{Alerts: []gtfs.Alert{
 				{ID: "alert-nil-entities", InformedEntities: nil},
 				{ID: "alert-empty-entities", InformedEntities: []gtfs.AlertInformedEntity{}},
-			},
+			}},
 		},
 	}
-	manager.rebuildMergedRealtimeLocked()
+	manager.buildMergedRealtime()
 
 	assert.Empty(t, manager.GetAlertsForStop("any-stop"))
 	assert.Empty(t, manager.GetAlertsByIDs("any-trip", "any-route", "any-agency"))
@@ -1146,12 +1213,12 @@ func TestAlertIndex_CrossFeedDeduplication(t *testing.T) {
 	// regardless of how many feeds contributed the same alert.
 	manager := &Manager{
 		realTimeMutex: sync.RWMutex{},
-		feedAlerts: map[string][]gtfs.Alert{
-			"feed-0": {{ID: "alert1", InformedEntities: []gtfs.AlertInformedEntity{{StopID: &stopID}}}},
-			"feed-1": {{ID: "alert1", InformedEntities: []gtfs.AlertInformedEntity{{StopID: &stopID}}}},
+		feedData: map[string]*FeedData{
+			"feed-0": &FeedData{Alerts: []gtfs.Alert{{ID: "alert1", InformedEntities: []gtfs.AlertInformedEntity{{StopID: &stopID}}}}},
+			"feed-1": &FeedData{Alerts: []gtfs.Alert{{ID: "alert1", InformedEntities: []gtfs.AlertInformedEntity{{StopID: &stopID}}}}},
 		},
 	}
-	manager.rebuildMergedRealtimeLocked()
+	manager.buildMergedRealtime()
 
 	stopAlerts := manager.GetAlertsForStop(stopID)
 	assert.Len(t, stopAlerts, 1, "GetAlertsForStop deduplicates by alert ID across feeds")
@@ -1258,12 +1325,8 @@ func TestUpdateFeedRealtime_SubFeedSuccess_OrLogic(t *testing.T) {
 
 	// Fully initialize all maps to prevent "assignment to entry in nil map" panics
 	manager := &Manager{
-		realTimeMutex:        sync.RWMutex{},
-		feedTrips:            make(map[string][]gtfs.Trip),
-		feedVehicles:         make(map[string][]gtfs.Vehicle),
-		feedAlerts:           make(map[string][]gtfs.Alert),
-		feedVehicleTimestamp: make(map[string]uint64),
-		feedVehicleLastSeen:  make(map[string]map[string]time.Time),
+		realTimeMutex: sync.RWMutex{},
+		feedData:      make(map[string]*FeedData),
 	}
 
 	// 1. Test partial success (OR logic): Trip updates succeed, Vehicle positions fail
@@ -1508,4 +1571,53 @@ func TestGetDuplicatedVehiclesForRoute_NoMatchReturnsEmpty(t *testing.T) {
 	result := manager.GetDuplicatedVehiclesForRoute("route-unknown")
 
 	assert.Empty(t, result, "route miss should return empty result")
+}
+
+func TestUpdateFeedRealtime_StaleVehicles(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(emptyValidGTFSRTPayload) // Empty -> no new vehicles fetched
+	}))
+	defer server.Close()
+
+	manager := &Manager{
+		feedData:      make(map[string]*FeedData),
+		realTimeMutex: sync.RWMutex{},
+	}
+
+	now := time.Now()
+
+	// v1 seen 5 mins ago (should be kept)
+	v1 := gtfs.Vehicle{ID: &gtfs.VehicleID{ID: "v1"}}
+
+	// v2 seen 20 mins ago (should be removed, staleVehicleTimeout = 15m)
+	v2 := gtfs.Vehicle{ID: &gtfs.VehicleID{ID: "v2"}}
+
+	manager.feedData["feed1"] = &FeedData{
+		Vehicles: []gtfs.Vehicle{v1, v2},
+		VehicleLastSeen: map[string]time.Time{
+			"v1": now.Add(-5 * time.Minute),
+			"v2": now.Add(-20 * time.Minute),
+		},
+	}
+
+	feedCfg := RTFeedConfig{
+		ID:                  "feed1",
+		VehiclePositionsURL: server.URL,
+	}
+
+	manager.updateFeedRealtime(context.Background(), feedCfg)
+
+	feed := manager.feedData["feed1"]
+
+	assert.Len(t, feed.Vehicles, 1, "Only 1 vehicle should remain")
+	if len(feed.Vehicles) > 0 {
+		assert.Equal(t, "v1", feed.Vehicles[0].ID.ID, "Recently seen vehicle should be kept")
+	}
+
+	_, ok1 := feed.VehicleLastSeen["v1"]
+	assert.True(t, ok1, "v1 should still be in VehicleLastSeen map")
+
+	_, ok2 := feed.VehicleLastSeen["v2"]
+	assert.False(t, ok2, "v2 should be removed from VehicleLastSeen map due to staleness")
 }

--- a/internal/gtfs/realtime_test.go
+++ b/internal/gtfs/realtime_test.go
@@ -1107,16 +1107,16 @@ func TestAlertIndex_RouteStopEntityAlsoIndexedByStop(t *testing.T) {
 
 	manager := &Manager{
 		realTimeMutex: sync.RWMutex{},
-		feedAlerts: map[string][]gtfs.Alert{
-			"feed-0": {
+		feedData: map[string]*FeedData{
+			"feed-0": &FeedData{Alerts: []gtfs.Alert{
 				{
 					ID:               "alert1",
 					InformedEntities: []gtfs.AlertInformedEntity{{RouteID: &routeID, StopID: &stopID}},
 				},
-			},
+			}},
 		},
 	}
-	manager.rebuildMergedRealtimeLocked()
+	manager.buildMergedRealtime()
 
 	stopAlerts := manager.GetAlertsForStop(stopID)
 	assert.Len(t, stopAlerts, 1, "route+stop entity should appear in byStop")
@@ -1188,7 +1188,7 @@ func TestMockAddAlert_IndexIsImmediatelySynced(t *testing.T) {
 
 func TestAlertIndex_NilInformedEntitiesExcludedFromAllBuckets(t *testing.T) {
 	// Two different code paths both produce empty buckets:
-	//   - nil InformedEntities: hits the `continue` guard in rebuildMergedRealtimeLocked
+	//   - nil InformedEntities: hits the `continue` guard in buildMergedRealtime
 	//   - non-nil but empty slice: falls through to an inner loop that never executes
 	// Both are tested here to guard against regressions in either branch.
 	manager := &Manager{
@@ -1232,12 +1232,12 @@ func TestAlertIndex_CrossFeedDeduplicationByIDs(t *testing.T) {
 	// buckets. GetAlertsByIDs must still deduplicate by alert ID before returning.
 	manager := &Manager{
 		realTimeMutex: sync.RWMutex{},
-		feedAlerts: map[string][]gtfs.Alert{
-			"feed-0": {{ID: "alert1", InformedEntities: []gtfs.AlertInformedEntity{{RouteID: &routeID}}}},
-			"feed-1": {{ID: "alert1", InformedEntities: []gtfs.AlertInformedEntity{{TripID: &tripID}}}},
+		feedData: map[string]*FeedData{
+			"feed-0": &FeedData{Alerts: []gtfs.Alert{{ID: "alert1", InformedEntities: []gtfs.AlertInformedEntity{{RouteID: &routeID}}}}},
+			"feed-1": &FeedData{Alerts: []gtfs.Alert{{ID: "alert1", InformedEntities: []gtfs.AlertInformedEntity{{TripID: &tripID}}}}},
 		},
 	}
-	manager.rebuildMergedRealtimeLocked()
+	manager.buildMergedRealtime()
 
 	alerts := manager.GetAlertsByIDs(tripID.ID, routeID, "")
 	assert.Len(t, alerts, 1, "GetAlertsByIDs deduplicates by alert ID across feeds")
@@ -1362,9 +1362,10 @@ func TestUpdateFeedRealtime_SubFeedSuccess_OrLogic(t *testing.T) {
 
 func TestGetDuplicatedVehiclesForRoute_MatchesWithRouteID(t *testing.T) {
 	manager := &Manager{
-		realTimeMutex: sync.RWMutex{},
-		feedVehicles: map[string][]gtfs.Vehicle{
-			"feed-0": {
+		realTimeMutex:            sync.RWMutex{},
+		duplicatedVehicleByRoute: make(map[string][]gtfs.Vehicle),
+		feedData: map[string]*FeedData{
+			"feed-0": &FeedData{Vehicles: []gtfs.Vehicle{
 				{
 					ID: &gtfs.VehicleID{ID: "v1"},
 					Trip: &gtfs.Trip{
@@ -1375,11 +1376,11 @@ func TestGetDuplicatedVehiclesForRoute_MatchesWithRouteID(t *testing.T) {
 						},
 					},
 				},
-			},
+			}},
 		},
 	}
 
-	manager.rebuildMergedRealtimeLocked()
+	manager.buildMergedRealtime()
 
 	result := manager.GetDuplicatedVehiclesForRoute("route-A")
 	require.Len(t, result, 1, "expected exactly one duplicated vehicle")
@@ -1389,34 +1390,35 @@ func TestGetDuplicatedVehiclesForRoute_MatchesWithRouteID(t *testing.T) {
 func TestGetDuplicatedVehiclesForRoute_FallbackViaTripUpdate(t *testing.T) {
 	// Vehicle has no route_id in its trip descriptor; the TripUpdate carries it.
 	manager := &Manager{
-		realTimeMutex: sync.RWMutex{},
-		feedVehicles: map[string][]gtfs.Vehicle{
-			"feed-0": {
-				{
-					ID: &gtfs.VehicleID{ID: "v2"},
-					Trip: &gtfs.Trip{
-						ID: gtfs.TripID{
-							ID:                   "trip2",
-							RouteID:              "", // omitted in VehiclePosition
-							ScheduleRelationship: gtfsrt.TripDescriptor_DUPLICATED,
+		realTimeMutex:            sync.RWMutex{},
+		duplicatedVehicleByRoute: make(map[string][]gtfs.Vehicle),
+		feedData: map[string]*FeedData{
+			"feed-0": &FeedData{
+				Vehicles: []gtfs.Vehicle{
+					{
+						ID: &gtfs.VehicleID{ID: "v2"},
+						Trip: &gtfs.Trip{
+							ID: gtfs.TripID{
+								ID:                   "trip2",
+								RouteID:              "", // omitted in VehiclePosition
+								ScheduleRelationship: gtfsrt.TripDescriptor_DUPLICATED,
+							},
 						},
 					},
 				},
-			},
-		},
-		feedTrips: map[string][]gtfs.Trip{
-			"feed-0": {
-				{
-					ID: gtfs.TripID{
-						ID:      "trip2",
-						RouteID: "route-B",
+				Trips: []gtfs.Trip{
+					{
+						ID: gtfs.TripID{
+							ID:      "trip2",
+							RouteID: "route-B",
+						},
 					},
 				},
 			},
 		},
 	}
 
-	manager.rebuildMergedRealtimeLocked()
+	manager.buildMergedRealtime()
 
 	result := manager.GetDuplicatedVehiclesForRoute("route-B")
 	require.Len(t, result, 1, "expected exactly one duplicated vehicle matched via trip update fallback")
@@ -1425,9 +1427,10 @@ func TestGetDuplicatedVehiclesForRoute_FallbackViaTripUpdate(t *testing.T) {
 
 func TestGetDuplicatedVehiclesForRoute_ExcludesNonDuplicated(t *testing.T) {
 	manager := &Manager{
-		realTimeMutex: sync.RWMutex{},
-		feedVehicles: map[string][]gtfs.Vehicle{
-			"feed-0": {
+		realTimeMutex:            sync.RWMutex{},
+		duplicatedVehicleByRoute: make(map[string][]gtfs.Vehicle),
+		feedData: map[string]*FeedData{
+			"feed-0": &FeedData{Vehicles: []gtfs.Vehicle{
 				{
 					ID: &gtfs.VehicleID{ID: "v3"},
 					Trip: &gtfs.Trip{
@@ -1448,11 +1451,11 @@ func TestGetDuplicatedVehiclesForRoute_ExcludesNonDuplicated(t *testing.T) {
 						},
 					},
 				},
-			},
+			}},
 		},
 	}
 
-	manager.rebuildMergedRealtimeLocked()
+	manager.buildMergedRealtime()
 
 	result := manager.GetDuplicatedVehiclesForRoute("route-C")
 	assert.Empty(t, result, "SCHEDULED and CANCELED vehicles must be excluded")
@@ -1460,9 +1463,10 @@ func TestGetDuplicatedVehiclesForRoute_ExcludesNonDuplicated(t *testing.T) {
 
 func TestGetDuplicatedVehiclesForRoute_RebuildClearsStaleIndex(t *testing.T) {
 	manager := &Manager{
-		realTimeMutex: sync.RWMutex{},
-		feedVehicles: map[string][]gtfs.Vehicle{
-			"feed-0": {
+		realTimeMutex:            sync.RWMutex{},
+		duplicatedVehicleByRoute: make(map[string][]gtfs.Vehicle),
+		feedData: map[string]*FeedData{
+			"feed-0": &FeedData{Vehicles: []gtfs.Vehicle{
 				{
 					ID: &gtfs.VehicleID{ID: "v6"},
 					Trip: &gtfs.Trip{
@@ -1473,24 +1477,25 @@ func TestGetDuplicatedVehiclesForRoute_RebuildClearsStaleIndex(t *testing.T) {
 						},
 					},
 				},
-			},
+			}},
 		},
 	}
 
-	manager.rebuildMergedRealtimeLocked()
+	manager.buildMergedRealtime()
 	require.Len(t, manager.GetDuplicatedVehiclesForRoute("route-E"), 1)
 
-	manager.feedVehicles["feed-0"] = nil
-	manager.rebuildMergedRealtimeLocked()
+	manager.feedData["feed-0"] = &FeedData{}
+	manager.buildMergedRealtime()
 
 	assert.Empty(t, manager.GetDuplicatedVehiclesForRoute("route-E"))
 }
 
 func TestGetDuplicatedVehiclesForRoute_MissingRouteIDWithoutTripUpdate(t *testing.T) {
 	manager := &Manager{
-		realTimeMutex: sync.RWMutex{},
-		feedVehicles: map[string][]gtfs.Vehicle{
-			"feed-0": {
+		realTimeMutex:            sync.RWMutex{},
+		duplicatedVehicleByRoute: make(map[string][]gtfs.Vehicle),
+		feedData: map[string]*FeedData{
+			"feed-0": &FeedData{Vehicles: []gtfs.Vehicle{
 				{
 					ID: &gtfs.VehicleID{ID: "v7"},
 					Trip: &gtfs.Trip{
@@ -1501,11 +1506,11 @@ func TestGetDuplicatedVehiclesForRoute_MissingRouteIDWithoutTripUpdate(t *testin
 						},
 					},
 				},
-			},
+			}},
 		},
 	}
 
-	manager.rebuildMergedRealtimeLocked()
+	manager.buildMergedRealtime()
 
 	result := manager.GetDuplicatedVehiclesForRoute("route-F")
 	assert.Empty(t, result, "Vehicle without route_id and no matching trip_id should not be included")
@@ -1513,9 +1518,10 @@ func TestGetDuplicatedVehiclesForRoute_MissingRouteIDWithoutTripUpdate(t *testin
 
 func TestGetDuplicatedVehiclesForRoute_MultipleVehiclesSameRoute(t *testing.T) {
 	manager := &Manager{
-		realTimeMutex: sync.RWMutex{},
-		feedVehicles: map[string][]gtfs.Vehicle{
-			"feed-0": {
+		realTimeMutex:            sync.RWMutex{},
+		duplicatedVehicleByRoute: make(map[string][]gtfs.Vehicle),
+		feedData: map[string]*FeedData{
+			"feed-0": &FeedData{Vehicles: []gtfs.Vehicle{
 				{
 					ID: &gtfs.VehicleID{ID: "v8"},
 					Trip: &gtfs.Trip{
@@ -1536,11 +1542,11 @@ func TestGetDuplicatedVehiclesForRoute_MultipleVehiclesSameRoute(t *testing.T) {
 						},
 					},
 				},
-			},
+			}},
 		},
 	}
 
-	manager.rebuildMergedRealtimeLocked()
+	manager.buildMergedRealtime()
 
 	result := manager.GetDuplicatedVehiclesForRoute("route-G")
 	require.Len(t, result, 2, "all DUPLICATED vehicles for the same route should be retained")
@@ -1550,9 +1556,10 @@ func TestGetDuplicatedVehiclesForRoute_MultipleVehiclesSameRoute(t *testing.T) {
 
 func TestGetDuplicatedVehiclesForRoute_NoMatchReturnsEmpty(t *testing.T) {
 	manager := &Manager{
-		realTimeMutex: sync.RWMutex{},
-		feedVehicles: map[string][]gtfs.Vehicle{
-			"feed-0": {
+		realTimeMutex:            sync.RWMutex{},
+		duplicatedVehicleByRoute: make(map[string][]gtfs.Vehicle),
+		feedData: map[string]*FeedData{
+			"feed-0": &FeedData{Vehicles: []gtfs.Vehicle{
 				{
 					ID: &gtfs.VehicleID{ID: "v10"},
 					Trip: &gtfs.Trip{
@@ -1563,10 +1570,10 @@ func TestGetDuplicatedVehiclesForRoute_NoMatchReturnsEmpty(t *testing.T) {
 						},
 					},
 				},
-			},
+			}},
 		},
 	}
-	manager.rebuildMergedRealtimeLocked()
+	manager.buildMergedRealtime()
 
 	result := manager.GetDuplicatedVehiclesForRoute("route-unknown")
 

--- a/internal/restapi/arrivals_and_departures_for_stop_handler_test.go
+++ b/internal/restapi/arrivals_and_departures_for_stop_handler_test.go
@@ -1305,6 +1305,8 @@ func TestArrivalsAndDeparturesForStop_VehicleWithNilID(t *testing.T) {
 	})
 	require.NoError(t, err)
 
+	// Clear the service-IDs cache so the upcoming request sees the newly inserted
+	// calendar entry rather than a result cached by an earlier test in this package.
 	api.GtfsManager.MockClearServiceIDsCache()
 
 	api.GtfsManager.MockAddVehicleWithOptions("", tripID, routeID, internalgtfs.MockVehicleOptions{


### PR DESCRIPTION
Fixes #479 
# Description

This PR refactors the GTFS Manager to use **fine-grained, per-feed locking** for realtime data ingestion.

Previously, a global reader/writer lock (`realTimeMutex`) was held for the entire duration of a feed update. In environments with multiple realtime feeds updating concurrently, this caused significant lock contention. A slower feed update would block all other feeds from writing and could potentially block readers trying to access the current state.

This change introduces a localized `FeedData` struct with its own `sync.RWMutex`. This allows individual feeds to process and store their realtime data independently and concurrently. The global lock is now only acquired briefly during the final aggregation step (`buildMergedRealtime`), where pointers to the updated feed data are merged into the global system view.

---

# Changes Proposed

## 1. Introduced `FeedData` Struct

Replaced the separate:

- `feedTrips`
- `feedVehicles`
- `feedAlerts`
- `feedVehicleLastSeen`

With a single:

```go
map[string]*FeedData
```

This bundles a feed's realtime state into a cohesive structure, improving maintainability and encapsulation.

---

## 2. Added Per-Feed Locks

- Added a `sync.RWMutex` inside `FeedData`.
- Data extraction, parsing, transformation, and assignment for a specific feed now hold **only that feed’s lock**.
- Independent feeds no longer block each other during ingestion.

This enables true parallel processing of realtime feeds.

---

## 3. Map Synchronization

- Introduced a `feedMapMutex`.
- Ensures safe read/write access to the top-level `map[string]*FeedData`.
- Allows new feeds to be registered safely without race conditions.

This guarantees thread-safe feed lifecycle management.

---

## 4. Optimized Merging (`buildMergedRealtime`)

### a) Merge Serialization

- Introduced a `mergeMutex` to serialize concurrent merge operations.
- Prevents overlapping global aggregation steps.

### b) Feed-Level Locking During Merge

- Iterates over sorted feeds.
- Acquires each feed’s `RWMutex` **only long enough to copy its data slices**.
- Releases immediately after copying.

This ensures minimal blocking at the feed level.

---

## 5. Updated Tests

- Refactored existing unit tests and benchmarks to align with the new `FeedData` architecture.
- Updated mocks and test setup where necessary to support per-feed locking.

---

## 6. Added Test Coverage

New test cases were added to validate:

- Retaining previous realtime data on HTTP failures.
- Correctly handling empty payload responses.
- Proper expiration of stale vehicles based on last-seen timestamps.
- Safe concurrent execution of feed updates.
