### PR TITLE
fix: wrap GTFS import in a single transaction to ensure atomic datase…

### DIFF
--- a/gtfsdb/bulk_insert_frequency_test.go
+++ b/gtfsdb/bulk_insert_frequency_test.go
@@ -135,7 +135,7 @@ func TestBulkInsertFrequencies(t *testing.T) {
 				}
 			}
 
-			err := client.bulkInsertFrequencies(ctx, frequencies)
+			err := client.bulkInsertFrequencies(ctx, frequencies, nil)
 			require.NoError(t, err)
 
 			if tc.count == 0 {
@@ -181,7 +181,7 @@ func TestBulkInsertFrequencies_MultipleTrips(t *testing.T) {
 		{TripID: "trip_3", StartTime: int64(8 * 3600 * 1e9), EndTime: int64(12 * 3600 * 1e9), HeadwaySecs: 1200, ExactTimes: 0},
 	}
 
-	err := client.bulkInsertFrequencies(ctx, frequencies)
+	err := client.bulkInsertFrequencies(ctx, frequencies, nil)
 	require.NoError(t, err)
 
 	rows1, err := client.Queries.GetFrequenciesForTrip(ctx, "trip_1")
@@ -215,7 +215,7 @@ func TestBulkInsertFrequencies_DuplicatePrimaryKey(t *testing.T) {
 		{TripID: "trip_1", StartTime: startTime, EndTime: int64(10 * 3600 * 1e9), HeadwaySecs: 900, ExactTimes: 1},
 	}
 
-	err := client.bulkInsertFrequencies(ctx, frequencies)
+	err := client.bulkInsertFrequencies(ctx, frequencies, nil)
 	require.NoError(t, err)
 
 	rows, err := client.Queries.GetFrequenciesForTrip(ctx, "trip_1")
@@ -237,7 +237,7 @@ func TestGetFrequencyTripIDs(t *testing.T) {
 		{TripID: "trip_3", StartTime: int64(8 * 3600 * 1e9), EndTime: int64(12 * 3600 * 1e9), HeadwaySecs: 1200, ExactTimes: 0},
 	}
 
-	err := client.bulkInsertFrequencies(ctx, frequencies)
+	err := client.bulkInsertFrequencies(ctx, frequencies, nil)
 	require.NoError(t, err)
 
 	tripIDs, err := client.Queries.GetFrequencyTripIDs(ctx)
@@ -258,7 +258,7 @@ func TestClearFrequencies(t *testing.T) {
 		{TripID: "trip_2", StartTime: int64(7 * 3600 * 1e9), EndTime: int64(10 * 3600 * 1e9), HeadwaySecs: 300, ExactTimes: 1},
 	}
 
-	err := client.bulkInsertFrequencies(ctx, frequencies)
+	err := client.bulkInsertFrequencies(ctx, frequencies, nil)
 	require.NoError(t, err)
 
 	rows, err := client.Queries.GetFrequenciesForTrip(ctx, "trip_1")
@@ -289,7 +289,7 @@ func TestGetFrequenciesForTrips(t *testing.T) {
 		{TripID: "trip_3", StartTime: int64(8 * 3600 * 1e9), EndTime: int64(12 * 3600 * 1e9), HeadwaySecs: 1200, ExactTimes: 0},
 	}
 
-	err := client.bulkInsertFrequencies(ctx, frequencies)
+	err := client.bulkInsertFrequencies(ctx, frequencies, nil)
 	require.NoError(t, err)
 
 	rows, err := client.Queries.GetFrequenciesForTrips(ctx, []string{"trip_1", "trip_2"})

--- a/gtfsdb/bulk_insert_test.go
+++ b/gtfsdb/bulk_insert_test.go
@@ -106,7 +106,7 @@ func TestBulkInsertStopTimes(t *testing.T) {
 			}
 
 			// Perform bulk insert
-			err = client.bulkInsertStopTimes(ctx, stopTimes)
+			err = client.bulkInsertStopTimes(ctx, stopTimes, nil)
 			require.NoError(t, err, "Bulk insert should succeed")
 
 			// Verify all records were inserted
@@ -176,7 +176,7 @@ func TestBulkInsertShapes(t *testing.T) {
 			}
 
 			// Perform bulk insert
-			err = client.bulkInsertShapes(ctx, shapes)
+			err = client.bulkInsertShapes(ctx, shapes, nil)
 			require.NoError(t, err, "Bulk insert should succeed")
 
 			// Verify all records were inserted
@@ -234,7 +234,7 @@ func TestBulkInsertWithNullValues(t *testing.T) {
 		},
 	}
 
