### PR TITLE
chore: address Phase 2 feedback (logging, types, tests)

### DIFF
--- a/internal/gtfs/frequency_helper_test.go
+++ b/internal/gtfs/frequency_helper_test.go
@@ -112,19 +112,27 @@ func TestExpandFrequencyTrips_Basic(t *testing.T) {
 
 	// First departure: 06:00 (no shift since base arrival == window start)
 	assert.Equal(t, int64(6*time.Hour), expanded[0].ArrivalTime)
+	assert.Equal(t, int64(6*time.Hour+1*time.Minute), expanded[0].DepartureTime)
 	assert.Equal(t, "A", expanded[0].StopID)
 	assert.Equal(t, int64(6*time.Hour+10*time.Minute), expanded[1].ArrivalTime)
+	assert.Equal(t, int64(6*time.Hour+11*time.Minute), expanded[1].DepartureTime)
 	assert.Equal(t, "B", expanded[1].StopID)
 
 	// Second departure: 06:20
 	assert.Equal(t, int64(6*time.Hour+20*time.Minute), expanded[2].ArrivalTime)
+	assert.Equal(t, int64(6*time.Hour+21*time.Minute), expanded[2].DepartureTime)
 	assert.Equal(t, "A", expanded[2].StopID)
 	assert.Equal(t, int64(6*time.Hour+30*time.Minute), expanded[3].ArrivalTime)
+	assert.Equal(t, int64(6*time.Hour+31*time.Minute), expanded[3].DepartureTime)
 	assert.Equal(t, "B", expanded[3].StopID)
 
 	// Third departure: 06:40
 	assert.Equal(t, int64(6*time.Hour+40*time.Minute), expanded[4].ArrivalTime)
+	assert.Equal(t, int64(6*time.Hour+41*time.Minute), expanded[4].DepartureTime)
 	assert.Equal(t, "A", expanded[4].StopID)
+	assert.Equal(t, int64(6*time.Hour+50*time.Minute), expanded[5].ArrivalTime)
+	assert.Equal(t, int64(6*time.Hour+51*time.Minute), expanded[5].DepartureTime)
+	assert.Equal(t, "B", expanded[5].StopID)
 }
 
 func TestExpandFrequencyTrips_PreservesFields(t *testing.T) {
@@ -197,6 +205,23 @@ func TestExpandFrequencyTrips_ZeroHeadway(t *testing.T) {
 
 	result := ExpandFrequencyTrips(baseStopTimes, freq)
 	assert.Nil(t, result)
+}
+
+func TestExpandFrequencyTrips_NegativeHeadway(t *testing.T) {
+	baseStopTimes := []gtfsdb.StopTime{
+		{TripID: "t1", ArrivalTime: int64(6 * time.Hour), DepartureTime: int64(6 * time.Hour), StopID: "A", StopSequence: 1},
+	}
+
+	freq := gtfsdb.Frequency{
+		TripID:      "t1",
+		StartTime:   int64(6 * time.Hour),
+		EndTime:     int64(9 * time.Hour),
+		HeadwaySecs: -600,
+		ExactTimes:  1,
+	}
+
+	result := ExpandFrequencyTrips(baseStopTimes, freq)
+	assert.Nil(t, result, "Should return nil and avoid infinite loop on negative headway")
 }
 
 func TestExpandFrequencyTrips_BaseOffsetDiffersFromWindowStart(t *testing.T) {

--- a/internal/gtfs/gtfs_manager.go
+++ b/internal/gtfs/gtfs_manager.go
@@ -314,7 +314,7 @@ func InitGTFSManager(ctx context.Context, config Config) (*Manager, error) {
 			freqTripIDs[id] = struct{}{}
 		}
 	} else {
-		logger.Error("failed to load frequency trip IDs", "error", err)
+		logging.LogError(logger, "failed to load frequency trip IDs", err)
 	}
 	manager.frequencyTripIDs = freqTripIDs
 

--- a/internal/models/trip.go
+++ b/internal/models/trip.go
@@ -41,7 +41,7 @@ func NewTripReference(id, routeID, serviceID, headSign, shortName string, direct
 }
 
 type TripsSchedule struct {
-	Frequency      *int64     `json:"frequency"`
+	Frequency      *Frequency `json:"frequency"`
 	NextTripId     string     `json:"nextTripId"`
 	PreviousTripId string     `json:"previousTripId"`
 	StopTimes      []StopTime `json:"stopTimes"`

--- a/internal/models/trip_test.go
+++ b/internal/models/trip_test.go
@@ -144,7 +144,7 @@ func TestTripResponseJSON(t *testing.T) {
 }
 
 func TestTripsScheduleJSON(t *testing.T) {
-	frequency := int64(300)
+	frequency := Frequency{}
 	schedule := TripsSchedule{
 		Frequency:      &frequency,
 		NextTripId:     "next_trip",


### PR DESCRIPTION
### Phase 2 Follow-up / Feedback Resolution

This PR addresses the non-blocking suggestions and feedback provided in the Phase 2 PR review. 

### Changes Implemented:
* **Standardized Logging:** Replaced `logger.Error` with `logging.LogError` in `internal/gtfs/gtfs_manager.go:293` to ensure proper Sentry tracking during startup cache failures.
* **Type Alignment:** Updated `TripsSchedule.Frequency` from `*int64` to `*Frequency` in `internal/models/trip.go` to maintain JSON shape consistency across endpoints for Phase 3.
* **Enhanced Test Assertions:** Added `DepartureTime` assertions in `TestExpandFrequencyTrips_Basic` to strictly verify that arrival-to-departure shifts are applied correctly.
* **Negative Headway Edge Case:** Added `TestExpandFrequencyTrips_NegativeHeadway` to guarantee the `<= 0` guard properly prevents infinite loops.

All tests are passing, and types are now fully aligned for Phase 3 implementation. 
@aaronbrethorst 
closes: #582 