### PR TITLE
perf: replace N+1 queries with batch fetches in arrivals-and-departur…

### DIFF
--- a/internal/restapi/arrivals_and_departure_for_stop.go
+++ b/internal/restapi/arrivals_and_departure_for_stop.go
@@ -247,6 +247,19 @@ func (api *RestAPI) arrivalsAndDeparturesForStopHandler(w http.ResponseWriter, r
 		tripsLookup[trip.ID] = trip
 	}
 
+	// Batch-fetch stop counts per trip to avoid per-arrival N+1 queries for totalStopsInTrip.
+	tripStopCountMap := make(map[string]int, len(uniqueTripIDs))
+	if len(uniqueTripIDs) > 0 {
+		allStopTimesForTrips, err := api.GtfsManager.GtfsDB.Queries.GetStopTimesForTripIDs(ctx, uniqueTripIDs)
+		if err != nil {
+			api.Logger.Warn("failed to batch fetch stop times for trips", slog.Any("error", err))
+		} else {
+			for _, st := range allStopTimesForTrips {
+				tripStopCountMap[st.TripID]++
+			}
+		}
+	}
+
 	for _, ast := range allActiveStopTimes {
 		st := ast.GetStopTimesForStopInWindowRow
 
@@ -419,16 +432,7 @@ func (api *RestAPI) arrivalsAndDeparturesForStopHandler(w http.ResponseWriter, r
 			predictedDepartureTime = 0
 		}
 
-		tripStopTimes, err := api.GtfsManager.GtfsDB.Queries.GetStopTimesForTrip(ctx, st.TripID)
-		var totalStopsInTrip int
-		if err != nil {
-			api.Logger.Debug("failed to get stop times for trip",
-				slog.String("tripID", st.TripID),
-				slog.Any("error", err))
-			totalStopsInTrip = 0
-		} else {
-			totalStopsInTrip = len(tripStopTimes)
-		}
+		totalStopsInTrip := tripStopCountMap[st.TripID]
 
 		blockTripSequence := api.calculateBlockTripSequence(ctx, st.TripID, serviceMidnight)
 
@@ -501,26 +505,46 @@ func (api *RestAPI) arrivalsAndDeparturesForStopHandler(w http.ResponseWriter, r
 		references.Trips = append(references.Trips, tripRef)
 	}
 
+	// Batch-fetch all stop references in one shot instead of one query per stop.
+	stopIDsSlice := make([]string, 0, len(stopIDSet))
+	for sid := range stopIDSet {
+		stopIDsSlice = append(stopIDsSlice, sid)
+	}
+
+	batchStops, err := api.GtfsManager.GtfsDB.Queries.GetStopsByIDs(ctx, stopIDsSlice)
+	if err != nil {
+		api.Logger.Warn("failed to batch fetch stop references", slog.Any("error", err))
+		batchStops = nil
+	}
+
+	batchRoutesForStops, err := api.GtfsManager.GtfsDB.Queries.GetRoutesForStops(ctx, stopIDsSlice)
+	if err != nil {
+		api.Logger.Warn("failed to batch fetch routes for stop references", slog.Any("error", err))
+		batchRoutesForStops = nil
+	}
+
+	stopsMap := make(map[string]gtfsdb.Stop, len(batchStops))
+	for _, s := range batchStops {
+		stopsMap[s.ID] = s
+	}
+
+	routesByStop := make(map[string][]gtfsdb.GetRoutesForStopsRow)
+	for _, row := range batchRoutesForStops {
+		routesByStop[row.StopID] = append(routesByStop[row.StopID], row)
+	}
+
 	for stopID := range stopIDSet {
 		if ctx.Err() != nil {
 			return
 		}
 
-		stopData, err := api.GtfsManager.GtfsDB.Queries.GetStop(ctx, stopID)
-		if err != nil {
-			api.Logger.Debug("skipping stop reference: stop not found",
-				slog.String("stopID", stopID),
-				slog.Any("error", err))
+		stopData, ok := stopsMap[stopID]
+		if !ok {
+			api.Logger.Debug("skipping stop reference: stop not found", slog.String("stopID", stopID))
 			continue
 		}
 
-		routesForThisStop, err := api.GtfsManager.GtfsDB.Queries.GetRoutesForStops(ctx, []string{stopID})
-		if err != nil {
-			api.Logger.Debug("failed to get routes for stop",
-				slog.String("stopID", stopID),
-				slog.Any("error", err))
-			continue
-		}
+		routesForThisStop := routesByStop[stopID]
 		combinedRouteIDs := make([]string, len(routesForThisStop))
 		for i, route := range routesForThisStop {
 			// Use route.AgencyID instead of stopAgencyID


### PR DESCRIPTION
## Description

This PR removes two sequential query bottlenecks in:

    GET /api/where/arrivals-and-departures-for-stop/{id}

(internal/restapi/arrivals_and_departure_for_stop.go)

Per-iteration DB calls have been replaced with batch queries that already
exist in the `gtfsdb` layer.

Closes #538 

---

## Changes

### 1. totalStopsInTrip — N+1 inside main arrival loop (HIGH impact)

**Before**

`GetStopTimesForTrip(tripID)` was called once per active arrival inside
the main loop solely to compute `len(result)` for `totalStopsInTrip`.

**After**

A single:

    GetStopTimesForTripIDs(uniqueTripIDs)

call is made after the existing batch trip/route fetch.

Results are aggregated into:

    tripStopCountMap[tripID]

The loop body now performs:

    totalStopsInTrip := tripStopCountMap[st.TripID]

which is O(1).

---

### 2. Stop reference building — 2N queries in stopIDSet loop (MEDIUM impact)

**Before**

For each stop in `stopIDSet`, two queries were executed:

- `GetStop(ctx, stopID)`
- `GetRoutesForStops(ctx, []string{stopID})`

**After**

All stop IDs are collected into a slice and fetched in two batch calls:

    GetStopsByIDs(ctx, stopIDsSlice)
    GetRoutesForStops(ctx, stopIDsSlice)

Results are indexed into:

- `stopsMap`
- `routesByStop`

The loop now performs only in-memory lookups.

---

## Impact

**Performance**

Reduces per-request DB queries from:

    O(A + 2S)

to:

    O(1) fixed batch queries

Where:
- A = number of active arrivals
- S = number of stops in stopIDSet

**API Contract**

- No response structure changes
- No ordering changes
- No behavioral changes

**SQL**

- No new queries introduced
- Only existing batch query functions used

---

## Testing

- Ran `make fmt`
- Ran `make lint`
- Ran `make test`