### PR TITLE
Fix misleading column aliases in GetTripsByBlockIDOrdered

### DIFF
--- a/gtfsdb/query.sql
+++ b/gtfsdb/query.sql
@@ -685,8 +685,8 @@ SELECT
     t.id,
     t.block_id,
     t.service_id,
-    t.min_arrival_time AS first_departure_time,
-    t.max_departure_time AS last_arrival_time
+    t.min_arrival_time AS earliest_time,
+    t.max_departure_time AS latest_time
 FROM trips t
 WHERE t.block_id = ?
   AND t.service_id IN (sqlc.slice('service_ids'))

--- a/gtfsdb/query.sql.go
+++ b/gtfsdb/query.sql.go
@@ -3664,8 +3664,8 @@ SELECT
     t.id,
     t.block_id,
     t.service_id,
-    t.min_arrival_time AS first_departure_time,
-    t.max_departure_time AS last_arrival_time
+    t.min_arrival_time AS earliest_time,
+    t.max_departure_time AS latest_time
 FROM trips t
 WHERE t.block_id = ?
   AND t.service_id IN (/*SLICE:service_ids*/?)
@@ -3678,11 +3678,11 @@ type GetTripsByBlockIDOrderedParams struct {
 }
 
 type GetTripsByBlockIDOrderedRow struct {
-	ID                 string
-	BlockID            sql.NullString
-	ServiceID          string
-	FirstDepartureTime sql.NullInt64
-	LastArrivalTime    sql.NullInt64
+	ID           string
+	BlockID      sql.NullString
+	ServiceID    string
+	EarliestTime sql.NullInt64
+	LatestTime   sql.NullInt64
 }
 
 func (q *Queries) GetTripsByBlockIDOrdered(ctx context.Context, arg GetTripsByBlockIDOrderedParams) ([]GetTripsByBlockIDOrderedRow, error) {
@@ -3709,8 +3709,8 @@ func (q *Queries) GetTripsByBlockIDOrdered(ctx context.Context, arg GetTripsByBl
 			&i.ID,
 			&i.BlockID,
 			&i.ServiceID,
-			&i.FirstDepartureTime,
-			&i.LastArrivalTime,
+			&i.EarliestTime,
+			&i.LatestTime,
 		); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
### **Description**

This PR addresses the misleading column aliases in `GetTripsByBlockIDOrdered` that were left behind after PR #558 denormalized the trip time bounds.

Previously, the query aliased `min_arrival_time` as `first_departure_time` and `max_departure_time` as `last_arrival_time`. Because these bounds represent the absolute minimum arrival and maximum departure times across a trip, the old aliases were semantically incorrect and posed a maintenance hazard.

This PR renames the aliases to accurately reflect their data and regenerates the corresponding Go models.

### **Changes Made**

* **`gtfsdb/query.sql`**: Updated aliases in `GetTripsByBlockIDOrdered`.
* `t.min_arrival_time` is now aliased as `earliest_time`.
* `t.max_departure_time` is now aliased as `latest_time`.


* **`gtfsdb/query.sql.go`**: Regenerated Go code via `make models` to update the `GetTripsByBlockIDOrderedRow` struct, mapping the new aliases to `EarliestTime` and `LatestTime`.

### **Related Issue**

Closes #565

### **Testing / Verification**

* [x] Ran `make models` (or `sqlc generate`) to verify the generated Go code reflects the new aliases.
* [x] Verified that the code compiles successfully without breaking any current callers (as existing callers only iterate over the rows for trip IDs and don't reference the time bound fields directly).