### PR TITLE
feat(gtfsdb): implement database foundation for frequencies.txt (Phase 1)

### DIFF
--- a/gtfsdb/bulk_insert_frequency_test.go
+++ b/gtfsdb/bulk_insert_frequency_test.go
@@ -1,0 +1,311 @@
+package gtfsdb
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"maglev.onebusaway.org/internal/appconf"
+)
+
+// createFrequencyTestClient sets up a test client with the prerequisite data
+func createFrequencyTestClient(t *testing.T) *Client {
+	t.Helper()
+
+	config := Config{
+		DBPath: ":memory:",
+		Env:    appconf.Test,
+	}
+
+	client, err := NewClient(config)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	_, err = client.Queries.CreateAgency(ctx, CreateAgencyParams{
+		ID:       "test_agency",
+		Name:     "Test Agency",
+		Url:      "http://test.com",
+		Timezone: "America/New_York",
+	})
+	require.NoError(t, err)
+
+	_, err = client.Queries.CreateRoute(ctx, CreateRouteParams{
+		ID:        "test_route",
+		AgencyID:  "test_agency",
+		ShortName: sql.NullString{String: "TEST", Valid: true},
+		Type:      3,
+	})
+	require.NoError(t, err)
+
+	_, err = client.Queries.CreateCalendar(ctx, CreateCalendarParams{
+		ID:        "test_service",
+		Monday:    1,
+		Tuesday:   1,
+		Wednesday: 1,
+		Thursday:  1,
+		Friday:    1,
+		Saturday:  1,
+		Sunday:    1,
+		StartDate: "20240101",
+		EndDate:   "20241231",
+	})
+	require.NoError(t, err)
+
+	_, err = client.Queries.CreateStop(ctx, CreateStopParams{
+		ID:   "stop_1",
+		Name: sql.NullString{String: "Test Stop", Valid: true},
+		Lat:  40.0,
+		Lon:  -74.0,
+	})
+	require.NoError(t, err)
+
+	// Create multiple trips for testing
+	for _, tripID := range []string{"trip_1", "trip_2", "trip_3", "trip_4", "trip_5"} {
+		_, err = client.Queries.CreateTrip(ctx, CreateTripParams{
+			ID:           tripID,
+			RouteID:      "test_route",
+			ServiceID:    "test_service",
+			TripHeadsign: sql.NullString{String: "Test", Valid: true},
+		})
+		require.NoError(t, err)
+	}
+
+	return client
+}
+
+func TestBulkInsertFrequencies(t *testing.T) {
+	testCases := []struct {
+		name  string
+		count int
+	}{
+		{"Empty batch", 0},
+		{"Single record", 1},
+		{"Small batch", 5},
+		{"Multiple windows for one trip", 3},
+		{"Large batch", 50},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			client := createFrequencyTestClient(t)
+			defer func() { _ = client.Close() }()
+
+			ctx := context.Background()
+
+			var frequencies []CreateFrequencyParams
+			if tc.name == "Multiple windows for one trip" {
+				// Create 3 frequency windows for the same trip (morning/midday/evening)
+				frequencies = []CreateFrequencyParams{
+					{
+						TripID:      "trip_1",
+						StartTime:   int64(6 * 3600 * 1e9), // 6 AM in nanoseconds
+						EndTime:     int64(9 * 3600 * 1e9), // 9 AM
+						HeadwaySecs: 600,                   // 10 minutes
+						ExactTimes:  0,
+					},
+					{
+						TripID:      "trip_1",
+						StartTime:   int64(11 * 3600 * 1e9), // 11 AM
+						EndTime:     int64(14 * 3600 * 1e9), // 2 PM
+						HeadwaySecs: 900,                    // 15 minutes
+						ExactTimes:  0,
+					},
+					{
+						TripID:      "trip_1",
+						StartTime:   int64(16 * 3600 * 1e9), // 4 PM
+						EndTime:     int64(19 * 3600 * 1e9), // 7 PM
+						HeadwaySecs: 600,                    // 10 minutes
+						ExactTimes:  1,
+					},
+				}
+			} else {
+				frequencies = make([]CreateFrequencyParams, tc.count)
+				for i := 0; i < tc.count; i++ {
+					frequencies[i] = CreateFrequencyParams{
+						TripID:      "trip_1",
+						StartTime:   int64(i) * int64(3600*1e9), // Each hour
+						EndTime:     int64(i+1) * int64(3600*1e9),
+						HeadwaySecs: 600,
+						ExactTimes:  int64(i % 2), // Alternate between 0 and 1
+					}
+				}
+			}
+
+			err := client.bulkInsertFrequencies(ctx, frequencies)
+			require.NoError(t, err)
+
+			if tc.count == 0 {
+				return
+			}
+
+			rows, err := client.Queries.GetFrequenciesForTrip(ctx, "trip_1")
+			require.NoError(t, err)
+
+			expectedCount := tc.count
+			if tc.name == "Multiple windows for one trip" {
+				expectedCount = 3
+			}
+			assert.Equal(t, expectedCount, len(rows))
+
+			for i := 1; i < len(rows); i++ {
+				assert.Less(t, rows[i-1].StartTime, rows[i].StartTime,
+					"Rows should be ordered by start_time")
+			}
+
+			for _, row := range rows {
+				assert.Less(t, row.StartTime, row.EndTime,
+					"start_time should be less than end_time")
+				assert.Greater(t, row.HeadwaySecs, int64(0),
+					"headway_secs should be positive")
+				assert.Contains(t, []int64{0, 1}, row.ExactTimes,
+					"exact_times should be 0 or 1")
+			}
+		})
+	}
+}
+
+func TestBulkInsertFrequencies_MultipleTrips(t *testing.T) {
+	client := createFrequencyTestClient(t)
+	defer func() { _ = client.Close() }()
+
+	ctx := context.Background()
+
+	frequencies := []CreateFrequencyParams{
+		{TripID: "trip_1", StartTime: int64(6 * 3600 * 1e9), EndTime: int64(9 * 3600 * 1e9), HeadwaySecs: 600, ExactTimes: 0},
+		{TripID: "trip_1", StartTime: int64(16 * 3600 * 1e9), EndTime: int64(19 * 3600 * 1e9), HeadwaySecs: 600, ExactTimes: 0},
+		{TripID: "trip_2", StartTime: int64(7 * 3600 * 1e9), EndTime: int64(10 * 3600 * 1e9), HeadwaySecs: 300, ExactTimes: 1},
+		{TripID: "trip_3", StartTime: int64(8 * 3600 * 1e9), EndTime: int64(12 * 3600 * 1e9), HeadwaySecs: 1200, ExactTimes: 0},
+	}
+
+	err := client.bulkInsertFrequencies(ctx, frequencies)
+	require.NoError(t, err)
+
+	rows1, err := client.Queries.GetFrequenciesForTrip(ctx, "trip_1")
+	require.NoError(t, err)
+	assert.Equal(t, 2, len(rows1))
+
+	rows2, err := client.Queries.GetFrequenciesForTrip(ctx, "trip_2")
+	require.NoError(t, err)
+	assert.Equal(t, 1, len(rows2))
+	assert.Equal(t, int64(1), rows2[0].ExactTimes)
+	assert.Equal(t, int64(300), rows2[0].HeadwaySecs)
+
+	rows3, err := client.Queries.GetFrequenciesForTrip(ctx, "trip_3")
+	require.NoError(t, err)
+	assert.Equal(t, 1, len(rows3))
+
+	rows4, err := client.Queries.GetFrequenciesForTrip(ctx, "trip_4")
+	require.NoError(t, err)
+	assert.Equal(t, 0, len(rows4))
+}
+
+func TestBulkInsertFrequencies_DuplicatePrimaryKey(t *testing.T) {
+	client := createFrequencyTestClient(t)
+	defer func() { _ = client.Close() }()
+
+	ctx := context.Background()
+
+	startTime := int64(6 * 3600 * 1e9)
+	frequencies := []CreateFrequencyParams{
+		{TripID: "trip_1", StartTime: startTime, EndTime: int64(9 * 3600 * 1e9), HeadwaySecs: 600, ExactTimes: 0},
+		{TripID: "trip_1", StartTime: startTime, EndTime: int64(10 * 3600 * 1e9), HeadwaySecs: 900, ExactTimes: 1},
+	}
+
+	err := client.bulkInsertFrequencies(ctx, frequencies)
+	require.NoError(t, err)
+
+	rows, err := client.Queries.GetFrequenciesForTrip(ctx, "trip_1")
+	require.NoError(t, err)
+	assert.Equal(t, 1, len(rows), "Duplicate primary key should result in only 1 row")
+	assert.Equal(t, int64(600), rows[0].HeadwaySecs)
+	assert.Equal(t, int64(0), rows[0].ExactTimes)
+}
+
+func TestGetFrequencyTripIDs(t *testing.T) {
+	client := createFrequencyTestClient(t)
+	defer func() { _ = client.Close() }()
+
+	ctx := context.Background()
+
+	frequencies := []CreateFrequencyParams{
+		{TripID: "trip_1", StartTime: int64(6 * 3600 * 1e9), EndTime: int64(9 * 3600 * 1e9), HeadwaySecs: 600, ExactTimes: 0},
+		{TripID: "trip_1", StartTime: int64(16 * 3600 * 1e9), EndTime: int64(19 * 3600 * 1e9), HeadwaySecs: 600, ExactTimes: 0},
+		{TripID: "trip_3", StartTime: int64(8 * 3600 * 1e9), EndTime: int64(12 * 3600 * 1e9), HeadwaySecs: 1200, ExactTimes: 0},
+	}
+
+	err := client.bulkInsertFrequencies(ctx, frequencies)
+	require.NoError(t, err)
+
+	tripIDs, err := client.Queries.GetFrequencyTripIDs(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 2, len(tripIDs), "Should return 2 distinct trip IDs")
+	assert.Contains(t, tripIDs, "trip_1")
+	assert.Contains(t, tripIDs, "trip_3")
+}
+
+func TestClearFrequencies(t *testing.T) {
+	client := createFrequencyTestClient(t)
+	defer func() { _ = client.Close() }()
+
+	ctx := context.Background()
+
+	frequencies := []CreateFrequencyParams{
+		{TripID: "trip_1", StartTime: int64(6 * 3600 * 1e9), EndTime: int64(9 * 3600 * 1e9), HeadwaySecs: 600, ExactTimes: 0},
+		{TripID: "trip_2", StartTime: int64(7 * 3600 * 1e9), EndTime: int64(10 * 3600 * 1e9), HeadwaySecs: 300, ExactTimes: 1},
+	}
+
+	err := client.bulkInsertFrequencies(ctx, frequencies)
+	require.NoError(t, err)
+
+	rows, err := client.Queries.GetFrequenciesForTrip(ctx, "trip_1")
+	require.NoError(t, err)
+	assert.Equal(t, 1, len(rows))
+
+	err = client.Queries.ClearFrequencies(ctx)
+	require.NoError(t, err)
+
+	rows, err = client.Queries.GetFrequenciesForTrip(ctx, "trip_1")
+	require.NoError(t, err)
+	assert.Equal(t, 0, len(rows))
+
+	rows, err = client.Queries.GetFrequenciesForTrip(ctx, "trip_2")
+	require.NoError(t, err)
+	assert.Equal(t, 0, len(rows))
+}
+
+func TestGetFrequenciesForTrips(t *testing.T) {
+	client := createFrequencyTestClient(t)
+	defer func() { _ = client.Close() }()
+
+	ctx := context.Background()
+
+	frequencies := []CreateFrequencyParams{
+		{TripID: "trip_1", StartTime: int64(6 * 3600 * 1e9), EndTime: int64(9 * 3600 * 1e9), HeadwaySecs: 600, ExactTimes: 0},
+		{TripID: "trip_2", StartTime: int64(7 * 3600 * 1e9), EndTime: int64(10 * 3600 * 1e9), HeadwaySecs: 300, ExactTimes: 1},
+		{TripID: "trip_3", StartTime: int64(8 * 3600 * 1e9), EndTime: int64(12 * 3600 * 1e9), HeadwaySecs: 1200, ExactTimes: 0},
+	}
+
+	err := client.bulkInsertFrequencies(ctx, frequencies)
+	require.NoError(t, err)
+
+	rows, err := client.Queries.GetFrequenciesForTrips(ctx, []string{"trip_1", "trip_2"})
+	require.NoError(t, err)
+
+	assert.Equal(t, 2, len(rows), "Should return exactly 2 rows for the 2 requested trips")
+
+	var returnedTripIDs []string
+	for _, row := range rows {
+		returnedTripIDs = append(returnedTripIDs, row.TripID)
+	}
+	assert.Contains(t, returnedTripIDs, "trip_1")
+	assert.Contains(t, returnedTripIDs, "trip_2")
+	assert.NotContains(t, returnedTripIDs, "trip_3", "Should NOT return trip_3")
+
+	rowsEmpty, err := client.Queries.GetFrequenciesForTrips(ctx, []string{})
+	require.NoError(t, err)
+	assert.Equal(t, 0, len(rowsEmpty), "Empty input slice should return empty results")
+}

