### PR TITLE
gtfsdb: compute batch size via SQLite limit and fail fast on invalid …

### DIFF
--- a/gtfsdb/config.go
+++ b/gtfsdb/config.go
@@ -1,12 +1,12 @@
 package gtfsdb
 
-import "maglev.onebusaway.org/internal/appconf"
+import (
+	"fmt"
+
+	"maglev.onebusaway.org/internal/appconf"
+)
 
 const (
-	// DefaultBulkInsertBatchSize is the fallback batch size used when fieldsPerRow is
-	// unknown or <= 0.
-	DefaultBulkInsertBatchSize = 3000
-
 	// sqliteMaxVariables is the hard upper bound on bound parameters per SQLite
 	// statement (SQLITE_MAX_VARIABLE_NUMBER).
 	sqliteMaxVariables = 32766
@@ -18,20 +18,13 @@ type Config struct {
 	DBPath  string              // Path to SQLite database file
 	Env     appconf.Environment // Environment name: development, test, production.
 	verbose bool                // Enable verbose logging
-
-	// Performance tuning
-	// BulkInsertBatchSize is reserved for future use. Batch sizes are now computed
-	// automatically via SafeBatchSize based on SQLITE_MAX_VARIABLE_NUMBER (32766)
-	// and the number of fields bound per row.
-	BulkInsertBatchSize int
 }
 
 func NewConfig(dbPath string, env appconf.Environment, verbose bool) Config {
 	return Config{
-		DBPath:              dbPath,
-		Env:                 env,
-		verbose:             verbose,
-		BulkInsertBatchSize: DefaultBulkInsertBatchSize,
+		DBPath:  dbPath,
+		Env:     env,
+		verbose: verbose,
 	}
 }
 
@@ -39,10 +32,11 @@ func NewConfig(dbPath string, env appconf.Environment, verbose bool) Config {
 // the number of parameters bound per row. SQLite enforces a hard upper bound of
 // SQLITE_MAX_VARIABLE_NUMBER (32766) bound parameters per statement, so the safe
 // maximum is 32766 / fieldsPerRow.
-// If fieldsPerRow is <= 0, DefaultBulkInsertBatchSize is returned as a fallback.
+// Panics if fieldsPerRow <= 0 as this always indicates a programming error —
+// fieldsPerRow is a compile-time constant that must match the INSERT column list.
 func (c Config) SafeBatchSize(fieldsPerRow int) int {
 	if fieldsPerRow <= 0 {
-		return DefaultBulkInsertBatchSize
+		panic(fmt.Sprintf("SafeBatchSize: fieldsPerRow must be > 0, got %d", fieldsPerRow))
 	}
 	return sqliteMaxVariables / fieldsPerRow
 }

--- a/gtfsdb/config_test.go
+++ b/gtfsdb/config_test.go
@@ -96,42 +96,45 @@ func TestSafeBatchSize(t *testing.T) {
 	tests := []struct {
 		name         string
 		fieldsPerRow int
-		expected     int
+		want         int
+		expectPanic  bool
 	}{
 		{
-			name:         "zero fields falls back to default",
+			name:         "zero fieldsPerRow panics",
 			fieldsPerRow: 0,
-			expected:     DefaultBulkInsertBatchSize,
+			expectPanic:  true,
 		},
 		{
-			name:         "negative fields falls back to default",
+			name:         "negative fieldsPerRow panics",
 			fieldsPerRow: -1,
-			expected:     DefaultBulkInsertBatchSize,
+			expectPanic:  true,
 		},
 		{
 			name:         "10 fields per row (stop_times)",
 			fieldsPerRow: 10,
-			expected:     3276, // 32766 / 10
+			want:         3276, // 32766 / 10
 		},
 		{
 			name:         "5 fields per row (shapes)",
 			fieldsPerRow: 5,
-			expected:     6553, // 32766 / 5
+			want:         6553, // 32766 / 5
 		},
 		{
 			name:         "1 field per row",
 			fieldsPerRow: 1,
-			expected:     32766,
+			want:         32766,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			if tt.expectPanic {
+				assert.Panics(t, func() { config.SafeBatchSize(tt.fieldsPerRow) })
+				return
+			}
 			got := config.SafeBatchSize(tt.fieldsPerRow)
-			assert.Equal(t, tt.expected, got)
-			// Ensure result never exceeds SQLite's hard limit
-			assert.LessOrEqual(t, got*tt.fieldsPerRow, sqliteMaxVariables,
-				"batch_size * fields_per_row must not exceed SQLITE_MAX_VARIABLE_NUMBER")
+			assert.Equal(t, tt.want, got)
+			assert.LessOrEqual(t, got*tt.fieldsPerRow, sqliteMaxVariables)
 		})
 	}
 }

--- a/gtfsdb/helpers.go
+++ b/gtfsdb/helpers.go
@@ -583,7 +583,8 @@ func (c *Client) bulkInsertStopTimes(ctx context.Context, stopTimes []CreateStop
 		slog.Int("count", len(stopTimes)))
 
 	// ===== PIPELINE: PARALLEL PREPARATION + SEQUENTIAL EXECUTION =====
-	batchSize := c.config.SafeBatchSize(10) // 10 fields per stop_time row
+	const stopTimeFieldsPerRow = 10 // 10 fields per stop_time row
+	batchSize := c.config.SafeBatchSize(stopTimeFieldsPerRow)
 	const baseQuery = `INSERT INTO stop_times (
 		trip_id, arrival_time, departure_time, stop_id, stop_sequence,
 		stop_headsign, pickup_type, drop_off_type, shape_dist_traveled, timepoint
@@ -631,7 +632,7 @@ func (c *Client) bulkInsertStopTimes(ctx context.Context, stopTimes []CreateStop
 				// into the query string to prevent SQL injection attacks.
 				var query strings.Builder
 				query.WriteString(baseQuery)
-				args := make([]interface{}, 0, len(batch)*10)
+				args := make([]interface{}, 0, len(batch)*stopTimeFieldsPerRow)
 
 				for j, params := range batch {
 					if j > 0 {
@@ -753,7 +754,8 @@ func (c *Client) bulkInsertShapes(ctx context.Context, shapes []CreateShapeParam
 		slog.Int("count", len(shapes)))
 
 	// ===== PHASE 1: PARALLEL STATEMENT PREPARATION =====
-	batchSize := c.config.SafeBatchSize(5) // 5 fields per shape row
+	const shapeFieldsPerRow = 5 // 5 fields per shape row
+	batchSize := c.config.SafeBatchSize(shapeFieldsPerRow)
 	const baseQuery = `INSERT INTO shapes (
 		shape_id, lat, lon, shape_pt_sequence, shape_dist_traveled
 	) VALUES `
@@ -793,7 +795,7 @@ func (c *Client) bulkInsertShapes(ctx context.Context, shapes []CreateShapeParam
 				// into the query string to prevent SQL injection attacks.
 				var query strings.Builder
 				query.WriteString(baseQuery)
-				args := make([]interface{}, 0, len(batch)*5)
+				args := make([]interface{}, 0, len(batch)*shapeFieldsPerRow)
 
 				for j, params := range batch {
 					if j > 0 {
@@ -846,7 +848,7 @@ func (c *Client) bulkInsertShapes(ctx context.Context, shapes []CreateShapeParam
 	for batch := range resultsChan {
 		preparedBatches = append(preparedBatches, batch)
 
-		// Log preparation progress every 50 batches (150k records with batch size 3000)
+		// Log preparation progress every 50 batches (~327k records with batch size 6553)
 		if len(preparedBatches)-lastLoggedCount >= 50 {
 			logging.LogOperation(logger, "shapes_preparation_progress",
 				slog.Int("batches_prepared", len(preparedBatches)),


### PR DESCRIPTION
## Summary

Follow-up to #517 addressing review feedback.

## Changes

- Remove `BulkInsertBatchSize` field and `DefaultBulkInsertBatchSize` constant
- Compute batch size via `SafeBatchSize` using SQLite variable limit (32766)
- Add `stopTimeFieldsPerRow=10` and `shapeFieldsPerRow=5` constants for clarity
- Panic on `fieldsPerRow <= 0` (programmer error)
- Update stale comments in `bulkInsertShapes`
- Update `TestSafeBatchSize` to assert panic for invalid input

## Notes

`fieldsPerRow` is a compile-time constant at call sites, so invalid values
represent programmer error and should fail fast.

Follow-up to #517.