### PR TITLE
fix: Update Frequency struct to match OpenAPI spec

### DIFF
--- a/internal/models/frequency.go
+++ b/internal/models/frequency.go
@@ -13,7 +13,10 @@ type Frequency struct {
 	// Headway is the time between departures in seconds
 	Headway int `json:"headway"`
 	// ExactTimes is used internally for business logic but omitted from API responses
-	ExactTimes int `json:"-"`
+	ExactTimes  int    `json:"-"`
+	ServiceDate int64  `json:"serviceDate"`
+	ServiceID   string `json:"serviceId"`
+	TripID      string `json:"tripId"`
 }
 
 // NewFrequencyFromDB converts a database Frequency row into an API Frequency model.

--- a/internal/models/frequency_test.go
+++ b/internal/models/frequency_test.go
@@ -99,10 +99,13 @@ func TestNewFrequency(t *testing.T) {
 
 func TestFrequencyJSON(t *testing.T) {
 	freq := Frequency{
-		StartTime:  1705305600000,
-		EndTime:    1705316400000,
-		Headway:    600,
-		ExactTimes: 1, // This shouldn't be serialized to API clients
+		StartTime:   1705305600000,
+		EndTime:     1705316400000,
+		Headway:     600,
+		ExactTimes:  1, // This shouldn't be serialized to API clients
+		ServiceDate: 1705305600000,
+		ServiceID:   "service_123",
+		TripID:      "trip_67",
 	}
 
 	jsonData, err := json.Marshal(freq)
@@ -124,6 +127,9 @@ func TestFrequencyJSON(t *testing.T) {
 	assert.Contains(t, raw, "startTime")
 	assert.Contains(t, raw, "endTime")
 	assert.Contains(t, raw, "headway")
+	assert.Contains(t, raw, "serviceDate")
+	assert.Contains(t, raw, "serviceId")
+	assert.Contains(t, raw, "tripId")
 
 	// IMPORTANT: Verify exactTimes is NOT in the JSON (API Backward Compatibility)
 	assert.NotContains(t, raw, "exactTimes")

--- a/internal/models/schedule_for_route.go
+++ b/internal/models/schedule_for_route.go
@@ -29,4 +29,6 @@ type ScheduleForRouteEntry struct {
 	ScheduleDate      int64              `json:"scheduleDate"`
 	ServiceIDs        []string           `json:"serviceIds"`
 	StopTripGroupings []StopTripGrouping `json:"stopTripGroupings"`
+	Stops             []Stop             `json:"stops"`
+	Trips             []Trip             `json:"trips"`
 }

--- a/internal/models/trip_details_test.go
+++ b/internal/models/trip_details_test.go
@@ -27,9 +27,12 @@ func TestNewTripDetails(t *testing.T) {
 	serviceDate := int64(1609459200000)
 
 	frequency := &Frequency{
-		StartTime: 28800,
-		EndTime:   32400,
-		Headway:   300,
+		StartTime:   28800,
+		EndTime:     32400,
+		Headway:     300,
+		ServiceDate: serviceDate,
+		ServiceID:   "service_789",
+		TripID:      tripID,
 	}
 
 	status := &TripStatus{
@@ -71,9 +74,12 @@ func TestNewEmptyTripDetails(t *testing.T) {
 
 func TestTripDetailsJSON(t *testing.T) {
 	frequency := &Frequency{
-		StartTime: 28800,
-		EndTime:   32400,
-		Headway:   300,
+		StartTime:   28800,
+		EndTime:     32400,
+		Headway:     300,
+		ServiceDate: 1609459200000,
+		ServiceID:   "service_789",
+		TripID:      "trip_123",
 	}
 
 	status := NewTripStatus()

--- a/internal/restapi/schedule_for_route_handler.go
+++ b/internal/restapi/schedule_for_route_handler.go
@@ -82,6 +82,8 @@ func (api *RestAPI) scheduleForRouteHandler(w http.ResponseWriter, r *http.Reque
 			ScheduleDate:      scheduleDate,
 			ServiceIDs:        []string{},
 			StopTripGroupings: []models.StopTripGrouping{},
+			Stops:             []models.Stop{},
+			Trips:             []models.Trip{},
 		}
 		api.sendResponse(w, r, models.NewEntryResponse(entry, *models.NewEmptyReferences(), api.Clock))
 		return
@@ -109,6 +111,8 @@ func (api *RestAPI) scheduleForRouteHandler(w http.ResponseWriter, r *http.Reque
 			ScheduleDate:      scheduleDate,
 			ServiceIDs:        combinedServiceIDs,
 			StopTripGroupings: []models.StopTripGrouping{},
+			Stops:             []models.Stop{},
+			Trips:             []models.Trip{},
 		}
 		api.sendResponse(w, r, models.NewEntryResponse(entry, *models.NewEmptyReferences(), api.Clock))
 		return
@@ -302,6 +306,8 @@ func (api *RestAPI) scheduleForRouteHandler(w http.ResponseWriter, r *http.Reque
 		ScheduleDate:      scheduleDate,
 		ServiceIDs:        combinedServiceIDs,
 		StopTripGroupings: stopTripGroupings,
+		Stops:             references.Stops,
+		Trips:             references.Trips,
 	}
 	api.sendResponse(w, r, models.NewEntryResponse(entry, *references, api.Clock))
 }

--- a/internal/restapi/schedule_for_route_handler_test.go
+++ b/internal/restapi/schedule_for_route_handler_test.go
@@ -78,6 +78,14 @@ func TestScheduleForRouteHandler(t *testing.T) {
 		assert.True(t, hasT)
 		require.NotEmpty(t, tripsWithStopTimes)
 
+		entryStops, hasEntryStops := entry["stops"].([]interface{})
+		assert.True(t, hasEntryStops, "entry.stops should be present")
+		require.NotEmpty(t, entryStops)
+
+		entryTrips, hasEntryTrips := entry["trips"].([]interface{})
+		assert.True(t, hasEntryTrips, "entry.trips should be present")
+		require.NotEmpty(t, entryTrips)
+
 		firstTripWithStops := tripsWithStopTimes[0].(map[string]interface{})
 		tid, ok := firstTripWithStops["tripId"].(string)
 		require.True(t, ok)

--- a/internal/restapi/trip_details_handler.go
+++ b/internal/restapi/trip_details_handler.go
@@ -185,11 +185,31 @@ func (api *RestAPI) tripDetailsHandler(w http.ResponseWriter, r *http.Request) {
 		situationsIDs = api.GetSituationIDsForTrip(r.Context(), tripID)
 	}
 
+	freqRows, err := api.GtfsManager.GtfsDB.Queries.GetFrequenciesForTrip(ctx, tripID)
+	if err != nil {
+		slog.Warn("GetFrequenciesForTrip failed",
+			slog.String("trip_id", tripID),
+			slog.String("error", err.Error()))
+		freqRows = nil
+	}
+
+	var frequency *models.Frequency
+	if len(freqRows) > 0 {
+		// TripDetails has only one frequency field, but GetFrequenciesForTrip query can return multiple rows
+		// when there are multiple frequency entries for the same trip. In order to adhere to the API contract,
+		// we take the first row which gives us the frequency with the earliest start_time
+		converted := models.NewFrequencyFromDB(freqRows[0], serviceDate)
+		converted.ServiceDate = serviceDateMillis
+		converted.ServiceID = utils.FormCombinedID(agencyID, trip.ServiceID)
+		converted.TripID = utils.FormCombinedID(agencyID, trip.ID)
+		frequency = &converted
+	}
+
 	tripDetails := &models.TripDetails{
 		TripID:       utils.FormCombinedID(agencyID, trip.ID),
 		ServiceDate:  serviceDateMillis,
 		Schedule:     schedule,
-		Frequency:    nil,
+		Frequency:    frequency,
 		SituationIDs: situationsIDs,
 	}
 


### PR DESCRIPTION
Aims to resolve the issue in #618 .

## Key Changes
- Added `ServiceData`, `ServiceId`, and `TripId` fields to the Frequency Model in `internal/models/frequency.go`