### PR TITLE
chore: address PR review suggestions for GTFS feed expiry

### DIFF
--- a/internal/gtfs/gtfs_manager_test.go
+++ b/internal/gtfs/gtfs_manager_test.go
@@ -538,8 +538,8 @@ func TestInitGTFSManager_RetryLogic(t *testing.T) {
 	}
 
 	config := Config{
-		// Use a clearly invalid URL that will trigger failures
-		GtfsURL:        "http://invalid.url.that.will.fail.internal/gtfs.zip",
+		// Use a clearly invalid local URL that will trigger immediate connection refused
+		GtfsURL:        "http://127.0.0.1:9099/gtfs.zip",
 		GTFSDataPath:   ":memory:",
 		Env:            appconf.Test,
 		StartupRetries: backoffs, // Inject test backoffs
@@ -555,7 +555,7 @@ func TestInitGTFSManager_RetryLogic(t *testing.T) {
 
 	// Verify the entire process was fast (proving it used our 1ms, 2ms, 3ms backoffs)
 	duration := time.Since(start)
-	assert.Less(t, duration, 10*time.Second, "Retry logic should respect the configured backoff schedule")
+	assert.Less(t, duration, 2*time.Second, "Retry logic should respect the configured backoff schedule")
 }
 
 func TestParseAndLogFeedExpiryLocked(t *testing.T) {
@@ -599,4 +599,23 @@ func TestParseAndLogFeedExpiryLocked(t *testing.T) {
 
 	manager.parseAndLogFeedExpiryLocked(ctx, slog.Default())
 	assert.True(t, manager.feedExpiresAt.IsZero(), "Should reset to zero after hot swap to empty feed")
+
+	// 4. Test calendar_dates exception_type = 1 branch
+	// Insert a valid calendar date
+	_, err = db.Exec("INSERT INTO calendar (end_date) VALUES ('20260401')")
+	require.NoError(t, err)
+
+	// Insert an extra service day via calendar_dates (exception_type = 1) that is LATER than calendar end_date
+	_, err = db.Exec("INSERT INTO calendar_dates (date, exception_type) VALUES ('20260405', 1)")
+	require.NoError(t, err)
+	// Insert a removed service day (exception_type = 2) that is later than the added day, which should be ignored by the query calculation
+	_, err = db.Exec("INSERT INTO calendar_dates (date, exception_type) VALUES ('20260410', 2)")
+	require.NoError(t, err)
+
+	manager.parseAndLogFeedExpiryLocked(ctx, slog.Default())
+	assert.False(t, manager.feedExpiresAt.IsZero(), "Should parse end date")
+
+	// Valid end date should be 2026-04-05 23:59:59 (from calendar_dates exception_type = 1)
+	expectedTime2, _ := time.Parse("20060102150405", "20260405235959")
+	assert.Equal(t, expectedTime2.Unix(), manager.feedExpiresAt.Unix())
 }

--- a/internal/gtfs/static.go
+++ b/internal/gtfs/static.go
@@ -462,7 +462,7 @@ func buildFrequencyCache(ctx context.Context, queries *gtfsdb.Queries) (map[stri
 func (manager *Manager) parseAndLogFeedExpiryLocked(ctx context.Context, logger *slog.Logger) {
 	manager.feedExpiresAt = time.Time{}
 	if manager.Metrics != nil && manager.Metrics.FeedExpiresAt != nil {
-		manager.Metrics.FeedExpiresAt.Set(0)
+		manager.Metrics.FeedExpiresAt.Set(-1)
 	}
 
 	if manager.GtfsDB == nil || manager.GtfsDB.Queries == nil {
@@ -475,7 +475,16 @@ func (manager *Manager) parseAndLogFeedExpiryLocked(ctx context.Context, logger 
 		return
 	}
 
-	strVal, _ := val.(string)
+	var strVal string
+	switch v := val.(type) {
+	case string:
+		strVal = v
+	case []byte:
+		strVal = string(v)
+	default:
+		logging.LogError(logger, "Unexpected type from GetFeedEndDate", fmt.Errorf("expected string, got %T", val))
+		return
+	}
 
 	if strVal != "" {
 		parsedTime, err := time.Parse("20060102", strVal)

--- a/internal/restapi/gtfs_expiry_middleware.go
+++ b/internal/restapi/gtfs_expiry_middleware.go
@@ -2,6 +2,7 @@ package restapi
 
 import (
 	"net/http"
+	"strings"
 	"time"
 
 	"maglev.onebusaway.org/internal/gtfs"
@@ -13,7 +14,7 @@ func GtfsExpiryMiddleware(manager *gtfs.Manager) func(http.Handler) http.Handler
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			if manager != nil {
 				// Only apply this header to API routes to reduce noise on other endpoints
-				if len(r.URL.Path) >= 4 && r.URL.Path[:4] == "/api" {
+				if strings.HasPrefix(r.URL.Path, "/api/") {
 					expiresAt := manager.FeedExpiresAt()
 					if !expiresAt.IsZero() && time.Now().After(expiresAt) {
 						w.Header().Set("X-Data-Expired", "true")


### PR DESCRIPTION
## Summary
This PR is a follow-up to address the non-blocking suggestions from the #611 PR review.

## Changes
- **GTFS Manager:** Reset the `feedExpiresAt` Prometheus gauge to `-1` consistently (instead of `0`) in `parseAndLogFeedExpiryLocked` to properly represent the "unknown" state and avoid confusion with the UNIX epoch.
- **Type Safety:** Enhanced the `GetFeedEndDate` type assertion in `static.go` with a type switch to safely handle both `string` and `[]byte` types from SQLite, preventing silent parsing failures.
- **Middleware:** Improved the API path prefix check in `GtfsExpiryMiddleware` using `strings.HasPrefix(r.URL.Path, "/api/")` to avoid unintended matches with non-API routes (e.g. `/apiary`).
- **Tests:** 
  - Reduced the `TestInitGTFSManager_RetryLogic` timeout threshold from 10 seconds to 2 seconds and switched the mocked GTFS URL to a local unused port (`127.0.0.1:9099`) to ensure fast dial connection failures without DNS resolution delays.
  - Added new test coverage in `TestParseAndLogFeedExpiryLocked` for the `calendar_dates` where `exception_type = 1` occurs after the standard calendar end date.
