### PR TITLE
feat: Add GTFS feed structural validation on import

### DIFF
--- a/gtfsdb/helpers.go
+++ b/gtfsdb/helpers.go
@@ -86,16 +86,38 @@ func (c *Client) processAndStoreGTFSDataWithSource(b []byte, source string) erro
 
 	ctx := context.Background()
 
-	// Check if we already have this data imported
+	// 1. Check if we already have this data imported
+	var hasExisting bool
 	existingMetadata, err := c.Queries.GetImportMetadata(ctx)
 	if err == nil {
+		hasExisting = true
 		// We have existing metadata, check if hash matches
 		if existingMetadata.FileHash == hashStr && existingMetadata.FileSource == source {
 			logging.LogOperation(logger, "gtfs_data_unchanged_skipping_import",
 				slog.String("hash", hashStr[:8]))
 			return nil
 		}
-		// Hash differs, we need to clear existing data and reimport
+	} else if err != nil && err != sql.ErrNoRows {
+		// Some other error occurred
+		return fmt.Errorf("error checking import metadata: %w", err)
+	}
+
+	// 2. Parse the new data FIRST (before deleting the old working data)
+	staticData, err := gtfs.ParseStatic(b, gtfs.ParseStaticOptions{})
+	if err != nil {
+		return err
+	}
+
+	// 3. Perform Structural Validation
+	if err := ValidateGTFSData(staticData); err != nil {
+		logging.LogError(logger, "GTFS feed structural validation failed", err)
+		return fmt.Errorf("GTFS validation failed: %w", err)
+	}
+
+	logging.LogOperation(logger, "retrieved_static_data", slog.Int("warnings", len(staticData.Warnings)))
+
+	// 4. Clear the old data now that we know the new data is completely valid
+	if hasExisting {
 		logging.LogOperation(logger, "gtfs_data_changed_reimporting",
 			slog.String("old_hash", existingMetadata.FileHash[:8]),
 			slog.String("new_hash", hashStr[:8]))
@@ -103,22 +125,9 @@ func (c *Client) processAndStoreGTFSDataWithSource(b []byte, source string) erro
 		if err != nil {
 			return fmt.Errorf("error clearing existing GTFS data: %w", err)
 		}
-	} else if err != nil && err != sql.ErrNoRows {
-		// Some other error occurred
-		return fmt.Errorf("error checking import metadata: %w", err)
-	}
-	// If err == sql.ErrNoRows, this is the first import, continue normally
-
-	var staticCounts map[string]int
-
-	staticData, err := gtfs.ParseStatic(b, gtfs.ParseStaticOptions{})
-	if err != nil {
-		return err
 	}
 
-	logging.LogOperation(logger, "retrieved_static_data", slog.Int("warnings", len(staticData.Warnings)))
-
-	staticCounts = c.staticDataCounts(staticData)
+	staticCounts := c.staticDataCounts(staticData)
 	for k, v := range staticCounts {
 		logging.LogOperation(logger, "static_data_count", slog.String("entity_type", k), slog.Int("count", v))
 	}
@@ -1163,5 +1172,71 @@ func (c *Client) buildBlockTripIndex(ctx context.Context, staticData *gtfs.Stati
 		slog.Int("indices_created", len(indexGroups)),
 		slog.Int("entries_created", totalEntries))
 
