### PR TITLE
fix(api): add missing stops and trips arrays to ScheduleForRouteEntry

### DIFF
--- a/internal/models/schedule_for_route.go
+++ b/internal/models/schedule_for_route.go
@@ -29,4 +29,6 @@ type ScheduleForRouteEntry struct {
 	ScheduleDate      int64              `json:"scheduleDate"`
 	ServiceIDs        []string           `json:"serviceIds"`
 	StopTripGroupings []StopTripGrouping `json:"stopTripGroupings"`
+	Stops             []Stop             `json:"stops"`
+	Trips             []Trip             `json:"trips"`
 }

--- a/internal/restapi/schedule_for_route_handler.go
+++ b/internal/restapi/schedule_for_route_handler.go
@@ -76,6 +76,8 @@ func (api *RestAPI) scheduleForRouteHandler(w http.ResponseWriter, r *http.Reque
 			ScheduleDate:      scheduleDate,
 			ServiceIDs:        []string{},
 			StopTripGroupings: []models.StopTripGrouping{},
+			Stops:             []models.Stop{},
+			Trips:             []models.Trip{},
 		}
 		api.sendResponse(w, r, models.NewEntryResponse(entry, models.NewEmptyReferences(), api.Clock))
 		return
@@ -103,6 +105,8 @@ func (api *RestAPI) scheduleForRouteHandler(w http.ResponseWriter, r *http.Reque
 			ScheduleDate:      scheduleDate,
 			ServiceIDs:        combinedServiceIDs,
 			StopTripGroupings: []models.StopTripGrouping{},
+			Stops:             []models.Stop{},
+			Trips:             []models.Trip{},
 		}
 		api.sendResponse(w, r, models.NewEntryResponse(entry, models.NewEmptyReferences(), api.Clock))
 		return
@@ -229,6 +233,9 @@ func (api *RestAPI) scheduleForRouteHandler(w http.ResponseWriter, r *http.Reque
 	for tid := range tripIDsSet {
 		tripIDs = append(tripIDs, tid)
 	}
+
+	entryTrips := make([]models.Trip, 0)
+
 	if len(tripIDs) > 0 {
 		tripRows, err := api.GtfsManager.GtfsDB.Queries.GetTripsByIDs(ctx, tripIDs)
 		if err != nil {
@@ -249,6 +256,7 @@ func (api *RestAPI) scheduleForRouteHandler(w http.ResponseWriter, r *http.Reque
 				utils.FormCombinedID(agencyID, t.ShapeID.String),
 			)
 			references.Trips = append(references.Trips, tripRef)
+			entryTrips = append(entryTrips, *tripRef)
 		}
 	}
 
@@ -256,6 +264,9 @@ func (api *RestAPI) scheduleForRouteHandler(w http.ResponseWriter, r *http.Reque
 	for sid := range globalStopIDSet {
 		uniqueStopIDs = append(uniqueStopIDs, sid)
 	}
+
+	entryStops := make([]models.Stop, 0)
+
 	if len(uniqueStopIDs) > 0 {
 
 		modelStops, _, err := BuildStopReferencesAndRouteIDsForStops(api, ctx, agencyID, uniqueStopIDs)
@@ -264,6 +275,7 @@ func (api *RestAPI) scheduleForRouteHandler(w http.ResponseWriter, r *http.Reque
 			return
 		}
 		references.Stops = append(references.Stops, modelStops...)
+		entryStops = modelStops
 	}
 
 	for _, sref := range stopTimesRefs {
@@ -288,6 +300,8 @@ func (api *RestAPI) scheduleForRouteHandler(w http.ResponseWriter, r *http.Reque
 		ScheduleDate:      scheduleDate,
 		ServiceIDs:        combinedServiceIDs,
 		StopTripGroupings: stopTripGroupings,
+		Stops:             entryStops,
+		Trips:             entryTrips,
 	}
 	api.sendResponse(w, r, models.NewEntryResponse(entry, references, api.Clock))
 }

--- a/internal/restapi/schedule_for_route_handler_test.go
+++ b/internal/restapi/schedule_for_route_handler_test.go
@@ -55,6 +55,16 @@ func TestScheduleForRouteHandler(t *testing.T) {
 		require.True(t, ok)
 		require.NotEmpty(t, groupings)
 
+		// stops array should exist directly in the entry
+		stops, ok := entry["stops"].([]interface{})
+		require.True(t, ok, "stops should exist as an array in the entry")
+		assert.NotNil(t, stops)
+
+		// trips array should exist directly in the entry
+		trips, ok := entry["trips"].([]interface{})
+		require.True(t, ok, "trips should exist as an array in the entry")
+		assert.NotNil(t, trips)
+
 		firstGrouping, ok := groupings[0].(map[string]interface{})
 		require.True(t, ok)
 


### PR DESCRIPTION
#### **Description**

This PR resolves an inconsistency between the `ScheduleForRoute` API response and the OpenAPI specification. The OpenAPI spec requires the `stops` (array of `Stop` objects) and `trips` (array of `Trip` objects) to be present directly inside the `schedule-for-route` entry payload. Previously, these were only available in the `references` object, which resulted in a spec violation.

#### **Changes Made**

* **Models:** Updated the `ScheduleForRouteEntry` struct in `internal/models/schedule_for_route.go` to include the `Stops` and `Trips` slices.
* **API Handler:** * Updated `scheduleForRouteHandler` in `internal/restapi/schedule_for_route_handler.go` to capture and populate the `Stops` and `Trips` arrays dynamically while fetching GTFS data.
* Ensured empty state safety: Explicitly initialized `[]models.Stop{}` and `[]models.Trip{}` so the API returns empty arrays `[]` rather than `null` when no services or trips are found.

* **Tests:** Updated unit tests in `internal/restapi/schedule_for_route_handler_test.go` to assert the presence and non-nil status of the `stops` and `trips` arrays directly within the `entry` JSON map.

Closes #617