-	err = client.bulkInsertShapes(ctx, shapes)
+	err = client.bulkInsertShapes(ctx, shapes, nil)
 	require.NoError(t, err, "Should handle NULL values")
 
 	// Verify NULL was inserted correctly
@@ -333,7 +333,7 @@ func TestBulkInsertPerformance(t *testing.T) {
 
 	// Measure bulk insert performance
 	start := time.Now()
-	err = client.bulkInsertStopTimes(ctx, stopTimes)
+	err = client.bulkInsertStopTimes(ctx, stopTimes, nil)
 	duration := time.Since(start)
 
 	require.NoError(t, err, "Bulk insert should succeed")

--- a/gtfsdb/helpers.go
+++ b/gtfsdb/helpers.go
@@ -116,23 +116,30 @@ func (c *Client) processAndStoreGTFSDataWithSource(b []byte, source string) erro
 
 	logging.LogOperation(logger, "retrieved_static_data", slog.Int("warnings", len(staticData.Warnings)))
 
-	// 4. Clear the old data now that we know the new data is completely valid
-	if hasExisting {
-		logging.LogOperation(logger, "gtfs_data_changed_reimporting",
-			slog.String("old_hash", existingMetadata.FileHash[:8]),
-			slog.String("new_hash", hashStr[:8]))
-		err = c.clearAllGTFSData(ctx)
-		if err != nil {
-			return fmt.Errorf("error clearing existing GTFS data: %w", err)
-		}
-	}
-
 	staticCounts := c.staticDataCounts(staticData)
 	for k, v := range staticCounts {
 		logging.LogOperation(logger, "static_data_count", slog.String("entity_type", k), slog.Int("count", v))
 	}
 
 	logging.LogOperation(logger, "starting_database_import")
+
+	tx, err := c.DB.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("error starting import transaction: %w", err)
+	}
+	defer logging.SafeRollbackWithLogging(tx, logger, "processAndStoreGTFSDataWithSource")
+
+	qtx := c.Queries.WithTx(tx)
+
+	// Clear the old data inside the same transaction so the import is atomic
+	if hasExisting {
+		logging.LogOperation(logger, "gtfs_data_changed_reimporting",
+			slog.String("old_hash", existingMetadata.FileHash[:8]),
+			slog.String("new_hash", hashStr[:8]))
+		if err := c.clearAllGTFSDataWithQueries(ctx, qtx); err != nil {
+			return fmt.Errorf("error clearing existing GTFS data: %w", err)
+		}
+	}
 
 	logging.LogOperation(logger, "inserting_agencies_and_routes",
 		slog.Int("agencies", len(staticData.Agencies)),
@@ -150,7 +157,7 @@ func (c *Client) processAndStoreGTFSDataWithSource(b []byte, source string) erro
 			Email:    toNullString(a.Email),
 		}
 
-		_, err := c.Queries.CreateAgency(ctx, params)
+		_, err := qtx.CreateAgency(ctx, params)
 		if err != nil {
 			return fmt.Errorf("unable to create agency: %w", err)
 		}
@@ -176,7 +183,7 @@ func (c *Client) processAndStoreGTFSDataWithSource(b []byte, source string) erro
 			ContinuousDropOff: toNullInt64(int64(r.ContinuousDropOff)),
 		}
 
-		_, err := c.Queries.CreateRoute(ctx, route)
+		_, err := qtx.CreateRoute(ctx, route)
 
 		if err != nil {
 			return fmt.Errorf("unable to create route: %w", err)
@@ -216,8 +223,7 @@ func (c *Client) processAndStoreGTFSDataWithSource(b []byte, source string) erro
 
 		allStopParams = append(allStopParams, params)
 	}
