### PR TITLE
fix(api): change trip directionId to string for java parity

### DIFF
--- a/internal/models/trip.go
+++ b/internal/models/trip.go
@@ -2,7 +2,7 @@ package models
 
 type Trip struct {
 	BlockID        string `json:"blockId"`
-	DirectionID    int64  `json:"directionId"`
+	DirectionID    string `json:"directionId"`
 	ID             string `json:"id"`
 	RouteID        string `json:"routeId"`
 	ServiceID      string `json:"serviceId"`
@@ -24,7 +24,7 @@ func NewTripResponse(trip *Trip, timeZone string, peakOffPeak int) *TripResponse
 	}
 }
 
-func NewTripReference(id, routeID, serviceID, headSign, shortName string, directionID int64, blockID, shapeID string) *Trip {
+func NewTripReference(id, routeID, serviceID, headSign, shortName string, directionID string, blockID, shapeID string) *Trip {
 	return &Trip{
 		BlockID:        blockID,
 		DirectionID:    directionID,

--- a/internal/models/trip_details_test.go
+++ b/internal/models/trip_details_test.go
@@ -13,7 +13,7 @@ func TestNewTripDetails(t *testing.T) {
 		RouteID:        "route_456",
 		ServiceID:      "service_789",
 		TripHeadsign:   "Downtown Terminal",
-		DirectionID:    1,
+		DirectionID:    "1",
 		BlockID:        "block_1",
 		ShapeID:        "shape_1",
 		TripShortName:  "DT",

--- a/internal/models/trip_test.go
+++ b/internal/models/trip_test.go
@@ -13,7 +13,7 @@ func TestNewTripReference(t *testing.T) {
 	serviceID := "service_1"
 	headSign := "Downtown Terminal"
 	shortName := "FMS"
-	directionID := int64(1)
+	directionID := "1"
 	blockID := "block_1"
 	shapeID := "shape_1"
 
@@ -33,14 +33,14 @@ func TestNewTripReference(t *testing.T) {
 }
 
 func TestNewTripReferenceWithEmptyValues(t *testing.T) {
-	trip := NewTripReference("", "", "", "", "", 0, "", "")
+	trip := NewTripReference("", "", "", "", "", "0", "", "")
 
 	assert.Equal(t, "", trip.ID)
 	assert.Equal(t, "", trip.RouteID)
 	assert.Equal(t, "", trip.ServiceID)
 	assert.Equal(t, "", trip.TripHeadsign)
 	assert.Equal(t, "", trip.TripShortName)
-	assert.Equal(t, int64(0), trip.DirectionID)
+	assert.Equal(t, "0", trip.DirectionID)
 	assert.Equal(t, "", trip.BlockID)
 	assert.Equal(t, "", trip.ShapeID)
 	assert.Equal(t, "", trip.RouteShortName)
@@ -51,7 +51,7 @@ func TestNewTripReferenceWithEmptyValues(t *testing.T) {
 func TestNewTripResponse(t *testing.T) {
 	trip := &Trip{
 		BlockID:        "block_1",
-		DirectionID:    1,
+		DirectionID:    "1",
 		ID:             "unitrans_trip_1",
 		RouteID:        "unitrans_FMS",
 		ServiceID:      "service_1",
@@ -74,7 +74,7 @@ func TestNewTripResponse(t *testing.T) {
 func TestTripJSON(t *testing.T) {
 	trip := Trip{
 		BlockID:        "block_1",
-		DirectionID:    1,
+		DirectionID:    "1",
 		ID:             "unitrans_trip_1",
 		RouteID:        "unitrans_FMS",
 		ServiceID:      "service_1",
@@ -109,7 +109,7 @@ func TestTripJSON(t *testing.T) {
 func TestTripResponseJSON(t *testing.T) {
 	trip := &Trip{
 		BlockID:        "block_1",
-		DirectionID:    1,
+		DirectionID:    "1",
 		ID:             "unitrans_trip_1",
 		RouteID:        "unitrans_FMS",
 		ServiceID:      "service_1",

--- a/internal/restapi/arrival_and_departure_for_stop_handler.go
+++ b/internal/restapi/arrival_and_departure_for_stop_handler.go
@@ -411,7 +411,7 @@ func (api *RestAPI) arrivalAndDepartureForStopHandler(w http.ResponseWriter, r *
 		utils.FormCombinedID(route.AgencyID, trip.ServiceID),
 		trip.TripHeadsign.String,
 		"", // trip short name
-		trip.DirectionID.Int64,
+		strconv.FormatInt(trip.DirectionID.Int64, 10),
 		utils.FormCombinedID(route.AgencyID, trip.BlockID.String),
 		utils.FormCombinedID(route.AgencyID, trip.ShapeID.String),
 	)
@@ -433,7 +433,7 @@ func (api *RestAPI) arrivalAndDepartureForStopHandler(w http.ResponseWriter, r *
 						utils.FormCombinedID(activeRoute.AgencyID, activeTrip.ServiceID),
 						activeTrip.TripHeadsign.String,
 						"", // trip short name
-						activeTrip.DirectionID.Int64,
+						strconv.FormatInt(activeTrip.DirectionID.Int64, 10),
 						utils.FormCombinedID(activeRoute.AgencyID, activeTrip.BlockID.String),
 						utils.FormCombinedID(activeRoute.AgencyID, activeTrip.ShapeID.String),
 					)

--- a/internal/restapi/arrivals_and_departure_for_stop.go
+++ b/internal/restapi/arrivals_and_departure_for_stop.go
@@ -457,7 +457,7 @@ func (api *RestAPI) arrivalsAndDeparturesForStopHandler(w http.ResponseWriter, r
 			utils.FormCombinedID(routeAgencyID, trip.ServiceID), // Use route agency for service ID
 			trip.TripHeadsign.String,
 			"",
-			trip.DirectionID.Int64,
+			strconv.FormatInt(trip.DirectionID.Int64, 10),
 			utils.FormCombinedID(routeAgencyID, trip.BlockID.String), // Use route agency for block ID
 			utils.FormCombinedID(routeAgencyID, trip.ShapeID.String), // Use route agency for shape ID
 		)

--- a/internal/restapi/block_handler.go
+++ b/internal/restapi/block_handler.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"net/http"
 	"sort"
+	"strconv"
 
 	"maglev.onebusaway.org/gtfsdb"
 	"maglev.onebusaway.org/internal/models"
@@ -245,7 +246,7 @@ func (api *RestAPI) getReferences(ctx context.Context, agencyID string, block []
 			ID:           utils.FormCombinedID(agencyID, trip.ID),
 			RouteID:      utils.FormCombinedID(agencyID, trip.RouteID),
 			ServiceID:    utils.FormCombinedID(agencyID, trip.ServiceID),
-			DirectionID:  trip.DirectionID.Int64,
+			DirectionID:  strconv.FormatInt(trip.DirectionID.Int64, 10),
 			BlockID:      utils.FormCombinedID(agencyID, trip.BlockID.String),
 			ShapeID:      utils.FormCombinedID(agencyID, trip.ShapeID.String),
 			TripHeadsign: trip.TripHeadsign.String,

--- a/internal/restapi/schedule_for_route_handler.go
+++ b/internal/restapi/schedule_for_route_handler.go
@@ -2,6 +2,7 @@ package restapi
 
 import (
 	"net/http"
+	"strconv"
 	"time"
 
 	"maglev.onebusaway.org/gtfsdb"
@@ -242,7 +243,7 @@ func (api *RestAPI) scheduleForRouteHandler(w http.ResponseWriter, r *http.Reque
 				t.ServiceID,
 				t.TripHeadsign.String,
 				t.TripShortName.String,
-				t.DirectionID.Int64,
+				strconv.FormatInt(t.DirectionID.Int64, 10),
 				utils.FormCombinedID(agencyID, t.BlockID.String),
 				utils.FormCombinedID(agencyID, t.ShapeID.String),
 			)

--- a/internal/restapi/schedule_for_stop_handler.go
+++ b/internal/restapi/schedule_for_stop_handler.go
@@ -2,6 +2,7 @@ package restapi
 
 import (
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
@@ -279,7 +280,7 @@ func (api *RestAPI) scheduleForStopHandler(w http.ResponseWriter, r *http.Reques
 			utils.FormCombinedID(agencyID, trip.ServiceID),
 			trip.TripHeadsign.String,
 			trip.TripShortName.String,
-			trip.DirectionID.Int64,
+			strconv.FormatInt(trip.DirectionID.Int64, 10),
 			utils.FormCombinedID(agencyID, trip.BlockID.String),
 			utils.FormCombinedID(agencyID, trip.ShapeID.String),
 		)

--- a/internal/restapi/trip_details_handler.go
+++ b/internal/restapi/trip_details_handler.go
@@ -357,7 +357,7 @@ func (api *RestAPI) buildReferencedTrips(ctx context.Context, agencyID string, t
 			ShapeID:        utils.FormCombinedID(agencyID, refTrip.ShapeID.String),
 			TripHeadsign:   refTrip.TripHeadsign.String,
 			TripShortName:  refTrip.TripShortName.String,
-			DirectionID:    refTrip.DirectionID.Int64,
+			DirectionID:    strconv.FormatInt(refTrip.DirectionID.Int64, 10),
 			BlockID:        blockID,
 			RouteShortName: refRoute.ShortName.String,
 			TimeZone:       "",

--- a/internal/restapi/trip_for_vehicle_handler.go
+++ b/internal/restapi/trip_for_vehicle_handler.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"net/http"
+	"strconv"
 	"time"
 
 	"maglev.onebusaway.org/gtfsdb"
@@ -191,7 +192,7 @@ func (api *RestAPI) tripForVehicleHandler(w http.ResponseWriter, r *http.Request
 			utils.FormCombinedID(agencyID, trip.ServiceID),
 			trip.TripHeadsign.String,
 			trip.TripShortName.String,
-			trip.DirectionID.Int64,
+			strconv.FormatInt(trip.DirectionID.Int64, 10),
 			utils.FormCombinedID(agencyID, trip.BlockID.String),
 			utils.FormCombinedID(agencyID, trip.ShapeID.String),
 		)

--- a/internal/restapi/trip_handler.go
+++ b/internal/restapi/trip_handler.go
@@ -2,6 +2,7 @@ package restapi
 
 import (
 	"net/http"
+	"strconv"
 
 	"maglev.onebusaway.org/internal/models"
 	"maglev.onebusaway.org/internal/utils"
@@ -52,7 +53,7 @@ func (api *RestAPI) tripHandler(w http.ResponseWriter, r *http.Request) {
 		ID:             utils.FormCombinedID(agencyID, trip.ID),
 		RouteID:        utils.FormCombinedID(agencyID, trip.RouteID),
 		ServiceID:      utils.FormCombinedID(agencyID, trip.ServiceID),
-		DirectionID:    trip.DirectionID.Int64,
+		DirectionID:    strconv.FormatInt(trip.DirectionID.Int64, 10),
 		BlockID:        blockID,
 		ShapeID:        shapeID,
 		TripHeadsign:   trip.TripHeadsign.String,

--- a/internal/restapi/trip_handler_test.go
+++ b/internal/restapi/trip_handler_test.go
@@ -1,6 +1,7 @@
 package restapi
 
 import (
+	"fmt"
 	"net/http"
 	"testing"
 
@@ -42,7 +43,7 @@ func TestTripHandlerEndToEnd(t *testing.T) {
 	assert.Equal(t, tripID, entry["id"])
 	assert.Equal(t, utils.FormCombinedID(agency.Id, trips[0].Route.Id), entry["routeId"])
 	assert.Equal(t, utils.FormCombinedID(agency.Id, trips[0].Service.Id), entry["serviceId"])
-	assert.Equal(t, float64(trips[0].DirectionId), entry["directionId"])
+	assert.Equal(t, fmt.Sprintf("%d", trips[0].DirectionId), entry["directionId"])
 	assert.Equal(t, utils.FormCombinedID(agency.Id, trips[0].BlockID), entry["blockId"])
 	assert.Equal(t, utils.FormCombinedID(agency.Id, trips[0].Shape.ID), entry["shapeId"])
 	assert.Equal(t, trips[0].Headsign, entry["tripHeadsign"])

--- a/internal/restapi/trips_for_location_handler.go
+++ b/internal/restapi/trips_for_location_handler.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"net/http"
+	"strconv"
 	"time"
 
 	"github.com/OneBusAway/go-gtfs"
@@ -599,7 +600,7 @@ func (rb *referenceBuilder) createTrip(trip gtfsdb.Trip) models.Trip {
 		ServiceID:     trip.ServiceID,
 		TripHeadsign:  trip.TripHeadsign.String,
 		TripShortName: trip.TripShortName.String,
-		DirectionID:   trip.DirectionID.Int64,
+		DirectionID:   strconv.FormatInt(trip.DirectionID.Int64, 10),
 		BlockID:       trip.BlockID.String,
 		ShapeID:       trip.ShapeID.String,
 		PeakOffPeak:   0,
@@ -694,7 +695,7 @@ func (rb *referenceBuilder) createTripReference(tripDetails gtfsdb.Trip, current
 		ServiceID:     utils.FormCombinedID(currentAgency, trip.ServiceID),
 		TripHeadsign:  tripDetails.TripHeadsign.String,
 		TripShortName: tripDetails.TripShortName.String,
-		DirectionID:   tripDetails.DirectionID.Int64,
+		DirectionID:   strconv.FormatInt(tripDetails.DirectionID.Int64, 10),
 		BlockID:       utils.FormCombinedID(currentAgency, trip.BlockID),
 		ShapeID:       utils.FormCombinedID(currentAgency, tripDetails.ShapeID.String),
 		PeakOffPeak:   0,

--- a/internal/restapi/trips_for_route_handler.go
+++ b/internal/restapi/trips_for_route_handler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"net/http"
+	"strconv"
 	"time"
 
 	"github.com/OneBusAway/go-gtfs"
@@ -359,7 +360,7 @@ func buildTripReferences[T interface{ GetTripId() string }](
 				ServiceID:     trip.ServiceID,
 				TripHeadsign:  trip.TripHeadsign.String,
 				TripShortName: trip.TripShortName.String,
-				DirectionID:   trip.DirectionID.Int64,
+				DirectionID:   strconv.FormatInt(trip.DirectionID.Int64, 10),
 				BlockID:       trip.BlockID.String,
 				ShapeID:       trip.ShapeID.String,
 				PeakOffPeak:   0,


### PR DESCRIPTION
### Description
This PR fixes a critical type mismatch bug where `Trip.DirectionID` was being serialized as an `int64` instead of a `string`. This breaks strict parity with the legacy OBA Java server (`TripV2Bean`) and causes immediate crashes on mobile clients (Android/iOS) that use strict JSON parsing.

### What Changed
- **Models:** Changed `DirectionID` from `int64` to `string` in `models.Trip` and `models.NewTripReference()`.
- **Handlers:** Updated all relevant API handlers (e.g., `trips_for_route`, `arrivals_and_departure`, `block_handler`, etc.) to convert the database `int64` integer to a string using `strconv.FormatInt(trip.DirectionID.Int64, 10)`.
- **Tests:** Updated all corresponding unit tests to assert against string values (e.g., `"1"`) instead of numeric values (e.g., `float64(1)`).

### Testing
- All unit tests have been updated and are passing successfully (`make test`).
- The endpoint now correctly produces the standard `"directionId": "1"` format, exactly matching the Java server.
<img width="1915" height="498" alt="image" src="https://github.com/user-attachments/assets/e8f988d0-3e8e-4c70-8231-395923d67a90" />

@aaronbrethorst 
fixes: #585 