### PR TITLE
feat: add configurable logging options for log level and format

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -89,6 +89,8 @@ Example `config.json`:
   "env": "production",
   "api-keys": ["key1", "key2", "key3"],
   "rate-limit": 50,
+  "log-level": "info",
+  "log-format": "json",
   "gtfs-static-feed": {
     "url": "https://example.com/gtfs.zip",
     "auth-header-name": "Authorization",
@@ -116,7 +118,6 @@ Example `config.json`:
   ],
   "data-path": "/data/gtfs.db"
 }
-
 ```
 
 **Note:** The `-f` flag is mutually exclusive with other command-line flags. If you use `-f`, all other configuration flags will be ignored. The system will error if you try to use both.
@@ -146,30 +147,32 @@ A JSON schema file is provided at `config.schema.json` for IDE autocomplete and 
 
 ### Configuration Options
 
-| Option | Type | Default | Description |
-| --- | --- | --- | --- |
-| `port` | integer | 4000 | API server port |
-| `env` | string | "development" | Environment (development, test, production) |
-| `api-keys` | array | ["test"] | API keys for authentication |
-| `rate-limit` | integer | 100 | Requests per second per API key |
-| `gtfs-static-feed` | object | (Sound Transit) | Static GTFS feed configuration |
-| `gtfs-rt-feeds` | array | (Sound Transit) | GTFS-RT feed configurations (see below) |
-| `data-path` | string | "./gtfs.db" | Path to SQLite database |
+| Option             | Type    | Default         | Description                                 |
+| ------------------ | ------- | --------------- | ------------------------------------------- |
+| `port`             | integer | 4000            | API server port                             |
+| `env`              | string  | "development"   | Environment (development, test, production) |
+| `api-keys`         | array   | ["test"]        | API keys for authentication                 |
+| `log-level`        | string  | "info"          | Log level (debug, info, warn, error)        |
+| `log-format`       | string  | "text"          | Log format (text, json)                     |
+| `rate-limit`       | integer | 100             | Requests per second per API key             |
+| `gtfs-static-feed` | object  | (Sound Transit) | Static GTFS feed configuration              |
+| `gtfs-rt-feeds`    | array   | (Sound Transit) | GTFS-RT feed configurations (see below)     |
+| `data-path`        | string  | "./gtfs.db"     | Path to SQLite database                     |
 
 #### GTFS-RT Feed Options
 
 Each entry in the `gtfs-rt-feeds` array supports:
 
-| Field | Type | Default | Description |
-| --- | --- | --- | --- |
-| `id` | string | auto (`"feed-0"`, `"feed-1"`, …) | Unique identifier for the feed, used in logs and internal data partitioning |
-| `agency-ids` | array | `[]` | When set, only realtime data (trips, vehicles, alerts) belonging to the listed agency IDs is included. Data for other agencies in the same feed is filtered out. Agencies are resolved via route→agency mapping from the static GTFS data. |
-| `trip-updates-url` | string | `""` | URL for GTFS-RT trip updates protobuf |
-| `vehicle-positions-url` | string | `""` | URL for GTFS-RT vehicle positions protobuf |
-| `service-alerts-url` | string | `""` | URL for GTFS-RT service alerts protobuf |
-| `headers` | object | `{}` | HTTP headers sent with every request to this feed |
-| `refresh-interval` | integer | `30` | Polling interval in seconds |
-| `enabled` | boolean | `true` | Set to `false` to disable polling without removing the entry |
+| Field                   | Type    | Default                          | Description                                                                                                                                                                                                                                |
+| ----------------------- | ------- | -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `id`                    | string  | auto (`"feed-0"`, `"feed-1"`, …) | Unique identifier for the feed, used in logs and internal data partitioning                                                                                                                                                                |
+| `agency-ids`            | array   | `[]`                             | When set, only realtime data (trips, vehicles, alerts) belonging to the listed agency IDs is included. Data for other agencies in the same feed is filtered out. Agencies are resolved via route→agency mapping from the static GTFS data. |
+| `trip-updates-url`      | string  | `""`                             | URL for GTFS-RT trip updates protobuf                                                                                                                                                                                                      |
+| `vehicle-positions-url` | string  | `""`                             | URL for GTFS-RT vehicle positions protobuf                                                                                                                                                                                                 |
+| `service-alerts-url`    | string  | `""`                             | URL for GTFS-RT service alerts protobuf                                                                                                                                                                                                    |
+| `headers`               | object  | `{}`                             | HTTP headers sent with every request to this feed                                                                                                                                                                                          |
+| `refresh-interval`      | integer | `30`                             | Polling interval in seconds                                                                                                                                                                                                                |
+| `enabled`               | boolean | `true`                           | Set to `false` to disable polling without removing the entry                                                                                                                                                                               |
 
 A feed must have at least one URL (`trip-updates-url`, `vehicle-positions-url`, or `service-alerts-url`) to be activated. Each feed runs its own independent polling goroutine. Data from all enabled feeds is merged into a single unified view for the API.
 
@@ -331,15 +334,15 @@ make docker-compose-dev
 
 ### Docker Make Targets
 
-| Command | Description |
-| --- | --- |
-| `make docker-build` | Build the Docker image |
-| `make docker-run` | Build and run the container |
-| `make docker-stop` | Stop and remove the container |
-| `make docker-compose-up` | Start with Docker Compose |
-| `make docker-compose-down` | Stop Docker Compose services |
-| `make docker-compose-dev` | Start development environment |
-| `make docker-clean` | Remove all Docker artifacts |
+| Command                    | Description                   |
+| -------------------------- | ----------------------------- |
+| `make docker-build`        | Build the Docker image        |
+| `make docker-run`          | Build and run the container   |
+| `make docker-stop`         | Stop and remove the container |
+| `make docker-compose-up`   | Start with Docker Compose     |
+| `make docker-compose-down` | Stop Docker Compose services  |
+| `make docker-compose-dev`  | Start development environment |
+| `make docker-clean`        | Remove all Docker artifacts   |
 
 ### Data Persistence
 
@@ -438,15 +441,14 @@ docker inspect --format='{{.State.Health.Status}}' maglev
 # In docker-compose.yml or docker-compose.dev.yml
 environment:
   - HEALTH_CHECK_KEY=your-api-key
-
 ```
 
 ### Environment Variables
 