-	err = c.bulkInsertStops(ctx, allStopParams)
-	if err != nil {
+	if err := c.bulkInsertStops(ctx, allStopParams, tx); err != nil {
 		return fmt.Errorf("unable to create stops: %w", err)
 	}
 
@@ -241,7 +247,7 @@ func (c *Client) processAndStoreGTFSDataWithSource(b []byte, source string) erro
 			EndDate:   s.EndDate.Format("20060102"),
 		}
 
-		_, err := c.Queries.CreateCalendar(ctx, params)
+		_, err := qtx.CreateCalendar(ctx, params)
 		if err != nil {
 			return fmt.Errorf("unable to create calendar: %w", err)
 		}
@@ -272,8 +278,7 @@ func (c *Client) processAndStoreGTFSDataWithSource(b []byte, source string) erro
 		}
 		allTripParams = append(allTripParams, params)
 	}
-	err = c.bulkInsertTrips(ctx, allTripParams)
-	if err != nil {
+	if err := c.bulkInsertTrips(ctx, allTripParams, tx); err != nil {
 		return fmt.Errorf("unable to create trips: %w", err)
 	}
 
@@ -301,8 +306,7 @@ func (c *Client) processAndStoreGTFSDataWithSource(b []byte, source string) erro
 			allStopTimeParams = append(allStopTimeParams, params)
 		}
 	}
-	err = c.bulkInsertStopTimes(ctx, allStopTimeParams)
-	if err != nil {
+	if err := c.bulkInsertStopTimes(ctx, allStopTimeParams, tx); err != nil {
 		return fmt.Errorf("unable to create stop times: %w", err)
 	}
 
@@ -321,8 +325,7 @@ func (c *Client) processAndStoreGTFSDataWithSource(b []byte, source string) erro
 		}
 	}
 	if len(allFrequencyParams) > 0 {
-		err = c.bulkInsertFrequencies(ctx, allFrequencyParams)
-		if err != nil {
+		if err := c.bulkInsertFrequencies(ctx, allFrequencyParams, tx); err != nil {
 			return fmt.Errorf("unable to create frequencies: %w", err)
 		}
 	}
@@ -345,25 +348,15 @@ func (c *Client) processAndStoreGTFSDataWithSource(b []byte, source string) erro
 			allShapeParams = append(allShapeParams, params)
 		}
 	}
