### PR TITLE
fix: scope GTFS-RT alert matching to correct entity types

### DIFF
--- a/internal/gtfs/realtime.go
+++ b/internal/gtfs/realtime.go
@@ -105,24 +105,6 @@ func (manager *Manager) GetRealTimeVehicles() []gtfs.Vehicle {
 	return manager.realTimeVehicles
 }
 
-func (manager *Manager) GetAlertsForRoute(routeID string) []gtfs.Alert {
-	manager.realTimeMutex.RLock()
-	defer manager.realTimeMutex.RUnlock()
-
-	var alerts []gtfs.Alert
-	for _, alert := range manager.realTimeAlerts {
-		if alert.InformedEntities != nil {
-			for _, entity := range alert.InformedEntities {
-				if entity.RouteID != nil && *entity.RouteID == routeID {
-					alerts = append(alerts, alert)
-					break
-				}
-			}
-		}
-	}
-	return alerts
-}
-
 // It acquires the realTimeMutex internally; callers must NOT hold it.
 func (manager *Manager) GetAlertsByIDs(tripID, routeID, agencyID string) []gtfs.Alert {
 	manager.realTimeMutex.RLock()
@@ -138,11 +120,18 @@ func (manager *Manager) GetAlertsByIDs(tripID, routeID, agencyID string) []gtfs.
 				alerts = append(alerts, alert)
 				break
 			}
