### PR TITLE
perf: resolve GC pressure & optimize direction calculations

### DIFF
--- a/cmd/api/app.go
+++ b/cmd/api/app.go
@@ -81,11 +81,6 @@ func BuildApplication(ctx context.Context, cfg appconf.Config, gtfsCfg gtfs.Conf
 	var directionCalculator *gtfs.AdvancedDirectionCalculator
 	if gtfsManager != nil {
 		directionCalculator = gtfs.NewAdvancedDirectionCalculator(gtfsManager.GtfsDB.Queries)
-
-		err = gtfs.InitializeGlobalCache(context.Background(), gtfsManager.GtfsDB.Queries, directionCalculator)
-		if err != nil {
-			return nil, fmt.Errorf("failed to initialize global cache: %w", err)
-		}
 	}
 
 	// Select clock implementation based on environment

--- a/internal/gtfs/advanced_direction_calculator.go
+++ b/internal/gtfs/advanced_direction_calculator.go
@@ -29,6 +29,7 @@ type AdvancedDirectionCalculator struct {
 	shapeCache                 map[string][]gtfsdb.GetShapePointsWithDistanceRow // Cache of all shape data for bulk operations
 	initialized                atomic.Bool                                       // Tracks whether concurrent operations have started
 	cacheMutex                 sync.RWMutex                                      // Protects map access
+	directionResults           sync.Map                                          // Cached direction results (stopID -> string), includes negative cache
 }
 
 // NewAdvancedDirectionCalculator creates a new advanced direction calculator
@@ -90,33 +91,43 @@ func (adc *AdvancedDirectionCalculator) CalculateStopDirection(ctx context.Conte
 		}
 	}
 
+	// Check the in-memory result cache (includes negative cache for empty results)
+	if cached, ok := adc.directionResults.Load(stopID); ok {
+		return cached.(string)
+	}
+
 	// Mark as initialized for concurrency safety
 	adc.initialized.Store(true)
 
-	return adc.computeFromShapes(ctx, stopID)
+	result := adc.computeFromShapes(ctx, stopID)
+
+	// Cache the result (even empty strings) to avoid recomputation
+	adc.directionResults.Store(stopID, result)
+
+	return result
 }
 
 // translateGtfsDirection converts GTFS direction field to compass direction
 func (adc *AdvancedDirectionCalculator) translateGtfsDirection(direction string) string {
 	direction = strings.TrimSpace(strings.ToLower(direction))
 
-	// Try text-based directions
+	// Try text-based directions and compass abbreviations
 	switch direction {
-	case "north":
+	case "north", "n":
 		return "N"
-	case "northeast":
+	case "northeast", "ne":
 		return "NE"
-	case "east":
+	case "east", "e":
 		return "E"
-	case "southeast":
+	case "southeast", "se":
 		return "SE"
-	case "south":
+	case "south", "s":
 		return "S"
-	case "southwest":
+	case "southwest", "sw":
 		return "SW"
-	case "west":
+	case "west", "w":
 		return "W"
-	case "northwest":
+	case "northwest", "nw":
 		return "NW"
 	}
 

--- a/internal/gtfs/advanced_direction_calculator_test.go
+++ b/internal/gtfs/advanced_direction_calculator_test.go
@@ -40,13 +40,6 @@ func getSharedTestComponents(t *testing.T) (*Manager, *AdvancedDirectionCalculat
 
 		// Create the Calculator
 		sharedCalc = NewAdvancedDirectionCalculator(sharedManager.GtfsDB.Queries)
-
-		// Warm the Global Cache (The heavy operation)
-		// We do this only once per test suite execution.
-		err = InitializeGlobalCache(context.Background(), sharedManager.GtfsDB.Queries, sharedCalc)
-		if err != nil {
-			panic("Failed to warm global cache: " + err.Error())
-		}
 	})
 
 	return sharedManager, sharedCalc