+	return nil
+}
+
+// ValidateGTFSData performs structural validation on the parsed GTFS data before import.
+// It ensures that required files are present and basic foreign-key relationships hold true.
+func ValidateGTFSData(data *gtfs.Static) error {
+	if data == nil {
+		return fmt.Errorf("parsed GTFS data is nil")
+	}
+
+	// Check for required baseline entities
+	if len(data.Agencies) == 0 {
+		return fmt.Errorf("validation failed: no agencies found in feed (missing or empty agency.txt)")
+	}
+	if len(data.Routes) == 0 {
+		return fmt.Errorf("validation failed: no routes found in feed (missing or empty routes.txt)")
+	}
+	if len(data.Stops) == 0 {
+		return fmt.Errorf("validation failed: no stops found in feed (missing or empty stops.txt)")
+	}
+	if len(data.Trips) == 0 {
+		return fmt.Errorf("validation failed: no trips found in feed (missing or empty trips.txt)")
+	}
+
+	// Check for service information (Calendar or CalendarDates)
+	hasService := false
+	for _, service := range data.Services {
+		// Check for calendar.txt regular service
+		if service.Monday || service.Tuesday || service.Wednesday || service.Thursday || service.Friday || service.Saturday || service.Sunday {
+			hasService = true
+			break
+		}
+		// Check for calendar_dates.txt exception service
+		if len(service.AddedDates) > 0 || len(service.RemovedDates) > 0 {
+			hasService = true
+			break
+		}
+	}
+	if !hasService {
+		return fmt.Errorf("validation failed: no service calendars or calendar_dates found")
+	}
+
+	// Foreign Key / Relationship Checks
+	for _, trip := range data.Trips {
+		// Ensure the trip points to a valid route
+		if trip.Route == nil || trip.Route.Id == "" {
+			return fmt.Errorf("validation failed: trip %s references missing or invalid route", trip.ID)
+		}
+
+		// Ensure the trip points to a valid service (Fixes #3)
+		if trip.Service == nil || trip.Service.Id == "" {
+			return fmt.Errorf("validation failed: trip %s references missing or invalid service", trip.ID)
+		}
+
+		// Ensure the trip has stop times
+		if len(trip.StopTimes) == 0 {
+			return fmt.Errorf("validation failed: trip %s has no stop times", trip.ID)
+		}
+
+		// Ensure stop times reference valid stops
+		for _, st := range trip.StopTimes {
+			if st.Stop == nil || st.Stop.Id == "" {
+				return fmt.Errorf("validation failed: stop time for trip %s references missing stop", trip.ID)
+			}
+		}
+	}
 	return nil
 }

