### PR TITLE
fix: require lat/lon params in location endpoints

### DIFF
--- a/internal/restapi/routes_for_location_handler.go
+++ b/internal/restapi/routes_for_location_handler.go
@@ -12,8 +12,8 @@ import (
 func (api *RestAPI) routesForLocationHandler(w http.ResponseWriter, r *http.Request) {
 	queryParams := r.URL.Query()
 
-	lat, fieldErrors := utils.ParseFloatParam(queryParams, "lat", nil)
-	lon, _ := utils.ParseFloatParam(queryParams, "lon", fieldErrors)
+	lat, fieldErrors := utils.ParseRequiredFloatParam(queryParams, "lat", nil)
+	lon, _ := utils.ParseRequiredFloatParam(queryParams, "lon", fieldErrors)
 	radius, _ := utils.ParseFloatParam(queryParams, "radius", fieldErrors)
 	latSpan, _ := utils.ParseFloatParam(queryParams, "latSpan", fieldErrors)
 	lonSpan, _ := utils.ParseFloatParam(queryParams, "lonSpan", fieldErrors)

--- a/internal/restapi/routes_for_location_handler_test.go
+++ b/internal/restapi/routes_for_location_handler_test.go
@@ -239,3 +239,21 @@ func TestRoutesForLocationHandlerInRangeWithNoResults(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, 0, len(list))
 }
+
+func TestRoutesForLocationMissingLat(t *testing.T) {
+	_, resp, model := serveAndRetrieveEndpoint(t, "/api/where/routes-for-location.json?key=TEST&lon=-122.426966")
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	assert.Equal(t, http.StatusBadRequest, model.Code)
+}
+
+func TestRoutesForLocationMissingLon(t *testing.T) {
+	_, resp, model := serveAndRetrieveEndpoint(t, "/api/where/routes-for-location.json?key=TEST&lat=40.583321")
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	assert.Equal(t, http.StatusBadRequest, model.Code)
+}
+
+func TestRoutesForLocationMissingBothLatAndLon(t *testing.T) {
+	_, resp, model := serveAndRetrieveEndpoint(t, "/api/where/routes-for-location.json?key=TEST")
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	assert.Equal(t, http.StatusBadRequest, model.Code)
+}

--- a/internal/restapi/stops_for_location_handler.go
+++ b/internal/restapi/stops_for_location_handler.go
@@ -15,8 +15,8 @@ import (
 func (api *RestAPI) stopsForLocationHandler(w http.ResponseWriter, r *http.Request) {
 	queryParams := r.URL.Query()
 
-	lat, fieldErrors := utils.ParseFloatParam(queryParams, "lat", nil)
-	lon, _ := utils.ParseFloatParam(queryParams, "lon", fieldErrors)
+	lat, fieldErrors := utils.ParseRequiredFloatParam(queryParams, "lat", nil)
+	lon, _ := utils.ParseRequiredFloatParam(queryParams, "lon", fieldErrors)
 	radius, _ := utils.ParseFloatParam(queryParams, "radius", fieldErrors)
 	latSpan, _ := utils.ParseFloatParam(queryParams, "latSpan", fieldErrors)
 	lonSpan, _ := utils.ParseFloatParam(queryParams, "lonSpan", fieldErrors)

--- a/internal/restapi/stops_for_location_handler_test.go
+++ b/internal/restapi/stops_for_location_handler_test.go
@@ -347,3 +347,21 @@ func TestStopsForLocationQueryGlobalRadius(t *testing.T) {
 	require.True(t, ok)
 	assert.Len(t, list, 1, "Stop code query should find stops globally regardless of coordinates")
 }
+
+func TestStopsForLocationMissingLat(t *testing.T) {
+	_, resp, model := serveAndRetrieveEndpoint(t, "/api/where/stops-for-location.json?key=TEST&lon=-122.426966")
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	assert.Equal(t, http.StatusBadRequest, model.Code)
+}
+
+func TestStopsForLocationMissingLon(t *testing.T) {
+	_, resp, model := serveAndRetrieveEndpoint(t, "/api/where/stops-for-location.json?key=TEST&lat=40.583321")
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	assert.Equal(t, http.StatusBadRequest, model.Code)
+}
+
+func TestStopsForLocationMissingBothLatAndLon(t *testing.T) {
+	_, resp, model := serveAndRetrieveEndpoint(t, "/api/where/stops-for-location.json?key=TEST")
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	assert.Equal(t, http.StatusBadRequest, model.Code)
+}

--- a/internal/restapi/trips_for_location_handler.go
+++ b/internal/restapi/trips_for_location_handler.go
@@ -126,8 +126,8 @@ func (api *RestAPI) parseAndValidateRequest(r *http.Request) (
 ) {
 	queryParams := r.URL.Query()
 
-	lat, fieldErrors = utils.ParseFloatParam(queryParams, "lat", nil)
-	lon, _ = utils.ParseFloatParam(queryParams, "lon", fieldErrors)
+	lat, fieldErrors = utils.ParseRequiredFloatParam(queryParams, "lat", nil)
+	lon, _ = utils.ParseRequiredFloatParam(queryParams, "lon", fieldErrors)
 	latSpan, _ = utils.ParseFloatParam(queryParams, "latSpan", fieldErrors)
 	lonSpan, _ = utils.ParseFloatParam(queryParams, "lonSpan", fieldErrors)
 	includeTrip = queryParams.Get("includeTrip") == "true"
@@ -145,7 +145,12 @@ func (api *RestAPI) parseAndValidateRequest(r *http.Request) (
 	currentTime := api.Clock.Now().In(currentLocation)
 	todayMidnight = time.Date(currentTime.Year(), currentTime.Month(), currentTime.Day(), 0, 0, 0, 0, currentLocation)
 
-	_, serviceDate, fieldErrors, success := utils.ParseTimeParameter(timeParam, currentLocation)
+	var timeFieldErrors map[string][]string
+	var success bool
+	_, serviceDate, timeFieldErrors, success = utils.ParseTimeParameter(timeParam, currentLocation)
+	for k, v := range timeFieldErrors {
+		fieldErrors[k] = append(fieldErrors[k], v...)
+	}
 
 	ctx := r.Context()
 	if ctx.Err() != nil {
@@ -159,14 +164,8 @@ func (api *RestAPI) parseAndValidateRequest(r *http.Request) (
 	}
 
 	locationErrors := utils.ValidateLocationParams(lat, lon, 0, latSpan, lonSpan)
-	if len(locationErrors) > 0 {
-		if fieldErrors == nil {
-			fieldErrors = locationErrors
-		} else {
-			for k, v := range locationErrors {
-				fieldErrors[k] = append(fieldErrors[k], v...)
-			}
-		}
+	for k, v := range locationErrors {
+		fieldErrors[k] = append(fieldErrors[k], v...)
 	}
 
 	if len(fieldErrors) > 0 {

--- a/internal/restapi/trips_for_location_handler_test.go
+++ b/internal/restapi/trips_for_location_handler_test.go
@@ -237,3 +237,21 @@ func TestTripsForLocationHandler_ScheduleInclusion(t *testing.T) {
 		})
 	}
 }
+
+func TestTripsForLocationMissingLat(t *testing.T) {
+	_, resp, model := serveAndRetrieveEndpoint(t, "/api/where/trips-for-location.json?key=TEST&lon=-122.426966&latSpan=0.01&lonSpan=0.01")
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	assert.Equal(t, http.StatusBadRequest, model.Code)
+}
+
+func TestTripsForLocationMissingLon(t *testing.T) {
+	_, resp, model := serveAndRetrieveEndpoint(t, "/api/where/trips-for-location.json?key=TEST&lat=40.583321&latSpan=0.01&lonSpan=0.01")
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	assert.Equal(t, http.StatusBadRequest, model.Code)
+}
+
+func TestTripsForLocationMissingBothLatAndLon(t *testing.T) {
+	_, resp, model := serveAndRetrieveEndpoint(t, "/api/where/trips-for-location.json?key=TEST&latSpan=0.01&lonSpan=0.01")
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	assert.Equal(t, http.StatusBadRequest, model.Code)
+}

--- a/internal/utils/api.go
+++ b/internal/utils/api.go
@@ -150,6 +150,26 @@ func ParseFloatParam(params url.Values, key string, fieldErrors map[string][]str
 	return f, fieldErrors
 }
 
+func ParseRequiredFloatParam(params url.Values, key string, fieldErrors map[string][]string) (float64, map[string][]string) {
+	if fieldErrors == nil {
+		fieldErrors = make(map[string][]string)
+	}
+
+	val := params.Get(key)
+	if val == "" {
+		fieldErrors[key] = append(fieldErrors[key], fmt.Sprintf("Missing required field %q.", key))
+		return 0, fieldErrors
+	}
+
+	f, err := strconv.ParseFloat(val, 64)
+	if err != nil {
+		fieldErrors[key] = append(fieldErrors[key], fmt.Sprintf("Invalid field value for field %q.", key))
+		return 0, fieldErrors
+	}
+	return f, fieldErrors
+
+}
+
 func ParseTimeParameter(timeParam string, currentLocation *time.Location) (string, time.Time, map[string][]string, bool) {
 	if timeParam == "" {
 		// No time parameter, use current date

--- a/internal/utils/api_test.go
+++ b/internal/utils/api_test.go
@@ -976,3 +976,37 @@ func TestValidateNumericParam(t *testing.T) {
 		})
 	}
 }
+
+func TestParseRequiredFloatParam(t *testing.T) {
+	t.Run("missing key returns error", func(t *testing.T) {
+		params := url.Values{}
+		val, fieldErrors := ParseRequiredFloatParam(params, "lat", nil)
+		assert.Equal(t, float64(0), val)
+		assert.Contains(t, fieldErrors["lat"][0], "Missing required field")
+	})
+	t.Run("present valid value is parsed correctly", func(t *testing.T) {
+		params := url.Values{"lat": []string{"40.583321"}}
+		val, fieldErrors := ParseRequiredFloatParam(params, "lat", nil)
+		assert.Equal(t, 40.583321, val)
+		assert.Empty(t, fieldErrors)
+	})
+	t.Run("present invalid value adds parse error", func(t *testing.T) {
+		params := url.Values{"lat": []string{"not-a-float"}}
+		val, fieldErrors := ParseRequiredFloatParam(params, "lat", nil)
+		assert.Equal(t, float64(0), val)
+		assert.Contains(t, fieldErrors["lat"][0], "Invalid field value")
+	})
+	t.Run("explicit zero is accepted (not treated as missing)", func(t *testing.T) {
+		params := url.Values{"lat": []string{"0.0"}}
+		val, fieldErrors := ParseRequiredFloatParam(params, "lat", nil)
+		assert.Equal(t, float64(0), val)
+		assert.Empty(t, fieldErrors)
+	})
+	t.Run("existing fieldErrors are preserved", func(t *testing.T) {
+		params := url.Values{}
+		existing := map[string][]string{"other": {"some error"}}
+		_, fieldErrors := ParseRequiredFloatParam(params, "lat", existing)
+		assert.Contains(t, fieldErrors["lat"][0], "Missing required field")
+		assert.Equal(t, []string{"some error"}, fieldErrors["other"])
+	})
+}


### PR DESCRIPTION
## Problem

All three location endpoints (`stops-for-location`, `routes-for-location`, `trips-for-location`) accepted requests without `lat` and/or `lon` and responded with **200 OK** with an empty list. The server was silently querying **(0°N, 0°E)**.

Root cause: `ParseFloatParam` returns `0.0` with no error when a key is absent, and coordinate range validation accepts `0.0` as valid.

The `trips` handler had a compounding bugs in `parseAndValidateRequest`:
- `ParseTimeParameter` was reassigning `fieldErrors` with `:=`, clobbering any `lat`/`lon` errors collected before it.

---

## Changes

### `api.go`

- Add `ParseRequiredFloatParam` — identical to `ParseFloatParam` except it adds a **"Missing required field"** error when the key is absent entirely.
- Explicit `"0.0"` is still accepted.

### `stops_for_location_handler.go` & `routes_for_location_handler.go`

- Replace `ParseFloatParam` with `ParseRequiredFloatParam` for **lat** and **lon** only.
- `radius`, `latSpan`, `lonSpan` remain optional (defaulting to `0` is intentional for these).

### `trips_for_location_handler.go`

- Same `ParseRequiredFloatParam` switch for `lat`/`lon` in `parseAndValidateRequest`.
- Fix `ParseTimeParameter` call from `:=` to `=` with a separate `timeFieldErrors` variable that is merged into `fieldErrors` — prevents clobbering `lat`/`lon` errors.
- Simplify subsequent nil-guard boilerplate now that `fieldErrors` is always initialised.

### `api_test.go`

Unit tests for `ParseRequiredFloatParam`:
- missing key
- valid value
- invalid value
- explicit zero
- error propagation

### `stops_for_location_handler_test.go`  , `routes_for_location_handler_test.go`  & `trips_for_location_handler_test.go`

Three tests per handler:
- missing `lat`
- missing `lon`
- missing both

---

## All tests passed

```bash
make fmt
make lint
make test
```

### Fixes #595 