### PR TITLE
chore: remove redundant error log on batch route fetch failure

### DIFF
--- a/internal/restapi/schedule_for_stop_handler.go
+++ b/internal/restapi/schedule_for_stop_handler.go
@@ -143,7 +143,6 @@ func (api *RestAPI) scheduleForStopHandler(w http.ResponseWriter, r *http.Reques
 	if len(routeIDsToFetch) > 0 {
 		fetchedRoutes, err := api.GtfsManager.GtfsDB.Queries.GetRoutesByIDs(ctx, routeIDsToFetch)
 		if err != nil {
-			api.Logger.Error("Failed to batch fetch routes for schedule stop", "error", err)
 			api.serverErrorResponse(w, r, err)
 			return
 		}


### PR DESCRIPTION
# Remove redundant error log in route fetching

### Summary
This is a quick follow-up PR to clean up a minor logging issue from the previous merge. 
- **main PR #488**

### Changes
- **Removed** `api.Logger.Error("Failed to batch fetch routes for schedule stop", "error", err)` from the GTFS batch fetching logic.