-| Variable | Description | Default |
-| --- | --- | --- |
-| `TZ` | Timezone for the container | `UTC` |
-| `HEALTH_CHECK_KEY` | API key used for health check endpoint | `test` |
+| Variable           | Description                            | Default |
+| ------------------ | -------------------------------------- | ------- |
+| `TZ`               | Timezone for the container             | `UTC`   |
+| `HEALTH_CHECK_KEY` | API key used for health check endpoint | `test`  |
 
 ### Troubleshooting
 

--- a/cmd/api/app.go
+++ b/cmd/api/app.go
@@ -64,11 +64,35 @@ func ParseAPIKeys(apiKeysFlag string) []string {
 	return keys
 }
 
+func parseLogLevel(level string) slog.Level {
+	switch strings.ToLower(strings.TrimSpace(level)) {
+	case "debug":
+		return slog.LevelDebug
+	case "info":
+		return slog.LevelInfo
+	case "warn":
+		return slog.LevelWarn
+	case "error":
+		return slog.LevelError
+	default:
+		return slog.LevelInfo
+	}
+}
+
+func newLogHandler(format string, level slog.Level) slog.Handler {
+	opts := &slog.HandlerOptions{Level: level}
+	if strings.EqualFold(format, "json") {
+		return slog.NewJSONHandler(os.Stdout, opts)
+	}
+	return slog.NewTextHandler(os.Stdout, opts)
+}
+
 // BuildApplication creates and initializes the Application with all dependencies.
 // This includes creating the logger, initializing the GTFS manager, and creating the direction calculator.
 // Returns an error if GTFS manager initialization fails.
 func BuildApplication(ctx context.Context, cfg appconf.Config, gtfsCfg gtfs.Config) (*app.Application, error) {
-	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	level := parseLogLevel(cfg.LogLevel)
+	logger := slog.New(newLogHandler(cfg.LogFormat, level))
 
 	appMetrics := metrics.NewWithLogger(logger)
 	gtfsCfg.Metrics = appMetrics
@@ -144,9 +168,8 @@ func CreateServer(coreApp *app.Application, cfg appconf.Config) (*http.Server, *
 	// Add metrics middleware
 	metricsHandler := restapi.MetricsHandler(coreApp.Metrics)(secureHandler)
 
-	// Add request logging middleware
-	requestLogger := logging.NewStructuredLogger(os.Stdout, slog.LevelInfo)
-	requestLogMiddleware := restapi.NewRequestLoggingMiddleware(requestLogger)
+	// Add request logging middleware (outermost)
+	requestLogMiddleware := restapi.NewRequestLoggingMiddleware(coreApp.Logger)
 
 	sizeLimitMiddleware := restapi.SizeLimitMiddleware(1 << 20) // 1 MB limit
 

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -158,6 +158,8 @@ func main() {
 		// Set verbosity flags (CLI specific)
 		gtfsCfg.Verbose = true
 		cfg.Verbose = true
+		cfg.LogLevel = "info"
+		cfg.LogFormat = "text"
 	}
 
 	// Handle dump-config flag

--- a/config.example.json
+++ b/config.example.json
@@ -12,6 +12,8 @@
     "org.onebusaway.iphone"
   ],
   "rate-limit": 100,
+  "log-level": "info",
+  "log-format": "text",
   "gtfs-static-feed": {
     "url": "https://www.soundtransit.org/GTFS-rail/40_gtfs.zip",
     "enable-gtfs-tidy": false

--- a/config.schema.json
+++ b/config.schema.json
@@ -29,6 +29,18 @@
       "uniqueItems": true,
       "minItems": 1
     },
+    "log-level": {
+      "type": "string",
+      "description": "Log Level (debug|info|warn|error)",
+      "enum": ["debug", "info", "warn", "error"],
+      "default": "info"
+    },
+    "log-format": {
+      "type": "string",
+      "description": "Format of logging output (text|json)",
+      "enum": ["text", "json"],
+      "default": "text"
+    },
     "protected-api-keys": {
       "type": "array",
       "description": "Protected API keys for sensitive endpoints",

--- a/internal/appconf/config.go
+++ b/internal/appconf/config.go
@@ -13,6 +13,8 @@ type Config struct {
 	ExemptApiKeys    []string
 	Verbose          bool
 	RateLimit        int // Requests per second per API key for rate limiting
+	LogLevel         string
+	LogFormat        string
 }
 
 // Environment is an enumerated type representing various stages or configurations in the system's lifecycle.

--- a/internal/appconf/json_config.go
+++ b/internal/appconf/json_config.go
@@ -42,6 +42,8 @@ type JSONConfig struct {
 	GtfsStaticFeed   GtfsStaticFeed `json:"gtfs-static-feed"`
 	GtfsRtFeeds      []GtfsRtFeed   `json:"gtfs-rt-feeds"`
 	DataPath         string         `json:"data-path"`
+	LogLevel         string         `json:"log-level"`
+	LogFormat        string         `json:"log-format"`
 }
 
 // setDefaults applies default values to the JSON config if fields are missing or zero
@@ -77,6 +79,12 @@ func (j *JSONConfig) setDefaults() {
 	}
 	if j.DataPath == "" {
 		j.DataPath = "./gtfs.db"
+	}
+	if j.LogLevel == "" {
+		j.LogLevel = "info"
+	}
+	if j.LogFormat == "" {
+		j.LogFormat = "text"
 	}
 }
 
@@ -129,6 +137,24 @@ func (j *JSONConfig) Validate() error {
 			return fmt.Errorf("duplicate protected API key found: %q", key)
 		}
 		seenProtected[key] = true
+	}
+
+	validLogLevels := map[string]bool{
+		"debug": true,
+		"info":  true,
+		"warn":  true,
+		"error": true,
+	}
+	if !validLogLevels[j.LogLevel] {
+		return fmt.Errorf("log level must be one of [debug, info, warn, error], got %q", j.LogLevel)
+	}
+
+	validLogFormats := map[string]bool{
+		"text": true,
+		"json": true,
+	}
+	if !validLogFormats[j.LogFormat] {
+		return fmt.Errorf("log format must be one of [text, json], got %q", j.LogFormat)
 	}
 
 	// Validate DataPath for path traversal attempts
