### PR TITLE
Fix: Update TripBlock.AccumulatedSlackTime type to float64

### DIFF
--- a/internal/models/block.go
+++ b/internal/models/block.go
@@ -12,7 +12,7 @@ type BlockConfiguration struct {
 }
 
 type TripBlock struct {
-	AccumulatedSlackTime int             `json:"accumulatedSlackTime"`
+	AccumulatedSlackTime float64         `json:"accumulatedSlackTime"`
 	BlockStopTimes       []BlockStopTime `json:"blockStopTimes"`
 	DistanceAlongBlock   float64         `json:"distanceAlongBlock"`
 	TripId               string          `json:"tripId"`

--- a/internal/restapi/block_handler.go
+++ b/internal/restapi/block_handler.go
@@ -143,7 +143,7 @@ func transformBlockToEntry(block []gtfsdb.GetBlockDetailsRow, blockID, agencyID 
 			tripDistance := blockDistance - tripStartDistance
 
 			trip := models.TripBlock{
-				AccumulatedSlackTime: int(tripAccumulatedSlack),
+				AccumulatedSlackTime: tripAccumulatedSlack,
 				BlockStopTimes:       blockStopTimes,
 				DistanceAlongBlock:   tripDistance,
 				TripId:               utils.FormCombinedID(agencyID, tripID),


### PR DESCRIPTION
## Description
This PR resolves an inconsistency in the `TripBlock` model where `AccumulatedSlackTime` was typed as an `int`, which caused issues when the Java OBA server returned fractional slack times. 

### Changes Made:
* **`internal/models/block.go`**: Changed the data type of `TripBlock.AccumulatedSlackTime` from `int` to `float64`. This brings it in line with the OpenAPI spec and makes it consistent with `BlockStopTime.AccumulatedSlackTime`.
* **`internal/restapi/block_handler.go`**: Updated the assignment/type handling around line 146 to accommodate the change from `int` to `float64`.

## Related Issue
Closes #625

## Why is this necessary?
Typing this field as an `int` causes fractional slack times (e.g., `5.5`) to be truncated, which can lead to inaccuracies in block schedule calculations. This fix ensures the Go server correctly parses and retains the exact decimal values sent by the upstream server.

## Testing
- [x] Code compiles successfully.
- [x] All unit tests pass (`go test ./...`).