### PR TITLE
perf(docker): optimize build times with BuildKit and GHA caching

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -62,6 +62,8 @@ jobs:
           tags: |
             ghcr.io/onebusaway/maglev:latest
             ghcr.io/onebusaway/maglev:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
   # Push to Docker Hub on published releases (non-prerelease only)
   buildx-release:
@@ -104,3 +106,5 @@ jobs:
           tags: |
             opentransitsoftwarefoundation/maglev:${{ env.IMAGE_TAG }}
             opentransitsoftwarefoundation/maglev:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,8 @@ WORKDIR /build
 
 # Copy dependency files first for better layer caching
 COPY go.mod go.sum ./
-RUN go mod download
+RUN --mount=type=cache,target=/go/pkg/mod \
+    go mod download
 
 # Copy source code
 COPY . .
@@ -27,7 +28,9 @@ ARG BUILD_HOST=docker
 ARG GIT_COMMIT_TIME=unknown
 
 ARG TARGETARCH
-RUN CGO_ENABLED=1 GOOS=linux GOARCH=${TARGETARCH} go build -tags sqlite_fts5 \
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=1 GOOS=linux GOARCH=${TARGETARCH} go build -tags sqlite_fts5 \
     -ldflags "-X 'maglev.onebusaway.org/internal/buildinfo.CommitHash=${GIT_COMMIT}' \
               -X 'maglev.onebusaway.org/internal/buildinfo.Branch=${GIT_BRANCH}' \
               -X 'maglev.onebusaway.org/internal/buildinfo.BuildTime=${BUILD_TIME}' \

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -32,7 +32,8 @@ WORKDIR /app
 
 # Copy dependency files first
 COPY --chown=maglev:maglev go.mod go.sum ./
-RUN go mod download
+RUN --mount=type=cache,target=/go/pkg/mod,uid=1000,gid=1000 \
+    go mod download
 
 # Source code will be mounted via docker-compose volume
 # This allows live reload without rebuilding the container


### PR DESCRIPTION
## Description
This PR significantly reduces Docker build times for both local development and CI/CD pipelines by implementing BuildKit cache mounts and GitHub Actions cache backend support.

Closes #542

## Changes Made
* **`Dockerfile` & `Dockerfile.dev`**: Added `--mount=type=cache` to the `go mod download` and `go build` steps. 
  * Caching `/go/pkg/mod` prevents redundant dependency downloads.
  * Caching `/root/.cache/go-build` allows the Go compiler to reuse compiled object files, recompiling only the code that has changed.
* **`.github/workflows/docker-publish.yml`**: Configured `cache-from: type=gha` and `cache-to: type=gha,mode=max` in the `buildx` and `buildx-release` jobs to persist the Docker build cache across GitHub Actions workflow runs.

## Impact
* **Faster CI/CD**: Workflow execution time will drop significantly after the initial cache population.
* **Faster Local Builds**: Developers making small code changes will experience near-instant rebuilds.
* **Network Efficiency**: Saves bandwidth by not redownloading the entire `go.mod` dependency tree on every run.

## Testing
* [x] CI pipeline will validate the caching mechanism upon creation of this PR (watch for `importing cache manifest from type=gha` in the build logs).