### PR TITLE
Fix redundant double gzip compression middleware

### DIFF
--- a/cmd/api/app.go
+++ b/cmd/api/app.go
@@ -140,8 +140,11 @@ func CreateServer(coreApp *app.Application, cfg appconf.Config) (*http.Server, *
 		ErrorLog: slog.NewLogLogger(coreApp.Logger.Handler(), slog.LevelError),
 	}))
 
+	// Apply global compression around the entire mux
+	compressedMux := restapi.CompressionMiddleware(mux)
+
 	// Wrap with security middleware
-	secureHandler := api.WithSecurityHeaders(mux)
+	secureHandler := api.WithSecurityHeaders(compressedMux)
 
 	// Add metrics middleware
 	metricsHandler := restapi.MetricsHandler(coreApp.Metrics)(secureHandler)

--- a/internal/restapi/http_test.go
+++ b/internal/restapi/http_test.go
@@ -115,9 +115,8 @@ func serveAndRetrieveEndpoint(t testing.TB, endpoint string) (*RestAPI, *http.Re
 // serveApiAndRetrieveEndpoint performs the request against an existing API instance
 // Accepts testing.TB to support both *testing.T and *testing.B
 func serveApiAndRetrieveEndpoint(t testing.TB, api *RestAPI, endpoint string) (*http.Response, models.ResponseModel) {
-	mux := http.NewServeMux()
-	api.SetRoutes(mux)
-	server := httptest.NewServer(mux)
+	// Use SetupAPIRoutes to ensure global middleware (like compression) is applied
+	server := httptest.NewServer(api.SetupAPIRoutes())
 	defer server.Close()
 	resp, err := http.Get(server.URL + endpoint)
 	require.NoError(t, err)
@@ -234,10 +233,8 @@ func TestCompressionMiddlewareIntegration(t *testing.T) {
 	defer api.Shutdown()
 
 	t.Run("API responses are compressed when requested", func(t *testing.T) {
-		// Use the standard test setup approach
-		mux := http.NewServeMux()
-		api.SetRoutes(mux)
-		server := httptest.NewServer(mux)
+		// Use SetupAPIRoutes which includes the global compression middleware
+		server := httptest.NewServer(api.SetupAPIRoutes())
 		defer server.Close()
 
 		// Create request with gzip acceptance

--- a/internal/restapi/routes.go
+++ b/internal/restapi/routes.go
@@ -10,23 +10,19 @@ import (
 
 type handlerFunc func(w http.ResponseWriter, r *http.Request)
 
-// rateLimitAndValidateAPIKey combines rate limiting, API key validation, and compression
+// rateLimitAndValidateAPIKey combines rate limiting and API key validation
 func rateLimitAndValidateAPIKey(api *RestAPI, finalHandler handlerFunc) http.Handler {
-	// Create the handler chain: API key validation -> rate limiting -> compression -> final handler
 	finalHandlerHttp := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		finalHandler(w, r)
 	})
 
-	// Apply compression first (innermost)
-	compressedHandler := CompressionMiddleware(finalHandlerHttp)
-
-	// Then rate limiting - use the shared rate limiter instance
+	// Apply rate limiting directly to the final handler - use the shared rate limiter instance
 	var rateLimitedHandler http.Handler
 	if api.rateLimiter != nil {
-		rateLimitedHandler = api.rateLimiter.Handler()(compressedHandler)
+		rateLimitedHandler = api.rateLimiter.Handler()(finalHandlerHttp)
 	} else {
 		// Fallback for tests that don't use NewRestAPI constructor
-		rateLimitedHandler = compressedHandler
+		rateLimitedHandler = finalHandlerHttp
 	}
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -35,7 +31,7 @@ func rateLimitAndValidateAPIKey(api *RestAPI, finalHandler handlerFunc) http.Han
 			api.invalidAPIKeyResponse(w, r)
 			return
 		}
-		// Then apply rate limiting and compression
+		// Then apply rate limiting
 		rateLimitedHandler.ServeHTTP(w, r)
 	})
 }
@@ -79,15 +75,12 @@ func withProtectedCombinedID(api *RestAPI, handler http.HandlerFunc) http.Handle
 		innerHandler(w, r)
 	})
 
-	// Apply compression first (innermost)
-	compressedHandler := CompressionMiddleware(finalHandlerHttp)
-
-	// Then rate limiting
+	// Apply rate limiting directly to the final handler
 	var rateLimitedHandler http.Handler
 	if api.rateLimiter != nil {
-		rateLimitedHandler = api.rateLimiter.Handler()(compressedHandler)
+		rateLimitedHandler = api.rateLimiter.Handler()(finalHandlerHttp)
 	} else {
-		rateLimitedHandler = compressedHandler
+		rateLimitedHandler = finalHandlerHttp
 	}
 
 	// Auth check outermost, matching rateLimitAndValidateAPIKey pattern


### PR DESCRIPTION
### Description

This PR addresses the performance overhead caused by applying the `CompressionMiddleware` multiple times per request, and fixes a production bug where several endpoints were completely missing compression.

Previously, `CompressionMiddleware` was applied at the per-route level inside the authentication and rate-limiting wrappers, while also being intended for use globally at the multiplexer level. Additionally, because the production server (`CreateServer`) bypassed the global wrapper, endpoints outside the rate limiter (like `/healthz`, `/metrics`, and the WebUI) were served uncompressed.

### Changes Made

* **`internal/restapi/routes.go`:** Removed the redundant `CompressionMiddleware` wrapper from inside `rateLimitAndValidateAPIKey` and `withProtectedCombinedID` to prevent double-wrapping the `http.ResponseWriter`.
* **`cmd/api/app.go`:** Applied `CompressionMiddleware` globally to the root `mux` inside `CreateServer()` to ensure that the REST API, Health checks, Prometheus Metrics, and WebUI are all universally compressed in production.
* **`internal/restapi/http_test.go`:** Updated HTTP integration tests to use `SetupAPIRoutes()` rather than calling `SetRoutes(mux)` directly, ensuring the tests accurately reflect and validate the new global middleware chain.

### Impact

* **Performance:** Eliminates unnecessary heap allocations, redundant header parsing, and extra GC pressure per request.
* **Bandwidth:** Ensures that `/healthz`, `/metrics`, and the WebUI receive gzip compression in production environments.

### Testing

* [x] All unit and integration tests pass successfully (`go test ./...`).
* [x] Verified that the HTTP tests accurately evaluate the global middleware chain.

Closes #551