--- a/gtfsdb/conditional_import_test.go
+++ b/gtfsdb/conditional_import_test.go
@@ -278,6 +278,11 @@ func TestClearAllGTFSData(t *testing.T) {
 	require.NoError(t, err, "Should be able to count calendar_dates before clear")
 	assert.Greater(t, countBefore, 0, "Should have calendar_dates before clear")
 
+	// Verify frequencies table exists and can be queried before clear
+	var freqCountBefore int
+	err = client.DB.QueryRowContext(ctx, "SELECT COUNT(*) FROM frequencies").Scan(&freqCountBefore)
+	require.NoError(t, err, "Should be able to count frequencies before clear")
+
 	// Clear all data
 	err = client.clearAllGTFSData(ctx)
 	require.NoError(t, err, "Should be able to clear all GTFS data")
@@ -296,6 +301,12 @@ func TestClearAllGTFSData(t *testing.T) {
 	err = client.DB.QueryRowContext(ctx, "SELECT COUNT(*) FROM calendar_dates").Scan(&countAfter)
 	require.NoError(t, err, "Should be able to count calendar_dates after clear")
 	assert.Equal(t, 0, countAfter, "Should have no calendar_dates after clear")
+
+	// Verify frequencies are cleared
+	var freqCountAfter int
+	err = client.DB.QueryRowContext(ctx, "SELECT COUNT(*) FROM frequencies").Scan(&freqCountAfter)
+	require.NoError(t, err, "Should be able to count frequencies after clear")
+	assert.Equal(t, 0, freqCountAfter, "Should have no frequencies after clear")
 
 	// Note: Import metadata should NOT be cleared by clearAllGTFSData
 	metadata, err := client.Queries.GetImportMetadata(ctx)

--- a/gtfsdb/db.go
+++ b/gtfsdb/db.go
@@ -39,6 +39,9 @@ func Prepare(ctx context.Context, db DBTX) (*Queries, error) {
 	if q.clearCalendarDatesStmt, err = db.PrepareContext(ctx, clearCalendarDates); err != nil {
 		return nil, fmt.Errorf("error preparing query ClearCalendarDates: %w", err)
 	}
+	if q.clearFrequenciesStmt, err = db.PrepareContext(ctx, clearFrequencies); err != nil {
+		return nil, fmt.Errorf("error preparing query ClearFrequencies: %w", err)
+	}
 	if q.clearRoutesStmt, err = db.PrepareContext(ctx, clearRoutes); err != nil {
 		return nil, fmt.Errorf("error preparing query ClearRoutes: %w", err)
 	}
@@ -68,6 +71,9 @@ func Prepare(ctx context.Context, db DBTX) (*Queries, error) {
 	}
 	if q.createCalendarDateStmt, err = db.PrepareContext(ctx, createCalendarDate); err != nil {
 		return nil, fmt.Errorf("error preparing query CreateCalendarDate: %w", err)
+	}
+	if q.createFrequencyStmt, err = db.PrepareContext(ctx, createFrequency); err != nil {
+		return nil, fmt.Errorf("error preparing query CreateFrequency: %w", err)
 	}
 	if q.createProblemReportStopStmt, err = db.PrepareContext(ctx, createProblemReportStop); err != nil {
 		return nil, fmt.Errorf("error preparing query CreateProblemReportStop: %w", err)
@@ -146,6 +152,15 @@ func Prepare(ctx context.Context, db DBTX) (*Queries, error) {
 	}
 	if q.getCalendarDateExceptionsForServiceIDStmt, err = db.PrepareContext(ctx, getCalendarDateExceptionsForServiceID); err != nil {
 		return nil, fmt.Errorf("error preparing query GetCalendarDateExceptionsForServiceID: %w", err)
+	}
+	if q.getFrequenciesForTripStmt, err = db.PrepareContext(ctx, getFrequenciesForTrip); err != nil {
+		return nil, fmt.Errorf("error preparing query GetFrequenciesForTrip: %w", err)
+	}
+	if q.getFrequenciesForTripsStmt, err = db.PrepareContext(ctx, getFrequenciesForTrips); err != nil {
+		return nil, fmt.Errorf("error preparing query GetFrequenciesForTrips: %w", err)
+	}
+	if q.getFrequencyTripIDsStmt, err = db.PrepareContext(ctx, getFrequencyTripIDs); err != nil {
+		return nil, fmt.Errorf("error preparing query GetFrequencyTripIDs: %w", err)
 	}
 	if q.getImportMetadataStmt, err = db.PrepareContext(ctx, getImportMetadata); err != nil {
 		return nil, fmt.Errorf("error preparing query GetImportMetadata: %w", err)
@@ -333,6 +348,11 @@ func (q *Queries) Close() error {
 			err = fmt.Errorf("error closing clearCalendarDatesStmt: %w", cerr)
 		}
 	}
+	if q.clearFrequenciesStmt != nil {
+		if cerr := q.clearFrequenciesStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing clearFrequenciesStmt: %w", cerr)
+		}
+	}
 	if q.clearRoutesStmt != nil {
 		if cerr := q.clearRoutesStmt.Close(); cerr != nil {
 			err = fmt.Errorf("error closing clearRoutesStmt: %w", cerr)
@@ -381,6 +401,11 @@ func (q *Queries) Close() error {
 	if q.createCalendarDateStmt != nil {
 		if cerr := q.createCalendarDateStmt.Close(); cerr != nil {
 			err = fmt.Errorf("error closing createCalendarDateStmt: %w", cerr)
+		}
+	}
+	if q.createFrequencyStmt != nil {
+		if cerr := q.createFrequencyStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing createFrequencyStmt: %w", cerr)
 		}
 	}
 	if q.createProblemReportStopStmt != nil {
@@ -511,6 +536,21 @@ func (q *Queries) Close() error {
 	if q.getCalendarDateExceptionsForServiceIDStmt != nil {
 		if cerr := q.getCalendarDateExceptionsForServiceIDStmt.Close(); cerr != nil {
 			err = fmt.Errorf("error closing getCalendarDateExceptionsForServiceIDStmt: %w", cerr)
+		}
+	}
+	if q.getFrequenciesForTripStmt != nil {
+		if cerr := q.getFrequenciesForTripStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing getFrequenciesForTripStmt: %w", cerr)
+		}
+	}
+	if q.getFrequenciesForTripsStmt != nil {
+		if cerr := q.getFrequenciesForTripsStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing getFrequenciesForTripsStmt: %w", cerr)
+		}
+	}
+	if q.getFrequencyTripIDsStmt != nil {
+		if cerr := q.getFrequencyTripIDsStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing getFrequencyTripIDsStmt: %w", cerr)
 		}
 	}
 	if q.getImportMetadataStmt != nil {
@@ -817,6 +857,7 @@ type Queries struct {
 	clearBlockTripIndicesStmt                 *sql.Stmt
 	clearCalendarStmt                         *sql.Stmt
 	clearCalendarDatesStmt                    *sql.Stmt
+	clearFrequenciesStmt                      *sql.Stmt
 	clearRoutesStmt                           *sql.Stmt
 	clearShapesStmt                           *sql.Stmt
 	clearStopTimesStmt                        *sql.Stmt
@@ -827,6 +868,7 @@ type Queries struct {
 	createBlockTripIndexStmt                  *sql.Stmt
 	createCalendarStmt                        *sql.Stmt
 	createCalendarDateStmt                    *sql.Stmt
+	createFrequencyStmt                       *sql.Stmt
 	createProblemReportStopStmt               *sql.Stmt
 	createProblemReportTripStmt               *sql.Stmt
 	createRouteStmt                           *sql.Stmt
@@ -853,6 +895,9 @@ type Queries struct {
 	getBlocksForBlockTripIndexIDsStmt         *sql.Stmt
 	getCalendarByServiceIDStmt                *sql.Stmt
 	getCalendarDateExceptionsForServiceIDStmt *sql.Stmt
+	getFrequenciesForTripStmt                 *sql.Stmt
+	getFrequenciesForTripsStmt                *sql.Stmt
+	getFrequencyTripIDsStmt                   *sql.Stmt
 	getImportMetadataStmt                     *sql.Stmt
 	getNextStopInTripStmt                     *sql.Stmt
 	getOrderedStopIDsForTripStmt              *sql.Stmt
@@ -916,6 +961,7 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		clearBlockTripIndicesStmt:                 q.clearBlockTripIndicesStmt,
 		clearCalendarStmt:                         q.clearCalendarStmt,
 		clearCalendarDatesStmt:                    q.clearCalendarDatesStmt,
+		clearFrequenciesStmt:                      q.clearFrequenciesStmt,
 		clearRoutesStmt:                           q.clearRoutesStmt,
 		clearShapesStmt:                           q.clearShapesStmt,
 		clearStopTimesStmt:                        q.clearStopTimesStmt,
@@ -926,6 +972,7 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		createBlockTripIndexStmt:                  q.createBlockTripIndexStmt,
 		createCalendarStmt:                        q.createCalendarStmt,
 		createCalendarDateStmt:                    q.createCalendarDateStmt,
+		createFrequencyStmt:                       q.createFrequencyStmt,
 		createProblemReportStopStmt:               q.createProblemReportStopStmt,
 		createProblemReportTripStmt:               q.createProblemReportTripStmt,
 		createRouteStmt:                           q.createRouteStmt,
@@ -952,6 +999,9 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		getBlocksForBlockTripIndexIDsStmt:         q.getBlocksForBlockTripIndexIDsStmt,
 		getCalendarByServiceIDStmt:                q.getCalendarByServiceIDStmt,
 		getCalendarDateExceptionsForServiceIDStmt: q.getCalendarDateExceptionsForServiceIDStmt,
+		getFrequenciesForTripStmt:                 q.getFrequenciesForTripStmt,
+		getFrequenciesForTripsStmt:                q.getFrequenciesForTripsStmt,
+		getFrequencyTripIDsStmt:                   q.getFrequencyTripIDsStmt,
 		getImportMetadataStmt:                     q.getImportMetadataStmt,
 		getNextStopInTripStmt:                     q.getNextStopInTripStmt,
 		getOrderedStopIDsForTripStmt:              q.getOrderedStopIDsForTripStmt,

--- a/gtfsdb/debugging.go
+++ b/gtfsdb/debugging.go
@@ -43,15 +43,20 @@ func PrintSimpleSchema(db *sql.DB) error { // nolint:unused
 }
 
 func (c *Client) staticDataCounts(staticData *gtfs.Static) map[string]int {
+	frequencyCount := 0
+	for _, t := range staticData.Trips {
+		frequencyCount += len(t.Frequencies)
+	}
 	return map[string]int{
-		"routes":    len(staticData.Routes),
-		"services":  len(staticData.Services),
-		"stops":     len(staticData.Stops),
-		"agencies":  len(staticData.Agencies),
-		"transfers": len(staticData.Transfers),
-		"trips":     len(staticData.Trips),
-		"calendar":  len(staticData.Services),
-		"shapes":    len(staticData.Shapes),
+		"routes":      len(staticData.Routes),
+		"services":    len(staticData.Services),
+		"stops":       len(staticData.Stops),
+		"agencies":    len(staticData.Agencies),
+		"transfers":   len(staticData.Transfers),
+		"trips":       len(staticData.Trips),
+		"calendar":    len(staticData.Services),
+		"shapes":      len(staticData.Shapes),
+		"frequencies": frequencyCount,
 	}
 }
 
@@ -89,6 +94,7 @@ func (c *Client) TableCounts() (map[string]int, error) {
 		"block_trip_index": "SELECT COUNT(*) FROM block_trip_index",
 		"block_trip_entry": "SELECT COUNT(*) FROM block_trip_entry",
 		"import_metadata":  "SELECT COUNT(*) FROM import_metadata",
+		"frequencies":      "SELECT COUNT(*) FROM frequencies",
 	}
 
 	for _, table := range tables {

--- a/gtfsdb/debugging_test.go
+++ b/gtfsdb/debugging_test.go
@@ -4,6 +4,8 @@ import (
 	"database/sql"
 	"testing"
 
+	"github.com/OneBusAway/go-gtfs"
+	_ "github.com/mattn/go-sqlite3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -35,4 +37,60 @@ func TestTableCounts(t *testing.T) {
 
 	_, exists := counts["secret_table"]
 	assert.False(t, exists, "Should not include tables outside the whitelist")
+}
+
+func TestTableCounts_IncludesFrequencies(t *testing.T) {
+	db, err := sql.Open(DriverName, ":memory:")
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	client := &Client{DB: db}
+
+	_, err = db.Exec(`
+        CREATE TABLE frequencies (
+            trip_id TEXT NOT NULL,
+            start_time INTEGER NOT NULL,
+            end_time INTEGER NOT NULL,
+            headway_secs INTEGER NOT NULL,
+            exact_times INTEGER NOT NULL DEFAULT 0,
+            PRIMARY KEY (trip_id, start_time)
+        );
+        INSERT INTO frequencies VALUES ('trip_1', 21600000000000, 32400000000000, 600, 0);
+        INSERT INTO frequencies VALUES ('trip_1', 57600000000000, 68400000000000, 600, 1);
+        INSERT INTO frequencies VALUES ('trip_2', 25200000000000, 36000000000000, 300, 0);
+    `)
+	require.NoError(t, err)
+
+	counts, err := client.TableCounts()
+	require.NoError(t, err)
+
+	assert.Equal(t, 3, counts["frequencies"], "Should count frequencies correctly")
+}
+
+func TestStaticDataCounts_IncludesFrequencies(t *testing.T) {
+	client := &Client{}
+
+	// Create a mock gtfs.Static object.
+	// We only need to populate the arrays so len() works correctly.
+	mockStatic := &gtfs.Static{
+		Trips: []gtfs.ScheduledTrip{
+			{
+				Frequencies: []gtfs.Frequency{
+					{},
+					{},
+				},
+			},
+			{
+				Frequencies: []gtfs.Frequency{
+					{},
+				},
+			},
+			{},
+		},
+	}
+
+	counts := client.staticDataCounts(mockStatic)
+
+	assert.Equal(t, 3, counts["frequencies"], "Should aggregate all frequencies across all trips (2 + 1 + 0 = 3)")
+	assert.Equal(t, 3, counts["trips"], "Should count total trips correctly")
 }

--- a/gtfsdb/helpers.go
+++ b/gtfsdb/helpers.go
@@ -297,6 +297,27 @@ func (c *Client) processAndStoreGTFSDataWithSource(b []byte, source string) erro
 		return fmt.Errorf("unable to create stop times: %w", err)
 	}
 
+	// Collect frequency entries from all trips
+	var allFrequencyParams []CreateFrequencyParams
+	for _, t := range staticData.Trips {
+		for _, f := range t.Frequencies {
+			params := CreateFrequencyParams{
+				TripID:      t.ID,
+				StartTime:   int64(f.StartTime),
+				EndTime:     int64(f.EndTime),
+				HeadwaySecs: int64(f.Headway.Seconds()),
+				ExactTimes:  int64(f.ExactTimes),
+			}
+			allFrequencyParams = append(allFrequencyParams, params)
+		}
+	}
+	if len(allFrequencyParams) > 0 {
+		err = c.bulkInsertFrequencies(ctx, allFrequencyParams)
+		if err != nil {
+			return fmt.Errorf("unable to create frequencies: %w", err)
+		}
+	}
+
 	var allShapeParams []CreateShapeParams
 	for _, s := range staticData.Shapes {
 		for idx, pt := range s.Points {
@@ -398,6 +419,9 @@ func (c *Client) clearAllGTFSData(ctx context.Context) error {
 	}
 	if err := c.Queries.ClearBlockTripIndices(ctx); err != nil {
 		return fmt.Errorf("error clearing block_trip_index: %w", err)
+	}
+	if err := c.Queries.ClearFrequencies(ctx); err != nil {
+		return fmt.Errorf("error clearing frequencies: %w", err)
 	}
 	if err := c.Queries.ClearStopTimes(ctx); err != nil {
 		return fmt.Errorf("error clearing stop_times: %w", err)
@@ -903,6 +927,38 @@ func (c *Client) bulkInsertShapes(ctx context.Context, shapes []CreateShapeParam
 
 	logging.LogOperation(logger, "shapes_inserted",
 		slog.Int("count", len(shapes)))
+
+	return nil
+}
+
+func (c *Client) bulkInsertFrequencies(ctx context.Context, frequencies []CreateFrequencyParams) error {
+	db := c.DB
+	queries := c.Queries
+	logger := slog.Default().With(slog.String("component", "bulk_insert"))
+
+	logging.LogOperation(logger, "inserting_frequencies",
+		slog.Int("count", len(frequencies)))
+
+	tx, err := db.Begin()
+	if err != nil {
+		return err
+	}
+	defer logging.SafeRollbackWithLogging(tx, logger, "bulk_insert_frequencies")
+
+	qtx := queries.WithTx(tx)
+	for _, params := range frequencies {
+		err := qtx.CreateFrequency(ctx, params)
+		if err != nil {
+			return err
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return err
+	}
+
+	logging.LogOperation(logger, "frequencies_inserted",
+		slog.Int("count", len(frequencies)))
 
 	return nil
 }

--- a/gtfsdb/models.go
+++ b/gtfsdb/models.go
@@ -55,6 +55,14 @@ type CalendarDate struct {
 	ExceptionType int64
 }
 
+type Frequency struct {
+	TripID      string
+	StartTime   int64
+	EndTime     int64
+	HeadwaySecs int64
+	ExactTimes  int64
+}
+
 type ImportMetadatum struct {
 	ID         int64
 	FileHash   string

--- a/gtfsdb/query.sql
+++ b/gtfsdb/query.sql
@@ -109,6 +109,28 @@ OR REPLACE INTO stop_times (
 VALUES
     (?, ?, ?, ?, ?, ?, ?, ?, ?, ?) RETURNING *;
 
+-- name: CreateFrequency :exec
+INSERT OR IGNORE INTO frequencies (
+    trip_id,
+    start_time,
+    end_time,
+    headway_secs,
+    exact_times
+) VALUES (?, ?, ?, ?, ?);
+
+-- name: GetFrequenciesForTrip :many
+SELECT * FROM frequencies
+WHERE trip_id = ?
+ORDER BY start_time;
+
+-- name: GetFrequenciesForTrips :many
+SELECT * FROM frequencies
+WHERE trip_id IN (sqlc.slice('trip_ids'))
+ORDER BY trip_id, start_time;
+
+-- name: GetFrequencyTripIDs :many
+SELECT DISTINCT trip_id FROM frequencies;
+
 -- name: CreateTrip :one
 INSERT
 OR REPLACE INTO trips (
@@ -482,6 +504,9 @@ VALUES
 
 -- name: ClearStopTimes :exec
 DELETE FROM stop_times;
+
+-- name: ClearFrequencies :exec
+DELETE FROM frequencies;
 
 -- name: ClearShapes :exec
 DELETE FROM shapes;

--- a/gtfsdb/query.sql.go
+++ b/gtfsdb/query.sql.go
@@ -56,6 +56,15 @@ func (q *Queries) ClearCalendarDates(ctx context.Context) error {
 	return err
 }
 
+const clearFrequencies = `-- name: ClearFrequencies :exec
+DELETE FROM frequencies
+`
+
+func (q *Queries) ClearFrequencies(ctx context.Context) error {
+	_, err := q.exec(ctx, q.clearFrequenciesStmt, clearFrequencies)
+	return err
+}
+
 const clearRoutes = `-- name: ClearRoutes :exec
 DELETE FROM routes
 `
@@ -295,6 +304,35 @@ func (q *Queries) CreateCalendarDate(ctx context.Context, arg CreateCalendarDate
 	var i CalendarDate
 	err := row.Scan(&i.ServiceID, &i.Date, &i.ExceptionType)
 	return i, err
+}
+
+const createFrequency = `-- name: CreateFrequency :exec
+INSERT OR IGNORE INTO frequencies (
+    trip_id,
+    start_time,
+    end_time,
+    headway_secs,
+    exact_times
+) VALUES (?, ?, ?, ?, ?)
+`
+
+type CreateFrequencyParams struct {
+	TripID      string
+	StartTime   int64
+	EndTime     int64
+	HeadwaySecs int64
+	ExactTimes  int64
+}
+
+func (q *Queries) CreateFrequency(ctx context.Context, arg CreateFrequencyParams) error {
+	_, err := q.exec(ctx, q.createFrequencyStmt, createFrequency,
+		arg.TripID,
+		arg.StartTime,
+		arg.EndTime,
+		arg.HeadwaySecs,
+		arg.ExactTimes,
+	)
+	return err
 }
 
 const createProblemReportStop = `-- name: CreateProblemReportStop :exec
@@ -1584,6 +1622,113 @@ func (q *Queries) GetCalendarDateExceptionsForServiceID(ctx context.Context, ser
 			return nil, err
 		}
 		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const getFrequenciesForTrip = `-- name: GetFrequenciesForTrip :many
+SELECT trip_id, start_time, end_time, headway_secs, exact_times FROM frequencies
+WHERE trip_id = ?
+ORDER BY start_time
+`
+
+func (q *Queries) GetFrequenciesForTrip(ctx context.Context, tripID string) ([]Frequency, error) {
+	rows, err := q.query(ctx, q.getFrequenciesForTripStmt, getFrequenciesForTrip, tripID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []Frequency
+	for rows.Next() {
+		var i Frequency
+		if err := rows.Scan(
+			&i.TripID,
+			&i.StartTime,
+			&i.EndTime,
+			&i.HeadwaySecs,
+			&i.ExactTimes,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const getFrequenciesForTrips = `-- name: GetFrequenciesForTrips :many
+SELECT trip_id, start_time, end_time, headway_secs, exact_times FROM frequencies
+WHERE trip_id IN (/*SLICE:trip_ids*/?)
+ORDER BY trip_id, start_time
+`
+
+func (q *Queries) GetFrequenciesForTrips(ctx context.Context, tripIds []string) ([]Frequency, error) {
+	query := getFrequenciesForTrips
+	var queryParams []interface{}
+	if len(tripIds) > 0 {
+		for _, v := range tripIds {
+			queryParams = append(queryParams, v)
+		}
+		query = strings.Replace(query, "/*SLICE:trip_ids*/?", strings.Repeat(",?", len(tripIds))[1:], 1)
+	} else {
+		query = strings.Replace(query, "/*SLICE:trip_ids*/?", "NULL", 1)
+	}
+	rows, err := q.query(ctx, nil, query, queryParams...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []Frequency
+	for rows.Next() {
+		var i Frequency
+		if err := rows.Scan(
+			&i.TripID,
+			&i.StartTime,
+			&i.EndTime,
+			&i.HeadwaySecs,
+			&i.ExactTimes,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const getFrequencyTripIDs = `-- name: GetFrequencyTripIDs :many
+SELECT DISTINCT trip_id FROM frequencies
+`
+
+func (q *Queries) GetFrequencyTripIDs(ctx context.Context) ([]string, error) {
+	rows, err := q.query(ctx, q.getFrequencyTripIDsStmt, getFrequencyTripIDs)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []string
+	for rows.Next() {
+		var trip_id string
+		if err := rows.Scan(&trip_id); err != nil {
+			return nil, err
+		}
+		items = append(items, trip_id)
 	}
 	if err := rows.Close(); err != nil {
 		return nil, err

--- a/gtfsdb/schema.sql
+++ b/gtfsdb/schema.sql
@@ -278,6 +278,18 @@ CREATE TABLE
 
 -- migrate
 CREATE TABLE
+    IF NOT EXISTS frequencies (
+        trip_id TEXT NOT NULL,
+        start_time INTEGER NOT NULL, -- Nanoseconds since midnight (matches stop_times convention)
+        end_time INTEGER NOT NULL, -- Nanoseconds since midnight
+        headway_secs INTEGER NOT NULL, -- Headway in seconds
+        exact_times INTEGER NOT NULL DEFAULT 0, -- 0 = frequency-based, 1 = schedule-based
+        FOREIGN KEY (trip_id) REFERENCES trips (id),
+        PRIMARY KEY (trip_id, start_time)
+    );
+
+-- migrate
+CREATE TABLE
     IF NOT EXISTS calendar_dates (
         service_id TEXT NOT NULL,
         date TEXT NOT NULL,
@@ -358,6 +370,9 @@ CREATE INDEX IF NOT EXISTS idx_trips_block_id ON trips (block_id);
 
 -- migrate
 CREATE INDEX IF NOT EXISTS idx_shapes_shape_id ON shapes (shape_id);
+
+-- migrate
+CREATE INDEX IF NOT EXISTS idx_frequencies_trip_id ON frequencies (trip_id);
 
 -- Problem reports for trips
 -- migrate

--- a/gtfsdb/synthetic_gtfs_frequency_test.go
+++ b/gtfsdb/synthetic_gtfs_frequency_test.go
@@ -1,0 +1,247 @@
+package gtfsdb
+
+import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"testing"
+
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"maglev.onebusaway.org/internal/appconf"
+)
+
+// buildSyntheticGTFSZip creates a minimal valid GTFS zip archive in memory,
+func buildSyntheticGTFSZip(t *testing.T, includeFrequencies bool) []byte {
+	t.Helper()
+
+	var buf bytes.Buffer
+	w := zip.NewWriter(&buf)
+
+	files := map[string]string{
+		"agency.txt": "agency_id,agency_name,agency_url,agency_timezone\n" +
+			"agency_1,Synthetic Transit,http://example.com,America/Los_Angeles\n",
+
+		"routes.txt": "route_id,agency_id,route_short_name,route_long_name,route_type\n" +
+			"route_1,agency_1,R1,Route One,3\n" +
+			"route_2,agency_1,R2,Route Two,3\n",
+
+		"calendar.txt": "service_id,monday,tuesday,wednesday,thursday,friday,saturday,sunday,start_date,end_date\n" +
+			"service_1,1,1,1,1,1,0,0,20240101,20251231\n",
+
+		"stops.txt": "stop_id,stop_name,stop_lat,stop_lon\n" +
+			"stop_1,First Stop,37.7749,-122.4194\n" +
+			"stop_2,Second Stop,37.7849,-122.4094\n" +
+			"stop_3,Third Stop,37.7949,-122.3994\n",
+
+		"trips.txt": "route_id,service_id,trip_id,trip_headsign,direction_id,block_id,shape_id\n" +
+			"route_1,service_1,trip_freq_0,Downtown via Freq,0,,\n" +
+			"route_1,service_1,trip_freq_1,Uptown via Freq,1,,\n" +
+			"route_2,service_1,trip_exact,Express Exact,0,,\n" +
+			"route_2,service_1,trip_normal,Normal Trip,0,,\n",
+
+		"stop_times.txt": "trip_id,arrival_time,departure_time,stop_id,stop_sequence\n" +
+			"trip_freq_0,06:00:00,06:00:00,stop_1,1\n" +
+			"trip_freq_0,06:10:00,06:10:00,stop_2,2\n" +
+			"trip_freq_0,06:20:00,06:20:00,stop_3,3\n" +
+			"trip_freq_1,07:00:00,07:00:00,stop_3,1\n" +
+			"trip_freq_1,07:10:00,07:10:00,stop_2,2\n" +
+			"trip_freq_1,07:20:00,07:20:00,stop_1,3\n" +
+			"trip_exact,06:00:00,06:00:00,stop_1,1\n" +
+			"trip_exact,06:15:00,06:15:00,stop_2,2\n" +
+			"trip_exact,06:30:00,06:30:00,stop_3,3\n" +
+			"trip_normal,08:00:00,08:00:00,stop_1,1\n" +
+			"trip_normal,08:15:00,08:15:00,stop_2,2\n" +
+			"trip_normal,08:30:00,08:30:00,stop_3,3\n",
+	}
+
+	if includeFrequencies {
+		// Two headway-based (exact_times=0) entries for trip_freq_0:
+		//   Morning: 6 AM – 9 AM, every 10 minutes
+		//   Evening: 4 PM – 7 PM, every 15 minutes
+		// One headway-based entry for trip_freq_1:
+		//   Morning: 7 AM – 10 AM, every 12 minutes
+		// One schedule-based (exact_times=1) entry for trip_exact:
+		//   Morning: 6 AM – 9 AM, every 30 minutes
+		// trip_normal has NO frequency entry (standard scheduled trip)
+		files["frequencies.txt"] = "trip_id,start_time,end_time,headway_secs,exact_times\n" +
+			"trip_freq_0,06:00:00,09:00:00,600,0\n" +
+			"trip_freq_0,16:00:00,19:00:00,900,0\n" +
+			"trip_freq_1,07:00:00,10:00:00,720,0\n" +
+			"trip_exact,06:00:00,09:00:00,1800,1\n"
+	}
+
+	for name, content := range files {
+		f, err := w.Create(name)
+		require.NoError(t, err)
+		_, err = f.Write([]byte(content))
+		require.NoError(t, err)
+	}
+
+	require.NoError(t, w.Close())
+	return buf.Bytes()
+}
+
+func TestSyntheticGTFS_FrequencyIngestion(t *testing.T) {
+	config := Config{
+		DBPath:  ":memory:",
+		Env:     appconf.Test,
+		verbose: true,
+	}
+
+	client, err := NewClient(config)
+	require.NoError(t, err)
+	defer func() { _ = client.Close() }()
+
+	ctx := context.Background()
+	gtfsData := buildSyntheticGTFSZip(t, true)
+
+	err = client.processAndStoreGTFSDataWithSource(gtfsData, "synthetic-test")
+	require.NoError(t, err, "Ingestion of synthetic GTFS with frequencies should succeed")
+
+	// Verify basic data was imported
+	agencies, err := client.Queries.ListAgencies(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 1, len(agencies))
+	assert.Equal(t, "agency_1", agencies[0].ID)
+
+	routes, err := client.Queries.ListRoutes(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 2, len(routes))
+
+	// Verify frequencies were ingested for trip_freq_0
+	freqs0, err := client.Queries.GetFrequenciesForTrip(ctx, "trip_freq_0")
+	require.NoError(t, err)
+	assert.Equal(t, 2, len(freqs0), "trip_freq_0 should have 2 frequency windows")
+
+	// Verify ordering (morning window first, evening second)
+	assert.Less(t, freqs0[0].StartTime, freqs0[1].StartTime, "Frequencies should be ordered by start_time")
+
+	// Verify morning window values
+	assert.Equal(t, int64(600), freqs0[0].HeadwaySecs, "Morning headway should be 600 seconds (10 min)")
+	assert.Equal(t, int64(0), freqs0[0].ExactTimes, "Morning window should be frequency-based")
+
+	// Verify evening window values
+	assert.Equal(t, int64(900), freqs0[1].HeadwaySecs, "Evening headway should be 900 seconds (15 min)")
+	assert.Equal(t, int64(0), freqs0[1].ExactTimes, "Evening window should be frequency-based")
+
+	// Verify frequencies were ingested for trip_freq_1
+	freqs1, err := client.Queries.GetFrequenciesForTrip(ctx, "trip_freq_1")
+	require.NoError(t, err)
+	assert.Equal(t, 1, len(freqs1), "trip_freq_1 should have 1 frequency window")
+	assert.Equal(t, int64(720), freqs1[0].HeadwaySecs, "trip_freq_1 headway should be 720 seconds (12 min)")
+
+	// Verify exact_times=1 for trip_exact
+	freqsExact, err := client.Queries.GetFrequenciesForTrip(ctx, "trip_exact")
+	require.NoError(t, err)
+	assert.Equal(t, 1, len(freqsExact), "trip_exact should have 1 frequency window")
+	assert.Equal(t, int64(1), freqsExact[0].ExactTimes, "trip_exact should be schedule-based (exact_times=1)")
+	assert.Equal(t, int64(1800), freqsExact[0].HeadwaySecs, "trip_exact headway should be 1800 seconds (30 min)")
+
+	// Verify trip_normal has NO frequencies
+	freqsNormal, err := client.Queries.GetFrequenciesForTrip(ctx, "trip_normal")
+	require.NoError(t, err)
+	assert.Equal(t, 0, len(freqsNormal), "trip_normal should have no frequency entries")
+
+	// Verify GetFrequencyTripIDs returns all frequency-based trips
+	tripIDs, err := client.Queries.GetFrequencyTripIDs(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 3, len(tripIDs), "Should have 3 distinct frequency trip IDs")
+	assert.Contains(t, tripIDs, "trip_freq_0")
+	assert.Contains(t, tripIDs, "trip_freq_1")
+	assert.Contains(t, tripIDs, "trip_exact")
+}
+
+func TestSyntheticGTFS_NoFrequencyFile(t *testing.T) {
+	config := Config{
+		DBPath:  ":memory:",
+		Env:     appconf.Test,
+		verbose: true,
+	}
+
+	client, err := NewClient(config)
+	require.NoError(t, err)
+	defer func() { _ = client.Close() }()
+
+	ctx := context.Background()
+	gtfsData := buildSyntheticGTFSZip(t, false)
+
+	err = client.processAndStoreGTFSDataWithSource(gtfsData, "synthetic-no-freq")
+	require.NoError(t, err, "Ingestion of GTFS without frequencies.txt should succeed")
+
+	// Verify trips were still imported
+	trip, err := client.Queries.GetTrip(ctx, "trip_freq_0")
+	require.NoError(t, err)
+	assert.Equal(t, "trip_freq_0", trip.ID)
+
+	// Verify no frequencies exist
+	freqs, err := client.Queries.GetFrequenciesForTrip(ctx, "trip_freq_0")
+	require.NoError(t, err)
+	assert.Equal(t, 0, len(freqs), "Should have no frequencies when frequencies.txt is absent")
+
+	tripIDs, err := client.Queries.GetFrequencyTripIDs(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 0, len(tripIDs))
+}
+
+func TestSyntheticGTFS_FrequenciesClearedOnReimport(t *testing.T) {
+	config := Config{
+		DBPath:  ":memory:",
+		Env:     appconf.Test,
+		verbose: true,
+	}
+
+	client, err := NewClient(config)
+	require.NoError(t, err)
+	defer func() { _ = client.Close() }()
+
+	ctx := context.Background()
+
+	// First import: with frequencies
+	dataWithFreqs := buildSyntheticGTFSZip(t, true)
+	err = client.processAndStoreGTFSDataWithSource(dataWithFreqs, "source-a")
+	require.NoError(t, err)
+
+	// Verify frequencies exist
+	freqs, err := client.Queries.GetFrequenciesForTrip(ctx, "trip_freq_0")
+	require.NoError(t, err)
+	assert.Equal(t, 2, len(freqs), "Should have frequencies after first import")
+
+	// Second import: same data without frequencies (different source triggers reimport)
+	dataNoFreqs := buildSyntheticGTFSZip(t, false)
+	err = client.processAndStoreGTFSDataWithSource(dataNoFreqs, "source-b")
+	require.NoError(t, err)
+
+	// Verify frequencies were cleared
+	freqs, err = client.Queries.GetFrequenciesForTrip(ctx, "trip_freq_0")
+	require.NoError(t, err)
+	assert.Equal(t, 0, len(freqs), "Frequencies should be cleared after reimport without frequencies.txt")
+
+	tripIDs, err := client.Queries.GetFrequencyTripIDs(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 0, len(tripIDs), "No frequency trip IDs should remain")
+}
+
+func TestSyntheticGTFS_TableCountsIncludeFrequencies(t *testing.T) {
+	config := Config{
+		DBPath:  ":memory:",
+		Env:     appconf.Test,
+		verbose: true,
+	}
+
+	client, err := NewClient(config)
+	require.NoError(t, err)
+	defer func() { _ = client.Close() }()
+
+	gtfsData := buildSyntheticGTFSZip(t, true)
+	err = client.processAndStoreGTFSDataWithSource(gtfsData, "synthetic-test")
+	require.NoError(t, err)
+
+	counts, err := client.TableCounts()
+	require.NoError(t, err)
+
+	freqCount, exists := counts["frequencies"]
+	assert.True(t, exists, "TableCounts should include 'frequencies'")
+	assert.Equal(t, 4, freqCount, "Should have 4 frequency rows (2 + 1 + 1)")
+}


### PR DESCRIPTION
### Overview
This PR implements **Phase 1 (Database Foundation)** of the GTFS `frequencies.txt` integration plan. It establishes the database schema, models, and data ingestion pipeline required to support frequency-based trips, without modifying any public API handlers yet.

### Changes Included
- **Schema & Models:** Added `frequencies` table to `schema.sql` and regenerated `sqlc` models.
- **Database Queries:** Added queries for `GetFrequenciesForTrip`, `GetFrequenciesForTrips` (batch), `CreateFrequency`, and `ClearFrequencies` in `query.sql`.
- **Ingestion Logic:** Implemented `bulkInsertFrequencies` and integrated frequency parsing from `go-gtfs` into `processAndStoreGTFSDataWithSource()`.
- **Data Management:** Updated `clearAllGTFSData()` to clear the frequencies table and added frequency counts to `staticDataCounts()`.

### Testing
Added robust database-level testing to ensure ingestion reliability:
- `bulk_insert_frequency_test.go`: Verifies correct storage in SQLite.
- `synthetic_gtfs_frequency_test.go`: Tests ingestion using synthetic GTFS data.
- `conditional_import_test.go`: Ensures the system does not crash and degrades gracefully when a GTFS feed lacks a `frequencies.txt` file.

*(Note: Phase 2 and Phase 3 covering API handler integration and schedule endpoints will follow in subsequent PRs after merging this.)*

<img width="1918" height="481" alt="image" src="https://github.com/user-attachments/assets/621e13b1-1d3b-4fe8-9552-faae68bb3010" />

@aaronbrethorst
closes : #548 