### PR TITLE
fix: resolve stale DB reference in DirectionCalculator after hot-swap

### DIFF
--- a/cmd/api/app.go
+++ b/cmd/api/app.go
@@ -77,7 +77,7 @@ func BuildApplication(cfg appconf.Config, gtfsCfg gtfs.Config) (*app.Application
 
 	var directionCalculator *gtfs.AdvancedDirectionCalculator
 	if gtfsManager != nil {
-		directionCalculator = gtfs.NewAdvancedDirectionCalculator(gtfsManager.GtfsDB.Queries)
+		directionCalculator = gtfs.NewAdvancedDirectionCalculatorWithManager(gtfsManager)
 	}
 
 	// Select clock implementation based on environment


### PR DESCRIPTION
### Description

This PR fixes a latent bug where the `DirectionCalculator` held onto a stale, potentially closed database connection after a GTFS data hot-swap (daily refresh).

Previously, `AdvancedDirectionCalculator` was initialized at startup with a static reference to the `GtfsDB.Queries` object. When `ForceUpdate` runs to refresh the GTFS data, it performs a database hot-swap, replacing `manager.GtfsDB`. However, the application-level calculator continued trying to use the old connection, which would lead to stale data or panics.

### Changes Made

* **Lazy DB Resolution:** Refactored `AdvancedDirectionCalculator` to use a dynamic `queriesProvider` function instead of holding a static pointer to the queries object.
* **New Constructor:** Added `NewAdvancedDirectionCalculatorWithManager` which safely grabs the active queries object at runtime using the `GtfsManager`'s read-lock (`RLock()`).
* **Dependency Injection:** Updated `BuildApplication` in `cmd/api/app.go` to initialize the calculator using the new manager-aware constructor.
* **Regression Testing:** Added `TestDirectionCalculator_HotSwapResolution` to explicitly simulate a DB swap and ensure the calculator correctly drops the old reference and picks up the new one.

### Testing

* [x] Verified that existing tests in `app_test.go` and `advanced_direction_calculator_test.go` pass without breaking.
* [x] Ran `make test` locally with FTS5 enabled; all tests pass successfully.
* [x] Added dedicated hot-swap unit test which verifies the memory reference updates correctly.

Closes #499 