### PR TITLE
fix: prevent truncation of global stop code searches

### DIFF
--- a/internal/gtfs/gtfs_manager.go
+++ b/internal/gtfs/gtfs_manager.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"maglev.onebusaway.org/gtfsdb"
+	"maglev.onebusaway.org/internal/models"
 	"maglev.onebusaway.org/internal/utils"
 
 	"github.com/OneBusAway/go-gtfs"
@@ -351,7 +352,9 @@ func (manager *Manager) GetStopsForLocation(
 	} else {
 		if radius == 0 {
 			if query != "" {
-				radius = 10000
+				// Use a global radius (20,000 km) to ensure exact stop code
+				// searches are never artificially truncated by localized bounding boxes.
+				radius = models.GlobalSearchRadiusInMeters
 			} else {
 				radius = 500
 			}

--- a/internal/models/constants.go
+++ b/internal/models/constants.go
@@ -13,6 +13,7 @@ const (
 const (
 	DefaultSearchRadiusInMeters = 600
 	QuerySearchRadiusInMeters   = 10000
+	GlobalSearchRadiusInMeters  = 20_000_000
 )
 
 // Cache durations (in seconds) for different API data types.

--- a/internal/restapi/stops_for_location_handler_test.go
+++ b/internal/restapi/stops_for_location_handler_test.go
@@ -332,3 +332,18 @@ func TestStopsForLocationHandlerRouteTypeValidMultiple(t *testing.T) {
 	assert.NotNil(t, refs["agencies"])
 	assert.NotNil(t, refs["routes"])
 }
+
+func TestStopsForLocationQueryGlobalRadius(t *testing.T) {
+	clock := clock.NewMockClock(time.Date(2025, 6, 13, 14, 0, 0, 0, time.UTC))
+	api := createTestApiWithClock(t, clock)
+	// Use coordinates far from the RABA service area to verify global stop code search
+	resp, model := serveApiAndRetrieveEndpoint(t, api,
+		"/api/where/stops-for-location.json?key=TEST&lat=0.0&lon=0.0&query=2042")
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	data, ok := model.Data.(map[string]interface{})
+	require.True(t, ok)
+	list, ok := data["list"].([]interface{})
+	require.True(t, ok)
+	assert.Len(t, list, 1, "Stop code query should find stops globally regardless of coordinates")
+}


### PR DESCRIPTION
### **Description**

**The Problem:**
In `GetStopsForLocation`, when a specific stop code query was provided without an explicit radius (`radius == 0`), the backend automatically enforced a hardcoded `10km` bounding box around the provided or default coordinates. Because the spatial filter (`queryStopsInBounds`) runs *before* the exact string match check, any valid stop located more than 10km away was silently excluded from the results.

Closes #559

**The Solution:**
Updated the fallback logic in `internal/gtfs/gtfs_manager.go`. If an explicit string query is provided and no radius is specified, the fallback radius is now set to `20,000,000` meters (20,000 km) to encompass the globe.

**Why this approach?**
Because the `stopSpatialIndex` is an entirely in-memory RTree (`github.com/tidwall/rtree`), expanding the bounding box to capture all stops for the subsequent `O(N)` exact-match check is virtually instantaneous. It fully resolves the bug without requiring new database queries, schema changes, or incurring any performance penalty.

**Testing:**

* Verified that searching for distant stop codes now successfully returns the exact stop regardless of the default coordinates.
* Ran `go fmt ./...` and `go test ./...` to ensure no existing tests are broken.