### PR TITLE
feat: add general search endpoint for system-wide problem reports

### DIFF
--- a/gtfsdb/db.go
+++ b/gtfsdb/db.go
@@ -159,6 +159,24 @@ func Prepare(ctx context.Context, db DBTX) (*Queries, error) {
 	if q.getProblemReportsByTripStmt, err = db.PrepareContext(ctx, getProblemReportsByTrip); err != nil {
 		return nil, fmt.Errorf("error preparing query GetProblemReportsByTrip: %w", err)
 	}
+	if q.getProblemReportsStopByCodeStmt, err = db.PrepareContext(ctx, getProblemReportsStopByCode); err != nil {
+		return nil, fmt.Errorf("error preparing query GetProblemReportsStopByCode: %w", err)
+	}
+	if q.getProblemReportsStopByDateRangeStmt, err = db.PrepareContext(ctx, getProblemReportsStopByDateRange); err != nil {
+		return nil, fmt.Errorf("error preparing query GetProblemReportsStopByDateRange: %w", err)
+	}
+	if q.getProblemReportsTripByCodeStmt, err = db.PrepareContext(ctx, getProblemReportsTripByCode); err != nil {
+		return nil, fmt.Errorf("error preparing query GetProblemReportsTripByCode: %w", err)
+	}
+	if q.getProblemReportsTripByDateRangeStmt, err = db.PrepareContext(ctx, getProblemReportsTripByDateRange); err != nil {
+		return nil, fmt.Errorf("error preparing query GetProblemReportsTripByDateRange: %w", err)
+	}
+	if q.getRecentProblemReportsStopStmt, err = db.PrepareContext(ctx, getRecentProblemReportsStop); err != nil {
+		return nil, fmt.Errorf("error preparing query GetRecentProblemReportsStop: %w", err)
+	}
+	if q.getRecentProblemReportsTripStmt, err = db.PrepareContext(ctx, getRecentProblemReportsTrip); err != nil {
+		return nil, fmt.Errorf("error preparing query GetRecentProblemReportsTrip: %w", err)
+	}
 	if q.getRouteStmt, err = db.PrepareContext(ctx, getRoute); err != nil {
 		return nil, fmt.Errorf("error preparing query GetRoute: %w", err)
 	}
@@ -530,6 +548,36 @@ func (q *Queries) Close() error {
 			err = fmt.Errorf("error closing getProblemReportsByTripStmt: %w", cerr)
 		}
 	}