--- a/gtfsdb/helpers_test.go
+++ b/gtfsdb/helpers_test.go
@@ -1,11 +1,15 @@
 package gtfsdb
 
 import (
+	"archive/zip"
+	"bytes"
 	"context"
 	"database/sql"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"maglev.onebusaway.org/internal/appconf"
 )
 
 func TestPerformDatabaseMigration_Idempotency(t *testing.T) {
@@ -50,4 +54,75 @@ func TestPerformDatabaseMigration_ErrorHandling(t *testing.T) {
 
 	assert.Error(t, err, "Migration should fail on invalid SQL")
 	assert.Contains(t, err.Error(), "error executing DDL statement", "Error should wrap the failing context")
+}
+
+func TestProcessAndStoreGTFSData_ValidationFailurePreservesData(t *testing.T) {
+	db, err := sql.Open(DriverName, ":memory:")
+	assert.NoError(t, err)
+	t.Cleanup(func() {
+		if err := db.Close(); err != nil {
+			t.Errorf("failed to close database: %v", err)
+		}
+	})
+
+	ctx := context.Background()
+	err = performDatabaseMigration(ctx, db)
+	assert.NoError(t, err)
+
+	client := &Client{
+		DB:      db,
+		Queries: New(db),
+		config:  Config{Env: appconf.Test},
+	}
+
+	// 1. Read and load valid GTFS bytes
+	validBytes, err := os.ReadFile("../testdata/gtfs.zip")
+	if err != nil {
+		t.Skip("Skipping test: testdata/gtfs.zip not found")
+	}
+
+	err = client.processAndStoreGTFSDataWithSource(validBytes, "test-source-valid")
+	assert.NoError(t, err, "First import should succeed")
+
+	counts, err := client.TableCounts()
+	assert.NoError(t, err)
+	assert.Greater(t, counts["routes"], 0, "Valid data should be imported")
+	originalRouteCount := counts["routes"]
+
+	// 2. Create a GTFS feed that passes the parser but fails OUR structural validation
+	// We do this by creating a trip that has no stop times.
+	buf := new(bytes.Buffer)
+	w := zip.NewWriter(buf)
+
+	files := map[string]string{
+		"agency.txt":     "agency_id,agency_name,agency_url,agency_timezone\n1,BrokenFeed,http://test.com,America/Los_Angeles",
+		"routes.txt":     "route_id,agency_id,route_short_name,route_type\n1,1,BrokenRoute,3",
+		"stops.txt":      "stop_id,stop_name,stop_lat,stop_lon\n1,BrokenStop,47.6,-122.3",
+		"calendar.txt":   "service_id,monday,tuesday,wednesday,thursday,friday,saturday,sunday,start_date,end_date\n1,1,1,1,1,1,1,1,20230101,20240101",
+		"trips.txt":      "route_id,service_id,trip_id\n1,1,trip_1",                     // Trip exists
+		"stop_times.txt": "trip_id,arrival_time,departure_time,stop_id,stop_sequence\n", // But has NO stop times
+	}
+
+	for name, content := range files {
+		f, err := w.Create(name)
+		assert.NoError(t, err)
+
+		_, err = f.Write([]byte(content))
+		assert.NoError(t, err)
+	}
+
+	err = w.Close()
+	assert.NoError(t, err)
+
+	invalidBytes := buf.Bytes()
+
+	// 3. Attempt to import structurally invalid data
+	err = client.processAndStoreGTFSDataWithSource(invalidBytes, "test-source-invalid")
+	assert.Error(t, err, "Import should fail structural validation")
+	assert.Contains(t, err.Error(), "validation failed")
+
+	// 4. Verify original data was NOT cleared
+	countsAfter, err := client.TableCounts()
+	assert.NoError(t, err)
+	assert.Equal(t, originalRouteCount, countsAfter["routes"], "Database should remain intact after validation failure")
 }

--- a/gtfsdb/validation_test.go
+++ b/gtfsdb/validation_test.go
@@ -1,0 +1,187 @@
+package gtfsdb
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/OneBusAway/go-gtfs"
+)
+
+// Helper function to create a minimal, structurally valid GTFS dataset
+func createValidGTFS() *gtfs.Static {
+	agency := gtfs.Agency{Id: "agency1", Name: "Test Agency"}
+	route := gtfs.Route{Id: "route1", Agency: &agency}
+
+	lat, lon := 47.6, -122.3
+	stop := gtfs.Stop{Id: "stop1", Latitude: &lat, Longitude: &lon}
+
+	service := gtfs.Service{Id: "service1", Monday: true}
+
+	trip := gtfs.ScheduledTrip{
+		ID:      "trip1",
+		Route:   &route,
+		Service: &service,
+		StopTimes: []gtfs.ScheduledStopTime{
+			{Stop: &stop, StopSequence: 1},
+		},
+	}
+
+	return &gtfs.Static{
+		Agencies: []gtfs.Agency{agency},
+		Routes:   []gtfs.Route{route},
+		Stops:    []gtfs.Stop{stop},
+		Services: []gtfs.Service{service},
+		Trips:    []gtfs.ScheduledTrip{trip},
+	}
+}
+
+func TestValidateGTFSData_Valid(t *testing.T) {
+	data := createValidGTFS()
+	err := ValidateGTFSData(data)
+	if err != nil {
+		t.Fatalf("expected valid GTFS data to pass validation, got error: %v", err)
+	}
+}
+
+func TestValidateGTFSData_MissingEntities(t *testing.T) {
+	tests := []struct {
+		name        string
+		startNil    bool
+		mutate      func(*gtfs.Static) *gtfs.Static
+		errContains string
+	}{
+		{
+			name:        "nil data",
+			startNil:    true,
+			mutate:      func(d *gtfs.Static) *gtfs.Static { return nil },
+			errContains: "parsed GTFS data is nil",
+		},
+		{
+			name:        "missing agencies",
+			mutate:      func(d *gtfs.Static) *gtfs.Static { d.Agencies = nil; return d },
+			errContains: "no agencies found",
+		},
+		{
+			name:        "missing routes",
+			mutate:      func(d *gtfs.Static) *gtfs.Static { d.Routes = nil; return d },
+			errContains: "no routes found",
+		},
+		{
+			name:        "missing stops",
+			mutate:      func(d *gtfs.Static) *gtfs.Static { d.Stops = nil; return d },
+			errContains: "no stops found",
+		},
+		{
+			name:        "missing trips",
+			mutate:      func(d *gtfs.Static) *gtfs.Static { d.Trips = nil; return d },
+			errContains: "no trips found",
+		},
+		{
+			name:        "missing services",
+			mutate:      func(d *gtfs.Static) *gtfs.Static { d.Services = nil; return d },
+			errContains: "no service calendars",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var data *gtfs.Static
+			if !tc.startNil {
+				data = createValidGTFS()
+			}
+			data = tc.mutate(data)
+
+			err := ValidateGTFSData(data)
+			if err == nil {
+				t.Fatalf("expected error for %s, got nil", tc.name)
+			}
+			if !strings.Contains(err.Error(), tc.errContains) {
+				t.Errorf("expected error to contain %q, got %q", tc.errContains, err.Error())
+			}
+		})
+	}
+}
+
+func TestValidateGTFSData_CalendarDatesOnly(t *testing.T) {
+	data := createValidGTFS()
+
+	// Turn off all regular weekly service
+	data.Services[0].Monday = false
+	data.Services[0].Tuesday = false
+	data.Services[0].Wednesday = false
+	data.Services[0].Thursday = false
+	data.Services[0].Friday = false
+	data.Services[0].Saturday = false
+	data.Services[0].Sunday = false
+
+	// Add an exception date instead
+	data.Services[0].AddedDates = []time.Time{
+		time.Now(),
+	}
+
+	err := ValidateGTFSData(data)
+	if err != nil {
+		t.Fatalf("expected valid GTFS data with only calendar_dates to pass validation, got error: %v", err)
+	}
+}
+
+// Update the ForeignKeys test to check for empty strings AND the new service check
+func TestValidateGTFSData_ForeignKeys(t *testing.T) {
+	tests := []struct {
+		name        string
+		mutate      func(*gtfs.Static)
+		errContains string
+	}{
+		{
+			name:        "trip with missing route",
+			mutate:      func(d *gtfs.Static) { d.Trips[0].Route = nil },
+			errContains: "references missing or invalid route",
+		},
+		{
+			name:        "trip with empty route ID",
+			mutate:      func(d *gtfs.Static) { d.Trips[0].Route.Id = "" },
+			errContains: "references missing or invalid route",
+		},
+		{
+			name:        "trip with missing service",
+			mutate:      func(d *gtfs.Static) { d.Trips[0].Service = nil },
+			errContains: "references missing or invalid service",
+		},
+		{
+			name:        "trip with empty service ID",
+			mutate:      func(d *gtfs.Static) { d.Trips[0].Service.Id = "" },
+			errContains: "references missing or invalid service",
+		},
+		{
+			name:        "trip with missing stop times",
+			mutate:      func(d *gtfs.Static) { d.Trips[0].StopTimes = nil },
+			errContains: "has no stop times",
+		},
+		{
+			name:        "stop time with missing stop",
+			mutate:      func(d *gtfs.Static) { d.Trips[0].StopTimes[0].Stop = nil },
+			errContains: "references missing stop",
+		},
+		{
+			name:        "stop time with empty stop ID",
+			mutate:      func(d *gtfs.Static) { d.Trips[0].StopTimes[0].Stop.Id = "" },
+			errContains: "references missing stop",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			data := createValidGTFS()
+			tc.mutate(data)
+
+			err := ValidateGTFSData(data)
+			if err == nil {
+				t.Fatalf("expected error for %s, got nil", tc.name)
+			}
+			if !strings.Contains(err.Error(), tc.errContains) {
+				t.Errorf("expected error to contain %q, got %q", tc.errContains, err.Error())
+			}
+		})
+	}
+}