@@ -202,6 +228,8 @@ func (j *JSONConfig) ToAppConfig() Config {
 		ExemptApiKeys:    j.ExemptApiKeys,
 		Verbose:          true, // Always set to true like in main.go
 		RateLimit:        j.RateLimit,
+		LogLevel:         j.LogLevel,
+		LogFormat:        j.LogFormat,
 	}
 }
 
@@ -351,6 +379,14 @@ func LoadFromFile(path string) (*JSONConfig, error) {
 		}
 	}
 
+	// Override logging level and format
+	if logLevel := strings.TrimSpace(os.Getenv("MAGLEV_LOG_LEVEL")); logLevel != "" {
+		config.LogLevel = strings.ToLower(logLevel)
+	}
+	if logFormat := strings.TrimSpace(os.Getenv("MAGLEV_LOG_FORMAT")); logFormat != "" {
+		config.LogFormat = strings.ToLower(logFormat)
+	}
+
 	// Override Protected API Keys
 	if envProtectedKeys := os.Getenv("GTFS_PROTECTED_API_KEYS"); envProtectedKeys != "" {
 		rawKeys := strings.Split(envProtectedKeys, ",")
@@ -401,7 +437,9 @@ func LoadFromFile(path string) (*JSONConfig, error) {
 		"port", config.Port,
 		"env", config.Env,
 		"api_keys_count", len(config.ApiKeys),
-		"rate_limit", config.RateLimit)
+		"rate_limit", config.RateLimit,
+		"log_level", config.LogLevel,
+		"log_format", config.LogFormat)
 
 	return &config, nil
 }