-			if entity.RouteID != nil && routeID != "" && *entity.RouteID == routeID {
+			// Only match route-level entities that have no stop restriction.
+			// Entities with {routeId + stopId} are stop-specific alerts and should
+			// only appear when looking up a specific stop (matching Java's inverted
+			// index which files {routeId+stopId} entities in a separate bucket).
+			if entity.RouteID != nil && routeID != "" && *entity.RouteID == routeID &&
+				entity.StopID == nil {
 				alerts = append(alerts, alert)
 				break
 			}
-			if entity.AgencyID != nil && agencyID != "" && *entity.AgencyID == agencyID {
+			// Only match agency-wide alerts: entity has agencyId but no route or trip restriction.
+			if entity.AgencyID != nil && agencyID != "" && *entity.AgencyID == agencyID &&
+				entity.RouteID == nil && entity.TripID == nil {
 				alerts = append(alerts, alert)
 				break
 			}

--- a/internal/gtfs/realtime_test.go
+++ b/internal/gtfs/realtime_test.go
@@ -21,28 +21,6 @@ import (
 	logging "maglev.onebusaway.org/internal/logging"
 )
 
-func TestGetAlertsForRoute(t *testing.T) {
-	routeID := "route123"
-	manager := &Manager{
-		realTimeMutex: sync.RWMutex{},
-		realTimeAlerts: []gtfs.Alert{
-			{
-				ID: "alert1",
-				InformedEntities: []gtfs.AlertInformedEntity{
-					{
-						RouteID: &routeID,
-					},
-				},
-			},
-		},
-	}
-
-	alerts := manager.GetAlertsForRoute("route123")
-
-	assert.Len(t, alerts, 1)
-	assert.Equal(t, "alert1", alerts[0].ID)
-}
-
 func TestGetAlertsForTrip(t *testing.T) {
 	tripID := gtfs.TripID{ID: "trip123"}
 	manager := &Manager{
@@ -613,6 +591,116 @@ func TestIsVehicleStale(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got := isVehicleStale(tt.existing, tt.incoming)
 			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// TestGetAlertsByIDs_RouteScoping verifies that route-level alert matching
+// only fires for entities that have routeId with no stopId restriction.
+// Entities with {routeId + stopId} are stop-specific and must NOT bleed into route level alerts.
+func TestGetAlertsByIDs_RouteScoping(t *testing.T) {
+	routeID := "route123"
+	otherRoute := "other"
+	stopID := "stop456"
+	agencyID := "agency40"
+
+	tests := []struct {
+		name        string
+		entities    []gtfs.AlertInformedEntity
+		expectMatch bool
+	}{
+		{
+			name:        "route-only entity matches",
+			entities:    []gtfs.AlertInformedEntity{{RouteID: &routeID}},
+			expectMatch: true,
+		},
+		{
+			name:        "route+agency entity (no stop) matches",
+			entities:    []gtfs.AlertInformedEntity{{RouteID: &routeID, AgencyID: &agencyID}},
+			expectMatch: true,
+		},
+		{
+			name:        "route+stop entity does not match route query",
+			entities:    []gtfs.AlertInformedEntity{{RouteID: &routeID, StopID: &stopID}},
+			expectMatch: false,
+		},
+		{
+			name:        "route+agency+stop entity does not match route query",
+			entities:    []gtfs.AlertInformedEntity{{RouteID: &routeID, AgencyID: &agencyID, StopID: &stopID}},
+			expectMatch: false,
+		},
+		{
+			name: "mixed entities: route+stop and route-only — matches via route-only",
+			entities: []gtfs.AlertInformedEntity{
+				{RouteID: &routeID, StopID: &stopID},
+				{RouteID: &routeID},
+			},
+			expectMatch: true,
+		},
+		{
+			name:        "different route does not match",
+			entities:    []gtfs.AlertInformedEntity{{RouteID: &otherRoute}},
+			expectMatch: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			manager := &Manager{
+				realTimeMutex:  sync.RWMutex{},
+				realTimeAlerts: []gtfs.Alert{{ID: "alert1", InformedEntities: tt.entities}},
+			}
+			alerts := manager.GetAlertsByIDs("", routeID, "")
+			if tt.expectMatch {
+				assert.Len(t, alerts, 1)
+			} else {
+				assert.Empty(t, alerts)
+			}
+		})
+	}
+}
+
+// TestGetAlertsByIDs_AgencyScoping verifies that agency-wide matching only fires
+// for entities that have agencyId with no route or trip restriction.
+func TestGetAlertsByIDs_AgencyScoping(t *testing.T) {
+	agencyID := "agency40"
+	routeID := "route123"
+	tripID := gtfs.TripID{ID: "trip456"}
+
+	tests := []struct {
+		name        string
+		entities    []gtfs.AlertInformedEntity
+		expectMatch bool
+	}{
+		{
+			name:        "agency-only entity matches",
+			entities:    []gtfs.AlertInformedEntity{{AgencyID: &agencyID}},
+			expectMatch: true,
+		},
+		{
+			name:        "agency+route entity does not match agency-only query",
+			entities:    []gtfs.AlertInformedEntity{{AgencyID: &agencyID, RouteID: &routeID}},
+			expectMatch: false,
+		},
+		{
+			name:        "agency+trip entity does not match agency-only query",
+			entities:    []gtfs.AlertInformedEntity{{AgencyID: &agencyID, TripID: &tripID}},
+			expectMatch: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			manager := &Manager{
+				realTimeMutex:  sync.RWMutex{},
+				realTimeAlerts: []gtfs.Alert{{ID: "alert1", InformedEntities: tt.entities}},
+			}
+			alerts := manager.GetAlertsByIDs("", "", agencyID)
+			if tt.expectMatch {
+				assert.Len(t, alerts, 1)
+			} else {
+				assert.Empty(t, alerts)
+			}
 		})
 	}
 }

--- a/internal/restapi/arrivals_and_departure_for_stop.go
+++ b/internal/restapi/arrivals_and_departure_for_stop.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/OneBusAway/go-gtfs"
 	"maglev.onebusaway.org/gtfsdb"
 	"maglev.onebusaway.org/internal/models"
 	"maglev.onebusaway.org/internal/utils"
@@ -127,6 +128,9 @@ func (api *RestAPI) arrivalsAndDeparturesForStopHandler(w http.ResponseWriter, r
 	// Track which agencies we have already added to avoid duplicates
 	addedAgencyIDs := make(map[string]bool)
 	addedAgencyIDs[agency.ID] = true
+
+	collectedAlerts := make(map[string]gtfs.Alert)
+	alertAgencyID := stopAgencyID
 
 	type activeStopTime struct {
 		gtfsdb.GetStopTimesForStopInWindowRow
@@ -396,7 +400,20 @@ func (api *RestAPI) arrivalsAndDeparturesForStopHandler(w http.ResponseWriter, r
 		blockTripSequence := api.calculateBlockTripSequence(ctx, st.TripID, serviceMidnight)
 
 		lastUpdateTime := api.GtfsManager.GetVehicleLastUpdateTime(vehicle)
-		situationIDs := api.GetSituationIDsForTrip(r.Context(), st.TripID)
+		tripAlerts := api.GtfsManager.GetAlertsForTrip(r.Context(), st.TripID)
+		situationIDs := make([]string, 0, len(tripAlerts))
+		for _, alert := range tripAlerts {
+			if alert.ID == "" {
+				continue
+			}
+			situationIDs = append(situationIDs, utils.FormCombinedID(route.AgencyID, alert.ID))
+			if _, seen := collectedAlerts[alert.ID]; !seen {
+				collectedAlerts[alert.ID] = alert
+			}
+		}
+		if alertAgencyID == "" && route.AgencyID != "" {
+			alertAgencyID = route.AgencyID
+		}
 
 		arrival := models.NewArrivalAndDeparture(
 			utils.FormCombinedID(route.AgencyID, route.ID),  // routeID
@@ -569,8 +586,36 @@ func (api *RestAPI) arrivalsAndDeparturesForStopHandler(w http.ResponseWriter, r
 		}
 	}
 
+	for _, alert := range api.GtfsManager.GetAlertsForStop(stopCode) {
+		if alert.ID != "" {
+			if _, seen := collectedAlerts[alert.ID]; !seen {
+				collectedAlerts[alert.ID] = alert
+			}
+		}
+	}
+
+	if len(collectedAlerts) > 0 {
+		alertSlice := make([]gtfs.Alert, 0, len(collectedAlerts))
+		for _, a := range collectedAlerts {
+			alertSlice = append(alertSlice, a)
+		}
+		situations := api.BuildSituationReferences(alertSlice, alertAgencyID)
+		for _, s := range situations {
+			references.Situations = append(references.Situations, s)
+		}
+	}
+
+	topLevelSituationIDSet := make(map[string]struct{}, len(collectedAlerts))
+	for alertID := range collectedAlerts {
+		topLevelSituationIDSet[utils.FormCombinedID(alertAgencyID, alertID)] = struct{}{}
+	}
+	topLevelSituationIDs := make([]string, 0, len(topLevelSituationIDSet))
+	for id := range topLevelSituationIDSet {
+		topLevelSituationIDs = append(topLevelSituationIDs, id)
+	}
+
 	nearbyStopIDs := getNearbyStopIDs(api, ctx, stop.Lat, stop.Lon, stopCode, stopAgencyID)
-	response := models.NewArrivalsAndDepartureResponse(arrivals, references, nearbyStopIDs, []string{}, stopID, api.Clock)
+	response := models.NewArrivalsAndDepartureResponse(arrivals, references, nearbyStopIDs, topLevelSituationIDs, stopID, api.Clock)
 	api.sendResponse(w, r, response)
 }
 


### PR DESCRIPTION
Fixes #568

`GetAlertsByIDs` was matching `{routeId+stopId}` entities for route-level queries, causing stop-scoped alerts to leak into every arrival. Fix requires `entity.StopID == nil` for route matches and `entity.RouteID == nil && entity.TripID == nil` for agency matches. 

