### PR TITLE
chore: address PR #607 review feedback

### DIFF
--- a/cmd/api/app.go
+++ b/cmd/api/app.go
@@ -161,7 +161,7 @@ func CreateServer(coreApp *app.Application, cfg appconf.Config) (*http.Server, *
 		IdleTimeout:    time.Minute,
 		ReadTimeout:    5 * time.Second,
 		WriteTimeout:   10 * time.Second,
-		MaxHeaderBytes: 1 << 20, // 1 MB
+		MaxHeaderBytes: 1 << 20, // 1 MB (explicit; matches Go's default)
 		ErrorLog:       slog.NewLogLogger(coreApp.Logger.Handler(), slog.LevelError),
 	}
 

--- a/internal/restapi/size_limit_middleware_test.go
+++ b/internal/restapi/size_limit_middleware_test.go
@@ -34,9 +34,12 @@ func TestSizeLimitMiddleware_ExceedsLimit(t *testing.T) {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_, err := io.ReadAll(r.Body)
 		// io.ReadAll should return an error when the limit is exceeded
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "request body too large")
-
+		if err != nil {
+			assert.Contains(t, err.Error(), "request body too large")
+			http.Error(w, "payload too large", http.StatusRequestEntityTooLarge)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
 	})
 
 	limit := int64(10)
@@ -52,4 +55,6 @@ func TestSizeLimitMiddleware_ExceedsLimit(t *testing.T) {
 	w := httptest.NewRecorder()
 
 	wrappedHandler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusRequestEntityTooLarge, w.Code)
 }


### PR DESCRIPTION
## Summary
Follow-up for #607 PR review to address non-blocking suggestions.

## Changes
- **Explicit MaxHeaderBytes default:** Added a comment in `app.go` to clarify that `1 << 20` explicitly matches Go's default `http.DefaultMaxHeaderBytes`.
- **Improved Size Limit Tests:** Updated `TestSizeLimitMiddleware_ExceedsLimit` in `size_limit_middleware_test.go` to simulate returning a `413 Request Entity Too Large` error, ensuring the test verifies that clients receive the right HTTP status when the body exceeds the limit check.
