### PR TITLE
feat: add rate limit headers to successful responses (#603)

### DIFF
--- a/internal/restapi/rate_limit_middleware.go
+++ b/internal/restapi/rate_limit_middleware.go
@@ -142,7 +142,11 @@ func (rl *RateLimitMiddleware) rateLimitHandler(next http.Handler) http.Handler 
 
 		// rate limit headers for successful requests
 		w.Header().Set("X-RateLimit-Limit", strconv.Itoa(rl.burstSize))
-		w.Header().Set("X-RateLimit-Remaining", strconv.Itoa(int(math.Floor(limiter.Tokens()))))
+		remaining := int(math.Floor(limiter.Tokens()))
+		if remaining < 0 {
+			remaining = 0
+		}
+		w.Header().Set("X-RateLimit-Remaining", strconv.Itoa(remaining))
 
 		// Request is allowed, continue to next handler
 		next.ServeHTTP(w, r)

--- a/internal/restapi/rate_limit_middleware_test.go
+++ b/internal/restapi/rate_limit_middleware_test.go
@@ -28,7 +28,8 @@ func TestNewRateLimitMiddleware(t *testing.T) {
 }
 
 func TestRateLimitMiddleware_AllowsRequestsWithinLimit(t *testing.T) {
-	middleware := initRateLimitMiddleware(5, time.Second)
+	mockClock := clock.NewMockClock(time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC))
+	middleware := NewRateLimitMiddleware(5, time.Second, nil, mockClock)
 	defer middleware.Stop()
 
 	// Create a simple handler that responds with 200
@@ -54,7 +55,9 @@ func TestRateLimitMiddleware_AllowsRequestsWithinLimit(t *testing.T) {
 		assert.NotEmpty(t, remainingStr, "Should set X-RateLimit-Remaining")
 		remaining, err := strconv.Atoi(remainingStr)
 		assert.NoError(t, err)
-		assert.True(t, remaining >= 0 && remaining <= 5, "Remaining tokens should be between 0 and 5, got %d", remaining)
+
+		expectedRemaining := 5 - (i + 1)
+		assert.Equal(t, expectedRemaining, remaining, "Remaining tokens should decrease deterministically")
 	}
 }
 
@@ -343,6 +346,8 @@ func TestRateLimitMiddleware_RateLimitedResponseFormat(t *testing.T) {
 
 	// Check for rate limit headers
 	assert.NotEmpty(t, w.Header().Get("Retry-After"), "Should include Retry-After header")
+	assert.Equal(t, "1", w.Header().Get("X-RateLimit-Limit"), "Should include X-RateLimit-Limit header")
+	assert.Equal(t, "0", w.Header().Get("X-RateLimit-Remaining"), "Should include X-RateLimit-Remaining header")
 
 	// Check response body format
 	var responseBody map[string]interface{}


### PR DESCRIPTION
## Description
This PR addresses issue Closes #603

### Changes
* Added `X-RateLimit-Limit` and `X-RateLimit-Remaining` headers to successful API responses in the rate limit middleware.
* Added test cases to verify the new rate limit headers are correctly set on successful (HTTP 200) requests.
