### PR TITLE
chore: clean up dead sequence guard and standardize error logging

### DIFF
--- a/internal/restapi/arrival_and_departure_for_stop_handler.go
+++ b/internal/restapi/arrival_and_departure_for_stop_handler.go
@@ -230,11 +230,6 @@ func (api *RestAPI) arrivalAndDepartureForStopHandler(w http.ResponseWriter, r *
 		}
 	}
 
-	if params.StopSequence != nil && int64(*params.StopSequence) != targetRow.StopSequence {
-		api.sendNotFound(w, r)
-		return
-	}
-
 	targetStopTime := struct {
 		ArrivalTime   int64
 		DepartureTime int64

--- a/internal/restapi/trips_helper.go
+++ b/internal/restapi/trips_helper.go
@@ -1017,7 +1017,7 @@ func (api *RestAPI) getFirstStopOfNextTripInBlock(ctx context.Context, currentTr
 			slog.Warn("getFirstStopOfNextTripInBlock: query failed",
 				slog.String("trip_id", currentTripID),
 				slog.String("block_id", trip.BlockID.String),
-				slog.Any("error", err))
+				slog.String("error", err.Error()))
 		}
 		return nil
 	}


### PR DESCRIPTION
## Description
- This PR addresses follow-up suggestions PR #590

### Changes
* **Removed dead guard clause (`arrival_and_departure_for_stop_handler.go`):** Dropped the redundant `StopSequence` check. `GetTargetStopTimeWithTotalStopsBySequence` already filters by `stop_sequence` in the `WHERE` clause, making the subsequent sequence match check unnecessary.
* **Standardized error logging (`trips_helper.go`):** Updated `getFirstStopOfNextTripInBlock` to use `slog.String("error", err.Error())` instead of `slog.Any`, matching the logging style used throughout the rest of the file to make log queries easier to write.