--- a/internal/appconf/json_config_test.go
+++ b/internal/appconf/json_config_test.go
@@ -23,6 +23,8 @@ func TestLoadFromFile_ValidConfig(t *testing.T) {
 	assert.Equal(t, "https://www.soundtransit.org/GTFS-rail/40_gtfs.zip", config.GtfsStaticFeed.URL)
 	assert.Equal(t, "./gtfs.db", config.DataPath)
 	assert.Len(t, config.GtfsRtFeeds, 1)
+	assert.Equal(t, "info", config.LogLevel)
+	assert.Equal(t, "text", config.LogFormat)
 }
 
 func TestLoadFromFile_FullConfig(t *testing.T) {
@@ -36,6 +38,8 @@ func TestLoadFromFile_FullConfig(t *testing.T) {
 	assert.Equal(t, []string{"key1", "key2", "key3"}, config.ApiKeys)
 	assert.Equal(t, []string{"protected-key-1", "protected-key-2"}, config.ProtectedApiKeys)
 	assert.Equal(t, 50, config.RateLimit)
+	assert.Equal(t, "debug", config.LogLevel)
+	assert.Equal(t, "json", config.LogFormat)
 	assert.Equal(t, "https://example.com/gtfs.zip", config.GtfsStaticFeed.URL)
 	assert.Equal(t, "Authorization", config.GtfsStaticFeed.AuthHeaderName)
 	assert.Equal(t, "Bearer token456", config.GtfsStaticFeed.AuthHeaderValue)
@@ -122,6 +126,40 @@ func TestValidate_InvalidRateLimit(t *testing.T) {
 	err := config.Validate()
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "rate-limit must be at least 1")
+}
+
+func TestValidate_InvalidLogLevel(t *testing.T) {
+	config := &JSONConfig{
+		Port:             4000,
+		Env:              "development",
+		ApiKeys:          []string{"test"},
+		ProtectedApiKeys: []string{"test"},
+		RateLimit:        1,
+		LogLevel:         "other",
+		LogFormat:        "text",
+		DataPath:         "./gtfs.db",
+	}
+
+	err := config.Validate()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "log level must be one of")
+}
+
+func TestValidate_InvalidLogFormat(t *testing.T) {
+	config := &JSONConfig{
+		Port:             4000,
+		Env:              "development",
+		ApiKeys:          []string{"test"},
+		ProtectedApiKeys: []string{"test"},
+		RateLimit:        1,
+		LogLevel:         "info",
+		LogFormat:        "other",
+		DataPath:         "./gtfs.db",
+	}
+
+	err := config.Validate()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "log format must be one of")
 }
 
 func TestValidate_EmptyApiKeys(t *testing.T) {
@@ -338,6 +376,8 @@ func TestValidate_PathTraversalDataPath(t *testing.T) {
 				ProtectedApiKeys: []string{"test"},
 				RateLimit:        100,
 				DataPath:         tt.dataPath,
+				LogLevel:         "info",
+				LogFormat:        "text",
 			}
 			err := config.Validate()
 			if tt.shouldErr {
@@ -372,6 +412,8 @@ func TestValidate_FileURLNotAllowed(t *testing.T) {
 				GtfsStaticFeed: GtfsStaticFeed{
 					URL: tt.gtfsURL,
 				},
+				LogLevel:  "info",
+				LogFormat: "text",
 			}
 			err := config.Validate()
 			assert.Error(t, err)
@@ -408,6 +450,8 @@ func TestValidate_PathTraversalGtfsURL(t *testing.T) {
 				GtfsStaticFeed: GtfsStaticFeed{
 					URL: tt.gtfsURL,
 				},
+				LogLevel:  "info",
+				LogFormat: "text",
 			}
 			err := config.Validate()
 			if tt.shouldErr {
@@ -442,7 +486,9 @@ func TestValidate_ValidAbsolutePaths(t *testing.T) {
 				GtfsStaticFeed: GtfsStaticFeed{
 					URL: tt.gtfsURL,
 				},
-				DataPath: "./gtfs.db",
+				DataPath:  "./gtfs.db",
+				LogLevel:  "info",
+				LogFormat: "text",
 			}
 			err := config.Validate()
 			if tt.valid {
@@ -480,7 +526,9 @@ func TestValidate_PartialAuthHeaders(t *testing.T) {
 					AuthHeaderName:  tt.authName,
 					AuthHeaderValue: tt.authValue,
 				},
-				DataPath: "./gtfs.db",
+				DataPath:  "./gtfs.db",
+				LogLevel:  "info",
+				LogFormat: "text",
 			}
 			err := config.Validate()
 			if tt.shouldError {
@@ -543,6 +591,8 @@ func TestLoadFromFile_EnvVarOverrides(t *testing.T) {
 		t.Setenv("GTFS_STATIC_AUTH_VALUE", "env-static-secret")
 		t.Setenv("GTFS_REALTIME_AUTH_NAME", "X-Env-RT")
 		t.Setenv("GTFS_REALTIME_AUTH_VALUE", "env-rt-secret")
+		t.Setenv("MAGLEV_LOG_LEVEL", "debug")
+		t.Setenv("MAGLEV_LOG_FORMAT", "json")
 
 		config, err := LoadFromFile(tmpFile.Name())
 		require.NoError(t, err)
@@ -555,6 +605,8 @@ func TestLoadFromFile_EnvVarOverrides(t *testing.T) {
 		require.NotEmpty(t, config.GtfsRtFeeds)
 		assert.Equal(t, "X-Env-RT", config.GtfsRtFeeds[0].RealTimeAuthHeaderName)
 		assert.Equal(t, "env-rt-secret", config.GtfsRtFeeds[0].RealTimeAuthHeaderValue)
+		assert.Equal(t, "debug", config.LogLevel)
+		assert.Equal(t, "json", config.LogFormat)
 	})
 
 	t.Run("Parsing Edge Cases - Spaces and Empty Segments", func(t *testing.T) {

--- a/testdata/config_full.json
+++ b/testdata/config_full.json
@@ -17,6 +17,8 @@
     "auth-header-name": "Authorization",
     "auth-header-value": "Bearer token456"
   },
+  "log-level": "debug",
+  "log-format": "json",
   "gtfs-rt-feeds": [
     {
       "trip-updates-url": "https://api.example.com/trip-updates.pb",


### PR DESCRIPTION
This PR aims to address the enhancement in #601 .

## Key Changes
- Added configurable `log-level` (`debug|info|warn|error`, default `info`) and `log-format` (`text|json`, default `text`) to app config.
- Added defaults and validation for both fields in config loading, plus schema support in `config.schema.json`.
- Updated logger construction to use configured level/format for both app logs and request logs (removed hardcoded behavior).
- Added env var overrides: `MAGLEV_LOG_LEVEL` and `MAGLEV_LOG_FORMAT`.
- Updated `--dump-config`, `config.example.json`, and `README.markdown` to include the new options.
- Updated tests in `internal/appconf/json_config_test.go` for defaults, validation, and env override behavior.
