### PR TITLE
feat: implement dual sqlite drivers (CGo and Pure Go) to resolve #497

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -54,10 +54,18 @@ jobs:
       - name: Verify dependencies
         run: go mod verify
 
-      - name: Run tests
+      - name: Run tests (fast mode)
+        if: matrix.os == 'ubuntu-latest'
         run: go test -v -tags=sqlite_fts5 -coverprofile=profile.cov -timeout 40m ./...
         env:
           CGO_ENABLED: 1
+        shell: bash
+
+      - name: Run tests (compatible mode)
+        if: matrix.os == 'windows-latest'
+        run: go test -v -tags=purego -coverprofile=profile.cov -timeout 40m ./...
+        env:
+          CGO_ENABLED: 0
         shell: bash
 
 # Disabling coverage reporting for now. Re-enable once the project is made public.

--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,9 @@ run: build
 build: gtfstidy
 	$(SET_ENV) go build -tags "sqlite_fts5" $(LDFLAGS) -o bin/maglev ./cmd/api
 
+build-pure: gtfstidy
+	CGO_ENABLED=0 go build -tags "purego" $(LDFLAGS) -o bin/maglev ./cmd/api
+
 build-debug: gtfstidy
 	$(SET_ENV) go build -tags "sqlite_fts5" $(LDFLAGS) -gcflags "all=-N -l" -o bin/maglev ./cmd/api
 
@@ -76,6 +79,9 @@ fmt:
 
 test:
 	$(SET_ENV) go test -tags "sqlite_fts5" ./...
+
+test-pure:
+	CGO_ENABLED=0 go test -tags "purego" ./...
 
 models:
 	go tool sqlc generate -f gtfsdb/sqlc.yml

--- a/README.markdown
+++ b/README.markdown
@@ -198,6 +198,18 @@ CGO_ENABLED=1 go build -tags "sqlite_fts5" ./...
 
 Ensure you have a working C toolchain when CGO is enabled.
 
+## SQLite Drivers (Fast Mode vs. Compatible Mode)
+
+Maglev uses SQLite and supports two different drivers via Go build tags to balance production performance with developer experience:
+
+1. **Fast Mode (Default)**: Uses `github.com/mattn/go-sqlite3` (CGo). This is the default for production because of its high performance and support for advanced SQLite features like FTS5 (Full-Text Search). It requires a C compiler (GCC/Clang) installed on your system.
+   - Run tests: `make test`
+   - Build: `make build`
+
+2. **Compatible Mode**: Uses `modernc.org/sqlite` (Pure Go). This mode is intended for local development and CI on platforms where CGo is difficult to configure (like Windows). It does not require a C compiler.
+   - Run tests: `make test-pure`
+   - Build: `make build-pure`
+
 ## Directory Structure
 
 * `bin`: Compiled application binaries.

