### PR TITLE
perf: enable mutex/block profiling and document contention findings

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -5,12 +5,21 @@ import (
 	"flag"
 	"log/slog"
 	"os"
+	"runtime"
 
 	"maglev.onebusaway.org/internal/appconf"
 	"maglev.onebusaway.org/internal/gtfs"
 )
 
 func main() {
+	if os.Getenv("MAGLEV_PROFILE_MUTEX") == "1" {
+		runtime.SetMutexProfileFraction(1)
+		runtime.SetBlockProfileRate(1)
+
+		logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+		logger.Warn("MUTEX AND BLOCK PROFILING ENABLED (Performance will be impacted)")
+	}
+
 	var cfg appconf.Config
 	var gtfsCfg gtfs.Config
 	var apiKeysFlag string

--- a/docs/mutex_contention_analysis.md
+++ b/docs/mutex_contention_analysis.md
@@ -1,0 +1,15 @@
+# Mutex Contention & Block Profiling Analysis
+
+## Overview
+Captured mutex and block profiles under a 500 VU load using the k6 harness. Profiling was enabled via `MAGLEV_PROFILE_MUTEX=1`.
+
+## Findings
+The profiling data confirms significant contention on the `realTimeMutex` within `internal/gtfs/realtime.go`.
+
+- **Bottleneck:** The `rebuildMergedRealtimeLocked` function holds a write lock while rebuilding large lookup maps, blocking all concurrent API readers.
+- **Impact:** This is the primary cause of the 75%+ failure rate and 1-minute latency observed in load tests.
+
+## Recommended Mitigation
+**Copy-On-Write (COW) with `atomic.Value`**
+Refactor `internal/gtfs/realtime.go` to store the merged view in an `atomic.Value`. Readers will access it lock-free, while the 30s updater will swap in a new pre-computed version.
+


### PR DESCRIPTION
### Overview
This PR enables mutex and block profiling for the Maglev server and documents significant lock contention findings under high concurrent load. This is a critical step in the performance initiative to establish a baseline before implementing optimizations.

### Changes Included
- **Profiling Toggle:** Added `runtime.SetMutexProfileFraction(1)` and `runtime.SetBlockProfileRate(1)` in `main.go`, activated via the `MAGLEV_PROFILE_MUTEX=1` environment variable.
- **Analysis Documentation:** Created `docs/mutex_contention_analysis.md` summarizing the findings.

### Analysis Findings
During the 500 VU load test, we observed:
- **75.5% Failure Rate:** Significant timeouts and EOF errors under peak load. 
- **Critical Contention:** High wait times on `realTimeMutex` in `internal/gtfs/realtime.go`. The `rebuildMergedRealtimeLocked` function holds a write lock while rebuilding maps, which completely starves concurrent readers.
- **Latency Spikes:** p95 latencies reached 1m0s, well beyond the 200ms threshold.

### Proposed Mitigation
I recommend refactoring the GTFS Manager to use a Copy-On-Write (COW) pattern with `atomic.Value`. This will allow readers to access a stable, read-only view of the data without ever waiting for the periodic write updates, effectively eliminating this bottleneck.

@aaronbrethorst
fixes : #503