### PR TITLE
fix: redact API keys in configuration dump output

### DIFF
--- a/cmd/api/app.go
+++ b/cmd/api/app.go
@@ -252,8 +252,8 @@ func dumpConfigJSON(cfg appconf.Config, gtfsCfg gtfs.Config) {
 	jsonConfig := map[string]interface{}{
 		"port":             cfg.Port,
 		"env":              envStr,
-		"api-keys":         cfg.ApiKeys,
-		"exempt-api-keys":  cfg.ExemptApiKeys,
+		"api-keys":         fmt.Sprintf("***REDACTED*** (%d keys)", len(cfg.ApiKeys)),
+		"exempt-api-keys":  fmt.Sprintf("***REDACTED*** (%d keys)", len(cfg.ExemptApiKeys)),
 		"rate-limit":       cfg.RateLimit,
 		"gtfs-static-feed": staticFeed,
 		"data-path":        gtfsCfg.GTFSDataPath,

--- a/cmd/api/app_test.go
+++ b/cmd/api/app_test.go
@@ -593,6 +593,15 @@ func TestDumpConfigJSON_WithExampleFile(t *testing.T) {
 	assert.NotEqual(t, "my-secret-api-key", headersMap["X-API-Key"])
 	assert.Equal(t, "***REDACTED***", headersMap["X-API-Key"])
 
+	// Check that API keys are redacted
+	apiKeysStr, ok := parsed["api-keys"].(string)
+	require.True(t, ok, "api-keys should be a string")
+	assert.Contains(t, apiKeysStr, "REDACTED", "API keys should be redacted")
+
+	exemptApiKeysStr, ok := parsed["exempt-api-keys"].(string)
+	require.True(t, ok, "exempt-api-keys should be a string")
+	assert.Contains(t, exemptApiKeysStr, "REDACTED", "Exempt API keys should be redacted")
+
 	assert.NotEqual(t, "", rtFeed["trip-updates-url"])
 	assert.Equal(t, gtfsCfg.GTFSDataPath, parsed["data-path"])
 }


### PR DESCRIPTION
**Description:**

### Background

Previously, running the application with the `--dump-config` flag would print the `api-keys` and `exempt-api-keys` arrays in plaintext to standard output. This posed a security risk as these sensitive credentials could be inadvertently captured in CI/CD pipeline logs, container logs, or log aggregation platforms.

### Changes Made

* **`cmd/api/app.go`**: Updated the `dumpConfigJSON` function to replace the raw API key arrays with a redacted string (`***REDACTED*** (N keys)`). This aligns the security posture with how GTFS static and RT auth headers are already handled.
* **`cmd/api/app_test.go`**: Added explicit assertions to `TestDumpConfigJSON_WithExampleFile` to verify that `api-keys` and `exempt-api-keys` are properly masked in the JSON output.

### How to Test / Verify

1. Check out this branch locally.
2. Build the application: `make build`
3. Run the config dump command using an existing config file:
`./bin/maglev -f config.json --dump-config`
4. Verify the JSON output correctly masks the keys while showing the count:
```json
"api-keys": "***REDACTED*** (1 keys)",
"exempt-api-keys": "***REDACTED*** (1 keys)",

```

5. Ensure all tests pass: `make test`

### Checklist

* [x] I have run `make test` locally, and all tests pass.
* [x] I have added/updated tests to cover my changes.
* [x] I have run `make lint` (or `golangci-lint run`) and fixed any issues.

Closes #553