--- a/cmd/api/app_test.go
+++ b/cmd/api/app_test.go
@@ -13,7 +13,6 @@ import (
 	"testing"
 	"time"
 
-	_ "github.com/mattn/go-sqlite3" // CGo-based SQLite driver
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"maglev.onebusaway.org/internal/app"

--- a/cmd/api/lock_safety_test.go
+++ b/cmd/api/lock_safety_test.go
@@ -18,7 +18,6 @@ import (
 	"maglev.onebusaway.org/internal/gtfs"
 	"maglev.onebusaway.org/internal/models"
 
-	_ "github.com/mattn/go-sqlite3"
 )
 
 func TestHandlerLockSafety(t *testing.T) {

--- a/gtfsdb/bulk_insert_test.go
+++ b/gtfsdb/bulk_insert_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 	"time"
 
-	_ "github.com/mattn/go-sqlite3" // CGo-based SQLite driver
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"maglev.onebusaway.org/internal/appconf"

--- a/gtfsdb/client.go
+++ b/gtfsdb/client.go
@@ -10,7 +10,6 @@ import (
 	"os"
 	"time"
 
-	_ "github.com/mattn/go-sqlite3" // CGo-based SQLite driver
 )
 
 // Client is the main entry point for the library

--- a/gtfsdb/conditional_import_test.go
+++ b/gtfsdb/conditional_import_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 	"time"
 
-	_ "github.com/mattn/go-sqlite3" // CGo-based SQLite driver
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"maglev.onebusaway.org/internal/appconf"

--- a/gtfsdb/connection_pool_test.go
+++ b/gtfsdb/connection_pool_test.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"testing"
 
-	_ "github.com/mattn/go-sqlite3" // CGo-based SQLite driver
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"maglev.onebusaway.org/internal/appconf"
@@ -103,7 +102,7 @@ func TestConnectionLifetime(t *testing.T) {
 
 func TestConnectionPoolConfiguration(t *testing.T) {
 	// Test the specific configuration values for in-memory databases
-	db, err := sql.Open("sqlite3", ":memory:")
+	db, err := sql.Open(DriverName, ":memory:")
 	require.NoError(t, err, "Should open database")
 	defer func() { _ = db.Close() }()
 

--- a/gtfsdb/debugging_test.go
+++ b/gtfsdb/debugging_test.go
@@ -4,13 +4,12 @@ import (
 	"database/sql"
 	"testing"
 
-	_ "github.com/mattn/go-sqlite3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestTableCounts(t *testing.T) {
-	db, err := sql.Open("sqlite3", ":memory:")
+	db, err := sql.Open(DriverName, ":memory:")
 	require.NoError(t, err)
 	defer func() { _ = db.Close() }()
 

--- a/gtfsdb/driver_cgo.go
+++ b/gtfsdb/driver_cgo.go
@@ -1,0 +1,7 @@
+//go:build !purego
+
+package gtfsdb
+
+import _ "github.com/mattn/go-sqlite3" // CGo-based SQLite driver
+
+const DriverName = "sqlite3"

--- a/gtfsdb/driver_pure.go
+++ b/gtfsdb/driver_pure.go
@@ -1,0 +1,7 @@
+//go:build purego
+
+package gtfsdb
+
+import _ "modernc.org/sqlite" // Pure Go SQLite driver
+
+const DriverName = "sqlite"

--- a/gtfsdb/error_handling_test.go
+++ b/gtfsdb/error_handling_test.go
@@ -6,7 +6,6 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	_ "github.com/mattn/go-sqlite3" // CGo-based SQLite driver
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"maglev.onebusaway.org/internal/appconf"

--- a/gtfsdb/fts_queries_test.go
+++ b/gtfsdb/fts_queries_test.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"testing"
 
-	_ "github.com/mattn/go-sqlite3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"maglev.onebusaway.org/internal/appconf"

--- a/gtfsdb/helpers.go
+++ b/gtfsdb/helpers.go
@@ -16,7 +16,6 @@ import (
 	"time"
 
 	"github.com/OneBusAway/go-gtfs"
-	_ "github.com/mattn/go-sqlite3" // CGo-based SQLite driver
 	"maglev.onebusaway.org/internal/appconf"
 	"maglev.onebusaway.org/internal/logging"
 )
@@ -30,7 +29,7 @@ func createDB(config Config) (*sql.DB, error) {
 		return nil, fmt.Errorf("test database must use in-memory storage, got path: %s", config.DBPath)
 	}
 
-	db, err := sql.Open("sqlite3", config.DBPath)
+	db, err := sql.Open(DriverName, config.DBPath)
 	if err != nil {
 		return nil, err
 	}

--- a/gtfsdb/nil_shape_test.go
+++ b/gtfsdb/nil_shape_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	_ "github.com/mattn/go-sqlite3" // CGo-based SQLite driver
 	"github.com/stretchr/testify/require"
 	"maglev.onebusaway.org/internal/appconf"
 )

--- a/gtfsdb/sqlite_performance_test.go
+++ b/gtfsdb/sqlite_performance_test.go
@@ -7,7 +7,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	_ "github.com/mattn/go-sqlite3" // CGo-based SQLite driver
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"maglev.onebusaway.org/internal/appconf"
@@ -232,7 +231,7 @@ func TestConfigureConnectionPoolWithDifferentConfigs(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			db, err := sql.Open("sqlite3", ":memory:")
+			db, err := sql.Open(DriverName, ":memory:")
 			require.NoError(t, err)
 			defer func() { _ = db.Close() }()
 

--- a/internal/gtfs/gtfs_manager.go
+++ b/internal/gtfs/gtfs_manager.go
@@ -14,7 +14,6 @@ import (
 	"maglev.onebusaway.org/internal/utils"
 
 	"github.com/OneBusAway/go-gtfs"
-	_ "github.com/mattn/go-sqlite3" // CGo-based SQLite driver
 	"github.com/tidwall/rtree"
 	"maglev.onebusaway.org/internal/logging"
 )

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -5,10 +5,10 @@ import (
 	"testing"
 	"time"
 
-	_ "github.com/mattn/go-sqlite3"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"maglev.onebusaway.org/gtfsdb"
 )
 
 func TestNew(t *testing.T) {
@@ -38,7 +38,7 @@ func TestStartDBStatsCollector_NilDB(t *testing.T) {
 }
 
 func TestStartDBStatsCollector_Idempotent(t *testing.T) {
-	db, err := sql.Open("sqlite3", ":memory:")
+	db, err := sql.Open(gtfsdb.DriverName, ":memory:")
 	require.NoError(t, err)
 	defer func() { _ = db.Close() }()
 
@@ -56,7 +56,7 @@ func TestStartDBStatsCollector_Idempotent(t *testing.T) {
 }
 
 func TestStartDBStatsCollector_CollectsStats(t *testing.T) {
-	db, err := sql.Open("sqlite3", ":memory:")
+	db, err := sql.Open(gtfsdb.DriverName, ":memory:")
 	require.NoError(t, err)
 	defer func() { _ = db.Close() }()
 
@@ -80,7 +80,7 @@ func TestStartDBStatsCollector_CollectsStats(t *testing.T) {
 }
 
 func TestShutdown_StopsGoroutine(t *testing.T) {
-	db, err := sql.Open("sqlite3", ":memory:")
+	db, err := sql.Open(gtfsdb.DriverName, ":memory:")
 	require.NoError(t, err)
 	defer func() { _ = db.Close() }()
 

--- a/internal/restapi/health_handler_test.go
+++ b/internal/restapi/health_handler_test.go
@@ -37,7 +37,7 @@ func TestHealthHandlerWithNilApplication(t *testing.T) {
 
 func TestHealthHandlerReturnsOK(t *testing.T) {
 	// Use in-memory DB to test the health check successfully
-	db, err := sql.Open("sqlite3", ":memory:")
+	db, err := sql.Open(gtfsdb.DriverName, ":memory:")
 	require.NoError(t, err)
 	defer func() { _ = db.Close() }()
 
@@ -78,7 +78,7 @@ func TestHealthHandlerReturnsOK(t *testing.T) {
 
 func TestHealthHandlerStarting(t *testing.T) {
 	// Use in-memory DB to test the health check during startup
-	db, err := sql.Open("sqlite3", ":memory:")
+	db, err := sql.Open(gtfsdb.DriverName, ":memory:")
 	require.NoError(t, err)
 	defer func() { _ = db.Close() }()
 

--- a/internal/utils/filters_test.go
+++ b/internal/utils/filters_test.go
@@ -11,7 +11,6 @@ import (
 	"maglev.onebusaway.org/internal/appconf"
 	"maglev.onebusaway.org/internal/models"
 
-	_ "github.com/mattn/go-sqlite3"
 )
 
 func TestFilterAgencies(t *testing.T) {


### PR DESCRIPTION
### Description
This PR addresses issue #497 by implementing the dual-driver build-tag approach for SQLite, exactly as outlined in the previous PR's feedback. 

It keeps the high-performance CGo driver (`mattn/go-sqlite3`) as the default for production deployments ("fast mode") while adding a fallback to the Pure Go driver (`modernc.org/sqlite`) for local development and CI environments where CGo is problematic ("compatible mode").

**Closes #497**

**Follow-up #515**

### Changes Made:
- **Driver Registration:** Created `gtfsdb/driver_cgo.go` (default) and `gtfsdb/driver_pure.go` (used when `purego` tag is passed) to centralize driver initialization using Go build tags.
- **Codebase Cleanup:** Removed the scattered `_ "github.com/mattn/go-sqlite3"` blank imports across the codebase and replaced hardcoded `"sqlite3"` strings with the dynamic `gtfsdb.DriverName` constant.
- **Makefile Updates:** Added `build-pure` and `test-pure` targets to make it easy for developers to run without a C toolchain.
- **CI Pipeline:** Updated `.github/workflows/go.yml` so that Windows tests now run smoothly in "compatible mode" (`-tags=purego`), while Linux continues testing "fast mode".
- **Documentation:** Added a section to `README.markdown` explaining the difference between Fast Mode and Compatible Mode and how to switch between them.

### How to Test:
**1. Fast Mode (Default - Requires CGo & GCC/Clang):**
`make test`
`make build`

**2. Compatible Mode (Pure Go - No C toolchain required):**
`make test-pure`
`make build-pure`