--- a/internal/gtfs/gtfs_manager.go
+++ b/internal/gtfs/gtfs_manager.go
@@ -161,6 +161,30 @@ func InitGTFSManager(ctx context.Context, config Config) (*Manager, error) {
 				}
 				return nil, fmt.Errorf("failed to load GTFS data after %d attempts: %w", maxAttempts, err)
 			}
+
+			// Perform structural validation on the in-memory data
+			if err = gtfsdb.ValidateGTFSData(staticData); err != nil {
+				if attempt < maxAttempts {
+					delay := backoffs[attempt-1]
+					logging.LogError(logger, "GTFS static data structural validation failed, retrying", err,
+						slog.Int("attempt", attempt),
+						slog.Int("max_attempts", maxAttempts),
+						slog.Duration("retry_delay", delay),
+					)
+
+					// Reset staticData to nil so the retry loop fetches it again
+					staticData = nil
+
+					// Cancellable sleep
+					select {
+					case <-ctx.Done():
+						return nil, ctx.Err()
+					case <-time.After(delay):
+					}
+					continue
+				}
+				return nil, fmt.Errorf("failed GTFS structural validation after %d attempts: %w", maxAttempts, err)
+			}
 		}
 
 		// Attempt to build the SQLite DB if we haven't already succeeded

