### PR TITLE
feat: add request body and header size limits to the API server.

### DIFF
--- a/cmd/api/app.go
+++ b/cmd/api/app.go
@@ -153,18 +153,21 @@ func CreateServer(coreApp *app.Application, cfg appconf.Config) (*http.Server, *
 	requestLogger := logging.NewStructuredLogger(os.Stdout, slog.LevelInfo)
 	requestLogMiddleware := restapi.NewRequestLoggingMiddleware(requestLogger)
 
+	sizeLimitMiddleware := restapi.SizeLimitMiddleware(1 << 20) // 1 MB limit
+
 	// Panic recovery outermost so all handler panics are caught
 	handler := restapi.NewRecoveryMiddleware(coreApp.Logger, coreApp.Clock)(
-		restapi.RequestIDMiddleware(requestLogMiddleware(metricsHandler)),
+		sizeLimitMiddleware(restapi.RequestIDMiddleware(requestLogMiddleware(metricsHandler))),
 	)
 
 	srv := &http.Server{
-		Addr:         fmt.Sprintf(":%d", cfg.Port),
-		Handler:      handler,
-		IdleTimeout:  time.Minute,
-		ReadTimeout:  5 * time.Second,
-		WriteTimeout: 10 * time.Second,
-		ErrorLog:     slog.NewLogLogger(coreApp.Logger.Handler(), slog.LevelError),
+		Addr:           fmt.Sprintf(":%d", cfg.Port),
+		Handler:        handler,
+		IdleTimeout:    time.Minute,
+		ReadTimeout:    5 * time.Second,
+		WriteTimeout:   10 * time.Second,
+		MaxHeaderBytes: 1 << 20, // 1 MB
+		ErrorLog:       slog.NewLogLogger(coreApp.Logger.Handler(), slog.LevelError),
 	}
 
 	return srv, api

--- a/internal/restapi/size_limit_middleware.go
+++ b/internal/restapi/size_limit_middleware.go
@@ -1,0 +1,15 @@
+package restapi
+
+import (
+	"net/http"
+)
+
+// SizeLimitMiddleware wraps the given handler with a maximum request body size limit.
+func SizeLimitMiddleware(limitBytes int64) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			r.Body = http.MaxBytesReader(w, r.Body, limitBytes)
+			next.ServeHTTP(w, r)
+		})
+	}
+}

--- a/internal/restapi/size_limit_middleware_test.go
+++ b/internal/restapi/size_limit_middleware_test.go
@@ -1,0 +1,55 @@
+package restapi
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSizeLimitMiddleware_WithinLimit(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		assert.NoError(t, err)
+		assert.Equal(t, "hello world", string(body))
+		w.WriteHeader(http.StatusOK)
+	})
+
+	middleware := SizeLimitMiddleware(1 << 20) // 1MB limit
+	wrappedHandler := middleware(handler)
+
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader("hello world"))
+	w := httptest.NewRecorder()
+
+	wrappedHandler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestSizeLimitMiddleware_ExceedsLimit(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, err := io.ReadAll(r.Body)
+		// io.ReadAll should return an error when the limit is exceeded
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "request body too large")
+		
+	})
+
+	limit := int64(10)
+	middleware := SizeLimitMiddleware(limit)
+	wrappedHandler := middleware(handler)
+
+	payload := make([]byte, 20)
+	for i := range payload {
+		payload[i] = 'a'
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(payload))
+	w := httptest.NewRecorder()
+
+	wrappedHandler.ServeHTTP(w, req)
+}


### PR DESCRIPTION
## Description
This PR addresses issue #600 

### Changes
*   **Set `MaxHeaderBytes`**: Explicitly limited the `http.Server` header size to 1 MB in `cmd/api/app.go` to prevent HTTP header allocation attacks.
*   **Added `SizeLimitMiddleware`**: Introduced a new generic middleware (`internal/restapi/size_limit_middleware.go`) that applies `http.MaxBytesReader` to wrap all incoming request bodies with a 1 MB limit. 
*   **Added Size Limit Tests**: Implemented test coverage in `size_limit_middleware_test.go` to verify appropriate handling of payloads both below and above the size threshold.
*   **Globally Applied Middleware**: Wrapped the main server handler with `SizeLimitMiddleware` in `cmd/api/app.go`, guaranteeing that all API endpoints inherently restrict excessive body data.

