### PR TITLE
fix: correct peakOffPeak JSON tag to peakOffpeak per OpenAPI spec

### DIFF
--- a/internal/models/trip.go
+++ b/internal/models/trip.go
@@ -10,7 +10,7 @@ type Trip struct {
 	TripHeadsign   string `json:"tripHeadsign"`
 	TripShortName  string `json:"tripShortName"`
 	RouteShortName string `json:"routeShortName"`
-	PeakOffPeak    int64  `json:"peakOffPeak"`
+	PeakOffPeak    int64  `json:"peakOffpeak"`
 	TimeZone       string `json:"timeZone"`
 }
 

--- a/internal/models/trip_test.go
+++ b/internal/models/trip_test.go
@@ -89,6 +89,14 @@ func TestTripJSON(t *testing.T) {
 	jsonData, err := json.Marshal(trip)
 	assert.NoError(t, err)
 
+	// Ensure JSON contains correct field name
+	var m map[string]interface{}
+	err = json.Unmarshal(jsonData, &m)
+	assert.NoError(t, err)
+
+	_, ok := m["peakOffpeak"]
+	assert.True(t, ok)
+
 	var unmarshaledTrip Trip
 	err = json.Unmarshal(jsonData, &unmarshaledTrip)
 	assert.NoError(t, err)


### PR DESCRIPTION
## Description

The `Trip` struct was serializing the field as `peakOffPeak` (capital **P**), while the OpenAPI specification defines the field as `peakOffpeak` (lowercase **p**).

This mismatch caused JSON responses from the server to differ from the API specification, breaking deserialization in SDK clients generated from the OpenAPI spec. As a result, clients could not correctly parse the `peakOffpeak` field in responses.

## Changes

- Updated the JSON tag for `PeakOffPeak` in `internal/models/trip.go` to `peakOffpeak` to match the OpenAPI specification.
- Updated a unit test to verify correct JSON serialization and deserialization of the `Trip` struct.

## Impact

This fix ensures that all endpoints returning `Trip` references serialize the field name according to the OpenAPI spec, restoring compatibility with spec-compliant SDK clients.

## Testing

All checks passed successfully:

```bash
make fmt
make test
```

## Fixes #614 