### PR TITLE
refactor: standardize default search radius fallback

### DIFF
--- a/internal/gtfs/gtfs_manager.go
+++ b/internal/gtfs/gtfs_manager.go
@@ -12,8 +12,8 @@ import (
 	"time"
 
 	"maglev.onebusaway.org/gtfsdb"
-	"maglev.onebusaway.org/internal/models"
 	"maglev.onebusaway.org/internal/metrics"
+	"maglev.onebusaway.org/internal/models"
 	"maglev.onebusaway.org/internal/utils"
 
 	"github.com/OneBusAway/go-gtfs"
@@ -381,7 +381,7 @@ func (manager *Manager) GetStopsForLocation(
 				// searches are never artificially truncated by localized bounding boxes.
 				radius = models.GlobalSearchRadiusInMeters
 			} else {
-				radius = 500
+				radius = models.DefaultSearchRadiusInMeters // Standard constant for radius
 			}
 		}
 		bounds = utils.CalculateBounds(lat, lon, radius)


### PR DESCRIPTION
**The Problem:**
As noted in the review for #560, the `GetStopsForLocation` function in `gtfs_manager.go` was using a hardcoded inline literal (`500`) for its default fallback radius instead of referencing the centralized constant defined in `models/constants.go`.

**The Solution:**
Replaced the `500` magic number with `models.DefaultSearchRadiusInMeters`. This establishes a single source of truth for search radii across the application and prevents future inconsistencies.

Follow-up to #560.

**Testing:**
* Ran `make test` locally to ensure the fallback transition to `600m` does not break any existing tests. All tests pass successfully.