### PR TITLE
perf(gtfs): optimize GetTripUpdatesForTrip with O(1) lookup map

### DIFF
--- a/internal/gtfs/gtfs_manager.go
+++ b/internal/gtfs/gtfs_manager.go
@@ -489,10 +489,8 @@ func (manager *Manager) GetTripUpdatesForTrip(tripID string) []gtfs.Trip {
 	defer manager.realTimeMutex.RUnlock()
 
 	var updates []gtfs.Trip
-	for _, v := range manager.realTimeTrips {
-		if v.ID.ID == tripID {
-			updates = append(updates, v)
-		}
+	if index, exists := manager.realTimeTripLookup[tripID]; exists {
+		updates = append(updates, manager.realTimeTrips[index])
 	}
 	return updates
 }

--- a/internal/gtfs/gtfs_manager_test.go
+++ b/internal/gtfs/gtfs_manager_test.go
@@ -147,6 +147,10 @@ func TestManager_GetTripUpdatesForTrip(t *testing.T) {
 				ID: gtfs.TripID{ID: "trip2"},
 			},
 		},
+		realTimeTripLookup: map[string]int{
+			"trip1": 0,
+			"trip2": 1,
+		},
 	}
 
 	updates := manager.GetTripUpdatesForTrip("trip1")


### PR DESCRIPTION
## Description

This PR optimizes the `GetTripUpdatesForTrip` method by replacing an O(N) linear scan with an O(1) map lookup using the **already-existing** `realTimeTripLookup` map.

Closes #544

## The Problem

Previously, `GetTripUpdatesForTrip` looped over all `manager.realTimeTrips` to find a matching trip update, even though the `realTimeTripLookup` map (which maps trip IDs to their index) was already being built and maintained in `rebuildMergedRealtimeLocked`. The map was simply not being used by this method.

## Changes Made

* **`internal/gtfs/gtfs_manager.go`**:
  * Replaced the O(N) loop in `GetTripUpdatesForTrip` with a single O(1) lookup using the existing `realTimeTripLookup` map.

* **`internal/gtfs/gtfs_manager_test.go`**:
  * Updated test fixtures to include the `realTimeTripLookup` map required by the optimized method.

> **Note:** No new struct fields or additional maps were needed. The optimization solely leverages a lookup map already maintained in `rebuildMergedRealtimeLocked`.

## Impact

* **Faster lookups:** O(1) instead of O(N) for trip update retrieval.
* **Consistency:** Aligns `GetTripUpdatesForTrip` with `GetTripUpdateByID`, which already used the map.

## Testing

- [x] Verified `make test` passes successfully.
- [x] Ensured no data races were introduced.