### PR TITLE
gtfsdb: replace GetBulkInsertBatchSize with SafeBatchSize(fieldsPerRow)

### DIFF
--- a/gtfsdb/helpers.go
+++ b/gtfsdb/helpers.go
@@ -583,7 +583,7 @@ func (c *Client) bulkInsertStopTimes(ctx context.Context, stopTimes []CreateStop
 		slog.Int("count", len(stopTimes)))
 
 	// ===== PIPELINE: PARALLEL PREPARATION + SEQUENTIAL EXECUTION =====
-	batchSize := c.config.GetBulkInsertBatchSize()
+	batchSize := c.config.SafeBatchSize(10) // 10 fields per stop_time row
 	const baseQuery = `INSERT INTO stop_times (
 		trip_id, arrival_time, departure_time, stop_id, stop_sequence,
 		stop_headsign, pickup_type, drop_off_type, shape_dist_traveled, timepoint
@@ -753,7 +753,7 @@ func (c *Client) bulkInsertShapes(ctx context.Context, shapes []CreateShapeParam
 		slog.Int("count", len(shapes)))
 
 	// ===== PHASE 1: PARALLEL STATEMENT PREPARATION =====
-	batchSize := c.config.GetBulkInsertBatchSize()
+	batchSize := c.config.SafeBatchSize(5) // 5 fields per shape row
 	const baseQuery = `INSERT INTO shapes (
 		shape_id, lat, lon, shape_pt_sequence, shape_dist_traveled
 	) VALUES `


### PR DESCRIPTION
## Summary
SQLite enforces a hard limit of 32766 bound parameters per statement
(`SQLITE_MAX_VARIABLE_NUMBER`). The safe max batch size therefore depends
on the number of fields bound per row:

    maxBatchSize = 32766 / fieldsPerRow

## Changes

- Add `sqliteMaxVariables = 32766` constant
- Replace `GetBulkInsertBatchSize()` with `SafeBatchSize(fieldsPerRow int)`
  which computes the optimal batch size per caller
- `bulkInsertStopTimes`: `SafeBatchSize(10)` → 3276 rows/batch (was 3000)
- `bulkInsertShapes`:    `SafeBatchSize(5)`  → 6553 rows/batch (was 3000)
  - Effectively halves the number of INSERT calls for large shape datasets
- Add `TestSafeBatchSize` covering:
  - edge cases
  - both callers

Fixes #483