### PR TITLE
feat: GTFS frequencies Phase 2 - Core Models & Business Logic

### DIFF
--- a/internal/gtfs/concurrency_test.go
+++ b/internal/gtfs/concurrency_test.go
@@ -292,3 +292,67 @@ func (manager *Manager) safeGetAgencies() []gtfs.Agency {
 	}
 	return manager.gtfsData.Agencies
 }
+
+func TestConcurrentFrequencyAccess(t *testing.T) {
+	// Test that our new O(1) in-memory frequency map is thread-safe
+	// when being read by API handlers while the static data is reloading
+
+	manager := &Manager{
+		frequencyTripIDs: make(map[string]struct{}),
+	}
+	manager.frequencyTripIDs["freq_trip_1"] = struct{}{}
+
+	var wg sync.WaitGroup
+	done := make(chan struct{})
+
+	// Start Readers (simulating API handlers calling IsFrequencyBasedTrip)
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-done:
+					return
+				default:
+					// Read from the cache. This uses manager.staticMutex.RLock() internally
+					_ = manager.IsFrequencyBasedTrip("freq_trip_1")
+					_ = manager.IsFrequencyBasedTrip("normal_trip")
+					time.Sleep(time.Microsecond)
+				}
+			}
+		}()
+	}
+
+	// Start Writer (simulating static data reload updating the cache)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 10; i++ {
+			select {
+			case <-done:
+				return
+			default:
+				// Simulate the hot-swap of the frequency cache
+				newFreqMap := make(map[string]struct{})
+				newFreqMap["freq_trip_2"] = struct{}{}
+				newFreqMap["freq_trip_3"] = struct{}{}
+
+				manager.staticMutex.Lock()
+				manager.frequencyTripIDs = newFreqMap
+				manager.staticMutex.Unlock()
+
+				time.Sleep(5 * time.Millisecond)
+			}
+		}
+	}()
+
+	// Let the race happen for a short time
+	time.Sleep(50 * time.Millisecond)
+	close(done)
+	wg.Wait()
+
+	// Verify the cache was actually updated by the writer
+	isFreq := manager.IsFrequencyBasedTrip("freq_trip_2")
+	assert.True(t, isFreq, "Expected freq_trip_2 to be in the frequency cache after writer finishes")
+}

--- a/internal/gtfs/frequency_helper.go
+++ b/internal/gtfs/frequency_helper.go
@@ -1,0 +1,102 @@
+package gtfs
+
+import (
+	"context"
+	"time"
+
+	"maglev.onebusaway.org/gtfsdb"
+)
+
+// IsFrequencyBasedTrip returns true if the given trip has any frequency entries in the database.
+func (manager *Manager) IsFrequencyBasedTrip(tripID string) bool {
+	manager.staticMutex.RLock()
+	defer manager.staticMutex.RUnlock()
+
+	_, isFreq := manager.frequencyTripIDs[tripID]
+	return isFreq
+}
+
+// GetFrequenciesForTrip returns all frequency entries for a trip, ordered by start_time.
+func (manager *Manager) GetFrequenciesForTrip(ctx context.Context, tripID string) ([]gtfsdb.Frequency, error) {
+	return manager.GtfsDB.Queries.GetFrequenciesForTrip(ctx, tripID)
+}
+
+// GetFrequenciesForTrips returns all frequency entries for multiple trips in a single batch query.
+func (manager *Manager) GetFrequenciesForTrips(ctx context.Context, tripIDs []string) ([]gtfsdb.Frequency, error) {
+	if len(tripIDs) == 0 {
+		return nil, nil
+	}
+	return manager.GtfsDB.Queries.GetFrequenciesForTrips(ctx, tripIDs)
+}
+
+// GetActiveHeadway returns the frequency entry that is active at the given time,
+// or nil if no frequency window covers the time.
+// currentTimeNanos is nanoseconds since midnight (same unit as DB start_time/end_time).
+func GetActiveHeadway(frequencies []gtfsdb.Frequency, currentTimeNanos int64) *gtfsdb.Frequency {
+	for i := range frequencies {
+		if currentTimeNanos >= frequencies[i].StartTime && currentTimeNanos < frequencies[i].EndTime {
+			return &frequencies[i]
+		}
+	}
+	return nil
+}
+
+// GetActiveHeadwayForTime returns the frequency entry active at a specific wall-clock time,
+func GetActiveHeadwayForTime(frequencies []gtfsdb.Frequency, serviceDate time.Time, now time.Time) *gtfsdb.Frequency {
+	startOfDay := time.Date(serviceDate.Year(), serviceDate.Month(), serviceDate.Day(), 0, 0, 0, 0, serviceDate.Location())
+	nanosSinceMidnight := now.Sub(startOfDay).Nanoseconds()
+	return GetActiveHeadway(frequencies, nanosSinceMidnight)
+}
+
+// ExpandFrequencyTrips generates the departure times for a schedule-based frequency
+// (exact_times = 1). For each frequency window, it creates repeated stop-time entries
+// offset by multiples of the headway from the window start time.
+//
+// Parameters:
+//   - baseStopTimes: the template stop times for the trip (from stop_times table)
+//   - freq: a single frequency entry with exact_times = 1
+//
+// Returns expanded stop times with adjusted arrival/departure times.
+func ExpandFrequencyTrips(baseStopTimes []gtfsdb.StopTime, freq gtfsdb.Frequency) []gtfsdb.StopTime {
+	if len(baseStopTimes) == 0 {
+		return nil
+	}
+
+	headwayNanos := freq.HeadwaySecs * int64(time.Second)
+	if headwayNanos <= 0 {
+		return nil
+	}
+
+	// The base offset is the first stop's arrival time in the template
+	baseOffset := baseStopTimes[0].ArrivalTime
+
+	numDepartures := int((freq.EndTime - freq.StartTime) / headwayNanos)
+	expanded := make([]gtfsdb.StopTime, 0, numDepartures*len(baseStopTimes))
+
+	for departureBase := freq.StartTime; departureBase < freq.EndTime; departureBase += headwayNanos {
+		// The time shift is: (departureBase - baseOffset)
+		// This shifts all stop times so the first stop departs at departureBase
+		shift := departureBase - baseOffset
+
+		for _, st := range baseStopTimes {
+			// Create a full struct copy, then modify only the time fields
+			expandedST := st
+			expandedST.ArrivalTime += shift
+			expandedST.DepartureTime += shift
+
+			expanded = append(expanded, expandedST)
+		}
+	}
+
+	return expanded
+}
+
+// GroupFrequenciesByTrip groups a flat slice of frequency rows (from a batch query)
+// into a map keyed by trip ID.
+func GroupFrequenciesByTrip(frequencies []gtfsdb.Frequency) map[string][]gtfsdb.Frequency {
+	result := make(map[string][]gtfsdb.Frequency)
+	for _, f := range frequencies {
+		result[f.TripID] = append(result[f.TripID], f)
+	}
+	return result
+}