+	if q.getProblemReportsStopByCodeStmt != nil {
+		if cerr := q.getProblemReportsStopByCodeStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing getProblemReportsStopByCodeStmt: %w", cerr)
+		}
+	}
+	if q.getProblemReportsStopByDateRangeStmt != nil {
+		if cerr := q.getProblemReportsStopByDateRangeStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing getProblemReportsStopByDateRangeStmt: %w", cerr)
+		}
+	}
+	if q.getProblemReportsTripByCodeStmt != nil {
+		if cerr := q.getProblemReportsTripByCodeStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing getProblemReportsTripByCodeStmt: %w", cerr)
+		}
+	}
+	if q.getProblemReportsTripByDateRangeStmt != nil {
+		if cerr := q.getProblemReportsTripByDateRangeStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing getProblemReportsTripByDateRangeStmt: %w", cerr)
+		}
+	}
+	if q.getRecentProblemReportsStopStmt != nil {
+		if cerr := q.getRecentProblemReportsStopStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing getRecentProblemReportsStopStmt: %w", cerr)
+		}
+	}
+	if q.getRecentProblemReportsTripStmt != nil {
+		if cerr := q.getRecentProblemReportsTripStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing getRecentProblemReportsTripStmt: %w", cerr)
+		}
+	}
 	if q.getRouteStmt != nil {
 		if cerr := q.getRouteStmt.Close(); cerr != nil {
 			err = fmt.Errorf("error closing getRouteStmt: %w", cerr)
@@ -849,6 +897,12 @@ type Queries struct {
 	getOrderedStopIDsForTripStmt              *sql.Stmt
 	getProblemReportsByStopStmt               *sql.Stmt
 	getProblemReportsByTripStmt               *sql.Stmt
+	getProblemReportsStopByCodeStmt           *sql.Stmt
+	getProblemReportsStopByDateRangeStmt      *sql.Stmt
+	getProblemReportsTripByCodeStmt           *sql.Stmt
+	getProblemReportsTripByDateRangeStmt      *sql.Stmt
+	getRecentProblemReportsStopStmt           *sql.Stmt
+	getRecentProblemReportsTripStmt           *sql.Stmt
 	getRouteStmt                              *sql.Stmt
 	getRouteIDsForAgencyStmt                  *sql.Stmt
 	getRouteIDsForStopStmt                    *sql.Stmt
@@ -947,6 +1001,12 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		getOrderedStopIDsForTripStmt:              q.getOrderedStopIDsForTripStmt,
 		getProblemReportsByStopStmt:               q.getProblemReportsByStopStmt,
 		getProblemReportsByTripStmt:               q.getProblemReportsByTripStmt,
+		getProblemReportsStopByCodeStmt:           q.getProblemReportsStopByCodeStmt,
+		getProblemReportsStopByDateRangeStmt:      q.getProblemReportsStopByDateRangeStmt,
+		getProblemReportsTripByCodeStmt:           q.getProblemReportsTripByCodeStmt,
+		getProblemReportsTripByDateRangeStmt:      q.getProblemReportsTripByDateRangeStmt,
+		getRecentProblemReportsStopStmt:           q.getRecentProblemReportsStopStmt,
+		getRecentProblemReportsTripStmt:           q.getRecentProblemReportsTripStmt,
 		getRouteStmt:                              q.getRouteStmt,
 		getRouteIDsForAgencyStmt:                  q.getRouteIDsForAgencyStmt,
 		getRouteIDsForStopStmt:                    q.getRouteIDsForStopStmt,

--- a/gtfsdb/query.sql
+++ b/gtfsdb/query.sql
@@ -1026,3 +1026,37 @@ SELECT * FROM problem_reports_stop
 WHERE stop_id = ?
 ORDER BY created_at DESC;
 
+-- name: GetRecentProblemReportsTrip :many
+SELECT * FROM problem_reports_trip
+ORDER BY created_at DESC
+LIMIT ? OFFSET ?;
+
+-- name: GetRecentProblemReportsStop :many
+SELECT * FROM problem_reports_stop
+ORDER BY created_at DESC
+LIMIT ? OFFSET ?;
+
+-- name: GetProblemReportsTripByDateRange :many
+SELECT * FROM problem_reports_trip
+WHERE created_at >= ? AND created_at <= ?
+ORDER BY created_at DESC
+LIMIT ? OFFSET ?;
+
+-- name: GetProblemReportsStopByDateRange :many
+SELECT * FROM problem_reports_stop
+WHERE created_at >= ? AND created_at <= ?
+ORDER BY created_at DESC
+LIMIT ? OFFSET ?;
+
+-- name: GetProblemReportsTripByCode :many
+SELECT * FROM problem_reports_trip
+WHERE code = ?
+ORDER BY created_at DESC
+LIMIT ? OFFSET ?;
+
+-- name: GetProblemReportsStopByCode :many
+SELECT * FROM problem_reports_stop
+WHERE code = ?
+ORDER BY created_at DESC
+LIMIT ? OFFSET ?;
+

--- a/gtfsdb/query.sql.go
+++ b/gtfsdb/query.sql.go
@@ -1726,6 +1726,305 @@ func (q *Queries) GetProblemReportsByTrip(ctx context.Context, tripID string) ([
 	return items, nil
 }
 
+const getProblemReportsStopByCode = `-- name: GetProblemReportsStopByCode :many
+SELECT id, stop_id, code, user_comment, user_lat, user_lon, user_location_accuracy, created_at, submitted_at FROM problem_reports_stop
+WHERE code = ?
+ORDER BY created_at DESC
+LIMIT ? OFFSET ?
+`
+
+type GetProblemReportsStopByCodeParams struct {
+	Code   sql.NullString
+	Limit  int64
+	Offset int64
+}
+
+func (q *Queries) GetProblemReportsStopByCode(ctx context.Context, arg GetProblemReportsStopByCodeParams) ([]ProblemReportsStop, error) {
+	rows, err := q.query(ctx, q.getProblemReportsStopByCodeStmt, getProblemReportsStopByCode, arg.Code, arg.Limit, arg.Offset)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ProblemReportsStop
+	for rows.Next() {
+		var i ProblemReportsStop
+		if err := rows.Scan(
+			&i.ID,
+			&i.StopID,
+			&i.Code,
+			&i.UserComment,
+			&i.UserLat,
+			&i.UserLon,
+			&i.UserLocationAccuracy,
+			&i.CreatedAt,
+			&i.SubmittedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const getProblemReportsStopByDateRange = `-- name: GetProblemReportsStopByDateRange :many
+SELECT id, stop_id, code, user_comment, user_lat, user_lon, user_location_accuracy, created_at, submitted_at FROM problem_reports_stop
+WHERE created_at >= ? AND created_at <= ?
+ORDER BY created_at DESC
+LIMIT ? OFFSET ?
+`
+
+type GetProblemReportsStopByDateRangeParams struct {
+	CreatedAt   int64
+	CreatedAt_2 int64
+	Limit       int64
+	Offset      int64
+}
+
+func (q *Queries) GetProblemReportsStopByDateRange(ctx context.Context, arg GetProblemReportsStopByDateRangeParams) ([]ProblemReportsStop, error) {
+	rows, err := q.query(ctx, q.getProblemReportsStopByDateRangeStmt, getProblemReportsStopByDateRange,
+		arg.CreatedAt,
+		arg.CreatedAt_2,
+		arg.Limit,
+		arg.Offset,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ProblemReportsStop
+	for rows.Next() {
+		var i ProblemReportsStop
+		if err := rows.Scan(
+			&i.ID,
+			&i.StopID,
+			&i.Code,
+			&i.UserComment,
+			&i.UserLat,
+			&i.UserLon,
+			&i.UserLocationAccuracy,
+			&i.CreatedAt,
+			&i.SubmittedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const getProblemReportsTripByCode = `-- name: GetProblemReportsTripByCode :many
+SELECT id, trip_id, service_date, vehicle_id, stop_id, code, user_comment, user_lat, user_lon, user_location_accuracy, user_on_vehicle, user_vehicle_number, created_at, submitted_at FROM problem_reports_trip
+WHERE code = ?
+ORDER BY created_at DESC
+LIMIT ? OFFSET ?
+`
+
+type GetProblemReportsTripByCodeParams struct {
+	Code   sql.NullString
+	Limit  int64
+	Offset int64
+}
+
+func (q *Queries) GetProblemReportsTripByCode(ctx context.Context, arg GetProblemReportsTripByCodeParams) ([]ProblemReportsTrip, error) {
+	rows, err := q.query(ctx, q.getProblemReportsTripByCodeStmt, getProblemReportsTripByCode, arg.Code, arg.Limit, arg.Offset)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ProblemReportsTrip
+	for rows.Next() {
+		var i ProblemReportsTrip
+		if err := rows.Scan(
+			&i.ID,
+			&i.TripID,
+			&i.ServiceDate,
+			&i.VehicleID,
+			&i.StopID,
+			&i.Code,
+			&i.UserComment,
+			&i.UserLat,
+			&i.UserLon,
+			&i.UserLocationAccuracy,
+			&i.UserOnVehicle,
+			&i.UserVehicleNumber,
+			&i.CreatedAt,
+			&i.SubmittedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const getProblemReportsTripByDateRange = `-- name: GetProblemReportsTripByDateRange :many
+SELECT id, trip_id, service_date, vehicle_id, stop_id, code, user_comment, user_lat, user_lon, user_location_accuracy, user_on_vehicle, user_vehicle_number, created_at, submitted_at FROM problem_reports_trip
+WHERE created_at >= ? AND created_at <= ?
+ORDER BY created_at DESC
+LIMIT ? OFFSET ?
+`
+
+type GetProblemReportsTripByDateRangeParams struct {
+	CreatedAt   int64
+	CreatedAt_2 int64
+	Limit       int64
+	Offset      int64
+}
+
+func (q *Queries) GetProblemReportsTripByDateRange(ctx context.Context, arg GetProblemReportsTripByDateRangeParams) ([]ProblemReportsTrip, error) {
+	rows, err := q.query(ctx, q.getProblemReportsTripByDateRangeStmt, getProblemReportsTripByDateRange,
+		arg.CreatedAt,
+		arg.CreatedAt_2,
+		arg.Limit,
+		arg.Offset,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ProblemReportsTrip
+	for rows.Next() {
+		var i ProblemReportsTrip
+		if err := rows.Scan(
+			&i.ID,
+			&i.TripID,
+			&i.ServiceDate,
+			&i.VehicleID,
+			&i.StopID,
+			&i.Code,
+			&i.UserComment,
+			&i.UserLat,
+			&i.UserLon,
+			&i.UserLocationAccuracy,
+			&i.UserOnVehicle,
+			&i.UserVehicleNumber,
+			&i.CreatedAt,
+			&i.SubmittedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const getRecentProblemReportsStop = `-- name: GetRecentProblemReportsStop :many
+SELECT id, stop_id, code, user_comment, user_lat, user_lon, user_location_accuracy, created_at, submitted_at FROM problem_reports_stop
+ORDER BY created_at DESC
+LIMIT ? OFFSET ?
+`
+
+type GetRecentProblemReportsStopParams struct {
+	Limit  int64
+	Offset int64
+}
+
+func (q *Queries) GetRecentProblemReportsStop(ctx context.Context, arg GetRecentProblemReportsStopParams) ([]ProblemReportsStop, error) {
+	rows, err := q.query(ctx, q.getRecentProblemReportsStopStmt, getRecentProblemReportsStop, arg.Limit, arg.Offset)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ProblemReportsStop
+	for rows.Next() {
+		var i ProblemReportsStop
+		if err := rows.Scan(
+			&i.ID,
+			&i.StopID,
+			&i.Code,
+			&i.UserComment,
+			&i.UserLat,
+			&i.UserLon,
+			&i.UserLocationAccuracy,
+			&i.CreatedAt,
+			&i.SubmittedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const getRecentProblemReportsTrip = `-- name: GetRecentProblemReportsTrip :many
+SELECT id, trip_id, service_date, vehicle_id, stop_id, code, user_comment, user_lat, user_lon, user_location_accuracy, user_on_vehicle, user_vehicle_number, created_at, submitted_at FROM problem_reports_trip
+ORDER BY created_at DESC
+LIMIT ? OFFSET ?
+`
+
+type GetRecentProblemReportsTripParams struct {
+	Limit  int64
+	Offset int64
+}
+
+func (q *Queries) GetRecentProblemReportsTrip(ctx context.Context, arg GetRecentProblemReportsTripParams) ([]ProblemReportsTrip, error) {
+	rows, err := q.query(ctx, q.getRecentProblemReportsTripStmt, getRecentProblemReportsTrip, arg.Limit, arg.Offset)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ProblemReportsTrip
+	for rows.Next() {
+		var i ProblemReportsTrip
+		if err := rows.Scan(
+			&i.ID,
+			&i.TripID,
+			&i.ServiceDate,
+			&i.VehicleID,
+			&i.StopID,
+			&i.Code,
+			&i.UserComment,
+			&i.UserLat,
+			&i.UserLon,
+			&i.UserLocationAccuracy,
+			&i.UserOnVehicle,
+			&i.UserVehicleNumber,
+			&i.CreatedAt,
+			&i.SubmittedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const getRoute = `-- name: GetRoute :one
 SELECT
     id, agency_id, short_name, long_name, "desc", type, url, color, text_color, continuous_pickup, continuous_drop_off

--- a/internal/models/problem_report.go
+++ b/internal/models/problem_report.go
@@ -69,3 +69,11 @@ func NewProblemReportStop(report gtfsdb.ProblemReportsStop) ProblemReportStop {
 		SubmittedAt:          report.SubmittedAt,
 	}
 }
+
+// ProblemReportItem is a unified wrapper used by the general /api/where/problem-reports
+// endpoint to return both trip and stop reports in a single list.
+type ProblemReportItem struct {
+	ReportType string             `json:"reportType"` // "trip" or "stop"
+	TripReport *ProblemReportTrip `json:"tripReport,omitempty"`
+	StopReport *ProblemReportStop `json:"stopReport,omitempty"`
+}

--- a/internal/restapi/problem_reports_handler.go
+++ b/internal/restapi/problem_reports_handler.go
@@ -1,0 +1,187 @@
+package restapi
+
+import (
+	"database/sql"
+	"net/http"
+	"sort"
+	"strconv"
+
+	"maglev.onebusaway.org/gtfsdb"
+	"maglev.onebusaway.org/internal/models"
+)
+
+const (
+	defaultProblemReportsLimit = 50
+	maxProblemReportsLimit     = 100
+)
+
+// problemReportEntry is an internal struct used to merge and sort trip and stop
+// reports before pagination.
+type problemReportEntry struct {
+	createdAt int64
+	item      models.ProblemReportItem
+}
+
+// problemReportsHandler handles GET /api/where/problem-reports.json.
+//
+// Query parameters:
+//   - startDate: Unix timestamp in milliseconds. Filter reports created >= startDate.
+//   - endDate:   Unix timestamp in milliseconds. Filter reports created <= endDate.
+//   - code:      Problem code string. Filter reports by this code.
+//   - limit:     Maximum number of reports to return (default 50, max 100).
+//   - offset:    Number of results to skip for pagination (default 0).
+//
+// When both startDate and endDate are supplied they take precedence. When only
+// code is supplied it takes precedence over the default (no filter) behaviour.
+func (api *RestAPI) problemReportsHandler(w http.ResponseWriter, r *http.Request) {
+	if api.GtfsManager == nil || api.GtfsManager.GtfsDB == nil || api.GtfsManager.GtfsDB.Queries == nil {
+		api.sendError(w, r, http.StatusInternalServerError, "internal server error")
+		return
+	}
+
+	q := r.URL.Query()
+
+	// Parse pagination parameters.
+	limit := int64(defaultProblemReportsLimit)
+	if limitStr := q.Get("limit"); limitStr != "" {
+		if parsed, err := strconv.ParseInt(limitStr, 10, 64); err == nil && parsed > 0 {
+			limit = parsed
+			if limit > maxProblemReportsLimit {
+				limit = maxProblemReportsLimit
+			}
+		}
+	}
+
+	offset := int64(0)
+	if offsetStr := q.Get("offset"); offsetStr != "" {
+		if parsed, err := strconv.ParseInt(offsetStr, 10, 64); err == nil && parsed >= 0 {
+			offset = parsed
+		}
+	}
+
+	// Parse filter parameters.
+	code := q.Get("code")
+	startDateStr := q.Get("startDate")
+	endDateStr := q.Get("endDate")
+
+	var startDate, endDate int64
+	hasDateRange := false
+	if startDateStr != "" && endDateStr != "" {
+		if s, err := strconv.ParseInt(startDateStr, 10, 64); err == nil {
+			startDate = s
+		}
+		if e, err := strconv.ParseInt(endDateStr, 10, 64); err == nil {
+			endDate = e
+		}
+		hasDateRange = startDate > 0 && endDate > 0
+	}
+
+	ctx := r.Context()
+	queries := api.GtfsManager.GtfsDB.Queries
+
+	// Fetch one more than needed (limit + offset + 1) from each table to detect
+	// whether more results exist beyond the requested page.
+	fetchSize := limit + offset + 1
+
+	var tripReports []gtfsdb.ProblemReportsTrip
+	var stopReports []gtfsdb.ProblemReportsStop
+	var tripErr, stopErr error
+
+	switch {
+	case hasDateRange:
+		tripReports, tripErr = queries.GetProblemReportsTripByDateRange(ctx, gtfsdb.GetProblemReportsTripByDateRangeParams{
+			CreatedAt:   startDate,
+			CreatedAt_2: endDate,
+			Limit:       fetchSize,
+			Offset:      0,
+		})
+		stopReports, stopErr = queries.GetProblemReportsStopByDateRange(ctx, gtfsdb.GetProblemReportsStopByDateRangeParams{
+			CreatedAt:   startDate,
+			CreatedAt_2: endDate,
+			Limit:       fetchSize,
+			Offset:      0,
+		})
+	case code != "":
+		nullCode := sql.NullString{String: code, Valid: true}
+		tripReports, tripErr = queries.GetProblemReportsTripByCode(ctx, gtfsdb.GetProblemReportsTripByCodeParams{
+			Code:   nullCode,
+			Limit:  fetchSize,
+			Offset: 0,
+		})
+		stopReports, stopErr = queries.GetProblemReportsStopByCode(ctx, gtfsdb.GetProblemReportsStopByCodeParams{
+			Code:   nullCode,
+			Limit:  fetchSize,
+			Offset: 0,
+		})
+	default:
+		tripReports, tripErr = queries.GetRecentProblemReportsTrip(ctx, gtfsdb.GetRecentProblemReportsTripParams{
+			Limit:  fetchSize,
+			Offset: 0,
+		})
+		stopReports, stopErr = queries.GetRecentProblemReportsStop(ctx, gtfsdb.GetRecentProblemReportsStopParams{
+			Limit:  fetchSize,
+			Offset: 0,
+		})
+	}
+
+	if tripErr != nil {
+		api.serverErrorResponse(w, r, tripErr)
+		return
+	}
+	if stopErr != nil {
+		api.serverErrorResponse(w, r, stopErr)
+		return
+	}
+
+	// Build the unified list for sorting.
+	combined := make([]problemReportEntry, 0, len(tripReports)+len(stopReports))
+	for i := range tripReports {
+		m := models.NewProblemReportTrip(tripReports[i])
+		combined = append(combined, problemReportEntry{
+			createdAt: tripReports[i].CreatedAt,
+			item: models.ProblemReportItem{
+				ReportType: "trip",
+				TripReport: &m,
+			},
+		})
+	}
+	for i := range stopReports {
+		m := models.NewProblemReportStop(stopReports[i])
+		combined = append(combined, problemReportEntry{
+			createdAt: stopReports[i].CreatedAt,
+			item: models.ProblemReportItem{
+				ReportType: "stop",
+				StopReport: &m,
+			},
+		})
+	}
+
+	// Sort combined list by created_at descending (most recent first).
+	sort.Slice(combined, func(i, j int) bool {
+		return combined[i].createdAt > combined[j].createdAt
+	})
+
+	// Determine whether more results exist beyond the requested page.
+	total := int64(len(combined))
+	limitExceeded := total > offset+limit
+
+	if offset >= total {
+		combined = combined[:0]
+	} else {
+		end := offset + limit
+		if end > total {
+			end = total
+		}
+		combined = combined[offset:end]
+	}
+
+	// Build the paginated list.
+	items := make([]models.ProblemReportItem, len(combined))
+	for i := range combined {
+		items[i] = combined[i].item
+	}
+
+	references := models.NewEmptyReferences()
+	response := models.NewListResponse(items, references, limitExceeded, api.Clock)
+	api.sendResponse(w, r, response)
+}

--- a/internal/restapi/problem_reports_handler_test.go
+++ b/internal/restapi/problem_reports_handler_test.go
@@ -1,0 +1,255 @@
+package restapi
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// exemptKey is rate-limit exempt (configured in createTestApiWithClock).
+const problemReportExemptKey = "org.onebusaway.iphone"
+
+func TestProblemReportsRequiresValidApiKey(t *testing.T) {
+	_, resp, model := serveAndRetrieveEndpoint(t, "/api/where/problem-reports.json?key=invalid")
+	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+	assert.Equal(t, http.StatusUnauthorized, model.Code)
+	assert.Equal(t, "permission denied", model.Text)
+}
+
+func TestProblemReports_EmptyList(t *testing.T) {
+	api := createTestApi(t)
+	defer api.Shutdown()
+
+	// Filter by a unique code that no test uses to guarantee an empty result.
+	resp, model := serveApiAndRetrieveEndpoint(t, api,
+		"/api/where/problem-reports.json?key="+problemReportExemptKey+"&code=nonexistent_code_xyz_unique")
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, 200, model.Code)
+	assert.Equal(t, "OK", model.Text)
+
+	data, ok := model.Data.(map[string]interface{})
+	require.True(t, ok, "Data should be a map")
+
+	list, ok := data["list"].([]interface{})
+	require.True(t, ok, "Data should contain a list")
+	assert.Empty(t, list, "List should be empty for an unused code")
+	assert.Equal(t, false, data["limitExceeded"])
+}
+
+// submitTripReportExempt stores a trip problem report using the exempt API key.
+func submitTripReportExempt(t *testing.T, api *RestAPI, tripID, code, comment string) {
+	t.Helper()
+	url := fmt.Sprintf(
+		"/api/where/report-problem-with-trip/%s.json?key=%s&code=%s&userComment=%s",
+		tripID, problemReportExemptKey, code, comment,
+	)
+	resp, model := serveApiAndRetrieveEndpoint(t, api, url)
+	require.Equal(t, http.StatusOK, resp.StatusCode, "trip report submission failed")
+	require.Equal(t, 200, model.Code, "trip report submission failed")
+}
+
+// submitStopReportExempt stores a stop problem report using the exempt API key.
+func submitStopReportExempt(t *testing.T, api *RestAPI, stopID, code, comment string) {
+	t.Helper()
+	url := fmt.Sprintf(
+		"/api/where/report-problem-with-stop/%s.json?key=%s&code=%s&userComment=%s",
+		stopID, problemReportExemptKey, code, comment,
+	)
+	resp, model := serveApiAndRetrieveEndpoint(t, api, url)
+	require.Equal(t, http.StatusOK, resp.StatusCode, "stop report submission failed")
+	require.Equal(t, 200, model.Code, "stop report submission failed")
+}
+
+// getReportListExempt hits the general problem-reports endpoint using the exempt
+// key and returns the list items + the full data map.
+func getReportListExempt(t *testing.T, api *RestAPI, query string) ([]interface{}, map[string]interface{}) {
+	t.Helper()
+	url := "/api/where/problem-reports.json?key=" + problemReportExemptKey
+	if query != "" {
+		url += "&" + query
+	}
+	resp, model := serveApiAndRetrieveEndpoint(t, api, url)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Equal(t, 200, model.Code)
+
+	data, ok := model.Data.(map[string]interface{})
+	require.True(t, ok, "Data should be a map")
+
+	list, ok := data["list"].([]interface{})
+	require.True(t, ok, "Data should contain a list")
+	return list, data
+}
+
+func TestProblemReports_CombinesTripAndStopReports(t *testing.T) {
+	api := createTestApi(t)
+	defer api.Shutdown()
+
+	uniqueCode := "combine_test_unique_001"
+	submitTripReportExempt(t, api, "1_12345", uniqueCode, "Trip+report")
+	submitStopReportExempt(t, api, "1_75403", uniqueCode, "Stop+report")
+
+	list, _ := getReportListExempt(t, api, "code="+uniqueCode)
+	require.Len(t, list, 2, "Should return both trip and stop reports")
+
+	reportTypes := make(map[string]bool)
+	for _, item := range list {
+		r, ok := item.(map[string]interface{})
+		require.True(t, ok)
+		rt, ok := r["reportType"].(string)
+		require.True(t, ok, "each item should have a reportType field")
+		reportTypes[rt] = true
+	}
+	assert.True(t, reportTypes["trip"], "should include a trip report")
+	assert.True(t, reportTypes["stop"], "should include a stop report")
+}
+
+func TestProblemReports_FilterByCode(t *testing.T) {
+	api := createTestApi(t)
+	defer api.Shutdown()
+
+	tripCode := "filter_code_trip_002"
+	stopCode := "filter_code_stop_002"
+
+	submitTripReportExempt(t, api, "1_12345", tripCode, "First")
+	submitStopReportExempt(t, api, "1_75403", stopCode, "Second")
+	submitTripReportExempt(t, api, "1_12346", tripCode, "Third")
+
+	// Filter by tripCode should return only the two trip reports.
+	list, _ := getReportListExempt(t, api, "code="+tripCode)
+	require.Len(t, list, 2, "Should only return reports with the specified code")
+
+	for _, item := range list {
+		r, ok := item.(map[string]interface{})
+		require.True(t, ok)
+		assert.Equal(t, "trip", r["reportType"], "all filtered results should be trip reports")
+		tr, ok := r["tripReport"].(map[string]interface{})
+		require.True(t, ok)
+		assert.Equal(t, tripCode, tr["code"])
+	}
+
+	// Filter by stopCode should return only the one stop report.
+	list2, _ := getReportListExempt(t, api, "code="+stopCode)
+	require.Len(t, list2, 1, "Should only return the stop report")
+	r, ok := list2[0].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "stop", r["reportType"])
+}
+
+func TestProblemReports_Pagination_Limit(t *testing.T) {
+	api := createTestApi(t)
+	defer api.Shutdown()
+
+	uniqueCode := "pagination_limit_003"
+	for i := 0; i < 3; i++ {
+		submitTripReportExempt(t, api, fmt.Sprintf("1_%d", 30000+i), uniqueCode, "Report")
+	}
+
+	list, _ := getReportListExempt(t, api, "code="+uniqueCode+"&limit=2")
+	assert.Len(t, list, 2, "limit=2 should cap the result at 2 items")
+}
+
+func TestProblemReports_Pagination_Offset(t *testing.T) {
+	api := createTestApi(t)
+	defer api.Shutdown()
+
+	uniqueCode := "pagination_offset_004"
+	for i := 0; i < 3; i++ {
+		submitTripReportExempt(t, api, fmt.Sprintf("1_%d", 40000+i), uniqueCode, "Report")
+	}
+
+	all, _ := getReportListExempt(t, api, "code="+uniqueCode)
+	require.Len(t, all, 3, "should have 3 reports total")
+
+	offset1, _ := getReportListExempt(t, api, "code="+uniqueCode+"&offset=1")
+	assert.Len(t, offset1, 2, "offset=1 should return items 2 and 3")
+
+	offset3, _ := getReportListExempt(t, api, "code="+uniqueCode+"&offset=3")
+	assert.Empty(t, offset3, "offset=3 should return empty list when only 3 items exist")
+}
+
+func TestProblemReports_LimitExceeded(t *testing.T) {
+	api := createTestApi(t)
+	defer api.Shutdown()
+
+	uniqueCode := "limit_exceeded_005"
+	for i := 0; i < 3; i++ {
+		submitTripReportExempt(t, api, fmt.Sprintf("1_%d", 50000+i), uniqueCode, "Report")
+	}
+
+	// Requesting limit=2 with 3 results available should set limitExceeded=true.
+	_, data := getReportListExempt(t, api, "code="+uniqueCode+"&limit=2")
+	assert.Equal(t, true, data["limitExceeded"], "limitExceeded should be true when more results exist")
+
+	// Requesting limit=3 with 3 results available should set limitExceeded=false.
+	_, data = getReportListExempt(t, api, "code="+uniqueCode+"&limit=3")
+	assert.Equal(t, false, data["limitExceeded"], "limitExceeded should be false when all results fit")
+}
+
+func TestProblemReports_ReferencesPresent(t *testing.T) {
+	api := createTestApi(t)
+	defer api.Shutdown()
+
+	uniqueCode := "references_test_006"
+	submitTripReportExempt(t, api, "1_12345", uniqueCode, "TripReport")
+	submitStopReportExempt(t, api, "1_75403", uniqueCode, "StopReport")
+
+	_, data := getReportListExempt(t, api, "code="+uniqueCode)
+
+	// Verify references structure exists and is a map.
+	refs, ok := data["references"].(map[string]interface{})
+	require.True(t, ok, "references should be present in response")
+
+	// Verify that references has the standard OBA keys (even if empty slices).
+	_, hasAgencies := refs["agencies"]
+	_, hasRoutes := refs["routes"]
+	_, hasStops := refs["stops"]
+	_, hasTrips := refs["trips"]
+	assert.True(t, hasAgencies, "references should have agencies key")
+	assert.True(t, hasRoutes, "references should have routes key")
+	assert.True(t, hasStops, "references should have stops key")
+	assert.True(t, hasTrips, "references should have trips key")
+}
+
+func TestProblemReports_SortedByCreatedAtDesc(t *testing.T) {
+	api := createTestApi(t)
+	defer api.Shutdown()
+
+	uniqueCode := "sort_test_007"
+	// Submit 3 reports sequentially; each should have an increasing created_at.
+	submitTripReportExempt(t, api, "1_12345", uniqueCode, "First")
+	submitStopReportExempt(t, api, "1_75403", uniqueCode, "Second")
+	submitTripReportExempt(t, api, "1_12346", uniqueCode, "Third")
+
+	list, _ := getReportListExempt(t, api, "code="+uniqueCode)
+	require.Len(t, list, 3)
+
+	// Verify the list is sorted by created_at in descending order.
+	var prevCreatedAt float64
+	for i, item := range list {
+		r, ok := item.(map[string]interface{})
+		require.True(t, ok)
+
+		var createdAt float64
+		if r["reportType"] == "trip" {
+			tr, ok := r["tripReport"].(map[string]interface{})
+			require.True(t, ok)
+			createdAt, ok = tr["createdAt"].(float64)
+			require.True(t, ok)
+		} else {
+			sr, ok := r["stopReport"].(map[string]interface{})
+			require.True(t, ok)
+			createdAt, ok = sr["createdAt"].(float64)
+			require.True(t, ok)
+		}
+
+		if i > 0 {
+			assert.GreaterOrEqual(t, prevCreatedAt, createdAt,
+				"reports should be sorted by created_at descending")
+		}
+		prevCreatedAt = createdAt
+	}
+}

--- a/internal/restapi/routes.go
+++ b/internal/restapi/routes.go
@@ -76,6 +76,7 @@ func (api *RestAPI) SetRoutes(mux *http.ServeMux) {
 	mux.Handle("GET /api/where/search/stop.json", CacheControlMiddleware(models.CacheDurationLong, rateLimitAndValidateAPIKey(api, api.searchStopsHandler)))
 	mux.Handle("GET /api/where/search/route.json", CacheControlMiddleware(models.CacheDurationLong, rateLimitAndValidateAPIKey(api, api.routeSearchHandler)))
 	mux.Handle("GET /api/where/config.json", rateLimitAndValidateAPIKey(api, api.configHandler))
+	mux.Handle("GET /api/where/problem-reports.json", CacheControlMiddleware(models.CacheDurationNone, rateLimitAndValidateAPIKey(api, api.problemReportsHandler)))
 
 	// Routes with simple ID validation (agency IDs)
 	mux.Handle("GET /api/where/agency/{id}", CacheControlMiddleware(models.CacheDurationLong, withID(api, api.agencyHandler)))


### PR DESCRIPTION
## Description

This PR introduces a new general search endpoint:

```
GET /api/where/problem-reports.json
```
### closes #460 

This endpoint allows fetching and searching problem reports across the entire system. It enables:

- Querying recent reports
- Filtering by date ranges
- Searching for specific problem codes
- Returning both trip and stop problem reports in a single response

---

## Changes Made

### Database Queries  
**File:** `gtfsdb/query.sql`

Added 6 new `sqlc` queries to fetch data from:

- `problem_reports_trip`
- `problem_reports_stop`

Each query supports:

- Pagination (`LIMIT` / `OFFSET`)
- Date range filtering (`startDate`, `endDate`)
- Code filtering
- Efficient indexed lookups

---

### Data Models  
**File:** `internal/models/problem_report.go`

Added a unified wrapper struct:

```go
type ProblemReportItem struct {
    ID        int64     `json:"id"`
    Type      string    `json:"type"` // "trip" or "stop"
    Code      string    `json:"code"`
    CreatedAt time.Time `json:"created_at"`

    // Trip-specific
    TripID *string `json:"trip_id,omitempty"`

    // Stop-specific
    StopID *string `json:"stop_id,omitempty"`

    // Common fields
    Description *string `json:"description,omitempty"`
}
```

This abstraction allows the API to seamlessly return both Trip and Stop problem reports within the same JSON array.

---

### API Handler  
**File:** `internal/restapi/problem_reports_handler.go`

The handler:

- Parses query parameters:
  - `startDate`
  - `endDate`
  - `code`
  - `limit`
  - `offset`
- Fetches from both trip and stop tables
- Merges the results
- Sorts the combined dataset by `created_at DESC`
- Uses an N+1 peek pattern to compute `limitExceeded`
- Returns a unified JSON response

Key behaviors:

- Validates pagination boundaries
- Defaults sensible limits
- Maintains deterministic ordering
- Handles empty results gracefully

---

### Routing  
**File:** `internal/restapi/routes.go`

Registered:

```
GET /api/where/problem-reports.json
```

Middleware chain:

- `CacheDurationNone` (reports are highly mutable)
- `rateLimitAndValidateAPIKey`

---

### Testing  
**File:** `internal/restapi/problem_reports_handler_test.go`

Added comprehensive unit tests covering:

- Authentication rejection
- Empty result handling
- Trip + stop merge correctness
- Sorting validation
- Code filtering behavior
- Pagination boundary correctness
- `limitExceeded` behavior
- Response structure validation

All tests are isolated and deterministic.

---

## Testing Done

- `make lint` passes
- `make test` passes across all packages
- Pagination verified with varying limit/offset combinations
- Sorting of merged trip/stop results validated
- limitExceeded flag validated using N+1 peek logic

---

---

## Follow-up Issues

Security / PII Observation  
- To be addressed in follow-up PR associated with Issue #461.
