### PR TITLE
fix: migrate to pure Go sqlite driver to resolve FTS5 dependency 

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -10,8 +10,7 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     env:
-      CGO_ENABLED: 1
-      CGO_CFLAGS: "-DSQLITE_ENABLE_FTS5"
+      CGO_ENABLED: 0
     steps:
       - uses: actions/checkout@v4
 
@@ -28,7 +27,7 @@ jobs:
         uses: golangci/golangci-lint-action@v3
         with:
           version: latest
-          args: --timeout=5m --build-tags=sqlite_fts5
+          args: --timeout=5m
 
   test:
     name: Test
@@ -37,8 +36,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
     env:
-      CGO_ENABLED: 1
-      CGO_CFLAGS: "-DSQLITE_ENABLE_FTS5"
+      CGO_ENABLED: 0
     steps:
       - uses: actions/checkout@v4
 
@@ -55,9 +53,9 @@ jobs:
         run: go mod verify
 
       - name: Run tests
-        run: go test -v -tags=sqlite_fts5 -coverprofile=profile.cov -timeout 40m ./...
+        run: go test -v -coverprofile=profile.cov -timeout 40m ./...
         env:
-          CGO_ENABLED: 1
+          CGO_ENABLED: 0
         shell: bash
 
 # Disabling coverage reporting for now. Re-enable once the project is made public.

--- a/gtfsdb/client.go
+++ b/gtfsdb/client.go
@@ -10,7 +10,7 @@ import (
 	"os"
 	"time"
 
-	_ "github.com/mattn/go-sqlite3" // CGo-based SQLite driver
+	_ "modernc.org/sqlite" // Pure Go SQLite driver
 )
 
 // Client is the main entry point for the library

--- a/gtfsdb/connection_pool_test.go
+++ b/gtfsdb/connection_pool_test.go
@@ -5,7 +5,7 @@ import (
 	"database/sql"
 	"testing"
 
-	_ "github.com/mattn/go-sqlite3" // CGo-based SQLite driver
+	_ "modernc.org/sqlite"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"maglev.onebusaway.org/internal/appconf"
@@ -103,7 +103,7 @@ func TestConnectionLifetime(t *testing.T) {
 
 func TestConnectionPoolConfiguration(t *testing.T) {
 	// Test the specific configuration values for in-memory databases
-	db, err := sql.Open("sqlite3", ":memory:")
+	db, err := sql.Open("sqlite", ":memory:")
 	require.NoError(t, err, "Should open database")
 	defer func() { _ = db.Close() }()
 

--- a/gtfsdb/debugging_test.go
+++ b/gtfsdb/debugging_test.go
@@ -4,13 +4,13 @@ import (
 	"database/sql"
 	"testing"
 
-	_ "github.com/mattn/go-sqlite3"
+	_ "modernc.org/sqlite"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestTableCounts(t *testing.T) {
-	db, err := sql.Open("sqlite3", ":memory:")
+	db, err := sql.Open("sqlite", ":memory:")
 	require.NoError(t, err)
 	defer func() { _ = db.Close() }()
 

--- a/gtfsdb/helpers.go
+++ b/gtfsdb/helpers.go
@@ -16,9 +16,9 @@ import (
 	"time"
 
 	"github.com/OneBusAway/go-gtfs"
-	_ "github.com/mattn/go-sqlite3" // CGo-based SQLite driver
 	"maglev.onebusaway.org/internal/appconf"
 	"maglev.onebusaway.org/internal/logging"
+	_ "modernc.org/sqlite" // Pure Go SQLite driver
 )
 
 //go:embed schema.sql
@@ -30,7 +30,7 @@ func createDB(config Config) (*sql.DB, error) {
 		return nil, fmt.Errorf("test database must use in-memory storage, got path: %s", config.DBPath)
 	}
 
-	db, err := sql.Open("sqlite3", config.DBPath)
+	db, err := sql.Open("sqlite", config.DBPath)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/restapi/health_handler_test.go
+++ b/internal/restapi/health_handler_test.go
@@ -37,7 +37,7 @@ func TestHealthHandlerWithNilApplication(t *testing.T) {
 
 func TestHealthHandlerReturnsOK(t *testing.T) {
 	// Use in-memory DB to test the health check successfully
-	db, err := sql.Open("sqlite3", ":memory:")
+	db, err := sql.Open("sqlite", ":memory:")
 	require.NoError(t, err)
 	defer func() { _ = db.Close() }()
 
@@ -78,7 +78,7 @@ func TestHealthHandlerReturnsOK(t *testing.T) {
 
 func TestHealthHandlerStarting(t *testing.T) {
 	// Use in-memory DB to test the health check during startup
-	db, err := sql.Open("sqlite3", ":memory:")
+	db, err := sql.Open("sqlite", ":memory:")
 	require.NoError(t, err)
 	defer func() { _ = db.Close() }()
 


### PR DESCRIPTION
## Description

This PR resolves the issue where local tests and deployments would fail with `no such module: fts5` by migrating the database driver from the CGo-based `mattn/go-sqlite3` to the pure Go port `modernc.org/sqlite`.

Because `modernc.org/sqlite` bundles FTS5 by default, we no longer need to rely on the host system's C compiler or custom build tags to guarantee FTS5 availability. This makes the project much easier to build, test, and deploy across all environments.

### Changes Made:
* **Driver Swap:** Replaced `github.com/mattn/go-sqlite3` with `modernc.org/sqlite` in application and test files.
* **Connection Strings:** Updated all `sql.Open("sqlite3", ...)` calls to `sql.Open("sqlite", ...)`.
* **Removed CGO Requirements:** * Updated `Makefile` to use `CGO_ENABLED=0` by default and removed all `-tags "sqlite_fts5"` flags.
  * Updated `.github/workflows/go.yml` to disable CGO and remove custom FTS5 build tags from the linting and testing steps.

### Testing Instructions
1. Pull down this branch.
2. Run `make test`.
3. Verify that all tests pass successfully without needing to configure C compilers or custom Go build tags. (Tests were successfully run locally with `CGO_ENABLED=0`).

**Closes #497**