### PR TITLE
fix: isolate pprof debug endpoints to loopback interface (Security)

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -231,10 +231,30 @@ make build
 
 # Start the debugger
 dlv --listen=:2345 --headless=true --api-version=2 --accept-multiclient exec ./bin/maglev
-
 ```
 
 This allows debugging in the GoLand IDE.
+
+### Profiling (pprof)
+
+Maglev includes built-in Go `pprof` endpoints for debugging memory leaks and CPU bottlenecks. For security reasons, these are completely disabled by default and are never exposed on the public API port.
+
+To enable the profiling server, set the following environment variable:
+
+```bash
+MAGLEV_ENABLE_PPROF=1
+```
+
+When enabled, the debug server will start strictly on the local loopback interface at `127.0.0.1:6060`.
+
+**Accessing in Production:**  
+To securely access the profiles on a remote production server, do not open the port to the internet. Instead, use an SSH tunnel:
+
+```bash
+ssh -L 6060:localhost:6060 your-user@production-server
+```
+
+You can then view the profiles locally in your browser at `http://localhost:6060/debug/pprof/`.
 
 ## SQL
 

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"flag"
 	"log/slog"
+	"net/http"
+	_ "net/http/pprof" // Auto-registers pprof handlers to http.DefaultServeMux
 	"os"
 	"os/signal"
 	"runtime"
@@ -17,6 +19,18 @@ func main() {
 	// From fix/496-gtfs-startup-retry: Graceful shutdown context
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
+
+	// Start isolated pprof server on localhost only
+	if os.Getenv("MAGLEV_ENABLE_PPROF") == "1" {
+		go func() {
+			logger := slog.New(slog.NewTextHandler(os.Stdout, nil)).With(slog.String("component", "pprof"))
+			logger.Warn("STARTING PPROF DEBUG SERVER ON localhost:6060 (NOT PUBLIC)")
+			// Listens ONLY on loopback interface using DefaultServeMux
+			if err := http.ListenAndServe("127.0.0.1:6060", nil); err != nil {
+				logger.Error("pprof debug server failed", "error", err)
+			}
+		}()
+	}
 
 	// From main: Mutex profiling configuration
 	if os.Getenv("MAGLEV_PROFILE_MUTEX") == "1" {

--- a/internal/restapi/routes.go
+++ b/internal/restapi/routes.go
@@ -2,8 +2,6 @@ package restapi
 
 import (
 	"net/http"
-	"net/http/pprof"
-	"os"
 
 	"maglev.onebusaway.org/internal/models"
 )
@@ -87,33 +85,8 @@ func withProtectedCombinedID(api *RestAPI, handler http.HandlerFunc) http.Handle
 	return api.validateProtectedAPIKey(rateLimitedHandler)
 }
 
-// registerPprofHandlers registers standard pprof handlers
-func registerPprofHandlers(mux *http.ServeMux) {
-	// These endpoints trigger active data collection or symbol resolution
-	mux.HandleFunc("GET /debug/pprof/", pprof.Index)
-	mux.HandleFunc("GET /debug/pprof/cmdline", pprof.Cmdline)
-	mux.HandleFunc("GET /debug/pprof/profile", pprof.Profile)
-	mux.HandleFunc("POST /debug/pprof/profile", pprof.Profile)
-	mux.HandleFunc("GET /debug/pprof/symbol", pprof.Symbol)
-	mux.HandleFunc("POST /debug/pprof/symbol", pprof.Symbol)
-	mux.HandleFunc("GET /debug/pprof/trace", pprof.Trace)
-
-	// These all route through pprof.Index, which automatically serves
-	// the correct profile based on the URL path
-	mux.HandleFunc("GET /debug/pprof/mutex", pprof.Index)
-	mux.HandleFunc("GET /debug/pprof/block", pprof.Index)
-	mux.HandleFunc("GET /debug/pprof/heap", pprof.Index)
-	mux.HandleFunc("GET /debug/pprof/goroutine", pprof.Index)
-	mux.HandleFunc("GET /debug/pprof/allocs", pprof.Index)
-}
-
 // SetRoutes registers all API endpoints with the provided mux
 func (api *RestAPI) SetRoutes(mux *http.ServeMux) {
-	// Gate pprof endpoints behind environment variable for security
-	if os.Getenv("MAGLEV_ENABLE_PPROF") == "1" {
-		registerPprofHandlers(mux)
-	}
-
 	// Health check endpoint - no authentication required
 	mux.HandleFunc("GET /healthz", api.healthHandler)
 


### PR DESCRIPTION
### Description

This PR resolves a critical security vulnerability where the `net/http/pprof` debugging endpoints were exposed without authentication on the public-facing API router when `MAGLEV_ENABLE_PPROF=1` was set.

Exposing these endpoints publicly introduces severe Denial of Service (DoS) risks (e.g., maxing out CPU via `?seconds=30` profile requests) and Information Disclosure risks (e.g., leaking environment variables and heap memory dumps).

This patch enforces **Network Isolation** by moving the profiling endpoints to a dedicated background HTTP server that binds exclusively to the local loopback interface (`127.0.0.1:6060`).

### Changes Made

* **`internal/restapi/routes.go`**: Removed the `net/http/pprof` import, deleted the `registerPprofHandlers` function, and stripped the `MAGLEV_ENABLE_PPROF` block from the public `SetRoutes` multiplexer.
* **`cmd/api/main.go`**: Introduced a new goroutine during startup (gated by `MAGLEV_ENABLE_PPROF=1`) that launches `http.ListenAndServe("127.0.0.1:6060", nil)`. This auto-registers the default pprof handlers but physically restricts network access to the host machine.
* **`README.markdown`**: Added a new "Profiling (pprof)" section under Debugging to officially document how engineers can securely access these endpoints in production using an SSH tunnel.

### Security Impact

By hardcoding the loopback IP (`127.0.0.1`), the OS-level network stack physically drops any external internet or local-network traffic attempting to reach port `6060`. This guarantees a "Secure by Default" posture that cannot be accidentally bypassed via misconfigured proxy routing or missing authentication middleware.

### How to Test / Verify

1. Pull this branch and run the application with profiling enabled: `MAGLEV_ENABLE_PPROF=1 make run`
2. **Verify Public API is Secure:** Attempt to access `http://localhost:4000/debug/pprof/` (or whatever your public port is). It should return a `404 Not Found`.
3. **Verify Local Access Works:** Attempt to access the isolated server at `http://127.0.0.1:6060/debug/pprof/`. The profiling dashboard should load successfully.
4. **Verify External Block (Optional):** If running on a networked machine or Docker, attempt to access `http://<your-lan-ip>:6060/debug/pprof/`. The connection should be entirely refused.

 Closes #596