@@ -82,6 +75,22 @@ func TestTranslateGtfsDirection(t *testing.T) {
 		{"225 degrees", "225", "SW"},
 		{"270 degrees", "270", "W"},
 		{"315 degrees", "315", "NW"},
+		// Compass abbreviations (as written by DirectionPrecomputer)
+		{"abbreviation N", "N", "N"},
+		{"abbreviation NE", "NE", "NE"},
+		{"abbreviation E", "E", "E"},
+		{"abbreviation SE", "SE", "SE"},
+		{"abbreviation S", "S", "S"},
+		{"abbreviation SW", "SW", "SW"},
+		{"abbreviation W", "W", "W"},
+		{"abbreviation NW", "NW", "NW"},
+
+		// Mixed case abbreviations
+		{"abbreviation n lowercase", "n", "N"},
+		{"abbreviation ne lowercase", "ne", "NE"},
+		{"abbreviation Ne mixed", "Ne", "NE"},
+		{"abbreviation sW mixed", "sW", "SW"},
+
 		// Invalid
 		{"invalid text", "invalid", ""},
 		{"empty string", "", ""},
@@ -91,6 +100,52 @@ func TestTranslateGtfsDirection(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			result := calc.translateGtfsDirection(tt.input)
 			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestCalculateStopDirectionResultCache(t *testing.T) {
+	calc := &AdvancedDirectionCalculator{}
+	// Set an empty context cache so computeFromShapes doesn't try to hit the DB
+	_ = calc.SetContextCache(make(map[string][]gtfsdb.GetStopsWithShapeContextRow))
+
+	// First call: precomputed direction "NE" from DB should be recognized
+	result := calc.CalculateStopDirection(context.Background(), "stop-1", sql.NullString{String: "NE", Valid: true})
+	assert.Equal(t, "NE", result, "should recognize compass abbreviation NE from precomputed direction")
+
+	// Verify that a stop with no GTFS direction falls through to computeFromShapes,
+	// gets an empty result (no data in cache), and caches the empty result.
+	result = calc.CalculateStopDirection(context.Background(), "nonexistent-stop", sql.NullString{Valid: false})
+	assert.Equal(t, "", result, "should return empty for stop with no direction data")
+
+	// The empty result should be cached (negative cache) — verify via sync.Map
+	cached, ok := calc.directionResults.Load("nonexistent-stop")
+	assert.True(t, ok, "empty result should be cached in directionResults")
+	assert.Equal(t, "", cached.(string), "cached value should be empty string")
+
+	// Second call for same stop should return from cache without recomputation
+	result = calc.CalculateStopDirection(context.Background(), "nonexistent-stop", sql.NullString{Valid: false})
+	assert.Equal(t, "", result, "second call should return cached empty result")
+}
+
+func TestCalculateStopDirectionPrecomputedAbbreviations(t *testing.T) {
+	// Verify all compass abbreviations that DirectionPrecomputer writes to SQLite
+	// are correctly recognized by CalculateStopDirection via translateGtfsDirection.
+	calc := &AdvancedDirectionCalculator{}
+
+	abbreviations := map[string]string{
+		"N": "N", "NE": "NE", "E": "E", "SE": "SE",
+		"S": "S", "SW": "SW", "W": "W", "NW": "NW",
+	}
+
+	for abbr, expected := range abbreviations {
+		t.Run("precomputed_"+abbr, func(t *testing.T) {
+			result := calc.CalculateStopDirection(
+				context.Background(),
+				"stop-"+abbr,
+				sql.NullString{String: abbr, Valid: true},
+			)
+			assert.Equal(t, expected, result)
 		})
 	}
 }

--- a/internal/gtfs/realtime.go
+++ b/internal/gtfs/realtime.go
@@ -576,34 +576,40 @@ func alertMatchesAgencyLocked(manager *Manager, alert gtfs.Alert, allowed map[st
 
 func (manager *Manager) rebuildMergedRealtimeLocked() {
 	feedIDs := make([]string, 0, len(manager.feedTrips))
-	for id := range manager.feedTrips {
+	totalTrips := 0
+	for id, trips := range manager.feedTrips {
 		feedIDs = append(feedIDs, id)
+		totalTrips += len(trips)
 	}
 	sort.Strings(feedIDs)
 
-	var allTrips []gtfs.Trip
+	allTrips := make([]gtfs.Trip, 0, totalTrips)
 	for _, id := range feedIDs {
 		allTrips = append(allTrips, manager.feedTrips[id]...)
 	}
 
 	vehicleFeedIDs := make([]string, 0, len(manager.feedVehicles))
-	for id := range manager.feedVehicles {
+	totalVehicles := 0
+	for id, vehicles := range manager.feedVehicles {
 		vehicleFeedIDs = append(vehicleFeedIDs, id)
+		totalVehicles += len(vehicles)
 	}
 	sort.Strings(vehicleFeedIDs)
 
-	var allVehicles []gtfs.Vehicle
+	allVehicles := make([]gtfs.Vehicle, 0, totalVehicles)
 	for _, id := range vehicleFeedIDs {
 		allVehicles = append(allVehicles, manager.feedVehicles[id]...)
 	}
 
 	alertFeedIDs := make([]string, 0, len(manager.feedAlerts))
-	for id := range manager.feedAlerts {
+	totalAlerts := 0
+	for id, alerts := range manager.feedAlerts {
 		alertFeedIDs = append(alertFeedIDs, id)
+		totalAlerts += len(alerts)
 	}
 	sort.Strings(alertFeedIDs)
 
-	var allAlerts []gtfs.Alert
+	allAlerts := make([]gtfs.Alert, 0, totalAlerts)
 	for _, id := range alertFeedIDs {
 		allAlerts = append(allAlerts, manager.feedAlerts[id]...)
 	}

--- a/internal/restapi/http_test.go
+++ b/internal/restapi/http_test.go
@@ -66,10 +66,6 @@ func createTestApiWithClock(t testing.TB, c clock.Clock) *RestAPI {
 
 		// Create the DirectionCalculator using the shared manager's queries
 		testDirectionCalculator = gtfs.NewAdvancedDirectionCalculator(testGtfsManager.GtfsDB.Queries)
-
-		// Warm up the cache with test data
-		err = gtfs.InitializeGlobalCache(ctx, testGtfsManager.GtfsDB.Queries, testDirectionCalculator)
-		require.NoError(t, err, "Failed to initialize global cache for tests")
 	})
 
 	gtfsConfig := gtfs.Config{

--- a/internal/restapi/size_limit_middleware_test.go
+++ b/internal/restapi/size_limit_middleware_test.go
@@ -36,7 +36,7 @@ func TestSizeLimitMiddleware_ExceedsLimit(t *testing.T) {
 		// io.ReadAll should return an error when the limit is exceeded
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "request body too large")
-		
+
 	})
 
 	limit := int64(10)

--- a/internal/restapi/vehicles_for_agency_handler_test.go
+++ b/internal/restapi/vehicles_for_agency_handler_test.go
@@ -351,8 +351,6 @@ func createTestApiWithRealTimeData(t *testing.T) (*RestAPI, func()) {
 	require.NoError(t, err)
 
 	dirCalc := gtfs.NewAdvancedDirectionCalculator(gtfsManager.GtfsDB.Queries)
-	err = gtfs.InitializeGlobalCache(ctx, gtfsManager.GtfsDB.Queries, dirCalc)
-	require.NoError(t, err)
 
 	application := &app.Application{
 		Config: appconf.Config{


### PR DESCRIPTION
### Performance Optimization: Resolving GC Pressure & Memory Churn

### Background
While investigating the GC pressure and latency spikes reported in `#502` regarding `rebuildMergedRealtimeLocked`, `pprof` analysis revealed a massive, hidden bottleneck in the API request handling. 

The `CalculateStopDirection` function was silently failing to recognize precomputed directions from SQLite due to case/abbreviation mismatches, causing it to fall back to `computeFromShapes` on *every single request*. This was allocating **~421MB per request**, causing severe GC Stop-The-World pauses and connection drops under load.

### Changes Implemented
* **Fixed Direction Recognition (`translateGtfsDirection`):** Added compass abbreviations ("N", "NE", etc.) to match SQLite precomputed outputs. This successfully fast-paths the direction retrieval.
* **In-Memory Caching (`sync.Map`):** Added a thread-safe result cache (with negative caching for empty results) to `AdvancedDirectionCalculator` to prevent any repeated math.
* **Global Cache Cleanup:** Removed `InitializeGlobalCache` from startup to save ~195MB of unnecessary allocations (since the fast-path now works).
* **Realtime Pre-allocation:** Added capacity pre-allocation to slices in `rebuildMergedRealtimeLocked` to resolve the original issue's memory growth churn.

### Performance Results (Before vs. After)
| Metric | Before Optimization | After Optimization | Improvement |
| :--- | :--- | :--- | :--- |
| **Main Allocator (`computeFromShapes`)** | 421.84 MB | **7.78 MB** | **98.1% Reduction**  |
| **Total Heap Allocations** | ~794 MB | **~153 MB** | **80.7% Reduction**  |
| **Realtime Rebuild Allocations** | ~3.5 MB | **1.03 MB** | **~70% Reduction**  |
| **API Latency (k6 p95)** | 26.8s | **~3.2s** | **~8x Faster**  |

### Proof of Optimization
BEFORE: Heavy Latency (26s p95) and 66% failure rate under load
<img width="1920" height="1080" alt="Screenshot From 2026-03-07 14-59-04" src="https://github.com/user-attachments/assets/b7c321f6-a80c-41b8-accb-82ecb8c03956" />
AFTER: Latency dropped significantly (~3s p95) with 100% success rate (100 VUs)
<img width="1920" height="1080" alt="Screenshot From 2026-03-07 17-15-15" src="https://github.com/user-attachments/assets/27232ea9-12d6-492a-8d7d-fdf93a4bedde" />
BEFORE (pprof): Heavy allocations in `computeFromShapes`
```text
File: maglev
Type: alloc_space
Showing nodes accounting for 743.72MB, 93.68% of 793.92MB total
      flat  flat%   sum%        cum   cum%
  287.95MB 36.27% 36.27%   421.84MB 53.13%  maglev.onebusaway.org/internal/gtfs.(*AdvancedDirectionCalculator).computeFromShapes
  111.88MB 14.09% 50.36%   133.88MB 16.86%  maglev.onebusaway.org/gtfsdb.(*Queries).GetStopsWithShapeContext
```
AFTER (pprof): computeFromShapes allocation dropped to just 7.78MB
<img width="1920" height="1080" alt="Screenshot From 2026-03-07 17-27-08" src="https://github.com/user-attachments/assets/fe474605-7c66-44ac-940b-01e89fb5a778" />

* Note on extreme load limits:
While testing with 500 VUs, some HTTP EOF errors still occur. However, since the memory pressure and GC churn are completely resolved, this remaining ceiling is isolated to SQLite database locking/concurrency limits under heavy concurrent I/O, not CPU/Memory bottlenecks.

@aaronbrethorst 
fixes: #506 