### PR TITLE
fix(config): enforce full validation on CLI flags

### DIFF
--- a/internal/appconf/json_config.go
+++ b/internal/appconf/json_config.go
@@ -77,7 +77,7 @@ func (j *JSONConfig) setDefaults() {
 }
 
 // validate checks that the configuration is valid
-func (j *JSONConfig) validate() error {
+func (j *JSONConfig) Validate() error {
 	if j.Port < 1 || j.Port > 65535 {
 		return fmt.Errorf("port must be between 1 and 65535, got %d", j.Port)
 	}
@@ -358,7 +358,7 @@ func LoadFromFile(path string) (*JSONConfig, error) {
 	}
 
 	// Validate
-	if err := config.validate(); err != nil {
+	if err := config.Validate(); err != nil {
 		return nil, fmt.Errorf("invalid configuration: %w", err)
 	}
 

--- a/internal/appconf/json_config_test.go
+++ b/internal/appconf/json_config_test.go
@@ -89,7 +89,7 @@ func TestValidate_InvalidPort(t *testing.T) {
 				ApiKeys:   []string{"test"},
 				RateLimit: 100,
 			}
-			err := config.validate()
+			err := config.Validate()
 			assert.Error(t, err)
 			assert.Contains(t, err.Error(), "port must be between")
 		})
@@ -103,7 +103,7 @@ func TestValidate_InvalidEnv(t *testing.T) {
 		ApiKeys:   []string{"test"},
 		RateLimit: 100,
 	}
-	err := config.validate()
+	err := config.Validate()
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "env must be one of")
 }
@@ -115,7 +115,7 @@ func TestValidate_InvalidRateLimit(t *testing.T) {
 		ApiKeys:   []string{"test"},
 		RateLimit: 0,
 	}
-	err := config.validate()
+	err := config.Validate()
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "rate-limit must be at least 1")
 }
@@ -127,7 +127,7 @@ func TestValidate_EmptyApiKeys(t *testing.T) {
 		ApiKeys:   []string{},
 		RateLimit: 100,
 	}
-	err := config.validate()
+	err := config.Validate()
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "api-keys cannot be empty")
 }
@@ -139,7 +139,7 @@ func TestValidate_EmptyApiKeyString(t *testing.T) {
 		ApiKeys:   []string{"key1", "", "key2"},
 		RateLimit: 100,
 	}
-	err := config.validate()
+	err := config.Validate()
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "api-keys cannot contain empty strings")
 }
@@ -151,7 +151,7 @@ func TestValidate_DuplicateApiKeys(t *testing.T) {
 		ApiKeys:   []string{"key1", "key2", "key1"},
 		RateLimit: 100,
 	}
-	err := config.validate()
+	err := config.Validate()
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "duplicate API key found")
 }
@@ -330,7 +330,7 @@ func TestValidate_PathTraversalDataPath(t *testing.T) {
 				RateLimit: 100,
 				DataPath:  tt.dataPath,
 			}
-			err := config.validate()
+			err := config.Validate()
 			if tt.shouldErr {
 				assert.Error(t, err)
 				assert.Contains(t, err.Error(), "data-path")
@@ -363,7 +363,7 @@ func TestValidate_FileURLNotAllowed(t *testing.T) {
 					URL: tt.gtfsURL,
 				},
 			}
-			err := config.validate()
+			err := config.Validate()
 			assert.Error(t, err)
 			assert.Contains(t, err.Error(), "file:// URLs are not allowed")
 		})
@@ -398,7 +398,7 @@ func TestValidate_PathTraversalGtfsURL(t *testing.T) {
 					URL: tt.gtfsURL,
 				},
 			}
-			err := config.validate()
+			err := config.Validate()
 			if tt.shouldErr {
 				assert.Error(t, err)
 				assert.Contains(t, err.Error(), "gtfs-static-feed")
@@ -432,7 +432,7 @@ func TestValidate_ValidAbsolutePaths(t *testing.T) {
 				},
 				DataPath: "./gtfs.db",
 			}
-			err := config.validate()
+			err := config.Validate()
 			if tt.valid {
 				assert.NoError(t, err)
 			} else {
@@ -469,7 +469,7 @@ func TestValidate_PartialAuthHeaders(t *testing.T) {
 				},
 				DataPath: "./gtfs.db",
 			}
-			err := config.validate()
+			err := config.Validate()
 			if tt.shouldError {
 				assert.Error(t, err)
 				assert.Contains(t, err.Error(), "both auth-header-name and auth-header-value must be provided together")


### PR DESCRIPTION
Description
This PR addresses the configuration validation bypass issue where validation rules were only applied when loading configurations from a JSON file, leaving CLI flags unchecked.

The Problem:
Previously, an operator could start the server via CLI flags with misconfigured values (e.g., port=0, empty API keys, invalid rate limits) and receive no warnings or errors, potentially leading to insecure or unstable states.

The Solution:
Instead of duplicating the validation logic, this PR enforces the existing robust validation rules on CLI inputs by:
* Exporting the validate() method to Validate() in internal/appconf/json_config.go.

* Packing the parsed CLI flags into a temporary JSONConfig struct in cmd/api/main.go.

* Running the shared Validate() method before converting the struct to the internal app configurations.

Impact:
CLI inputs are now strictly protected by the same rules as JSON configurations, including:

* Port range enforcement (1-65535)

* Valid environment name checks

* Rate limit minimums

* Non-empty and duplicate API key detection

* Path traversal prevention for data paths

@aaronbrethorst 
fixes : #498 