-	err = c.bulkInsertShapes(ctx, allShapeParams)
-	if err != nil {
+	if err := c.bulkInsertShapes(ctx, allShapeParams, tx); err != nil {
 		return fmt.Errorf("unable to create shapes: %w", err)
-	}
-
-	counts, err := c.TableCounts()
-	if err != nil {
-		logging.LogError(logger, "Error getting table counts", err)
-		return fmt.Errorf("failed to get table counts: %w", err)
-	}
-	for k, v := range counts {
-		logging.LogOperation(logger, "table_count", slog.String("table", k), slog.Int("count", v), slog.Bool("static_matches", v == staticCounts[k]))
 	}
 
 	logging.LogOperation(logger, "updating_import_metadata",
 		slog.String("hash", hashStr[:8]),
 		slog.String("source", source))
 
-	_, err = c.Queries.UpsertImportMetadata(ctx, UpsertImportMetadataParams{
+	_, err = qtx.UpsertImportMetadata(ctx, UpsertImportMetadataParams{
 		FileHash:   hashStr,
 		ImportTime: time.Now().Unix(),
 		FileSource: source,
@@ -399,64 +392,87 @@ func (c *Client) processAndStoreGTFSDataWithSource(b []byte, source string) erro
 		}
 	}
 
-	// Insert calendar dates into the database
 	if len(allCalendarDateParams) > 0 {
-		err = c.bulkInsertCalendarDates(ctx, allCalendarDateParams)
-		if err != nil {
+		if err := c.bulkInsertCalendarDates(ctx, allCalendarDateParams, tx); err != nil {
 			logging.LogError(logger, "Unable to create calendar dates", err)
 			return fmt.Errorf("unable to create calendar dates: %w", err)
 		}
 	}
 
-	// Build BlockTripIndex after all trips and stop_times are inserted
 	logging.LogOperation(logger, "building_block_trip_index")
-	err = c.buildBlockTripIndex(ctx, staticData)
-	if err != nil {
+	if err := c.buildBlockTripIndex(ctx, staticData, tx); err != nil {
 		logging.LogError(logger, "Unable to build block trip index", err)
 		return fmt.Errorf("unable to build block trip index: %w", err)
 	}
 	logging.LogOperation(logger, "block_trip_index_built")
 
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("error committing import transaction: %w", err)
+	}
+
+	counts, err := c.TableCounts()
+	if err != nil {
+		logging.LogError(logger, "Error getting table counts", err)
+		return fmt.Errorf("failed to get table counts: %w", err)
+	}
+	for k, v := range counts {
+		logging.LogOperation(logger, "table_count", slog.String("table", k), slog.Int("count", v), slog.Bool("static_matches", v == staticCounts[k]))
+	}
+
 	return nil
 }
 
-// clearAllGTFSData clears all GTFS data from the database in the correct order to respect foreign key constraints
-func (c *Client) clearAllGTFSData(ctx context.Context) error {
-	// Delete in reverse order of dependencies to avoid foreign key constraint violations
-	if err := c.Queries.ClearBlockTripEntries(ctx); err != nil {
+// clearAllGTFSDataWithQueries clears all GTFS data using the given Queries (e.g. transaction-scoped).
+// Delete order respects foreign key constraints.
+func (c *Client) clearAllGTFSDataWithQueries(ctx context.Context, q *Queries) error {
+	if err := q.ClearBlockTripEntries(ctx); err != nil {
 		return fmt.Errorf("error clearing block_trip_entry: %w", err)
 	}
-	if err := c.Queries.ClearBlockTripIndices(ctx); err != nil {
+	if err := q.ClearBlockTripIndices(ctx); err != nil {
 		return fmt.Errorf("error clearing block_trip_index: %w", err)
 	}
-	if err := c.Queries.ClearFrequencies(ctx); err != nil {
+	if err := q.ClearFrequencies(ctx); err != nil {
 		return fmt.Errorf("error clearing frequencies: %w", err)
 	}
-	if err := c.Queries.ClearStopTimes(ctx); err != nil {
+	if err := q.ClearStopTimes(ctx); err != nil {
 		return fmt.Errorf("error clearing stop_times: %w", err)
 	}
-	if err := c.Queries.ClearShapes(ctx); err != nil {
+	if err := q.ClearShapes(ctx); err != nil {
 		return fmt.Errorf("error clearing shapes: %w", err)
 	}
-	if err := c.Queries.ClearTrips(ctx); err != nil {
+	if err := q.ClearTrips(ctx); err != nil {
 		return fmt.Errorf("error clearing trips: %w", err)
 	}
-	if err := c.Queries.ClearCalendarDates(ctx); err != nil {
+	if err := q.ClearCalendarDates(ctx); err != nil {
 		return fmt.Errorf("error clearing calendar dates: %w", err)
 	}
-	if err := c.Queries.ClearCalendar(ctx); err != nil {
+	if err := q.ClearCalendar(ctx); err != nil {
 		return fmt.Errorf("error clearing calendar: %w", err)
 	}
-	if err := c.Queries.ClearStops(ctx); err != nil {
+	if err := q.ClearStops(ctx); err != nil {
 		return fmt.Errorf("error clearing stops: %w", err)
 	}
-	if err := c.Queries.ClearRoutes(ctx); err != nil {
+	if err := q.ClearRoutes(ctx); err != nil {
 		return fmt.Errorf("error clearing routes: %w", err)
 	}
-	if err := c.Queries.ClearAgencies(ctx); err != nil {
+	if err := q.ClearAgencies(ctx); err != nil {
 		return fmt.Errorf("error clearing agencies: %w", err)
 	}
 	return nil
+}
+
+// clearAllGTFSData clears all GTFS data from the database in the correct order to respect foreign key constraints.
+// It runs in its own transaction. Use clearAllGTFSDataWithQueries when you need to clear within an existing transaction.
+func (c *Client) clearAllGTFSData(ctx context.Context) error {
+	tx, err := c.DB.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer logging.SafeRollbackWithLogging(tx, slog.Default().With(slog.String("component", "gtfs_importer")), "clearAllGTFSData")
+	if err := c.clearAllGTFSDataWithQueries(ctx, c.Queries.WithTx(tx)); err != nil {
+		return err
+	}
+	return tx.Commit()
 }
 
 func boolToInt(b bool) int64 {
@@ -535,7 +551,8 @@ func pickFirstAvailable(a, b string) string {
 	return b
 }
 
-func (c *Client) bulkInsertStops(ctx context.Context, stops []CreateStopParams) error {
+// bulkInsertStops inserts stops. If tx is non-nil it uses that transaction and does not commit; if nil it starts its own and commits.
+func (c *Client) bulkInsertStops(ctx context.Context, stops []CreateStopParams, tx *sql.Tx) error {
 	db := c.DB
 	queries := c.Queries
 	logger := slog.Default().With(slog.String("component", "bulk_insert"))
@@ -543,13 +560,17 @@ func (c *Client) bulkInsertStops(ctx context.Context, stops []CreateStopParams) 
 	logging.LogOperation(logger, "inserting_stops",
 		slog.Int("count", len(stops)))
 
-	tx, err := db.Begin()
-	if err != nil {
-		return err
+	useTx := tx
+	if useTx == nil {
+		var err error
+		useTx, err = db.Begin()
+		if err != nil {
+			return err
+		}
+		defer logging.SafeRollbackWithLogging(useTx, logger, "bulk_insert_stops")
 	}
-	defer logging.SafeRollbackWithLogging(tx, logger, "bulk_insert_stops")
 
-	qtx := queries.WithTx(tx)
+	qtx := queries.WithTx(useTx)
 	for _, params := range stops {
 		_, err := qtx.CreateStop(ctx, params)
 		if err != nil {
@@ -557,8 +578,10 @@ func (c *Client) bulkInsertStops(ctx context.Context, stops []CreateStopParams) 
 		}
 	}
 
-	if err := tx.Commit(); err != nil {
-		return err
+	if tx == nil {
+		if err := useTx.Commit(); err != nil {
+			return err
+		}
 	}
 
 	logging.LogOperation(logger, "stops_inserted",
@@ -567,7 +590,8 @@ func (c *Client) bulkInsertStops(ctx context.Context, stops []CreateStopParams) 
 	return nil
 }
 
-func (c *Client) bulkInsertTrips(ctx context.Context, trips []CreateTripParams) error {
+// bulkInsertTrips inserts trips. If tx is non-nil it uses that transaction and does not commit; if nil it starts its own and commits.
+func (c *Client) bulkInsertTrips(ctx context.Context, trips []CreateTripParams, tx *sql.Tx) error {
 	db := c.DB
 	queries := c.Queries
 	logger := slog.Default().With(slog.String("component", "bulk_insert"))
@@ -575,13 +599,17 @@ func (c *Client) bulkInsertTrips(ctx context.Context, trips []CreateTripParams) 
 	logging.LogOperation(logger, "inserting_trips",
 		slog.Int("count", len(trips)))
 
-	tx, err := db.Begin()
-	if err != nil {
-		return err
+	useTx := tx
+	if useTx == nil {
+		var err error
+		useTx, err = db.Begin()
+		if err != nil {
+			return err
+		}
+		defer logging.SafeRollbackWithLogging(useTx, logger, "bulk_insert_trips")
 	}
-	defer logging.SafeRollbackWithLogging(tx, logger, "bulk_insert_trips")
 
-	qtx := queries.WithTx(tx)
+	qtx := queries.WithTx(useTx)
 	for _, params := range trips {
 		_, err := qtx.CreateTrip(ctx, params)
 		if err != nil {
@@ -589,8 +617,10 @@ func (c *Client) bulkInsertTrips(ctx context.Context, trips []CreateTripParams) 
 		}
 	}
 
-	if err := tx.Commit(); err != nil {
-		return err
+	if tx == nil {
+		if err := useTx.Commit(); err != nil {
+			return err
+		}
 	}
 
 	logging.LogOperation(logger, "trips_inserted",
@@ -607,7 +637,8 @@ type preparedStopTimeBatch struct {
 	end   int // End position for progress logging
 }
 
-func (c *Client) bulkInsertStopTimes(ctx context.Context, stopTimes []CreateStopTimeParams) error {
+// bulkInsertStopTimes inserts stop times. If tx is non-nil it uses that transaction and does not commit; if nil it starts its own and commits.
+func (c *Client) bulkInsertStopTimes(ctx context.Context, stopTimes []CreateStopTimeParams, tx *sql.Tx) error {
 	db := c.DB
 	logger := slog.Default().With(slog.String("component", "bulk_insert"))
 
@@ -625,12 +656,16 @@ func (c *Client) bulkInsertStopTimes(ctx context.Context, stopTimes []CreateStop
 	// Calculate number of batches
 	numBatches := (len(stopTimes) + batchSize - 1) / batchSize
 
-	// Start database transaction
-	tx, err := db.Begin()
-	if err != nil {
-		return err
+	// Use provided transaction or start our own
+	useTx := tx
+	if useTx == nil {
+		var err error
+		useTx, err = db.Begin()
+		if err != nil {
+			return err
+		}
+		defer logging.SafeRollbackWithLogging(useTx, logger, "bulk_insert_stop_times")
 	}
-	defer logging.SafeRollbackWithLogging(tx, logger, "bulk_insert_stop_times")
 
 	// Create channels for pipeline
 	numWorkers := runtime.NumCPU()
@@ -747,7 +782,7 @@ func (c *Client) bulkInsertStopTimes(ctx context.Context, stopTimes []CreateStop
 		}
 
 		// Execute the batch insert
-		_, err := tx.ExecContext(ctx, batch.query, batch.args...)
+		_, err := useTx.ExecContext(ctx, batch.query, batch.args...)
 		if err != nil {
 			return fmt.Errorf("failed to insert stop_times batch: %w", err)
 		}
@@ -760,8 +795,10 @@ func (c *Client) bulkInsertStopTimes(ctx context.Context, stopTimes []CreateStop
 		}
 	}
 
-	if err := tx.Commit(); err != nil {
-		return err
+	if tx == nil {
+		if err := useTx.Commit(); err != nil {
+			return err
+		}
 	}
 
 	logging.LogOperation(logger, "stop_times_inserted",
@@ -778,7 +815,8 @@ type preparedShapeBatch struct {
 	end   int // End position for progress logging
 }
 
-func (c *Client) bulkInsertShapes(ctx context.Context, shapes []CreateShapeParams) error {
+// bulkInsertShapes inserts shapes. If tx is non-nil it uses that transaction and does not commit; if nil it starts its own and commits.
+func (c *Client) bulkInsertShapes(ctx context.Context, shapes []CreateShapeParams, tx *sql.Tx) error {
 	db := c.DB
 	logger := slog.Default().With(slog.String("component", "bulk_insert"))
 
@@ -904,11 +942,15 @@ func (c *Client) bulkInsertShapes(ctx context.Context, shapes []CreateShapeParam
 	})
 
 	// ===== PHASE 3: SEQUENTIAL DATABASE EXECUTION =====
-	tx, err := db.Begin()
-	if err != nil {
-		return err
+	useTx := tx
+	if useTx == nil {
+		var err error
+		useTx, err = db.Begin()
+		if err != nil {
+			return err
+		}
+		defer logging.SafeRollbackWithLogging(useTx, logger, "bulk_insert_shapes")
 	}
-	defer logging.SafeRollbackWithLogging(tx, logger, "bulk_insert_shapes")
 
 	for _, batch := range preparedBatches {
 		// Check context before executing
@@ -917,7 +959,7 @@ func (c *Client) bulkInsertShapes(ctx context.Context, shapes []CreateShapeParam
 		}
 
 		// Execute the batch insert
-		_, err := tx.ExecContext(ctx, batch.query, batch.args...)
+		_, err := useTx.ExecContext(ctx, batch.query, batch.args...)
 		if err != nil {
 			return fmt.Errorf("failed to insert shapes batch: %w", err)
 		}
@@ -930,8 +972,10 @@ func (c *Client) bulkInsertShapes(ctx context.Context, shapes []CreateShapeParam
 		}
 	}
 
-	if err := tx.Commit(); err != nil {
-		return err
+	if tx == nil {
+		if err := useTx.Commit(); err != nil {
+			return err
+		}
 	}
 
 	logging.LogOperation(logger, "shapes_inserted",
@@ -940,7 +984,8 @@ func (c *Client) bulkInsertShapes(ctx context.Context, shapes []CreateShapeParam
 	return nil
 }
 
-func (c *Client) bulkInsertFrequencies(ctx context.Context, frequencies []CreateFrequencyParams) error {
+// bulkInsertFrequencies inserts frequencies. If tx is non-nil it uses that transaction and does not commit; if nil it starts its own and commits.
+func (c *Client) bulkInsertFrequencies(ctx context.Context, frequencies []CreateFrequencyParams, tx *sql.Tx) error {
 	db := c.DB
 	queries := c.Queries
 	logger := slog.Default().With(slog.String("component", "bulk_insert"))
@@ -948,13 +993,17 @@ func (c *Client) bulkInsertFrequencies(ctx context.Context, frequencies []Create
 	logging.LogOperation(logger, "inserting_frequencies",
 		slog.Int("count", len(frequencies)))
 
-	tx, err := db.Begin()
-	if err != nil {
-		return err
+	useTx := tx
+	if useTx == nil {
+		var err error
+		useTx, err = db.Begin()
+		if err != nil {
+			return err
+		}
+		defer logging.SafeRollbackWithLogging(useTx, logger, "bulk_insert_frequencies")
 	}
-	defer logging.SafeRollbackWithLogging(tx, logger, "bulk_insert_frequencies")
 
-	qtx := queries.WithTx(tx)
+	qtx := queries.WithTx(useTx)
 	for _, params := range frequencies {
 		err := qtx.CreateFrequency(ctx, params)
 		if err != nil {
@@ -962,8 +1011,10 @@ func (c *Client) bulkInsertFrequencies(ctx context.Context, frequencies []Create
 		}
 	}
 
-	if err := tx.Commit(); err != nil {
-		return err
+	if tx == nil {
+		if err := useTx.Commit(); err != nil {
+			return err
+		}
 	}
 
 	logging.LogOperation(logger, "frequencies_inserted",
@@ -972,25 +1023,33 @@ func (c *Client) bulkInsertFrequencies(ctx context.Context, frequencies []Create
 	return nil
 }
 
-func (c *Client) bulkInsertCalendarDates(ctx context.Context, calendarDates []CreateCalendarDateParams) error {
+// bulkInsertCalendarDates inserts calendar dates. If tx is non-nil it uses that transaction and does not commit; if nil it starts its own and commits.
+func (c *Client) bulkInsertCalendarDates(ctx context.Context, calendarDates []CreateCalendarDateParams, tx *sql.Tx) error {
 	db := c.DB
 	queries := c.Queries
 	logger := slog.Default().With(slog.String("component", "bulk_insert"))
 
-	tx, err := db.Begin()
-	if err != nil {
-		return err
+	useTx := tx
+	if useTx == nil {
+		var err error
+		useTx, err = db.Begin()
+		if err != nil {
+			return err
+		}
+		defer logging.SafeRollbackWithLogging(useTx, logger, "bulk_insert_calendar_dates")
 	}
-	defer logging.SafeRollbackWithLogging(tx, logger, "bulk_insert_calendar_dates")
 
-	qtx := queries.WithTx(tx)
+	qtx := queries.WithTx(useTx)
 	for _, params := range calendarDates {
 		_, err := qtx.CreateCalendarDate(ctx, params)
 		if err != nil {
 			return err
 		}
 	}
-	return tx.Commit()
+	if tx == nil {
+		return useTx.Commit()
+	}
+	return nil
 }
 
 // configureSQLitePerformance applies PRAGMA settings to optimize SQLite performance
@@ -1066,8 +1125,8 @@ type blockTripIndexKey struct {
 }
 
 // buildBlockTripIndex creates BlockTripIndex entries by grouping trips with identical
-// service IDs and stop sequences.
-func (c *Client) buildBlockTripIndex(ctx context.Context, staticData *gtfs.Static) error {
+// service IDs and stop sequences. If tx is non-nil it uses that transaction and does not commit; if nil it starts its own and commits.
+func (c *Client) buildBlockTripIndex(ctx context.Context, staticData *gtfs.Static, tx *sql.Tx) error {
 	logger := slog.Default().With(slog.String("component", "block_trip_index_builder"))
 
 	// Build terminal layover location for each trip
@@ -1113,13 +1172,18 @@ func (c *Client) buildBlockTripIndex(ctx context.Context, staticData *gtfs.Stati
 		slog.Int("total_trips", len(tripMap)),
 		slog.Int("unique_indices", len(indexGroups)))
 
-	tx, err := c.DB.BeginTx(ctx, nil)
-	if err != nil {
-		return err
+	// buildBlockTripIndex uses tx if provided; otherwise starts its own transaction and commits.
+	useTx := tx
+	if useTx == nil {
+		var err error
+		useTx, err = c.DB.BeginTx(ctx, nil)
+		if err != nil {
+			return err
+		}
+		defer logging.SafeRollbackWithLogging(useTx, logger, "build_block_trip_index")
 	}
-	defer logging.SafeRollbackWithLogging(tx, logger, "build_block_trip_index")
 
-	qtx := c.Queries.WithTx(tx)
+	qtx := c.Queries.WithTx(useTx)
 	createdAt := time.Now().Unix()
 
 	for key, trips := range indexGroups {
@@ -1159,8 +1223,10 @@ func (c *Client) buildBlockTripIndex(ctx context.Context, staticData *gtfs.Stati
 		}
 	}
 
-	if err := tx.Commit(); err != nil {
-		return err
+	if tx == nil {
+		if err := useTx.Commit(); err != nil {
+			return err
+		}
 	}
 
 	totalEntries := 0

--- a/gtfsdb/sqlite_performance_test.go
+++ b/gtfsdb/sqlite_performance_test.go
@@ -329,7 +329,7 @@ func TestSQLitePerformanceWithBulkOperations(t *testing.T) {
 	}
 
 	// This should complete quickly with proper pragmas
-	err = client.bulkInsertStopTimes(ctx, stopTimes)
+	err = client.bulkInsertStopTimes(ctx, stopTimes, nil)
 	require.NoError(t, err, "Bulk insert should succeed with performance pragmas")
 
 	// Verify all inserted


### PR DESCRIPTION
This change makes the GTFS import process atomic by wrapping the full import inside a single database transaction.

## Problem

The current GTFS import flow clears existing data and then inserts the new dataset step by step. If an error occurs during the import (for example malformed feed data or runtime failure), the database can be left in a partially populated state because the previous dataset has already been cleared.

This can result in the server running with incomplete GTFS data until the next successful import.

## Solution

The entire import process is now executed inside a single transaction.

The transaction includes:
- clearing existing GTFS data (when re-importing)
- all insert operations (agencies, routes, stops, trips, stop_times, etc.)
- block index generation

If any step fails, the transaction is rolled back and the previous dataset remains intact.

## Implementation Details

- Added `clearAllGTFSDataWithQueries()` to allow clearing tables using a provided `Queries` instance (so it can run inside a transaction).
- `processAndStoreGTFSDataWithSource()` now starts a single `BeginTx` that wraps the full import.
- Bulk helper functions now accept an optional `*sql.Tx`:
  - if `tx == nil` → they create their own transaction (existing behavior)
  - if `tx != nil` → they run inside the provided transaction
- Updated test call sites to pass `nil` so existing behavior remains unchanged.

## Why this is safe

The change preserves existing behavior for bulk helper functions when no transaction is provided, while allowing the GTFS importer to run fully inside a single transaction.

## Result

GTFS imports are now atomic:

- successful import → commit
- failed import → rollback

This prevents the database from ending up in a partially populated state.

fixes #650 