--- a/internal/gtfs/frequency_helper_test.go
+++ b/internal/gtfs/frequency_helper_test.go
@@ -1,0 +1,314 @@
+package gtfs
+
+import (
+	"context"
+	"database/sql"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/OneBusAway/go-gtfs"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"maglev.onebusaway.org/gtfsdb"
+)
+
+func TestGetActiveHeadway_MatchesWindow(t *testing.T) {
+	freqs := []gtfsdb.Frequency{
+		{TripID: "t1", StartTime: int64(6 * time.Hour), EndTime: int64(9 * time.Hour), HeadwaySecs: 600, ExactTimes: 0},
+		{TripID: "t1", StartTime: int64(9 * time.Hour), EndTime: int64(12 * time.Hour), HeadwaySecs: 300, ExactTimes: 0},
+	}
+
+	// 7:00 AM — falls in first window
+	result := GetActiveHeadway(freqs, int64(7*time.Hour))
+	require.NotNil(t, result)
+	assert.Equal(t, int64(600), result.HeadwaySecs)
+
+	// 10:00 AM — falls in second window
+	result = GetActiveHeadway(freqs, int64(10*time.Hour))
+	require.NotNil(t, result)
+	assert.Equal(t, int64(300), result.HeadwaySecs)
+}
+
+func TestGetActiveHeadway_ExactBoundary(t *testing.T) {
+	freqs := []gtfsdb.Frequency{
+		{TripID: "t1", StartTime: int64(6 * time.Hour), EndTime: int64(9 * time.Hour), HeadwaySecs: 600},
+	}
+
+	// Exactly at start time — should match (inclusive)
+	result := GetActiveHeadway(freqs, int64(6*time.Hour))
+	require.NotNil(t, result)
+
+	// Exactly at end time — should NOT match (exclusive)
+	result = GetActiveHeadway(freqs, int64(9*time.Hour))
+	assert.Nil(t, result)
+}
+
+func TestGetActiveHeadway_NoMatch(t *testing.T) {
+	freqs := []gtfsdb.Frequency{
+		{TripID: "t1", StartTime: int64(6 * time.Hour), EndTime: int64(9 * time.Hour), HeadwaySecs: 600},
+	}
+
+	// 5:00 AM — before any window
+	result := GetActiveHeadway(freqs, int64(5*time.Hour))
+	assert.Nil(t, result)
+
+	// 10:00 AM — after all windows
+	result = GetActiveHeadway(freqs, int64(10*time.Hour))
+	assert.Nil(t, result)
+}
+
+func TestGetActiveHeadway_EmptySlice(t *testing.T) {
+	result := GetActiveHeadway(nil, int64(7*time.Hour))
+	assert.Nil(t, result)
+
+	result = GetActiveHeadway([]gtfsdb.Frequency{}, int64(7*time.Hour))
+	assert.Nil(t, result)
+}
+
+func TestGetActiveHeadwayForTime(t *testing.T) {
+	// Use a non-UTC timezone to ensure the timezone logic works correctly
+	loc, err := time.LoadLocation("America/New_York")
+	require.NoError(t, err)
+
+	serviceDate := time.Date(2024, 1, 15, 0, 0, 0, 0, loc)
+
+	freqs := []gtfsdb.Frequency{
+		{TripID: "t1", StartTime: int64(6 * time.Hour), EndTime: int64(9 * time.Hour), HeadwaySecs: 600},
+	}
+
+	// 7:30 AM on Jan 15 (Local Time) — within window
+	now := time.Date(2024, 1, 15, 7, 30, 0, 0, loc)
+	result := GetActiveHeadwayForTime(freqs, serviceDate, now)
+	require.NotNil(t, result)
+	assert.Equal(t, int64(600), result.HeadwaySecs)
+
+	// 10:00 AM (Local Time) — outside window
+	now = time.Date(2024, 1, 15, 10, 0, 0, 0, loc)
+	result = GetActiveHeadwayForTime(freqs, serviceDate, now)
+	assert.Nil(t, result)
+}
+
+func TestExpandFrequencyTrips_Basic(t *testing.T) {
+	// Template: trip departs stop A at 06:00, arrives stop B at 06:10
+	baseStopTimes := []gtfsdb.StopTime{
+		{TripID: "t1", ArrivalTime: int64(6 * time.Hour), DepartureTime: int64(6*time.Hour + 1*time.Minute), StopID: "A", StopSequence: 1},
+		{TripID: "t1", ArrivalTime: int64(6*time.Hour + 10*time.Minute), DepartureTime: int64(6*time.Hour + 11*time.Minute), StopID: "B", StopSequence: 2},
+	}
+
+	// Frequency window: 06:00 - 07:00, headway 20 min
+	freq := gtfsdb.Frequency{
+		TripID:      "t1",
+		StartTime:   int64(6 * time.Hour),
+		EndTime:     int64(7 * time.Hour),
+		HeadwaySecs: 1200, // 20 minutes
+		ExactTimes:  1,
+	}
+
+	expanded := ExpandFrequencyTrips(baseStopTimes, freq)
+
+	// 3 departures: 06:00, 06:20, 06:40
+	assert.Equal(t, 6, len(expanded)) // 3 departures * 2 stops
+
+	// First departure: 06:00 (no shift since base arrival == window start)
+	assert.Equal(t, int64(6*time.Hour), expanded[0].ArrivalTime)
+	assert.Equal(t, "A", expanded[0].StopID)
+	assert.Equal(t, int64(6*time.Hour+10*time.Minute), expanded[1].ArrivalTime)
+	assert.Equal(t, "B", expanded[1].StopID)
+
+	// Second departure: 06:20
+	assert.Equal(t, int64(6*time.Hour+20*time.Minute), expanded[2].ArrivalTime)
+	assert.Equal(t, "A", expanded[2].StopID)
+	assert.Equal(t, int64(6*time.Hour+30*time.Minute), expanded[3].ArrivalTime)
+	assert.Equal(t, "B", expanded[3].StopID)
+
+	// Third departure: 06:40
+	assert.Equal(t, int64(6*time.Hour+40*time.Minute), expanded[4].ArrivalTime)
+	assert.Equal(t, "A", expanded[4].StopID)
+}
+
+func TestExpandFrequencyTrips_PreservesFields(t *testing.T) {
+	baseStopTimes := []gtfsdb.StopTime{
+		{
+			TripID:            "t1",
+			ArrivalTime:       int64(8 * time.Hour),
+			DepartureTime:     int64(8*time.Hour + 30*time.Second),
+			StopID:            "stop_42",
+			StopSequence:      5,
+			StopHeadsign:      sql.NullString{String: "Downtown", Valid: true},
+			PickupType:        sql.NullInt64{Int64: 0, Valid: true},
+			DropOffType:       sql.NullInt64{Int64: 1, Valid: true},
+			ShapeDistTraveled: sql.NullFloat64{Float64: 1234.5, Valid: true},
+			Timepoint:         sql.NullInt64{Int64: 1, Valid: true},
+		},
+	}
+
+	freq := gtfsdb.Frequency{
+		TripID:      "t1",
+		StartTime:   int64(8 * time.Hour),
+		EndTime:     int64(9 * time.Hour),
+		HeadwaySecs: 3600, // exactly one departure
+		ExactTimes:  1,
+	}
+
+	expanded := ExpandFrequencyTrips(baseStopTimes, freq)
+	require.Equal(t, 1, len(expanded))
+
+	st := expanded[0]
+	assert.Equal(t, "t1", st.TripID)
+	assert.Equal(t, "stop_42", st.StopID)
+	assert.Equal(t, int64(5), st.StopSequence)
+	assert.Equal(t, "Downtown", st.StopHeadsign.String)
+	assert.True(t, st.StopHeadsign.Valid)
+	assert.Equal(t, int64(0), st.PickupType.Int64)
+	assert.Equal(t, int64(1), st.DropOffType.Int64)
+	assert.Equal(t, 1234.5, st.ShapeDistTraveled.Float64)
+	assert.Equal(t, int64(1), st.Timepoint.Int64)
+}
+
+func TestExpandFrequencyTrips_EmptyStopTimes(t *testing.T) {
+	freq := gtfsdb.Frequency{
+		TripID:      "t1",
+		StartTime:   int64(6 * time.Hour),
+		EndTime:     int64(9 * time.Hour),
+		HeadwaySecs: 600,
+		ExactTimes:  1,
+	}
+
+	result := ExpandFrequencyTrips(nil, freq)
+	assert.Nil(t, result)
+
+	result = ExpandFrequencyTrips([]gtfsdb.StopTime{}, freq)
+	assert.Nil(t, result)
+}
+
+func TestExpandFrequencyTrips_ZeroHeadway(t *testing.T) {
+	baseStopTimes := []gtfsdb.StopTime{
+		{TripID: "t1", ArrivalTime: int64(6 * time.Hour), DepartureTime: int64(6 * time.Hour), StopID: "A", StopSequence: 1},
+	}
+
+	freq := gtfsdb.Frequency{
+		TripID:      "t1",
+		StartTime:   int64(6 * time.Hour),
+		EndTime:     int64(9 * time.Hour),
+		HeadwaySecs: 0, // invalid
+		ExactTimes:  1,
+	}
+
+	result := ExpandFrequencyTrips(baseStopTimes, freq)
+	assert.Nil(t, result)
+}
+
+func TestExpandFrequencyTrips_BaseOffsetDiffersFromWindowStart(t *testing.T) {
+	// Base template starts at 05:00 but frequency window starts at 06:00
+	// The shift should align the first stop to the window start
+	baseStopTimes := []gtfsdb.StopTime{
+		{TripID: "t1", ArrivalTime: int64(5 * time.Hour), DepartureTime: int64(5*time.Hour + 1*time.Minute), StopID: "A", StopSequence: 1},
+		{TripID: "t1", ArrivalTime: int64(5*time.Hour + 15*time.Minute), DepartureTime: int64(5*time.Hour + 16*time.Minute), StopID: "B", StopSequence: 2},
+	}
+
+	freq := gtfsdb.Frequency{
+		TripID:      "t1",
+		StartTime:   int64(6 * time.Hour),
+		EndTime:     int64(7 * time.Hour),
+		HeadwaySecs: 1800, // 30 min headway => 2 departures (06:00, 06:30)
+		ExactTimes:  1,
+	}
+
+	expanded := ExpandFrequencyTrips(baseStopTimes, freq)
+	assert.Equal(t, 4, len(expanded)) // 2 departures * 2 stops
+
+	// First departure aligned to window start: stop A at 06:00, stop B at 06:15
+	assert.Equal(t, int64(6*time.Hour), expanded[0].ArrivalTime)
+	assert.Equal(t, int64(6*time.Hour+15*time.Minute), expanded[1].ArrivalTime)
+
+	// Second departure at 06:30: stop A at 06:30, stop B at 06:45
+	assert.Equal(t, int64(6*time.Hour+30*time.Minute), expanded[2].ArrivalTime)
+	assert.Equal(t, int64(6*time.Hour+45*time.Minute), expanded[3].ArrivalTime)
+}
+
+func TestGroupFrequenciesByTrip(t *testing.T) {
+	freqs := []gtfsdb.Frequency{
+		{TripID: "t1", StartTime: int64(6 * time.Hour), EndTime: int64(9 * time.Hour), HeadwaySecs: 600},
+		{TripID: "t1", StartTime: int64(9 * time.Hour), EndTime: int64(12 * time.Hour), HeadwaySecs: 300},
+		{TripID: "t2", StartTime: int64(7 * time.Hour), EndTime: int64(10 * time.Hour), HeadwaySecs: 900},
+	}
+
+	grouped := GroupFrequenciesByTrip(freqs)
+
+	assert.Equal(t, 2, len(grouped))
+	assert.Equal(t, 2, len(grouped["t1"]))
+	assert.Equal(t, 1, len(grouped["t2"]))
+	assert.Equal(t, int64(600), grouped["t1"][0].HeadwaySecs)
+	assert.Equal(t, int64(300), grouped["t1"][1].HeadwaySecs)
+	assert.Equal(t, int64(900), grouped["t2"][0].HeadwaySecs)
+}
+
+func TestGroupFrequenciesByTrip_Empty(t *testing.T) {
+	grouped := GroupFrequenciesByTrip(nil)
+	assert.Empty(t, grouped)
+
+	grouped = GroupFrequenciesByTrip([]gtfsdb.Frequency{})
+	assert.Empty(t, grouped)
+}
+
+func TestIsFrequencyBasedTrip(t *testing.T) {
+	manager := &Manager{
+		frequencyTripIDs: make(map[string]struct{}),
+	}
+
+	manager.frequencyTripIDs["trip_freq_1"] = struct{}{}
+	manager.frequencyTripIDs["trip_freq_2"] = struct{}{}
+
+	assert.True(t, manager.IsFrequencyBasedTrip("trip_freq_1"))
+	assert.True(t, manager.IsFrequencyBasedTrip("trip_freq_2"))
+
+	assert.False(t, manager.IsFrequencyBasedTrip("trip_normal_1"))
+	assert.False(t, manager.IsFrequencyBasedTrip("trip_normal_2"))
+	assert.False(t, manager.IsFrequencyBasedTrip(""))
+}
+
+func TestGetActiveHeadwayForTime_PostMidnight(t *testing.T) {
+	serviceDate := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	now := time.Date(2024, 1, 2, 2, 0, 0, 0, time.UTC)
+
+	frequencies := []gtfsdb.Frequency{
+		{
+			StartTime:   int64(25 * time.Hour),
+			EndTime:     int64(27 * time.Hour),
+			HeadwaySecs: 1800,
+		},
+	}
+
+	result := GetActiveHeadwayForTime(frequencies, serviceDate, now)
+
+	require.NotNil(t, result, "Should find matching frequency for overnight trip")
+	assert.Equal(t, int64(1800), result.HeadwaySecs, "Should correctly match overnight frequencies > 24h")
+}
+
+func TestGetFrequenciesForTrips_EmptyInput(t *testing.T) {
+	manager := &Manager{}
+	ctx := context.Background()
+
+	res, err := manager.GetFrequenciesForTrips(ctx, nil)
+	assert.NoError(t, err)
+	assert.Nil(t, res)
+
+	res, err = manager.GetFrequenciesForTrips(ctx, []string{})
+	assert.NoError(t, err)
+	assert.Nil(t, res)
+}
+
+func TestSetStaticGTFS_RetainsFrequencyCache(t *testing.T) {
+	manager := &Manager{
+		frequencyTripIDs: map[string]struct{}{
+			"existing_freq_trip": {},
+		},
+		staticMutex: sync.RWMutex{},
+	}
+
+	manager.setStaticGTFS(&gtfs.Static{})
+
+	assert.True(t, manager.IsFrequencyBasedTrip("existing_freq_trip"), "Frequency cache should be retained and not wiped by variable shadowing")
+}

--- a/internal/gtfs/gtfs_manager.go
+++ b/internal/gtfs/gtfs_manager.go
@@ -54,6 +54,7 @@ type Manager struct {
 	realTimeVehicleLookupByVehicle map[string]int
 	agenciesMap                    map[string]*gtfs.Agency
 	routesMap                      map[string]*gtfs.Route
+	frequencyTripIDs               map[string]struct{}
 	staticUpdateMutex              sync.Mutex   // Protects against concurrent ForceUpdate calls
 	staticMutex                    sync.RWMutex // Protects gtfsData and lastUpdated
 	config                         Config
@@ -218,6 +219,7 @@ func InitGTFSManager(ctx context.Context, config Config) (*Manager, error) {
 		feedAgencyFilter:               make(map[string]map[string]bool),
 		feedVehicleLastSeen:            make(map[string]map[string]time.Time),
 		feedVehicleTimestamp:           make(map[string]uint64),
+		frequencyTripIDs:               make(map[string]struct{}),
 		Metrics:                        config.Metrics,
 	}
 
@@ -280,6 +282,17 @@ func InitGTFSManager(ctx context.Context, config Config) (*Manager, error) {
 		return nil, fmt.Errorf("error building spatial index: %w", err)
 	}
 	manager.stopSpatialIndex = spatialIndex
+
+	freqTripIDs := make(map[string]struct{})
+	ids, err := gtfsDB.Queries.GetFrequencyTripIDs(ctx)
+	if err == nil {
+		for _, id := range ids {
+			freqTripIDs[id] = struct{}{}
+		}
+	} else {
+		logger.Error("failed to load frequency trip IDs", "error", err)
+	}
+	manager.frequencyTripIDs = freqTripIDs
 
 	// STARTUP SEQUENCING:
 	// If realtime is enabled, perform the first fetch synchronously for each feed

--- a/internal/gtfs/static.go
+++ b/internal/gtfs/static.go
@@ -318,6 +318,12 @@ func (manager *Manager) ForceUpdate(ctx context.Context) error {
 
 	manager.routesByAgencyID = buildRouteIndex(newStaticData)
 
+	if newCache, freqErr := buildFrequencyCache(ctx, client.Queries); freqErr == nil {
+		manager.frequencyTripIDs = newCache
+	} else {
+		logging.LogError(logger, "failed to reload frequency trip IDs during hot-swap; retaining previous cache", freqErr)
+	}
+
 	manager.lastUpdated = time.Now()
 
 	metadata, err := manager.GtfsDB.Queries.GetImportMetadata(ctx)
@@ -362,6 +368,8 @@ func (manager *Manager) setStaticGTFS(staticData *gtfs.Static) {
 
 	// Rebuild spatial index with updated data
 	ctx := context.Background()
+
+	// GtfsDB may be nil during initial construction; frequency cache is populated by InitGTFSManager directly
 	if manager.GtfsDB != nil && manager.GtfsDB.Queries != nil {
 		spatialIndex, err := buildStopSpatialIndex(ctx, manager.GtfsDB.Queries)
 		if err == nil {
@@ -369,6 +377,13 @@ func (manager *Manager) setStaticGTFS(staticData *gtfs.Static) {
 		} else if manager.config.Verbose {
 			logger := slog.Default().With(slog.String("component", "gtfs_manager"))
 			logging.LogError(logger, "Failed to rebuild spatial index", err)
+		}
+
+		if newCache, freqErr := buildFrequencyCache(ctx, manager.GtfsDB.Queries); freqErr == nil {
+			manager.frequencyTripIDs = newCache
+		} else {
+			logger := slog.Default().With(slog.String("component", "gtfs_manager"))
+			logging.LogError(logger, "failed to load frequency trip IDs during initial load; retaining previous cache", freqErr)
 		}
 
 		logger := slog.Default().With(slog.String("component", "gtfs_manager"))
@@ -418,6 +433,22 @@ func buildRouteIndex(staticData *gtfs.Static) map[string][]*gtfs.Route {
 	}
 
 	return index
+}
+
+// buildFrequencyCache queries the DB for frequency trip IDs and returns a set.
+// It returns an error if the query fails, allowing the caller to retain the previous cache.
+func buildFrequencyCache(ctx context.Context, queries *gtfsdb.Queries) (map[string]struct{}, error) {
+	ids, err := queries.GetFrequencyTripIDs(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	cache := make(map[string]struct{}, len(ids))
+	for _, id := range ids {
+		cache[id] = struct{}{}
+	}
+
+	return cache, nil
 }
 
 // parseAndLogFeedExpiryLocked checks the GTFS calendar for the last active service date

--- a/internal/models/frequency.go
+++ b/internal/models/frequency.go
@@ -1,7 +1,43 @@
 package models
 
+import (
+	"time"
+
+	"maglev.onebusaway.org/gtfsdb"
+)
+
+// Frequency represents a GTFS frequency entry in API responses.
 type Frequency struct {
 	StartTime int64 `json:"startTime"`
 	EndTime   int64 `json:"endTime"`
-	Headway   int   `json:"headway"`
+	// Headway is the time between departures in seconds
+	Headway int `json:"headway"`
+	// ExactTimes is used internally for business logic but omitted from API responses
+	ExactTimes int `json:"-"`
+}
+
+// NewFrequencyFromDB converts a database Frequency row into an API Frequency model.
+// serviceDate is the start-of-day in the agency's local timezone.
+// The DB stores start_time / end_time as nanoseconds since midnight (time.Duration).
+// The resulting StartTime/EndTime are Unix epoch milliseconds.
+func NewFrequencyFromDB(dbFreq gtfsdb.Frequency, serviceDate time.Time) Frequency {
+	// Correctly compute start of day in the agency's local timezone
+	startOfDay := time.Date(serviceDate.Year(), serviceDate.Month(), serviceDate.Day(), 0, 0, 0, 0, serviceDate.Location())
+
+	return Frequency{
+		StartTime:  startOfDay.Add(time.Duration(dbFreq.StartTime)).UnixMilli(),
+		EndTime:    startOfDay.Add(time.Duration(dbFreq.EndTime)).UnixMilli(),
+		Headway:    int(dbFreq.HeadwaySecs),
+		ExactTimes: int(dbFreq.ExactTimes),
+	}
+}
+
+// NewFrequency creates a Frequency with explicit values (times already in epoch ms).
+func NewFrequency(startTime, endTime int64, headway, exactTimes int) Frequency {
+	return Frequency{
+		StartTime:  startTime,
+		EndTime:    endTime,
+		Headway:    headway,
+		ExactTimes: exactTimes,
+	}
 }

--- a/internal/models/frequency_test.go
+++ b/internal/models/frequency_test.go
@@ -1,0 +1,159 @@
+package models
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"maglev.onebusaway.org/gtfsdb"
+)
+
+func TestNewFrequencyFromDB(t *testing.T) {
+	// Use a non-UTC timezone to properly verify the Local timezone fix
+	loc, err := time.LoadLocation("America/New_York")
+	require.NoError(t, err)
+
+	// Service date: 2024-01-15 midnight in New York
+	serviceDate := time.Date(2024, 1, 15, 0, 0, 0, 0, loc)
+
+	// DB stores times as nanoseconds since midnight (time.Duration)
+	// 06:00:00 = 6h * 3600s * 1e9 ns
+	startNanos := int64(6 * time.Hour)
+	// 09:00:00 = 9h * 3600s * 1e9 ns
+	endNanos := int64(9 * time.Hour)
+
+	dbFreq := gtfsdb.Frequency{
+		TripID:      "trip_1",
+		StartTime:   startNanos,
+		EndTime:     endNanos,
+		HeadwaySecs: 600, // 10 minutes in seconds
+		ExactTimes:  1,
+	}
+
+	freq := NewFrequencyFromDB(dbFreq, serviceDate)
+
+	expectedStart := time.Date(2024, 1, 15, 6, 0, 0, 0, loc).UnixMilli()
+	expectedEnd := time.Date(2024, 1, 15, 9, 0, 0, 0, loc).UnixMilli()
+
+	assert.Equal(t, expectedStart, freq.StartTime)
+	assert.Equal(t, expectedEnd, freq.EndTime)
+	assert.Equal(t, 600, freq.Headway)
+	assert.Equal(t, 1, freq.ExactTimes)
+}
+
+func TestNewFrequencyFromDB_FrequencyBased(t *testing.T) {
+	serviceDate := time.Date(2024, 6, 1, 0, 0, 0, 0, time.UTC)
+
+	dbFreq := gtfsdb.Frequency{
+		TripID:      "trip_2",
+		StartTime:   int64(7 * time.Hour),
+		EndTime:     int64(22 * time.Hour),
+		HeadwaySecs: 300, // 5 minutes
+		ExactTimes:  0,   // frequency-based
+	}
+
+	freq := NewFrequencyFromDB(dbFreq, serviceDate)
+
+	assert.Equal(t, 300, freq.Headway)
+	assert.Equal(t, 0, freq.ExactTimes)
+	assert.Greater(t, freq.EndTime, freq.StartTime)
+}
+
+func TestNewFrequencyFromDB_OverMidnight(t *testing.T) {
+	// GTFS supports times > 24h for trips that span past midnight
+	serviceDate := time.Date(2024, 1, 15, 0, 0, 0, 0, time.UTC)
+
+	// 25:00:00 = 1:00 AM next day
+	startNanos := int64(25 * time.Hour)
+	// 27:00:00 = 3:00 AM next day
+	endNanos := int64(27 * time.Hour)
+
+	dbFreq := gtfsdb.Frequency{
+		TripID:      "trip_late",
+		StartTime:   startNanos,
+		EndTime:     endNanos,
+		HeadwaySecs: 1800,
+		ExactTimes:  0,
+	}
+
+	freq := NewFrequencyFromDB(dbFreq, serviceDate)
+
+	// Should resolve to Jan 16 at 1:00 AM and 3:00 AM
+	expectedStart := time.Date(2024, 1, 16, 1, 0, 0, 0, time.UTC).UnixMilli()
+	expectedEnd := time.Date(2024, 1, 16, 3, 0, 0, 0, time.UTC).UnixMilli()
+
+	assert.Equal(t, expectedStart, freq.StartTime)
+	assert.Equal(t, expectedEnd, freq.EndTime)
+}
+
+func TestNewFrequency(t *testing.T) {
+	freq := NewFrequency(1705305600000, 1705316400000, 600, 1)
+
+	assert.Equal(t, int64(1705305600000), freq.StartTime)
+	assert.Equal(t, int64(1705316400000), freq.EndTime)
+	assert.Equal(t, 600, freq.Headway)
+	assert.Equal(t, 1, freq.ExactTimes)
+}
+
+func TestFrequencyJSON(t *testing.T) {
+	freq := Frequency{
+		StartTime:  1705305600000,
+		EndTime:    1705316400000,
+		Headway:    600,
+		ExactTimes: 1, // This shouldn't be serialized to API clients
+	}
+
+	jsonData, err := json.Marshal(freq)
+	require.NoError(t, err)
+
+	var unmarshaled Frequency
+	err = json.Unmarshal(jsonData, &unmarshaled)
+	require.NoError(t, err)
+
+	// Since ExactTimes is ignored in JSON, it defaults to 0 when unmarshaled
+	expected := freq
+	expected.ExactTimes = 0
+	assert.Equal(t, expected, unmarshaled)
+
+	// Verify JSON field names
+	var raw map[string]interface{}
+	err = json.Unmarshal(jsonData, &raw)
+	require.NoError(t, err)
+	assert.Contains(t, raw, "startTime")
+	assert.Contains(t, raw, "endTime")
+	assert.Contains(t, raw, "headway")
+
+	// IMPORTANT: Verify exactTimes is NOT in the JSON (API Backward Compatibility)
+	assert.NotContains(t, raw, "exactTimes")
+}
+
+func TestFrequencyJSON_NilPointer(t *testing.T) {
+	// When Frequency is a pointer field and nil, it should serialize as null
+	type wrapper struct {
+		Freq *Frequency `json:"frequency"`
+	}
+
+	w := wrapper{Freq: nil}
+	jsonData, err := json.Marshal(w)
+	require.NoError(t, err)
+	assert.Contains(t, string(jsonData), `"frequency":null`)
+}
+
+func TestFrequencyJSON_NonNilPointer(t *testing.T) {
+	type wrapper struct {
+		Freq *Frequency `json:"frequency"`
+	}
+
+	freq := NewFrequency(1000, 2000, 300, 0)
+	w := wrapper{Freq: &freq}
+	jsonData, err := json.Marshal(w)
+	require.NoError(t, err)
+
+	var result wrapper
+	err = json.Unmarshal(jsonData, &result)
+	require.NoError(t, err)
+	assert.NotNil(t, result.Freq)
+	assert.Equal(t, 300, result.Freq.Headway)
+}

--- a/internal/models/schedule_for_trip_details.go
+++ b/internal/models/schedule_for_trip_details.go
@@ -1,14 +1,14 @@
 package models
 
 type Schedule struct {
-	Frequency      int64      `json:"frequency"`
+	Frequency      *Frequency `json:"frequency"`
 	NextTripID     string     `json:"nextTripId"`
 	PreviousTripID string     `json:"previousTripId"`
 	StopTimes      []StopTime `json:"stopTimes"`
 	TimeZone       string     `json:"timeZone"`
 }
 
-func NewSchedule(frequency int64, nextTripID, previousTripID string, stopTimes []StopTime, timeZone string) *Schedule {
+func NewSchedule(frequency *Frequency, nextTripID, previousTripID string, stopTimes []StopTime, timeZone string) *Schedule {
 	return &Schedule{
 		Frequency:      frequency,
 		NextTripID:     nextTripID,

--- a/internal/models/schedule_for_trip_details_test.go
+++ b/internal/models/schedule_for_trip_details_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestNewSchedule(t *testing.T) {
-	frequency := int64(300)
+	freq := &Frequency{StartTime: 1000, EndTime: 2000, Headway: 300, ExactTimes: 0}
 	nextTripID := "next_trip_123"
 	previousTripID := "prev_trip_456"
 	stopTime1 := NewStopTime(28800, 28900, "stop_1", "Downtown", 100.0, "MANY_SEATS_AVAILABLE")
@@ -16,9 +16,9 @@ func TestNewSchedule(t *testing.T) {
 	stopTimes := []StopTime{stopTime1, stopTime2}
 	timeZone := "America/Los_Angeles"
 
-	schedule := NewSchedule(frequency, nextTripID, previousTripID, stopTimes, timeZone)
+	schedule := NewSchedule(freq, nextTripID, previousTripID, stopTimes, timeZone)
 
-	assert.Equal(t, frequency, schedule.Frequency)
+	assert.Equal(t, freq, schedule.Frequency)
 	assert.Equal(t, nextTripID, schedule.NextTripID)
 	assert.Equal(t, previousTripID, schedule.PreviousTripID)
 	assert.Equal(t, stopTimes, schedule.StopTimes)
@@ -30,7 +30,7 @@ func TestScheduleJSON(t *testing.T) {
 	stopTime := NewStopTime(28800, 28900, "stop_1", "Downtown", 100.0, "MANY_SEATS_AVAILABLE")
 
 	schedule := Schedule{
-		Frequency:      300,
+		Frequency:      nil,
 		NextTripID:     "next_trip",
 		PreviousTripID: "prev_trip",
 		StopTimes:      []StopTime{stopTime},
@@ -44,7 +44,7 @@ func TestScheduleJSON(t *testing.T) {
 	err = json.Unmarshal(jsonData, &unmarshaledSchedule)
 	assert.NoError(t, err)
 
-	assert.Equal(t, schedule.Frequency, unmarshaledSchedule.Frequency)
+	assert.Nil(t, unmarshaledSchedule.Frequency)
 	assert.Equal(t, schedule.NextTripID, unmarshaledSchedule.NextTripID)
 	assert.Equal(t, schedule.PreviousTripID, unmarshaledSchedule.PreviousTripID)
 	assert.Equal(t, schedule.TimeZone, unmarshaledSchedule.TimeZone)
@@ -53,9 +53,9 @@ func TestScheduleJSON(t *testing.T) {
 }
 
 func TestScheduleWithEmptyValues(t *testing.T) {
-	schedule := NewSchedule(0, "", "", []StopTime{}, "")
+	schedule := NewSchedule(nil, "", "", []StopTime{}, "")
 
-	assert.Equal(t, int64(0), schedule.Frequency)
+	assert.Nil(t, schedule.Frequency)
 	assert.Equal(t, "", schedule.NextTripID)
 	assert.Equal(t, "", schedule.PreviousTripID)
 	assert.Empty(t, schedule.StopTimes)
@@ -69,7 +69,7 @@ func TestScheduleWithMultipleStopTimes(t *testing.T) {
 		NewStopTime(29200, 29300, "stop_3", "Midtown", 300.0, "STANDING_ROOM_ONLY"),
 	}
 
-	schedule := NewSchedule(600, "trip_next", "trip_prev", stopTimes, "America/New_York")
+	schedule := NewSchedule(nil, "trip_next", "trip_prev", stopTimes, "America/New_York")
 
 	assert.Equal(t, 3, len(schedule.StopTimes))
 	assert.Equal(t, "stop_1", schedule.StopTimes[0].StopID)

--- a/internal/models/stop_time_schedule.go
+++ b/internal/models/stop_time_schedule.go
@@ -13,7 +13,7 @@ type ScheduleStopTime struct {
 
 // StopRouteDirectionSchedule represents schedule for a specific direction of a route
 type StopRouteDirectionSchedule struct {
-	ScheduleFrequencies []interface{}      `json:"scheduleFrequencies"`
+	ScheduleFrequencies []Frequency        `json:"scheduleFrequencies"`
 	ScheduleStopTimes   []ScheduleStopTime `json:"scheduleStopTimes"`
 	TripHeadsign        string             `json:"tripHeadsign"`
 }
@@ -45,9 +45,12 @@ func NewScheduleStopTime(arrivalTime, departureTime int64, serviceID, stopHeadsi
 }
 
 // NewStopRouteDirectionSchedule creates a new StopRouteDirectionSchedule
-func NewStopRouteDirectionSchedule(tripHeadsign string, stopTimes []ScheduleStopTime) StopRouteDirectionSchedule {
+func NewStopRouteDirectionSchedule(tripHeadsign string, stopTimes []ScheduleStopTime, frequencies []Frequency) StopRouteDirectionSchedule {
+	if frequencies == nil {
+		frequencies = []Frequency{}
+	}
 	return StopRouteDirectionSchedule{
-		ScheduleFrequencies: []interface{}{}, // Always empty array in the API
+		ScheduleFrequencies: frequencies,
 		ScheduleStopTimes:   stopTimes,
 		TripHeadsign:        tripHeadsign,
 	}

--- a/internal/models/stop_time_schedule_test.go
+++ b/internal/models/stop_time_schedule_test.go
@@ -58,7 +58,7 @@ func TestNewStopRouteDirectionSchedule(t *testing.T) {
 	stopTime2 := NewScheduleStopTime(1609463000000, 1609463100000, "service_1", "Uptown", "trip_2")
 	stopTimes := []ScheduleStopTime{stopTime1, stopTime2}
 
-	directionSchedule := NewStopRouteDirectionSchedule(tripHeadsign, stopTimes)
+	directionSchedule := NewStopRouteDirectionSchedule(tripHeadsign, stopTimes, nil)
 
 	assert.Equal(t, tripHeadsign, directionSchedule.TripHeadsign)
 	assert.Equal(t, stopTimes, directionSchedule.ScheduleStopTimes)
@@ -70,7 +70,7 @@ func TestStopRouteDirectionScheduleJSON(t *testing.T) {
 	stopTime := NewScheduleStopTime(1609462800000, 1609462900000, "service_1", "Downtown", "trip_1")
 
 	directionSchedule := StopRouteDirectionSchedule{
-		ScheduleFrequencies: []interface{}{},
+		ScheduleFrequencies: []Frequency{},
 		ScheduleStopTimes:   []ScheduleStopTime{stopTime},
 		TripHeadsign:        "Northbound to Terminal",
 	}
@@ -90,8 +90,8 @@ func TestStopRouteDirectionScheduleJSON(t *testing.T) {
 func TestNewStopRouteSchedule(t *testing.T) {
 	routeID := "route_789"
 	stopTime1 := NewScheduleStopTime(1609462800000, 1609462900000, "service_1", "Downtown", "trip_1")
-	directionSchedule1 := NewStopRouteDirectionSchedule("Northbound", []ScheduleStopTime{stopTime1})
-	directionSchedule2 := NewStopRouteDirectionSchedule("Southbound", []ScheduleStopTime{})
+	directionSchedule1 := NewStopRouteDirectionSchedule("Northbound", []ScheduleStopTime{stopTime1}, nil)
+	directionSchedule2 := NewStopRouteDirectionSchedule("Southbound", []ScheduleStopTime{}, nil)
 	directionSchedules := []StopRouteDirectionSchedule{directionSchedule1, directionSchedule2}
 
 	routeSchedule := NewStopRouteSchedule(routeID, directionSchedules)
@@ -103,7 +103,7 @@ func TestNewStopRouteSchedule(t *testing.T) {
 
 func TestStopRouteScheduleJSON(t *testing.T) {
 	stopTime := NewScheduleStopTime(1609462800000, 1609462900000, "service_1", "Downtown", "trip_1")
-	directionSchedule := NewStopRouteDirectionSchedule("Northbound", []ScheduleStopTime{stopTime})
+	directionSchedule := NewStopRouteDirectionSchedule("Northbound", []ScheduleStopTime{stopTime}, nil)
 
 	routeSchedule := StopRouteSchedule{
 		RouteID:                     "route_789",
@@ -125,7 +125,7 @@ func TestNewScheduleForStopEntry(t *testing.T) {
 	stopID := "stop_123"
 	date := int64(1609459200000)
 	stopTime1 := NewScheduleStopTime(1609462800000, 1609462900000, "service_1", "Downtown", "trip_1")
-	directionSchedule := NewStopRouteDirectionSchedule("Northbound", []ScheduleStopTime{stopTime1})
+	directionSchedule := NewStopRouteDirectionSchedule("Northbound", []ScheduleStopTime{stopTime1}, nil)
 	routeSchedule1 := NewStopRouteSchedule("route_1", []StopRouteDirectionSchedule{directionSchedule})
 	routeSchedule2 := NewStopRouteSchedule("route_2", []StopRouteDirectionSchedule{})
 	routeSchedules := []StopRouteSchedule{routeSchedule1, routeSchedule2}
@@ -140,7 +140,7 @@ func TestNewScheduleForStopEntry(t *testing.T) {
 
 func TestScheduleForStopEntryJSON(t *testing.T) {
 	stopTime := NewScheduleStopTime(1609462800000, 1609462900000, "service_1", "Downtown", "trip_1")
-	directionSchedule := NewStopRouteDirectionSchedule("Northbound", []ScheduleStopTime{stopTime})
+	directionSchedule := NewStopRouteDirectionSchedule("Northbound", []ScheduleStopTime{stopTime}, nil)
 	routeSchedule := NewStopRouteSchedule("route_1", []StopRouteDirectionSchedule{directionSchedule})
 
 	scheduleEntry := ScheduleForStopEntry{
@@ -174,7 +174,7 @@ func TestScheduleStopTimeWithEmptyValues(t *testing.T) {
 }
 
 func TestStopRouteDirectionScheduleWithEmptyStopTimes(t *testing.T) {
-	directionSchedule := NewStopRouteDirectionSchedule("Northbound", []ScheduleStopTime{})
+	directionSchedule := NewStopRouteDirectionSchedule("Northbound", []ScheduleStopTime{}, nil)
 
 	assert.Equal(t, "Northbound", directionSchedule.TripHeadsign)
 	assert.Empty(t, directionSchedule.ScheduleStopTimes)
@@ -194,4 +194,17 @@ func TestScheduleForStopEntryWithEmptyRouteSchedules(t *testing.T) {
 	assert.Equal(t, "stop_1", scheduleEntry.StopID)
 	assert.Equal(t, int64(1609459200000), scheduleEntry.Date)
 	assert.Empty(t, scheduleEntry.StopRouteSchedules)
+}
+
+func TestNewStopRouteDirectionSchedule_WithFrequencies(t *testing.T) {
+	schedule := []ScheduleStopTime{}
+	frequencies := []Frequency{
+		{StartTime: 28800, EndTime: 32400, Headway: 600, ExactTimes: 0},
+	}
+
+	directionSchedule := NewStopRouteDirectionSchedule("trip1", schedule, frequencies)
+
+	assert.NotNil(t, directionSchedule.ScheduleFrequencies)
+	assert.Len(t, directionSchedule.ScheduleFrequencies, 1)
+	assert.Equal(t, 600, directionSchedule.ScheduleFrequencies[0].Headway)
 }

--- a/internal/models/trip_details_test.go
+++ b/internal/models/trip_details_test.go
@@ -38,7 +38,7 @@ func TestNewTripDetails(t *testing.T) {
 	}
 
 	schedule := &Schedule{
-		Frequency:      600,
+		Frequency:      nil,
 		NextTripID:     "next_trip",
 		PreviousTripID: "prev_trip",
 		StopTimes:      []StopTime{},
@@ -82,7 +82,7 @@ func TestTripDetailsJSON(t *testing.T) {
 	}
 
 	schedule := &Schedule{
-		Frequency:      600,
+		Frequency:      nil,
 		NextTripID:     "next_trip",
 		PreviousTripID: "prev_trip",
 		StopTimes:      []StopTime{},

--- a/internal/restapi/schedule_for_stop_handler.go
+++ b/internal/restapi/schedule_for_stop_handler.go
@@ -255,7 +255,7 @@ func (api *RestAPI) scheduleForStopHandler(w http.ResponseWriter, r *http.Reques
 			}
 		}
 
-		directionSchedule := models.NewStopRouteDirectionSchedule(tripHeadsign, stopTimes)
+		directionSchedule := models.NewStopRouteDirectionSchedule(tripHeadsign, stopTimes, nil)
 		routeSchedule := models.NewStopRouteSchedule(routeID, []models.StopRouteDirectionSchedule{directionSchedule})
 		routeSchedules = append(routeSchedules, routeSchedule)
 	}

--- a/internal/restapi/trips_helper.go
+++ b/internal/restapi/trips_helper.go
@@ -211,7 +211,7 @@ func (api *RestAPI) BuildTripSchedule(ctx context.Context, agencyID string, serv
 	return &models.Schedule{
 		StopTimes:      stopTimesVals,
 		TimeZone:       loc.String(),
-		Frequency:      0,
+		Frequency:      nil,
 		NextTripID:     nextTripID,
 		PreviousTripID: previousTripID,
 	}, nil


### PR DESCRIPTION
Resolves #581 

Following the merged Phase 1 #549 , this PR implements **Phase 2** of the GTFS frequencies support. this phase focuses strictly on the data structures, core business logic, and performance infrastructure. 

**Note :** The actual population of the frequency data into the various API response handlers (e.g., `schedule_for_stop`, `trips_for_location`) is intentionally left for **Phase 3** (the immediate next PR). The handlers updated in this PR have been safely modified to use the new types while passing `nil`/empty slices.

### Key Changes & Optimizations:
* **Model Enrichment:** Added `Frequency` model and updated `ScheduleFrequencies` and `Schedule.Frequency` to use concrete types instead of `[]interface{}` and `int64`.
* **O(1) In-Memory Cache (Performance):** Implemented an in-memory `frequencyTripIDs` map inside `gtfs_manager.go` during static data load. This ensures `IsFrequencyBasedTrip` is an O(1) lookup, completely preventing N+1 database query issues in handlers.
* **Timezone Accuracy:** Fixed the nanosecond-to-millisecond time conversion in `NewFrequencyFromDB` to properly calculate the start of the day based on the agency's specific local timezone rather than UTC truncation.
* **JSON Serialization Parity:** Ensured strict backward compatibility with the OBA API (e.g., empty frequency arrays serialize to `[]`, missing single frequencies serialize to `null`, and internal logic fields like `exactTimes` are properly omitted via `json:"-"`).
* **Java Parity Logic:** Implemented `ExpandFrequencyTrips` to handle `exact_times=1` (schedule-based) expansions in memory, mimicking OBA Java's `FrequencyBlockTripIndex` behavior.
* **Thread Safety:** Added concurrent access testing (`TestConcurrentFrequencyAccess`) to ensure the new frequency cache is completely thread-safe during hot-swaps of static data.

<img width="1915" height="498" alt="image" src="https://github.com/user-attachments/assets/181c2e61-b0cc-4da1-890b-b077d83961b7" />

@aaronbrethorst 
closes: #581 