### PR TITLE
perf: Eliminate O(N²) bottleneck in real-time block trip search queries

### DIFF
--- a/gtfsdb/db.go
+++ b/gtfsdb/db.go
@@ -24,6 +24,9 @@ func New(db DBTX) *Queries {
 func Prepare(ctx context.Context, db DBTX) (*Queries, error) {
 	q := Queries{db: db}
 	var err error
+	if q.bulkUpdateTripTimeBoundsStmt, err = db.PrepareContext(ctx, bulkUpdateTripTimeBounds); err != nil {
+		return nil, fmt.Errorf("error preparing query BulkUpdateTripTimeBounds: %w", err)
+	}
 	if q.clearAgenciesStmt, err = db.PrepareContext(ctx, clearAgencies); err != nil {
 		return nil, fmt.Errorf("error preparing query ClearAgencies: %w", err)
 	}
@@ -308,6 +311,11 @@ func Prepare(ctx context.Context, db DBTX) (*Queries, error) {
 
 func (q *Queries) Close() error {
 	var err error
+	if q.bulkUpdateTripTimeBoundsStmt != nil {
+		if cerr := q.bulkUpdateTripTimeBoundsStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing bulkUpdateTripTimeBoundsStmt: %w", cerr)
+		}
+	}
 	if q.clearAgenciesStmt != nil {
 		if cerr := q.clearAgenciesStmt.Close(); cerr != nil {
 			err = fmt.Errorf("error closing clearAgenciesStmt: %w", cerr)
@@ -812,6 +820,7 @@ func (q *Queries) queryRow(ctx context.Context, stmt *sql.Stmt, query string, ar
 type Queries struct {
 	db                                        DBTX
 	tx                                        *sql.Tx
+	bulkUpdateTripTimeBoundsStmt              *sql.Stmt
 	clearAgenciesStmt                         *sql.Stmt
 	clearBlockTripEntriesStmt                 *sql.Stmt
 	clearBlockTripIndicesStmt                 *sql.Stmt
@@ -911,6 +920,7 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 	return &Queries{
 		db:                                        tx,
 		tx:                                        tx,
+		bulkUpdateTripTimeBoundsStmt:              q.bulkUpdateTripTimeBoundsStmt,
 		clearAgenciesStmt:                         q.clearAgenciesStmt,
 		clearBlockTripEntriesStmt:                 q.clearBlockTripEntriesStmt,
 		clearBlockTripIndicesStmt:                 q.clearBlockTripIndicesStmt,

--- a/gtfsdb/models.go
+++ b/gtfsdb/models.go
@@ -183,4 +183,6 @@ type Trip struct {
 	ShapeID              sql.NullString
 	WheelchairAccessible sql.NullInt64
 	BikesAllowed         sql.NullInt64
+	MinArrivalTime       sql.NullInt64
+	MaxDepartureTime     sql.NullInt64
 }

--- a/gtfsdb/query.sql
+++ b/gtfsdb/query.sql
@@ -121,11 +121,19 @@ OR REPLACE INTO trips (
     block_id,
     shape_id,
     wheelchair_accessible,
-    bikes_allowed
+    bikes_allowed,
+    min_arrival_time,
+    max_departure_time
 )
 VALUES
-    (?, ?, ?, ?, ?, ?, ?, ?, ?, ?) RETURNING *;
+    (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) RETURNING *;
 
+-- name: BulkUpdateTripTimeBounds :exec
+UPDATE trips
+SET
+    min_arrival_time   = (SELECT MIN(arrival_time)   FROM stop_times WHERE trip_id = trips.id),
+    max_departure_time = (SELECT MAX(departure_time) FROM stop_times WHERE trip_id = trips.id)
+WHERE min_arrival_time IS NULL OR max_departure_time IS NULL;
 
 -- name: CreateCalendarDate :one
 INSERT
@@ -652,20 +660,12 @@ SELECT
     t.id,
     t.block_id,
     t.service_id,
-    MIN(st.departure_time) AS first_departure_time,
-    MAX(st.arrival_time) AS last_arrival_time
-FROM
-    trips t
-    JOIN stop_times st ON st.trip_id = t.id
-WHERE
-    t.block_id = ?
-    AND t.service_id IN (sqlc.slice('service_ids'))
-GROUP BY
-    t.id,
-    t.block_id,
-    t.service_id
-ORDER BY
-    MIN(st.departure_time);
+    t.min_arrival_time AS first_departure_time,
+    t.max_departure_time AS last_arrival_time
+FROM trips t
+WHERE t.block_id = ?
+  AND t.service_id IN (sqlc.slice('service_ids'))
+ORDER BY t.min_arrival_time;
 
 -- name: GetBlockIDByTripID :one
 SELECT
@@ -896,15 +896,8 @@ FROM trips t
 JOIN block_trip_entry bte ON t.id = bte.trip_id
 WHERE bte.block_trip_index_id IN (sqlc.slice('index_ids'))
   AND bte.service_id IN (sqlc.slice('service_ids'))
-  AND EXISTS (
-    -- Check if trip could be active: maxDeparture >= timeFrom AND minArrival <= timeTo
-    SELECT 1
-    FROM stop_times st
-    WHERE st.trip_id = t.id
-    GROUP BY st.trip_id
-    HAVING MAX(st.departure_time) >= sqlc.arg('from_time')
-       AND MIN(st.arrival_time) <= sqlc.arg('to_time')
-  )
+  AND t.max_departure_time >= sqlc.arg('from_time')
+  AND t.min_arrival_time <= sqlc.arg('to_time')
 ORDER BY t.route_id, bte.block_trip_sequence, t.id;
 
 -- name: GetActiveTripForRouteAtTime :one
@@ -915,14 +908,12 @@ SELECT
     t.direction_id, t.block_id, t.shape_id, t.wheelchair_accessible, t.bikes_allowed
 FROM trips t
 JOIN block_trip_entry bte ON t.id = bte.trip_id
-JOIN stop_times st ON t.id = st.trip_id
 WHERE bte.block_trip_index_id IN (sqlc.slice('index_ids'))
   AND t.route_id = sqlc.arg('route_id')
   AND bte.service_id IN (sqlc.slice('service_ids'))
-GROUP BY t.id
-HAVING MIN(st.departure_time) <= sqlc.arg('current_time')
-   AND MAX(st.arrival_time) >= sqlc.arg('from_time')
-ORDER BY MIN(st.departure_time) DESC
+  AND t.min_arrival_time <= sqlc.arg('current_time')
+  AND t.max_departure_time >= sqlc.arg('from_time')
+ORDER BY t.min_arrival_time DESC
 LIMIT 1;
 
 -- name: GetBlockTripIndexIDsForBlocks :many
@@ -947,13 +938,11 @@ WHERE bte.block_trip_index_id IN (sqlc.slice('index_ids'))
 -- Orders by departure time ASC to get the EARLIEST matching trip (the one currently in progress)
 SELECT t.id
 FROM trips t
-JOIN stop_times st ON t.id = st.trip_id
 WHERE t.block_id = sqlc.arg('block_id')
   AND t.service_id IN (sqlc.slice('service_ids'))
-GROUP BY t.id
-HAVING MIN(st.departure_time) <= sqlc.arg('current_time')
-   AND MAX(st.arrival_time) >= sqlc.arg('current_time')
-ORDER BY MIN(st.departure_time) ASC
+  AND t.min_arrival_time <= sqlc.arg('current_time')
+  AND t.max_departure_time >= sqlc.arg('current_time')
+ORDER BY t.min_arrival_time ASC
 LIMIT 1;
 
 -- name: GetTripsInBlock :many
@@ -986,11 +975,10 @@ ORDER BY trip_id, stop_sequence;
 -- name: GetTripsByBlockIDs :many
 SELECT t.*
 FROM trips t
-JOIN stop_times st ON t.id = st.trip_id
 WHERE t.block_id IN (sqlc.slice('block_ids'))
   AND t.service_id IN (sqlc.slice('service_ids'))
-GROUP BY t.id
-ORDER BY t.block_id, MIN(st.departure_time), t.id;
+ORDER BY t.block_id, t.min_arrival_time, t.id;
+
 -- Problem Report Queries
 
 -- name: CreateProblemReportTrip :exec

--- a/gtfsdb/query.sql.go
+++ b/gtfsdb/query.sql.go
@@ -11,6 +11,19 @@ import (
 	"strings"
 )
 
+const bulkUpdateTripTimeBounds = `-- name: BulkUpdateTripTimeBounds :exec
+UPDATE trips
+SET
+    min_arrival_time   = (SELECT MIN(arrival_time)   FROM stop_times WHERE trip_id = trips.id),
+    max_departure_time = (SELECT MAX(departure_time) FROM stop_times WHERE trip_id = trips.id)
+WHERE min_arrival_time IS NULL OR max_departure_time IS NULL
+`
+
+func (q *Queries) BulkUpdateTripTimeBounds(ctx context.Context) error {
+	_, err := q.exec(ctx, q.bulkUpdateTripTimeBoundsStmt, bulkUpdateTripTimeBounds)
+	return err
+}
+
 const clearAgencies = `-- name: ClearAgencies :exec
 DELETE FROM agencies
 `
@@ -634,10 +647,12 @@ OR REPLACE INTO trips (
     block_id,
     shape_id,
     wheelchair_accessible,
-    bikes_allowed
+    bikes_allowed,
+    min_arrival_time,
+    max_departure_time
 )
 VALUES
-    (?, ?, ?, ?, ?, ?, ?, ?, ?, ?) RETURNING id, route_id, service_id, trip_headsign, trip_short_name, direction_id, block_id, shape_id, wheelchair_accessible, bikes_allowed
+    (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) RETURNING id, route_id, service_id, trip_headsign, trip_short_name, direction_id, block_id, shape_id, wheelchair_accessible, bikes_allowed, min_arrival_time, max_departure_time
 `
 
 type CreateTripParams struct {
@@ -651,6 +666,8 @@ type CreateTripParams struct {
 	ShapeID              sql.NullString
 	WheelchairAccessible sql.NullInt64
 	BikesAllowed         sql.NullInt64
+	MinArrivalTime       sql.NullInt64
+	MaxDepartureTime     sql.NullInt64
 }
 
 func (q *Queries) CreateTrip(ctx context.Context, arg CreateTripParams) (Trip, error) {
@@ -665,6 +682,8 @@ func (q *Queries) CreateTrip(ctx context.Context, arg CreateTripParams) (Trip, e
 		arg.ShapeID,
 		arg.WheelchairAccessible,
 		arg.BikesAllowed,
+		arg.MinArrivalTime,
+		arg.MaxDepartureTime,
 	)
 	var i Trip
 	err := row.Scan(
@@ -678,6 +697,8 @@ func (q *Queries) CreateTrip(ctx context.Context, arg CreateTripParams) (Trip, e
 		&i.ShapeID,
 		&i.WheelchairAccessible,
 		&i.BikesAllowed,
+		&i.MinArrivalTime,
+		&i.MaxDepartureTime,
 	)
 	return i, err
 }
@@ -857,14 +878,12 @@ SELECT
     t.direction_id, t.block_id, t.shape_id, t.wheelchair_accessible, t.bikes_allowed
 FROM trips t
 JOIN block_trip_entry bte ON t.id = bte.trip_id
-JOIN stop_times st ON t.id = st.trip_id
 WHERE bte.block_trip_index_id IN (/*SLICE:index_ids*/?)
   AND t.route_id = ?2
   AND bte.service_id IN (/*SLICE:service_ids*/?)
-GROUP BY t.id
-HAVING MIN(st.departure_time) <= ?4
-   AND MAX(st.arrival_time) >= ?5
-ORDER BY MIN(st.departure_time) DESC
+  AND t.min_arrival_time <= ?4
+  AND t.max_departure_time >= ?5
+ORDER BY t.min_arrival_time DESC
 LIMIT 1
 `
 
@@ -872,13 +891,26 @@ type GetActiveTripForRouteAtTimeParams struct {
 	IndexIds    []int64
 	RouteID     string
 	ServiceIds  []string
-	CurrentTime int64
-	FromTime    int64
+	CurrentTime sql.NullInt64
+	FromTime    sql.NullInt64
+}
+
+type GetActiveTripForRouteAtTimeRow struct {
+	ID                   string
+	RouteID              string
+	ServiceID            string
+	TripHeadsign         sql.NullString
+	TripShortName        sql.NullString
+	DirectionID          sql.NullInt64
+	BlockID              sql.NullString
+	ShapeID              sql.NullString
+	WheelchairAccessible sql.NullInt64
+	BikesAllowed         sql.NullInt64
 }
 
 // Find the ONE trip from a specific route that is active at the given time
 // A trip is active if current_time falls within its stop times
-func (q *Queries) GetActiveTripForRouteAtTime(ctx context.Context, arg GetActiveTripForRouteAtTimeParams) (Trip, error) {
+func (q *Queries) GetActiveTripForRouteAtTime(ctx context.Context, arg GetActiveTripForRouteAtTimeParams) (GetActiveTripForRouteAtTimeRow, error) {
 	query := getActiveTripForRouteAtTime
 	var queryParams []interface{}
 	if len(arg.IndexIds) > 0 {
@@ -901,7 +933,7 @@ func (q *Queries) GetActiveTripForRouteAtTime(ctx context.Context, arg GetActive
 	queryParams = append(queryParams, arg.CurrentTime)
 	queryParams = append(queryParams, arg.FromTime)
 	row := q.queryRow(ctx, nil, query, queryParams...)
-	var i Trip
+	var i GetActiveTripForRouteAtTimeRow
 	err := row.Scan(
 		&i.ID,
 		&i.RouteID,
@@ -920,20 +952,18 @@ func (q *Queries) GetActiveTripForRouteAtTime(ctx context.Context, arg GetActive
 const getActiveTripInBlockAtTime = `-- name: GetActiveTripInBlockAtTime :one
 SELECT t.id
 FROM trips t
-JOIN stop_times st ON t.id = st.trip_id
 WHERE t.block_id = ?1
   AND t.service_id IN (/*SLICE:service_ids*/?)
-GROUP BY t.id
-HAVING MIN(st.departure_time) <= ?3
-   AND MAX(st.arrival_time) >= ?3
-ORDER BY MIN(st.departure_time) ASC
+  AND t.min_arrival_time <= ?3
+  AND t.max_departure_time >= ?3
+ORDER BY t.min_arrival_time ASC
 LIMIT 1
 `
 
 type GetActiveTripInBlockAtTimeParams struct {
 	BlockID     sql.NullString
 	ServiceIds  []string
-	CurrentTime int64
+	CurrentTime sql.NullInt64
 }
 
 // Find the currently active trip in a specific block at the given time
@@ -1167,7 +1197,7 @@ func (q *Queries) GetAllStopIDs(ctx context.Context) ([]string, error) {
 }
 
 const getAllTripsForRoute = `-- name: GetAllTripsForRoute :many
-SELECT DISTINCT id, route_id, service_id, trip_headsign, trip_short_name, direction_id, block_id, shape_id, wheelchair_accessible, bikes_allowed
+SELECT DISTINCT id, route_id, service_id, trip_headsign, trip_short_name, direction_id, block_id, shape_id, wheelchair_accessible, bikes_allowed, min_arrival_time, max_departure_time
 FROM trips t
 WHERE t.route_id = ?1
 ORDER BY t.direction_id, t.trip_headsign
@@ -1193,6 +1223,8 @@ func (q *Queries) GetAllTripsForRoute(ctx context.Context, routeID string) ([]Tr
 			&i.ShapeID,
 			&i.WheelchairAccessible,
 			&i.BikesAllowed,
+			&i.MinArrivalTime,
+			&i.MaxDepartureTime,
 		); err != nil {
 			return nil, err
 		}
@@ -3396,7 +3428,7 @@ func (q *Queries) GetStopsWithTripContext(ctx context.Context, id string) ([]Get
 
 const getTrip = `-- name: GetTrip :one
 SELECT
-    id, route_id, service_id, trip_headsign, trip_short_name, direction_id, block_id, shape_id, wheelchair_accessible, bikes_allowed
+    id, route_id, service_id, trip_headsign, trip_short_name, direction_id, block_id, shape_id, wheelchair_accessible, bikes_allowed, min_arrival_time, max_departure_time
 FROM
     trips
 WHERE
@@ -3417,6 +3449,8 @@ func (q *Queries) GetTrip(ctx context.Context, id string) (Trip, error) {
 		&i.ShapeID,
 		&i.WheelchairAccessible,
 		&i.BikesAllowed,
+		&i.MinArrivalTime,
+		&i.MaxDepartureTime,
 	)
 	return i, err
 }
@@ -3485,20 +3519,12 @@ SELECT
     t.id,
     t.block_id,
     t.service_id,
-    MIN(st.departure_time) AS first_departure_time,
-    MAX(st.arrival_time) AS last_arrival_time
-FROM
-    trips t
-    JOIN stop_times st ON st.trip_id = t.id
-WHERE
-    t.block_id = ?
-    AND t.service_id IN (/*SLICE:service_ids*/?)
-GROUP BY
-    t.id,
-    t.block_id,
-    t.service_id
-ORDER BY
-    MIN(st.departure_time)
+    t.min_arrival_time AS first_departure_time,
+    t.max_departure_time AS last_arrival_time
+FROM trips t
+WHERE t.block_id = ?
+  AND t.service_id IN (/*SLICE:service_ids*/?)
+ORDER BY t.min_arrival_time
 `
 
 type GetTripsByBlockIDOrderedParams struct {
@@ -3510,8 +3536,8 @@ type GetTripsByBlockIDOrderedRow struct {
 	ID                 string
 	BlockID            sql.NullString
 	ServiceID          string
-	FirstDepartureTime interface{}
-	LastArrivalTime    interface{}
+	FirstDepartureTime sql.NullInt64
+	LastArrivalTime    sql.NullInt64
 }
 
 func (q *Queries) GetTripsByBlockIDOrdered(ctx context.Context, arg GetTripsByBlockIDOrderedParams) ([]GetTripsByBlockIDOrderedRow, error) {
@@ -3555,13 +3581,11 @@ func (q *Queries) GetTripsByBlockIDOrdered(ctx context.Context, arg GetTripsByBl
 }
 
 const getTripsByBlockIDs = `-- name: GetTripsByBlockIDs :many
-SELECT t.id, t.route_id, t.service_id, t.trip_headsign, t.trip_short_name, t.direction_id, t.block_id, t.shape_id, t.wheelchair_accessible, t.bikes_allowed
+SELECT t.id, t.route_id, t.service_id, t.trip_headsign, t.trip_short_name, t.direction_id, t.block_id, t.shape_id, t.wheelchair_accessible, t.bikes_allowed, t.min_arrival_time, t.max_departure_time
 FROM trips t
-JOIN stop_times st ON t.id = st.trip_id
 WHERE t.block_id IN (/*SLICE:block_ids*/?)
   AND t.service_id IN (/*SLICE:service_ids*/?)
-GROUP BY t.id
-ORDER BY t.block_id, MIN(st.departure_time), t.id
+ORDER BY t.block_id, t.min_arrival_time, t.id
 `
 
 type GetTripsByBlockIDsParams struct {
@@ -3607,6 +3631,8 @@ func (q *Queries) GetTripsByBlockIDs(ctx context.Context, arg GetTripsByBlockIDs
 			&i.ShapeID,
 			&i.WheelchairAccessible,
 			&i.BikesAllowed,
+			&i.MinArrivalTime,
+			&i.MaxDepartureTime,
 		); err != nil {
 			return nil, err
 		}
@@ -3630,23 +3656,16 @@ FROM trips t
 JOIN block_trip_entry bte ON t.id = bte.trip_id
 WHERE bte.block_trip_index_id IN (/*SLICE:index_ids*/?)
   AND bte.service_id IN (/*SLICE:service_ids*/?)
-  AND EXISTS (
-    -- Check if trip could be active: maxDeparture >= timeFrom AND minArrival <= timeTo
-    SELECT 1
-    FROM stop_times st
-    WHERE st.trip_id = t.id
-    GROUP BY st.trip_id
-    HAVING MAX(st.departure_time) >= ?3
-       AND MIN(st.arrival_time) <= ?4
-  )
+  AND t.max_departure_time >= ?3
+  AND t.min_arrival_time <= ?4
 ORDER BY t.route_id, bte.block_trip_sequence, t.id
 `
 
 type GetTripsByBlockTripIndexIDsParams struct {
 	IndexIds   []int64
 	ServiceIds []string
-	FromTime   int64
-	ToTime     int64
+	FromTime   sql.NullInt64
+	ToTime     sql.NullInt64
 }
 
 type GetTripsByBlockTripIndexIDsRow struct {
@@ -3723,7 +3742,7 @@ func (q *Queries) GetTripsByBlockTripIndexIDs(ctx context.Context, arg GetTripsB
 
 const getTripsByIDs = `-- name: GetTripsByIDs :many
 SELECT
-    id, route_id, service_id, trip_headsign, trip_short_name, direction_id, block_id, shape_id, wheelchair_accessible, bikes_allowed
+    id, route_id, service_id, trip_headsign, trip_short_name, direction_id, block_id, shape_id, wheelchair_accessible, bikes_allowed, min_arrival_time, max_departure_time
 FROM
     trips
 WHERE
@@ -3762,6 +3781,8 @@ func (q *Queries) GetTripsByIDs(ctx context.Context, tripIds []string) ([]Trip, 
 			&i.ShapeID,
 			&i.WheelchairAccessible,
 			&i.BikesAllowed,
+			&i.MinArrivalTime,
+			&i.MaxDepartureTime,
 		); err != nil {
 			return nil, err
 		}
@@ -3828,7 +3849,7 @@ func (q *Queries) GetTripsByServiceID(ctx context.Context, serviceIds []string) 
 }
 
 const getTripsForRouteInActiveServiceIDs = `-- name: GetTripsForRouteInActiveServiceIDs :many
-SELECT DISTINCT id, route_id, service_id, trip_headsign, trip_short_name, direction_id, block_id, shape_id, wheelchair_accessible, bikes_allowed
+SELECT DISTINCT id, route_id, service_id, trip_headsign, trip_short_name, direction_id, block_id, shape_id, wheelchair_accessible, bikes_allowed, min_arrival_time, max_departure_time
 FROM trips t
 WHERE t.route_id = ?1
   AND t.service_id IN (/*SLICE:('service_ids')*/?)
@@ -3871,6 +3892,8 @@ func (q *Queries) GetTripsForRouteInActiveServiceIDs(ctx context.Context, arg Ge
 			&i.ShapeID,
 			&i.WheelchairAccessible,
 			&i.BikesAllowed,
+			&i.MinArrivalTime,
+			&i.MaxDepartureTime,
 		); err != nil {
 			return nil, err
 		}
@@ -4077,7 +4100,7 @@ func (q *Queries) ListStops(ctx context.Context) ([]Stop, error) {
 
 const listTrips = `-- name: ListTrips :many
 SELECT
-    id, route_id, service_id, trip_headsign, trip_short_name, direction_id, block_id, shape_id, wheelchair_accessible, bikes_allowed
+    id, route_id, service_id, trip_headsign, trip_short_name, direction_id, block_id, shape_id, wheelchair_accessible, bikes_allowed, min_arrival_time, max_departure_time
 FROM
     trips
 `
@@ -4102,6 +4125,8 @@ func (q *Queries) ListTrips(ctx context.Context) ([]Trip, error) {
 			&i.ShapeID,
 			&i.WheelchairAccessible,
 			&i.BikesAllowed,
+			&i.MinArrivalTime,
+			&i.MaxDepartureTime,
 		); err != nil {
 			return nil, err
 		}

--- a/gtfsdb/schema.sql
+++ b/gtfsdb/schema.sql
@@ -243,6 +243,8 @@ CREATE TABLE
         shape_id TEXT,
         wheelchair_accessible INTEGER DEFAULT 0,
         bikes_allowed INTEGER DEFAULT 0,
+        min_arrival_time INTEGER,    -- Cached MIN(stop_times.arrival_time)
+        max_departure_time INTEGER,  -- Cached MAX(stop_times.departure_time)
         FOREIGN KEY (route_id) REFERENCES routes (id),
         FOREIGN KEY (service_id) REFERENCES calendar (id)
     );
@@ -434,3 +436,6 @@ CREATE INDEX IF NOT EXISTS idx_stop_times_stop_arrival ON stop_times (stop_id, a
 
 -- migrate
 CREATE INDEX IF NOT EXISTS idx_trips_route_headsign ON trips (route_id, trip_headsign, shape_id);
+
+-- migrate
+CREATE INDEX IF NOT EXISTS idx_trips_time_window ON trips (max_departure_time, min_arrival_time);

--- a/internal/gtfs/static.go
+++ b/internal/gtfs/static.go
@@ -103,6 +103,13 @@ func buildGtfsDB(config Config, isLocalFile bool, dbPath string) (*gtfsdb.Client
 		return nil, err
 	}
 
+	// Backfill cached time bounds for O(1) trip lookups
+	logger := slog.Default().With(slog.String("component", "gtfs_db_builder"))
+	logging.LogOperation(logger, "calculating_trip_time_bounds")
+	if err := client.Queries.BulkUpdateTripTimeBounds(ctx); err != nil {
+		return nil, fmt.Errorf("failed to bulk update trip time bounds: %w", err)
+	}
+
 	// Precompute stop directions after GTFS data is loaded
 	precomputer := NewDirectionPrecomputer(client.Queries, client.DB)
 	if err := precomputer.PrecomputeAllDirections(ctx); err != nil {

--- a/internal/restapi/trips_for_route_handler.go
+++ b/internal/restapi/trips_for_route_handler.go
@@ -141,8 +141,7 @@ func (api *RestAPI) tripsForRouteHandler(w http.ResponseWriter, r *http.Request)
 		activeTrip, err := api.GtfsManager.GtfsDB.Queries.GetActiveTripInBlockAtTime(ctx, gtfsdb.GetActiveTripInBlockAtTimeParams{
 			BlockID:     blockIDNullStr,
 			ServiceIds:  serviceIDs,
-			CurrentTime: currentNanosSinceMidnight,
-		})
+			CurrentTime: sql.NullInt64{Int64: currentNanosSinceMidnight, Valid: true}})
 		if err != nil {
 			continue
 		}


### PR DESCRIPTION
### **Description**

**What does this PR do?**
This PR resolves a critical performance bottleneck where several real-time GTFS queries were performing dynamic `MIN()` and `MAX()` aggregations on the `stop_times` table during active HTTP requests.

By shifting this computational burden from read-time to import-time, this PR eliminates massive table scans and reduces time-window checks to highly efficient `O(1)` index range scans.

**Specific Changes:**

1. **Schema Update (`gtfsdb/schema.sql`)**:
* Added `min_arrival_time` and `max_departure_time` columns to the `trips` table to cache the trip boundaries permanently.
* Added a composite index on `(max_departure_time, min_arrival_time)` to optimize time-window searches.


2. **Import Hook (`internal/gtfs/static.go` & `gtfsdb/query.sql`)**:
* Added a `BulkUpdateTripTimeBounds` query that runs exactly *once* at the end of the GTFS static import pipeline to backfill the cached values.


3. **Query Optimization (`gtfsdb/query.sql`)**:
* Refactored `GetTripsByBlockTripIndexIDs`, `GetActiveTripForRouteAtTime`, `GetActiveTripInBlockAtTime`, `GetTripsByBlockIDOrdered`, and `GetTripsByBlockIDs` to replace dynamic `GROUP BY`/`EXISTS` subqueries with direct column comparisons on the `trips` table.


4. **Go Handlers (`internal/restapi/trips_for_route_handler.go`, etc.)**:
* Updated the API handlers to wrap `int64` time variables in `sql.NullInt64` to satisfy the newly generated `sqlc` models.



**Performance Impact:**

* Shifts the query time complexity for finding active trips from **O(M × N)** (where M is candidate trips and N is the number of stop times per trip) down to **O(M)**.
* Drastically reduces SQLite CPU/IO overhead and improves overall API throughput for real-time endpoints.

**Testing:**

* Successfully ran `make models` to regenerate `sqlc` bindings.
* Ran `go fmt ./...`.
* Verified all existing tests pass (`go test ./...`).

Closes #557 