### PR TITLE
fix(api): use pointer types for nullable numeric fields to match java parity

### DIFF
--- a/internal/models/arrival_and_departure.go
+++ b/internal/models/arrival_and_departure.go
@@ -8,7 +8,7 @@ type ArrivalAndDeparture struct {
 	DistanceFromStop           float64                   `json:"distanceFromStop"`
 	Frequency                  *Frequency                `json:"frequency"`
 	HistoricalOccupancy        string                    `json:"historicalOccupancy"`
-	LastUpdateTime             int64                     `json:"lastUpdateTime"`
+	LastUpdateTime             *int64                    `json:"lastUpdateTime,omitempty"`
 	NumberOfStopsAway          int                       `json:"numberOfStopsAway"`
 	OccupancyStatus            string                    `json:"occupancyStatus"`
 	Predicted                  bool                      `json:"predicted"`
@@ -39,7 +39,8 @@ type ArrivalAndDeparture struct {
 
 func NewArrivalAndDeparture(
 	routeID, routeShortName, routeLongName, tripID, tripHeadsign, stopID, vehicleID string,
-	serviceDate, scheduledArrivalTime, scheduledDepartureTime, predictedArrivalTime, predictedDepartureTime, lastUpdateTime int64,
+	serviceDate, scheduledArrivalTime, scheduledDepartureTime, predictedArrivalTime, predictedDepartureTime int64,
+	lastUpdateTime *int64,
 	predicted, arrivalEnabled, departureEnabled bool,
 	stopSequence, totalStopsInTrip, numberOfStopsAway, blockTripSequence int,
 	distanceFromStop float64,

--- a/internal/models/arrival_and_departure_test.go
+++ b/internal/models/arrival_and_departure_test.go
@@ -41,7 +41,8 @@ func TestNewArrivalAndDeparture(t *testing.T) {
 
 	arrival := NewArrivalAndDeparture(
 		routeID, routeShortName, routeLongName, tripID, tripHeadsign, stopID, vehicleID,
-		serviceDate, scheduledArrivalTime, scheduledDepartureTime, predictedArrivalTime, predictedDepartureTime, lastUpdateTime,
+		serviceDate, scheduledArrivalTime, scheduledDepartureTime, predictedArrivalTime, predictedDepartureTime,
+		&lastUpdateTime,
 		predicted, arrivalEnabled, departureEnabled,
 		stopSequence, totalStopsInTrip, numberOfStopsAway, blockTripSequence,
 		distanceFromStop,
@@ -62,7 +63,7 @@ func TestNewArrivalAndDeparture(t *testing.T) {
 	assert.Equal(t, scheduledDepartureTime, arrival.ScheduledDepartureTime)
 	assert.Equal(t, predictedArrivalTime, arrival.PredictedArrivalTime)
 	assert.Equal(t, predictedDepartureTime, arrival.PredictedDepartureTime)
-	assert.Equal(t, lastUpdateTime, arrival.LastUpdateTime)
+	assert.Equal(t, lastUpdateTime, *arrival.LastUpdateTime)
 	assert.Equal(t, predicted, arrival.Predicted)
 	assert.Equal(t, arrivalEnabled, arrival.ArrivalEnabled)
 	assert.Equal(t, departureEnabled, arrival.DepartureEnabled)
@@ -92,6 +93,7 @@ func TestArrivalAndDepartureJSON(t *testing.T) {
 		Status:    "in_progress",
 	}
 
+	lastUpdateTime := int64(1609462700000)
 	arrival := ArrivalAndDeparture{
 		ActualTrack:                "",
 		ArrivalEnabled:             true,
@@ -100,7 +102,7 @@ func TestArrivalAndDepartureJSON(t *testing.T) {
 		DistanceFromStop:           500.75,
 		Frequency:                  nil,
 		HistoricalOccupancy:        "STANDING_ROOM_ONLY",
-		LastUpdateTime:             1609462700000,
+		LastUpdateTime:             &lastUpdateTime,
 		NumberOfStopsAway:          3,
 		OccupancyStatus:            "MANY_SEATS_AVAILABLE",
 		Predicted:                  true,
@@ -149,7 +151,8 @@ func TestArrivalAndDepartureJSON(t *testing.T) {
 func TestArrivalAndDepartureWithEmptyValues(t *testing.T) {
 	arrival := NewArrivalAndDeparture(
 		"", "", "", "", "", "", "",
-		0, 0, 0, 0, 0, 0,
+		0, 0, 0, 0, 0,
+		nil,
 		false, false, false,
 		0, 0, 0, 0,
 		0.0,
@@ -171,12 +174,15 @@ func TestArrivalAndDepartureWithEmptyValues(t *testing.T) {
 	assert.Equal(t, false, arrival.DepartureEnabled)
 	assert.Nil(t, arrival.TripStatus)
 	assert.Nil(t, arrival.SituationIDs)
+	assert.Nil(t, arrival.LastUpdateTime)
 }
 
 func TestArrivalAndDepartureWithNilTripStatus(t *testing.T) {
+	lastUpdateTime := int64(1609462700000)
 	arrival := NewArrivalAndDeparture(
 		"route_1", "R1", "Route One", "trip_1", "Terminal", "stop_1", "vehicle_1",
-		1609459200000, 1609462800000, 1609462900000, 1609462850000, 1609462950000, 1609462700000,
+		1609459200000, 1609462800000, 1609462900000, 1609462850000, 1609462950000,
+		&lastUpdateTime,
 		true, true, true,
 		1, 10, 2, 1,
 		250.5,

--- a/internal/models/trip_details.go
+++ b/internal/models/trip_details.go
@@ -36,29 +36,29 @@ type TripStatusForTripDetails struct {
 	ActiveTripID               string     `json:"activeTripId"`
 	BlockTripSequence          int        `json:"blockTripSequence"`
 	ClosestStop                string     `json:"closestStop"`
-	ClosestStopTimeOffset      int        `json:"closestStopTimeOffset"`
-	DistanceAlongTrip          float64    `json:"distanceAlongTrip"`
+	ClosestStopTimeOffset      *int       `json:"closestStopTimeOffset,omitempty"`
+	DistanceAlongTrip          *float64   `json:"distanceAlongTrip,omitempty"`
 	Frequency                  *Frequency `json:"frequency,omitempty"`
-	LastKnownDistanceAlongTrip float64    `json:"lastKnownDistanceAlongTrip"`
+	LastKnownDistanceAlongTrip *float64   `json:"lastKnownDistanceAlongTrip,omitempty"`
 	LastKnownLocation          Location   `json:"lastKnownLocation"`
-	LastKnownOrientation       float64    `json:"lastKnownOrientation"`
-	LastLocationUpdateTime     int64      `json:"lastLocationUpdateTime"`
-	LastUpdateTime             int64      `json:"lastUpdateTime"`
+	LastKnownOrientation       *float64   `json:"lastKnownOrientation,omitempty"`
+	LastLocationUpdateTime     *int64     `json:"lastLocationUpdateTime,omitempty"`
+	LastUpdateTime             *int64     `json:"lastUpdateTime,omitempty"`
 	NextStop                   string     `json:"nextStop"`
-	NextStopTimeOffset         int        `json:"nextStopTimeOffset"`
-	OccupancyCapacity          int        `json:"occupancyCapacity"`
-	OccupancyCount             int        `json:"occupancyCount"`
+	NextStopTimeOffset         *int       `json:"nextStopTimeOffset,omitempty"`
+	OccupancyCapacity          *int       `json:"occupancyCapacity,omitempty"`
+	OccupancyCount             *int       `json:"occupancyCount,omitempty"`
 	OccupancyStatus            string     `json:"occupancyStatus"`
-	Orientation                float64    `json:"orientation"`
+	Orientation                *float64   `json:"orientation,omitempty"`
 	Phase                      string     `json:"phase"`
 	Position                   Location   `json:"position"`
 	Predicted                  bool       `json:"predicted"`
-	ScheduleDeviation          int        `json:"scheduleDeviation"`
-	ScheduledDistanceAlongTrip float64    `json:"scheduledDistanceAlongTrip"`
+	ScheduleDeviation          *int       `json:"scheduleDeviation,omitempty"`
+	ScheduledDistanceAlongTrip *float64   `json:"scheduledDistanceAlongTrip,omitempty"`
 	ServiceDate                int64      `json:"serviceDate"`
 	SituationIDs               []string   `json:"situationIds"`
 	Status                     string     `json:"status"`
-	TotalDistanceAlongTrip     float64    `json:"totalDistanceAlongTrip"`
+	TotalDistanceAlongTrip     *float64   `json:"totalDistanceAlongTrip,omitempty"`
 	VehicleFeatures            []string   `json:"vehicleFeatures,omitempty"`
 	VehicleID                  string     `json:"vehicleId"`
 	Scheduled                  bool       `json:"scheduled"`

--- a/internal/models/trip_details_test.go
+++ b/internal/models/trip_details_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewTripDetails(t *testing.T) {
@@ -126,39 +127,53 @@ func TestTripDetailsWithNilValues(t *testing.T) {
 }
 
 func TestTripStatusForTripDetailsJSON(t *testing.T) {
+	distanceAlongTrip := 1500.5
+	lastKnownDistanceAlongTrip := 1400.0
+	lastKnownOrientation := 90.0
+	lastLocationUpdateTime := int64(1609462700000)
+	lastUpdateTime := int64(1609462800000)
+	occupancyCapacity := 50
+	occupancyCount := 30
+	orientation := 95.0
+	scheduleDeviation := 60
+	scheduledDistanceAlongTrip := 1450.0
+	totalDistanceAlongTrip := 5000.0
+	closestOffset := 120
+	nextOffset := 240
+
 	tripStatus := TripStatusForTripDetails{
 		ActiveTripID:               "active_trip_123",
 		BlockTripSequence:          2,
 		ClosestStop:                "stop_456",
-		ClosestStopTimeOffset:      120,
-		DistanceAlongTrip:          1500.5,
+		ClosestStopTimeOffset:      &closestOffset,
+		DistanceAlongTrip:          &distanceAlongTrip,
 		Frequency:                  nil,
-		LastKnownDistanceAlongTrip: 1400.0,
+		LastKnownDistanceAlongTrip: &lastKnownDistanceAlongTrip,
 		LastKnownLocation: Location{
 			Lat: 38.542661,
 			Lon: -121.743914,
 		},
-		LastKnownOrientation:   90.0,
-		LastLocationUpdateTime: 1609462700000,
-		LastUpdateTime:         1609462800000,
+		LastKnownOrientation:   &lastKnownOrientation,
+		LastLocationUpdateTime: &lastLocationUpdateTime,
+		LastUpdateTime:         &lastUpdateTime,
 		NextStop:               "stop_789",
-		NextStopTimeOffset:     240,
-		OccupancyCapacity:      50,
-		OccupancyCount:         30,
+		NextStopTimeOffset:     &nextOffset,
+		OccupancyCapacity:      &occupancyCapacity,
+		OccupancyCount:         &occupancyCount,
 		OccupancyStatus:        "MANY_SEATS_AVAILABLE",
-		Orientation:            95.0,
+		Orientation:            &orientation,
 		Phase:                  "in_progress",
 		Position: Location{
 			Lat: 38.543000,
 			Lon: -121.744000,
 		},
 		Predicted:                  true,
-		ScheduleDeviation:          60,
-		ScheduledDistanceAlongTrip: 1450.0,
+		ScheduleDeviation:          &scheduleDeviation,
+		ScheduledDistanceAlongTrip: &scheduledDistanceAlongTrip,
 		ServiceDate:                1609459200000,
 		SituationIDs:               []string{"situation_1"},
 		Status:                     "SCHEDULED",
-		TotalDistanceAlongTrip:     5000.0,
+		TotalDistanceAlongTrip:     &totalDistanceAlongTrip,
 		VehicleFeatures:            []string{"wifi", "bike_rack"},
 		VehicleID:                  "vehicle_789",
 		Scheduled:                  true,
@@ -177,4 +192,19 @@ func TestTripStatusForTripDetailsJSON(t *testing.T) {
 	assert.Equal(t, tripStatus.Predicted, unmarshaledStatus.Predicted)
 	assert.Equal(t, tripStatus.Position.Lat, unmarshaledStatus.Position.Lat)
 	assert.Equal(t, tripStatus.Position.Lon, unmarshaledStatus.Position.Lon)
+}
+
+func TestTripStatusForTripDetails_JSONOmitEmpty(t *testing.T) {
+	status := TripStatusForTripDetails{
+		Status: "default",
+	}
+
+	data, err := json.Marshal(status)
+	require.NoError(t, err)
+	jsonStr := string(data)
+
+	assert.NotContains(t, jsonStr, `"scheduleDeviation"`, "scheduleDeviation should be omitted when nil")
+	assert.NotContains(t, jsonStr, `"distanceAlongTrip"`, "distanceAlongTrip should be omitted when nil")
+	assert.NotContains(t, jsonStr, `"closestStopTimeOffset"`, "closestStopTimeOffset should be omitted when nil")
+	assert.NotContains(t, jsonStr, `"orientation"`, "orientation should be omitted when nil")
 }

--- a/internal/models/vehicle.go
+++ b/internal/models/vehicle.go
@@ -2,8 +2,8 @@ package models
 
 type VehicleStatus struct {
 	VehicleID              string      `json:"vehicleId"`
-	LastLocationUpdateTime int64       `json:"lastLocationUpdateTime,omitempty"`
-	LastUpdateTime         int64       `json:"lastUpdateTime,omitempty"`
+	LastLocationUpdateTime *int64      `json:"lastLocationUpdateTime,omitempty"`
+	LastUpdateTime         *int64      `json:"lastUpdateTime,omitempty"`
 	Location               *Location   `json:"location,omitempty"`
 	Status                 string      `json:"status,omitempty"`
 	Phase                  string      `json:"phase,omitempty"`
@@ -19,16 +19,16 @@ type TripStatus struct {
 	ActiveTripID           string   `json:"activeTripId"`
 	BlockTripSequence      int      `json:"blockTripSequence"`
 	ServiceDate            int64    `json:"serviceDate"`
-	ScheduleDeviation      int      `json:"scheduleDeviation,omitempty"`
+	ScheduleDeviation      *int     `json:"scheduleDeviation,omitempty"`
 	Scheduled              bool     `json:"scheduled"`
-	TotalDistanceAlongTrip float64  `json:"totalDistanceAlongTrip,omitempty"`
-	DistanceAlongTrip      float64  `json:"distanceAlongTrip,omitempty"`
+	TotalDistanceAlongTrip *float64 `json:"totalDistanceAlongTrip,omitempty"`
+	DistanceAlongTrip      *float64 `json:"distanceAlongTrip,omitempty"`
 	Phase                  string   `json:"phase"`
 	Status                 string   `json:"status"`
 	ClosestStop            string   `json:"closestStop,omitempty"`
-	ClosestStopTimeOffset  int      `json:"closestStopTimeOffset,omitempty"`
+	ClosestStopTimeOffset  *int     `json:"closestStopTimeOffset,omitempty"`
 	NextStop               string   `json:"nextStop,omitempty"`
-	NextStopTimeOffset     int      `json:"nextStopTimeOffset,omitempty"`
-	Orientation            float32  `json:"orientation,omitempty"`
+	NextStopTimeOffset     *int     `json:"nextStopTimeOffset,omitempty"`
+	Orientation            *float64 `json:"orientation,omitempty"`
 	Position               Location `json:"position"`
 }

--- a/internal/restapi/arrival_and_departure_for_stop_handler.go
+++ b/internal/restapi/arrival_and_departure_for_stop_handler.go
@@ -339,6 +339,10 @@ func (api *RestAPI) arrivalAndDepartureForStopHandler(w http.ResponseWriter, r *
 	blockTripSequence := api.calculateBlockTripSequence(ctx, tripID, serviceDate)
 
 	lastUpdateTime := api.GtfsManager.GetVehicleLastUpdateTime(vehicle)
+	var lastUpdateTimePtr *int64
+	if lastUpdateTime > 0 {
+		lastUpdateTimePtr = utils.Int64Ptr(lastUpdateTime)
+	}
 
 	situationIDs := api.GetSituationIDsForTrip(r.Context(), tripID)
 
@@ -355,7 +359,7 @@ func (api *RestAPI) arrivalAndDepartureForStopHandler(w http.ResponseWriter, r *
 		scheduledDepartureTimeMs,                       // scheduledDepartureTime
 		predictedArrivalTime,                           // predictedArrivalTime
 		predictedDepartureTime,                         // predictedDepartureTime
-		lastUpdateTime,                                 // lastUpdateTime
+		lastUpdateTimePtr,                              // lastUpdateTime
 		predicted,                                      // predicted
 		true,                                           // arrivalEnabled
 		true,                                           // departureEnabled

--- a/internal/restapi/arrivals_and_departure_for_stop.go
+++ b/internal/restapi/arrivals_and_departure_for_stop.go
@@ -406,17 +406,24 @@ func (api *RestAPI) arrivalsAndDeparturesForStopHandler(w http.ResponseWriter, r
 		blockTripSequence := api.calculateBlockTripSequence(ctx, st.TripID, serviceMidnight)
 
 		lastUpdateTime := api.GtfsManager.GetVehicleLastUpdateTime(vehicle)
+		var lastUpdateTimePtr *int64
+		if lastUpdateTime > 0 {
+			lastUpdateTimePtr = utils.Int64Ptr(lastUpdateTime)
+		}
+
 		tripAlerts := api.GtfsManager.GetAlertsForTrip(r.Context(), st.TripID)
 		situationIDs := make([]string, 0, len(tripAlerts))
 		for _, alert := range tripAlerts {
 			if alert.ID == "" {
 				continue
 			}
+
 			situationIDs = append(situationIDs, utils.FormCombinedID(route.AgencyID, alert.ID))
 			if _, seen := collectedAlerts[alert.ID]; !seen {
 				collectedAlerts[alert.ID] = alert
 			}
 		}
+
 		if alertAgencyID == "" && route.AgencyID != "" {
 			alertAgencyID = route.AgencyID
 		}
@@ -434,7 +441,7 @@ func (api *RestAPI) arrivalsAndDeparturesForStopHandler(w http.ResponseWriter, r
 			scheduledDepartureTime,                          // scheduledDepartureTime
 			predictedArrivalTime,                            // predictedArrivalTime
 			predictedDepartureTime,                          // predictedDepartureTime
-			lastUpdateTime,                                  // lastUpdateTime
+			lastUpdateTimePtr,                               // lastUpdateTime
 			predicted,                                       // predicted
 			true,                                            // arrivalEnabled
 			true,                                            // departureEnabled

--- a/internal/restapi/trips_helper.go
+++ b/internal/restapi/trips_helper.go
@@ -25,11 +25,11 @@ func (api *RestAPI) BuildTripStatus(
 	sdMidnight := time.Date(serviceDate.Year(), serviceDate.Month(), serviceDate.Day(),
 		0, 0, 0, 0, serviceDate.Location())
 	status := &models.TripStatusForTripDetails{
-		ActiveTripID:      utils.FormCombinedID(agencyID, tripID),
-		ServiceDate:       sdMidnight.UnixMilli(),
-		SituationIDs:      api.GetSituationIDsForTrip(ctx, tripID),
-		OccupancyCapacity: -1,
-		OccupancyCount:    -1,
+		ActiveTripID: utils.FormCombinedID(agencyID, tripID),
+		ServiceDate:  sdMidnight.UnixMilli(),
+		SituationIDs: api.GetSituationIDsForTrip(ctx, tripID),
+		// OccupancyCapacity and OccupancyCount are left nil (null in JSON) when no data.
+		// Java OBA uses nullable Integer types that serialize conditionally.
 	}
 
 	vehicle := api.GtfsManager.GetVehicleForTrip(ctx, tripID)
@@ -44,7 +44,7 @@ func (api *RestAPI) BuildTripStatus(
 		// NOTE: GTFS-RT OccupancyPercentage (0-100%) has no direct equivalent in the
 		// OBA TripStatus schema. The Java OBA server populates occupancyCapacity from
 		// agency-provided vehicle capacity data, not from GTFS-RT percentages.
-		// We intentionally leave OccupancyCapacity at its default (-1) here.
+		// We intentionally leave OccupancyCapacity as nil here.
 		// See: TripStatusBeanServiceImpl.java in onebusaway-transit-data-federation.
 	}
 	api.BuildVehicleStatus(ctx, vehicle, tripID, agencyID, status, currentTime)
@@ -57,7 +57,7 @@ func (api *RestAPI) BuildTripStatus(
 	scheduleDeviation, hasRealtimeTripUpdate := api.GetScheduleDeviation(activeTripRawID)
 
 	if hasRealtimeTripUpdate {
-		status.ScheduleDeviation = scheduleDeviation
+		status.ScheduleDeviation = utils.IntPtr(scheduleDeviation)
 	}
 
 	hasVehicleRealtimeData := vehicle != nil && !defaultStaleDetector.Check(vehicle, currentTime)
@@ -110,11 +110,11 @@ func (api *RestAPI) BuildTripStatus(
 
 		if closestStopID != "" {
 			status.ClosestStop = utils.FormCombinedID(agencyID, closestStopID)
-			status.ClosestStopTimeOffset = closestOffset
+			status.ClosestStopTimeOffset = utils.IntPtr(closestOffset)
 		}
 		if nextStopID != "" {
 			status.NextStop = utils.FormCombinedID(agencyID, nextStopID)
-			status.NextStopTimeOffset = nextOffset
+			status.NextStopTimeOffset = utils.IntPtr(nextOffset)
 		}
 	}
 
@@ -131,7 +131,7 @@ func (api *RestAPI) BuildTripStatus(
 	if shapeErr == nil && len(shapeRows) > 1 {
 		shapePoints := shapeRowsToPoints(shapeRows)
 		cumulativeDistances := preCalculateCumulativeDistances(shapePoints)
-		status.TotalDistanceAlongTrip = cumulativeDistances[len(cumulativeDistances)-1]
+		status.TotalDistanceAlongTrip = utils.Float64Ptr(cumulativeDistances[len(cumulativeDistances)-1])
 
 		if vehicle != nil && vehicle.Position != nil && vehicle.Position.Latitude != nil && vehicle.Position.Longitude != nil {
 			// Refine the raw GPS position (set by BuildVehicleStatus) by projecting
@@ -142,14 +142,14 @@ func (api *RestAPI) BuildTripStatus(
 			}
 
 			actualDistance := api.getVehicleDistanceAlongShapeContextual(ctx, activeTripRawID, vehicle)
-			status.DistanceAlongTrip = actualDistance
+			status.DistanceAlongTrip = utils.Float64Ptr(actualDistance)
 
 			// If the feed does not provide a bearing, infer orientation from the
 			// heading of the closest shape segment at the vehicle's position.
 			if vehicle.Position.Bearing == nil {
 				if inferred := inferOrientationFromShape(actualPosition.Lat, actualPosition.Lon, shapePoints); inferred >= 0 {
-					status.Orientation = inferred
-					status.LastKnownOrientation = inferred
+					status.Orientation = utils.Float64Ptr(inferred)
+					status.LastKnownOrientation = utils.Float64Ptr(inferred)
 				}
 			}
 
@@ -158,7 +158,7 @@ func (api *RestAPI) BuildTripStatus(
 					ctx, actualDistance, scheduleDeviation, currentTime, serviceDate,
 					stopTimes, shapePoints, cumulativeDistances,
 				)
-				status.ScheduledDistanceAlongTrip = scheduledDistance
+				status.ScheduledDistanceAlongTrip = utils.Float64Ptr(scheduledDistance)
 			}
 		}
 	}
@@ -276,19 +276,25 @@ func (api *RestAPI) fillStopsFromSchedule(ctx context.Context, status *models.Tr
 
 	currentSeconds := utils.CalculateSecondsSinceServiceDate(currentTime, serviceDate)
 
+	// Dereference schedule deviation safely, default to 0 if not set
+	schedDev := int64(0)
+	if status.ScheduleDeviation != nil {
+		schedDev = int64(*status.ScheduleDeviation)
+	}
+
 	for i, st := range stopTimes {
 		arrivalTime := utils.EffectiveStopTimeSeconds(st.ArrivalTime, st.DepartureTime)
-		predictedArrival := arrivalTime + int64(status.ScheduleDeviation)
+		predictedArrival := arrivalTime + schedDev
 
 		if predictedArrival > currentSeconds {
 			if i > 0 && status.ClosestStop == "" {
 				status.ClosestStop = utils.FormCombinedID(agencyID, stopTimes[i-1].StopID)
 				closestArrival := utils.EffectiveStopTimeSeconds(stopTimes[i-1].ArrivalTime, stopTimes[i-1].DepartureTime)
-				status.ClosestStopTimeOffset = int(closestArrival + int64(status.ScheduleDeviation) - currentSeconds)
+				status.ClosestStopTimeOffset = utils.IntPtr(int(closestArrival + schedDev - currentSeconds))
 			}
 			if status.NextStop == "" {
 				status.NextStop = utils.FormCombinedID(agencyID, st.StopID)
-				status.NextStopTimeOffset = int(predictedArrival - currentSeconds)
+				status.NextStopTimeOffset = utils.IntPtr(int(predictedArrival - currentSeconds))
 			}
 			return
 		}
@@ -298,7 +304,7 @@ func (api *RestAPI) fillStopsFromSchedule(ctx context.Context, status *models.Tr
 		lastStop := stopTimes[len(stopTimes)-1]
 		status.ClosestStop = utils.FormCombinedID(agencyID, lastStop.StopID)
 		arrivalTime := utils.EffectiveStopTimeSeconds(lastStop.ArrivalTime, lastStop.DepartureTime)
-		status.ClosestStopTimeOffset = int(arrivalTime + int64(status.ScheduleDeviation) - currentSeconds)
+		status.ClosestStopTimeOffset = utils.IntPtr(int(arrivalTime + schedDev - currentSeconds))
 	}
 }
 

--- a/internal/restapi/trips_helper_test.go
+++ b/internal/restapi/trips_helper_test.go
@@ -590,7 +590,8 @@ func TestBuildTripStatus_ScheduleDeviation_SetsPredicted(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, status)
 
-	assert.Equal(t, 120, status.ScheduleDeviation, "ScheduleDeviation should reflect the trip update delay")
+	require.NotNil(t, status.ScheduleDeviation)
+	assert.Equal(t, 120, *status.ScheduleDeviation, "ScheduleDeviation should reflect the trip update delay")
 	assert.True(t, status.Predicted, "Predicted should be true when trip update exists")
 	assert.False(t, status.Scheduled, "Scheduled should be false when predicted is true")
 }
@@ -617,7 +618,7 @@ func TestBuildTripStatus_NoRealtimeData_SetsScheduled(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, status)
 
-	assert.Equal(t, 0, status.ScheduleDeviation, "ScheduleDeviation should be 0 with no real-time data")
+	assert.Nil(t, status.ScheduleDeviation, "ScheduleDeviation should be nil with no real-time data")
 	assert.False(t, status.Predicted, "Predicted should be false with no real-time data")
 	assert.True(t, status.Scheduled, "Scheduled should be true with no real-time data")
 	assert.Equal(t, "default", status.Status)
@@ -681,10 +682,11 @@ func TestBuildTripStatus_ShapeData_ComputesDistanceAlongTrip(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, status)
 
-	assert.Greater(t, status.TotalDistanceAlongTrip, 0.0, "TotalDistanceAlongTrip should be > 0 with shape data")
-	assert.Greater(t, status.DistanceAlongTrip, 0.0, "DistanceAlongTrip should be > 0 for a vehicle mid-route")
-	assert.Less(t, status.DistanceAlongTrip, status.TotalDistanceAlongTrip,
-		"DistanceAlongTrip should be less than total for a mid-route vehicle")
+	require.NotNil(t, status.TotalDistanceAlongTrip)
+	require.NotNil(t, status.DistanceAlongTrip)
+	assert.Greater(t, *status.TotalDistanceAlongTrip, float64(0), "TotalDistanceAlongTrip should be > 0 with shape data")
+	assert.Greater(t, *status.DistanceAlongTrip, float64(0), "DistanceAlongTrip should be > 0 for a vehicle mid-route")
+	assert.Less(t, *status.DistanceAlongTrip, *status.TotalDistanceAlongTrip, "DistanceAlongTrip should be less than total for a mid-route vehicle")
 }
 
 func TestBuildTripStatus_VehicleIDFormat(t *testing.T) {

--- a/internal/restapi/vehicles_for_agency_handler.go
+++ b/internal/restapi/vehicles_for_agency_handler.go
@@ -71,8 +71,9 @@ func (api *RestAPI) vehiclesForAgencyHandler(w http.ResponseWriter, r *http.Requ
 
 		// Set timestamps
 		if vehicle.Timestamp != nil {
-			vehicleStatus.LastLocationUpdateTime = vehicle.Timestamp.UnixNano() / int64(time.Millisecond)
-			vehicleStatus.LastUpdateTime = vehicle.Timestamp.UnixNano() / int64(time.Millisecond)
+			timestampMs := vehicle.Timestamp.UnixNano() / int64(time.Millisecond)
+			vehicleStatus.LastLocationUpdateTime = &timestampMs
+			vehicleStatus.LastUpdateTime = &timestampMs
 		}
 
 		// Set location if available
@@ -112,7 +113,7 @@ func (api *RestAPI) vehiclesForAgencyHandler(w http.ResponseWriter, r *http.Requ
 				if obaOrientation < 0 {
 					obaOrientation += 360
 				}
-				tripStatus.Orientation = float32(obaOrientation)
+				tripStatus.Orientation = utils.Float64Ptr(float64(obaOrientation))
 			}
 
 			// Set service date (use current date for now)

--- a/internal/restapi/vehicles_helper.go
+++ b/internal/restapi/vehicles_helper.go
@@ -121,7 +121,7 @@ func (api *RestAPI) BuildVehicleStatus(
 	var lastUpdateTime int64
 	if vehicle.Timestamp != nil {
 		lastUpdateTime = api.GtfsManager.GetVehicleLastUpdateTime(vehicle)
-		status.LastUpdateTime = lastUpdateTime
+		status.LastUpdateTime = utils.Int64Ptr(lastUpdateTime)
 	}
 
 	if vehicle.Position != nil && vehicle.Position.Latitude != nil && vehicle.Position.Longitude != nil {
@@ -137,7 +137,7 @@ func (api *RestAPI) BuildVehicleStatus(
 		status.Position = actualPosition
 
 		if vehicle.Timestamp != nil {
-			status.LastLocationUpdateTime = lastUpdateTime
+			status.LastLocationUpdateTime = utils.Int64Ptr(lastUpdateTime)
 		}
 	}
 
@@ -146,8 +146,8 @@ func (api *RestAPI) BuildVehicleStatus(
 		if obaOrientation < 0 {
 			obaOrientation += 360
 		}
-		status.Orientation = float64(obaOrientation)
-		status.LastKnownOrientation = float64(obaOrientation)
+		status.Orientation = utils.Float64Ptr(float64(obaOrientation))
+		status.LastKnownOrientation = utils.Float64Ptr(float64(obaOrientation))
 	}
 
 	status.Status, status.Phase = GetVehicleStatusAndPhase(vehicle)

--- a/internal/restapi/vehicles_helper_test.go
+++ b/internal/restapi/vehicles_helper_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/OneBusAway/go-gtfs"
 	gtfsrt "github.com/OneBusAway/go-gtfs/proto"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"maglev.onebusaway.org/internal/models"
 )
 
@@ -272,10 +273,10 @@ func TestBuildVehicleStatus_BearingConversion(t *testing.T) {
 			status := &models.TripStatusForTripDetails{}
 			api.BuildVehicleStatus(ctx, vehicle, "any-trip", "any-agency", status, now)
 
-			assert.Equal(t, tt.expectedOrientation, status.Orientation,
-				"Orientation should be (90 - bearing) with wraparound")
-			assert.Equal(t, tt.expectedOrientation, status.LastKnownOrientation,
-				"LastKnownOrientation should match Orientation")
+			require.NotNil(t, status.Orientation)
+			require.NotNil(t, status.LastKnownOrientation)
+			assert.Equal(t, tt.expectedOrientation, *status.Orientation, "Orientation should be (90 - bearing) with wraparound")
+			assert.Equal(t, tt.expectedOrientation, *status.LastKnownOrientation, "LastKnownOrientation should match Orientation")
 		})
 	}
 }

--- a/internal/utils/api.go
+++ b/internal/utils/api.go
@@ -14,6 +14,19 @@ import (
 	"maglev.onebusaway.org/internal/models"
 )
 
+// Pointer helper functions for nullable JSON fields.
+// These are used to convert primitive values to pointers for fields that should
+// serialize as null when no data is available, matching Java OBA's nullable wrapper types.
+
+// IntPtr returns a pointer to the given int value.
+func IntPtr(v int) *int { return &v }
+
+// Int64Ptr returns a pointer to the given int64 value.
+func Int64Ptr(v int64) *int64 { return &v }
+
+// Float64Ptr returns a pointer to the given float64 value.
+func Float64Ptr(v float64) *float64 { return &v }
+
 func CalculateServiceDate(currentTime time.Time) time.Time {
 	year, month, day := currentTime.Date()
 	return time.Date(year, month, day, 0, 0, 0, 0, currentTime.Location())


### PR DESCRIPTION
### Description
This PR addresses a major serialization mismatch between the Go `maglev` server and the legacy Java server. Previously, nullable numeric fields (e.g., `scheduleDeviation`, `distanceAlongTrip`, `orientation`) were using primitive types (`int`, `float64`), causing them to default to `0` and explicitly serialize in the JSON response even when no real-time data was present.

### What Changed
- **Models:** Converted 11 nullable numeric fields across `TripStatusForTripDetails`, `ArrivalAndDeparture`, and `VehicleStatus` structs from primitive types to pointers (`*int`, `*float64`, `*int64`) combined with the `omitempty` tag.
- **Utils:** Added pointer helper functions (`IntPtr`, `Int64Ptr`, `Float64Ptr`) to cleanly assign pointer values without inline variable declarations.
- **Handlers/Helpers:** Updated `trips_helper.go` and `vehicles_helper.go` to use the new pointer models. Removed the `-1` sentinel value workarounds for fields like `OccupancyCount` and `OccupancyCapacity`.
- **Tests:** Updated assertions in `trips_helper_test.go` and `vehicles_helper_test.go` to safely dereference pointers and explicitly test for `nil` when no real-time data is available.

### Testing
- All unit tests have been updated and are successfully passing (`make test`).
- Verified that fields are correctly omitted from the JSON payload when uninitialized, fully restoring client-side parity.

<img width="1915" height="498" alt="image" src="https://github.com/user-attachments/assets/58f9ee1d-47ef-4f4c-a5d3-1548fd96ddbf" />

@aaronbrethorst 
fixes: #591 