### PR TITLE
fix: Handle nil calendar data in GTFS static processing and add test …

### DIFF
--- a/internal/gtfs/static.go
+++ b/internal/gtfs/static.go
@@ -503,6 +503,9 @@ func (manager *Manager) parseAndLogFeedExpiryLocked(ctx context.Context, logger 
 
 	var strVal string
 	switch v := val.(type) {
+	case nil:
+		// No calendar data; strVal remains "" and falls through
+		// to the "no active calendar dates" warning below.
 	case string:
 		strVal = v
 	case []byte:

--- a/internal/restapi/gtfs_expiry_middleware_test.go
+++ b/internal/restapi/gtfs_expiry_middleware_test.go
@@ -53,6 +53,13 @@ func TestGtfsExpiryMiddleware(t *testing.T) {
 			setupManager:   func(m *gtfs.Manager) { m.SetFeedExpiresAt(time.Now().Add(-24 * time.Hour)) },
 			expectedHeader: "",
 		},
+		{
+			name:           "Non-API path /api (without trailing slash) is intentionally excluded",
+			path:           "/api",
+			manager:        &gtfs.Manager{},
+			setupManager:   func(m *gtfs.Manager) { m.SetFeedExpiresAt(time.Now().Add(-24 * time.Hour)) },
+			expectedHeader: "",
+		},
 	}
 
 	for _, tc := range tests {

--- a/internal/restapi/trips_helper_test.go
+++ b/internal/restapi/trips_helper_test.go
@@ -1859,7 +1859,6 @@ func TestFindClosestStopByTimeWithDelays_OvernightTrip(t *testing.T) {
 	assert.Equal(t, "stop-1am-next", closestID)
 }
 
-
 func TestInferOrientationFromShape(t *testing.T) {
 	tests := []struct {
 		name      string
@@ -2021,4 +2020,3 @@ func TestGetNextAndPreviousTripIDs_TripNotInBlockOnDate(t *testing.T) {
 	assert.Empty(t, next)
 	assert.Empty(t, prev)
 }
-

--- a/internal/utils/api.go
+++ b/internal/utils/api.go
@@ -1,7 +1,6 @@
 package utils
 
 import (
-
 	"fmt"
 	"log/slog"
 	"net/http"


### PR DESCRIPTION
## Description
This PR addresses Follow-up to: #637 

### Changes
* **Defensive Type Safety:** Added a `nil` case to the type switch in `static.go` (`parseAndLogFeedExpiryLocked`).
* **Middleware Testing:** Added a specific test case for the bare `/api` path (no trailing slash) in `gtfs_expiry_middleware_test.go`.
* **Code Formatting:** run `go fmt ./...` adjustments to several other files included in this PR.