### PR TITLE
chore: ignore SQLite WAL and shared-memory sidecar files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@ __debug_bin*
 .env
 *.db
 *.db-journal
+*.db-shm
+*.db-wal
 /cmd/api/api
 gtfsdb/tmp/main
 .claude


### PR DESCRIPTION
## Fixes #579 
## Summary

Extends `.gitignore` to cover the two sidecar files that SQLite creates
when operating in WAL (Write-Ahead Logging) mode.

## What changed

```diff
 *.db
 *.db-journal
+*.db-shm
+*.db-wal