--- a/internal/gtfs/static.go
+++ b/internal/gtfs/static.go
@@ -203,6 +203,12 @@ func (manager *Manager) ForceUpdate(ctx context.Context) error {
 		return err
 	}
 
+	// Validate the structural integrity of the in-memory data before proceeding
+	if err := gtfsdb.ValidateGTFSData(newStaticData); err != nil {
+		logging.LogError(logger, "GTFS structural validation failed during periodic update", err)
+		return fmt.Errorf("GTFS validation failed during update: %w", err)
+	}
+
 	if err := ctx.Err(); err != nil {
 		return err
 	}


### PR DESCRIPTION
## Description
This PR Fix #621 by implementing strict structural validation for GTFS static feeds before they replace the active database or get loaded into memory. 

Previously, the system would delete the existing SQLite database and attempt to parse the new data blindly, which would result in crashes and broken data if the downloaded feed was missing essential files or had invalid relational mappings.

### Changes Made:
* **`gtfsdb/helpers.go`**: 
  * Created `ValidateGTFSData` to verify the presence of required GTFS entities (Agencies, Routes, Stops, Trips) and service calendars (`calendar.txt` or `calendar_dates.txt`).
  * Enforced foreign key integrity checks (e.g., verifying trips have stop_times, trips reference valid routes, stop_times reference valid stops).
  * Refactored `processAndStoreGTFSDataWithSource` so the `clearAllGTFSData` step only executes **after** the new feed has successfully passed `gtfs.ParseStatic` and `ValidateGTFSData`.
* **`internal/gtfs/gtfs_manager.go`**: 
  * Added the same `ValidateGTFSData` check directly into the `InitGTFSManager` in-memory startup sequence. If validation fails, it safely nullifies the broken data and correctly triggers the application's built-in startup retry backoff loop.
* **`gtfsdb/validation_test.go`**: 
  * Added comprehensive unit tests to ensure `ValidateGTFSData` catches missing entities, null fields, and broken foreign-key relationships.

## How has this been tested?
- [x] All existing unit and integration tests pass via `make test`.
- [x] Added `TestValidateGTFSData_Valid`, `TestValidateGTFSData_MissingEntities`, and `TestValidateGTFSData_ForeignKeys` to thoroughly test the validation logic against both happy-paths and structurally broken feeds.

Closes #621 