### PR TITLE
fix: enable SQLite WAL mode to prevent locks (#493)

### DIFF
--- a/gtfsdb/helpers.go
+++ b/gtfsdb/helpers.go
@@ -938,6 +938,8 @@ func configureSQLitePerformance(ctx context.Context, db *sql.DB) error {
 		{"PRAGMA cache_size=-64000", "Set cache size to 64MB"},
 		// Store temp tables and indices in memory for faster operations
 		{"PRAGMA temp_store=MEMORY", "Store temporary data in memory"},
+		// Enable Write-Ahead Logging to allow concurrent readers and a single writer
+		{"PRAGMA journal_mode=WAL", "Enable WAL mode"},
 	}
 
 	logger := slog.Default().With(slog.String("component", "sqlite_performance"))


### PR DESCRIPTION
## Description
This PR addresses issue #493 by explicitly enabling Write-Ahead Logging (WAL) for SQLite databases. 

Previously, `WAL` mode was referenced in the connection pool comments but was never actually applied in the database configuration. Without WAL mode, SQLite falls back to the default rollback journal where readers block writers and writers block readers. With `MaxOpenConns` set to 25 for file-based databases, this would inevitably lead to `database is locked` errors under concurrent production load.

## Changes Made
* **`gtfsdb/helpers.go`**: Added `PRAGMA journal_mode=WAL` to the `configureSQLitePerformance` function to allow concurrent readers and a single writer.
* **`gtfsdb/sqlite_performance_test.go`**: 
  * Updated `TestFileDatabaseConnectionPool` to verify that `wal` mode is properly enabled for file-based databases.
  * Updated `TestSQLitePerformancePragmasApplied` to verify that `:memory:` databases safely fall back to `memory` journal mode (as SQLite does not support WAL in-memory).

## Related Issues
Closes #493 

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes