### PR TITLE
fix(api): remove double-nested response in block handler

### DIFF
--- a/internal/models/block.go
+++ b/internal/models/block.go
@@ -1,13 +1,5 @@
 package models
 
-type BlockResponse struct {
-	Data BlockData `json:"data"`
-}
-
-type BlockData struct {
-	Entry BlockEntry `json:"entry"`
-}
-
 type BlockEntry struct {
 	Configurations []BlockConfiguration `json:"configurations"`
 	ID             string               `json:"id"`

--- a/internal/restapi/block_handler.go
+++ b/internal/restapi/block_handler.go
@@ -48,20 +48,15 @@ func (api *RestAPI) blockHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	blockData := models.BlockData{
-		Entry: transformBlockToEntry(block, utils.FormCombinedID(agencyID, blockID), agencyID),
-	}
-
-	blockResponse := models.BlockResponse{
-		Data: blockData,
-	}
+	blockEntry := transformBlockToEntry(block, utils.FormCombinedID(agencyID, blockID), agencyID)
 
 	references, err := api.getReferences(ctx, agencyID, block)
 	if err != nil {
 		api.serverErrorResponse(w, r, err)
 		return
 	}
-	response := models.NewEntryResponse(blockResponse, references, api.Clock)
+
+	response := models.NewEntryResponse(blockEntry, references, api.Clock)
 	api.sendResponse(w, r, response)
 }
 

--- a/internal/restapi/block_handler_test.go
+++ b/internal/restapi/block_handler_test.go
@@ -23,13 +23,7 @@ func TestBlockHandlerEndToEnd(t *testing.T) {
 	data, ok := model.Data.(map[string]interface{})
 	require.True(t, ok)
 
-	entryWrapper, ok := data["entry"].(map[string]interface{})
-	require.True(t, ok)
-
-	entryData, ok := entryWrapper["data"].(map[string]interface{})
-	require.True(t, ok)
-
-	entry, ok := entryData["entry"].(map[string]interface{})
+	entry, ok := data["entry"].(map[string]interface{})
 	require.True(t, ok)
 
 	if id, exists := entry["id"]; exists {
@@ -126,13 +120,7 @@ func TestBlockHandlerVerifyBlockStopTimes(t *testing.T) {
 	data, ok := model.Data.(map[string]interface{})
 	require.True(t, ok)
 
-	entryWrapper, ok := data["entry"].(map[string]interface{})
-	require.True(t, ok)
-
-	entryData, ok := entryWrapper["data"].(map[string]interface{})
-	require.True(t, ok)
-
-	entry, ok := entryData["entry"].(map[string]interface{})
+	entry, ok := data["entry"].(map[string]interface{})
 	require.True(t, ok)
 
 	configs, ok := entry["configurations"].([]interface{})
@@ -269,15 +257,7 @@ func TestBlockHandlerResponseValidation(t *testing.T) {
 	require.Contains(t, data, "entry")
 	require.Contains(t, data, "references")
 
-	entryWrapper, ok := data["entry"].(map[string]interface{})
-	require.True(t, ok)
-	require.Contains(t, entryWrapper, "data")
-
-	entryData, ok := entryWrapper["data"].(map[string]interface{})
-	require.True(t, ok)
-	require.Contains(t, entryData, "entry")
-
-	entry, ok := entryData["entry"].(map[string]interface{})
+	entry, ok := data["entry"].(map[string]interface{})
 	require.True(t, ok)
 	require.Contains(t, entry, "id")
 	require.Contains(t, entry, "configurations")
@@ -419,13 +399,7 @@ func TestBlockHandlerReferencesConsistency(t *testing.T) {
 	assert.Contains(t, refs, "stopTimes")
 	assert.Contains(t, refs, "situations")
 
-	entryWrapper, ok := data["entry"].(map[string]interface{})
-	require.True(t, ok)
-
-	entryData, ok := entryWrapper["data"].(map[string]interface{})
-	require.True(t, ok)
-
-	entry, ok := entryData["entry"].(map[string]interface{})
+	entry, ok := data["entry"].(map[string]interface{})
 	require.True(t, ok)
 
 	configs, ok := entry["configurations"].([]interface{})


### PR DESCRIPTION
### Description
This PR fixes a bug in the `block_handler.go` endpoint that caused the JSON response to be double-nested (`data.entry.data.entry`), breaking parity with the legacy Java server.

### What Changed
- Removed the redundant `BlockResponse` and `BlockData` wrapper structs from `internal/models/block.go`.
- Updated `block_handler.go` to pass the flat `BlockEntry` directly to `NewEntryResponse()` (which handles the standard `data.entry` wrapping automatically).
- Updated the assertions in `block_handler_test.go` to correctly traverse and validate the flattened JSON structure.

### Testing
- All unit tests have been updated and are passing successfully (`make test`).
- The endpoint now correctly produces the standard `data.entry.{id, configurations}` format, exactly matching the OBA Java `BlockAction.java` endpoint.
<img width="1915" height="498" alt="image" src="https://github.com/user-attachments/assets/d31b6543-20ff-45aa-a7e8-3949424303fe" />

@aaronbrethorst 
fixes: #583 