### PR TITLE
fix: Standardize error logging across the codebase.

### DIFF
--- a/cmd/api/app.go
+++ b/cmd/api/app.go
@@ -287,7 +287,8 @@ func dumpConfigJSON(cfg appconf.Config, gtfsCfg gtfs.Config) {
 	// Marshal to JSON with indentation
 	output, err := json.MarshalIndent(jsonConfig, "", "  ")
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error marshaling config to JSON: %v\n", err)
+		logger := slog.Default().With(slog.String("component", "app"))
+		logging.LogError(logger, "Error marshaling config to JSON", err)
 		os.Exit(1)
 	}
 

--- a/internal/gtfs/gtfs_manager.go
+++ b/internal/gtfs/gtfs_manager.go
@@ -349,6 +349,10 @@ func (manager *Manager) GetStopsForLocation(
 
 			// Get active service IDs for current date
 			activeServiceIDs, err := manager.GtfsDB.Queries.GetActiveServiceIDsForDate(ctx, currentDate)
+			if err != nil {
+				logger := slog.Default().With(slog.String("component", "gtfs_manager"))
+				logging.LogError(logger, "could not get active service IDs for date", err, slog.String("date", currentDate))
+			}
 
 			if err == nil && len(activeServiceIDs) > 0 {
 				stopIDs := make([]string, 0, len(candidates))
@@ -360,6 +364,10 @@ func (manager *Manager) GetStopsForLocation(
 					StopIds:    stopIDs,
 					ServiceIds: activeServiceIDs,
 				})
+				if err != nil {
+					logger := slog.Default().With(slog.String("component", "gtfs_manager"))
+					logging.LogError(logger, "could not get stops with active service on date", err, slog.String("date", currentDate))
+				}
 
 				if err == nil {
 					stopsWithService := make(map[string]bool)

--- a/internal/restapi/errors.go
+++ b/internal/restapi/errors.go
@@ -2,8 +2,10 @@ package restapi
 
 import (
 	"encoding/json"
+	"log/slog"
 	"net/http"
 
+	"maglev.onebusaway.org/internal/logging"
 	"maglev.onebusaway.org/internal/models"
 )
 
@@ -27,12 +29,12 @@ func (api *RestAPI) invalidAPIKeyResponse(w http.ResponseWriter, r *http.Request
 	w.WriteHeader(http.StatusUnauthorized)
 	err := json.NewEncoder(w).Encode(response)
 	if err != nil {
-		api.Logger.Error("failed to encode invalid API key response", "error", err)
+		logging.LogError(api.Logger, "failed to encode invalid API key response", err)
 	}
 }
 
 func (api *RestAPI) serverErrorResponse(w http.ResponseWriter, r *http.Request, err error) {
-	api.Logger.Error("internal server error", "error", err, "path", r.URL.Path)
+	logging.LogError(api.Logger, "internal server error", err, slog.String("path", r.URL.Path))
 	// Send a 500 Internal Server Error response
 	response := struct {
 		Code        int    `json:"code"`
@@ -50,7 +52,7 @@ func (api *RestAPI) serverErrorResponse(w http.ResponseWriter, r *http.Request, 
 	w.WriteHeader(http.StatusInternalServerError)
 	encoderErr := json.NewEncoder(w).Encode(response)
 	if encoderErr != nil {
-		api.Logger.Error("failed to encode server error response", "error", encoderErr)
+		logging.LogError(api.Logger, "failed to encode server error response", encoderErr)
 	}
 }
 
@@ -86,6 +88,6 @@ func (api *RestAPI) validationErrorResponse(w http.ResponseWriter, r *http.Reque
 	w.WriteHeader(http.StatusBadRequest)
 	err := json.NewEncoder(w).Encode(response)
 	if err != nil {
-		api.Logger.Error("failed to encode validation error response", "error", err)
+		logging.LogError(api.Logger, "failed to encode validation error response", err)
 	}
 }

--- a/internal/restapi/rate_limit_middleware.go
+++ b/internal/restapi/rate_limit_middleware.go
@@ -10,6 +10,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	"maglev.onebusaway.org/internal/logging"
+
 	"golang.org/x/time/rate"
 	"maglev.onebusaway.org/internal/clock"
 )
@@ -181,7 +183,8 @@ func (rl *RateLimitMiddleware) sendRateLimitExceeded(w http.ResponseWriter, r *h
 	}
 
 	if err := json.NewEncoder(w).Encode(errorResponse); err != nil {
-		slog.Error("failed to encode rate limit response", "error", err)
+		logger := slog.Default().With(slog.String("component", "rate_limit_middleware"))
+		logging.LogError(logger, "failed to encode rate limit response", err)
 	}
 }
 


### PR DESCRIPTION
## Description

- closes #546 

This PR fixes multiple silent error logging issues within the codebase, ensuring critical system failures and unexpected encoding behaviors are funneled through the structured logging pipeline rather than discarded or redirected to `stderr`.

### Changes Included
- **`internal/gtfs/gtfs_manager.go`**: Captured error responses from `GtfsDB.Queries.GetActiveServiceIDsForDate` and `GetStopsWithActiveServiceOnDate` using the standard `logging.LogError` approach.
- **`cmd/api/app.go`**: Removed hardcoded `fmt.Fprintf(os.Stderr, ...)` calls during initialization in favor of proper structured logging.
- **`internal/restapi/rate_limit_middleware.go`**: Standardized the JSON-encoder failure logging path by importing `internal/logging` and swapping the raw `slog.Error` instance with `logging.LogError`.
- **`internal/restapi/errors.go`**: Modernized internal error handling functions (`invalidAPIKeyResponse`, `serverErrorResponse`, `validationErrorResponse`) by substituting `api.Logger.Error` with `logging.LogError`. This implicitly fortifies related methods downstream in `responses.go`. 
