### PR TITLE
enforce Predicted/Scheduled invariant via SetPredicted()

### DIFF
--- a/internal/models/trip_details.go
+++ b/internal/models/trip_details.go
@@ -64,10 +64,19 @@ type TripStatus struct {
 	Scheduled                  bool       `json:"scheduled"` // (Scheduled = !Predicted) ,this field is not part of the OpenAPI TripStatus schema but is retained for compatibility with existing API consumers. Tracked as a known spec deviation.
 }
 
+// SetPredicted keeps Predicted and Scheduled logically consistent.
+func (ts *TripStatus) SetPredicted(predicted bool) {
+	ts.Predicted = predicted
+	ts.Scheduled = !predicted
+}
+
 // SituationIDs initialized to []string{} for Go-side convenience.
 // JSON output is unaffected because omitempty omits both nil and empty slices.
 func NewTripStatus() *TripStatus {
-	return &TripStatus{
+	status := &TripStatus{
 		SituationIDs: []string{},
 	}
+	status.SetPredicted(false)
+
+	return status
 }

--- a/internal/models/trip_details_test.go
+++ b/internal/models/trip_details_test.go
@@ -175,7 +175,7 @@ func TestTripStatusJSON(t *testing.T) {
 		TotalDistanceAlongTrip:     &totalDistanceAlongTrip,
 		VehicleFeatures:            []string{"wifi", "bike_rack"},
 		VehicleID:                  "vehicle_789",
-		Scheduled:                  true,
+		Scheduled:                  false,
 	}
 
 	jsonData, err := json.Marshal(tripStatus)
@@ -191,6 +191,7 @@ func TestTripStatusJSON(t *testing.T) {
 	assert.Equal(t, tripStatus.Predicted, unmarshaledStatus.Predicted)
 	assert.Equal(t, tripStatus.Position.Lat, unmarshaledStatus.Position.Lat)
 	assert.Equal(t, tripStatus.Position.Lon, unmarshaledStatus.Position.Lon)
+	assert.Equal(t, tripStatus.Scheduled, unmarshaledStatus.Scheduled)
 }
 
 func TestTripStatus_JSONOmitEmpty(t *testing.T) {
@@ -209,4 +210,18 @@ func TestTripStatus_JSONOmitEmpty(t *testing.T) {
 	// These are required fields per the OpenAPI spec — must always appear, even when empty string
 	assert.Contains(t, jsonStr, `"closestStop":""`, "closestStop is required by OpenAPI spec and must always be present")
 	assert.Contains(t, jsonStr, `"occupancyStatus":""`, "occupancyStatus is required by OpenAPI spec and must always be present")
+	assert.Contains(t, jsonStr, `"predicted":false`, "predicted defaults to false in NewTripStatus")
+	assert.Contains(t, jsonStr, `"scheduled":true`, "scheduled must stay inverse of predicted")
+}
+
+func TestTripStatus_SetPredicted_KeepsInverseScheduled(t *testing.T) {
+	status := NewTripStatus()
+
+	status.SetPredicted(true)
+	assert.True(t, status.Predicted)
+	assert.False(t, status.Scheduled)
+
+	status.SetPredicted(false)
+	assert.False(t, status.Predicted)
+	assert.True(t, status.Scheduled)
 }

--- a/internal/restapi/trips_helper.go
+++ b/internal/restapi/trips_helper.go
@@ -61,8 +61,7 @@ func (api *RestAPI) BuildTripStatus(
 	}
 
 	hasVehicleRealtimeData := vehicle != nil && !defaultStaleDetector.Check(vehicle, currentTime)
-	status.Predicted = hasVehicleRealtimeData || hasRealtimeTripUpdate
-	status.Scheduled = !status.Predicted
+	status.SetPredicted(hasVehicleRealtimeData || hasRealtimeTripUpdate)
 
 	stopTimes, err := api.GtfsManager.GtfsDB.Queries.GetStopTimesForTrip(ctx, activeTripRawID)
 	if err != nil {

--- a/internal/restapi/vehicles_for_agency_handler.go
+++ b/internal/restapi/vehicles_for_agency_handler.go
@@ -95,7 +95,7 @@ func (api *RestAPI) vehiclesForAgencyHandler(w http.ResponseWriter, r *http.Requ
 			tripStatus := models.NewTripStatus()
 			tripStatus.ActiveTripID = vehicle.Trip.ID.ID
 			tripStatus.BlockTripSequence = 0
-			tripStatus.Scheduled = true
+			tripStatus.SetPredicted(false)
 			tripStatus.Phase = vehicleStatus.Phase
 			tripStatus.Status = vehicleStatus.Status
 


### PR DESCRIPTION
### Summary
This PR removes a future inconsistency risk in `TripStatus` by centralizing
updates to `Predicted` and `Scheduled` through a single method.

Closes #654

### What Changed
- Added `TripStatus.SetPredicted(predicted bool)` in `internal/models/trip_details.go`.
- Updated `NewTripStatus()` to initialize through `SetPredicted(false)` so defaults are explicit and invariant-safe.
- Replaced direct boolean assignments with setter usage in:
  - `internal/restapi/trips_helper.go`
  - `internal/restapi/vehicles_for_agency_handler.go`
- Strengthened tests in `internal/models/trip_details_test.go`:
  - Corrected fixture to use consistent `Predicted`/`Scheduled` values.
  - Added explicit assertion that `scheduled` round-trips correctly in JSON.
  - Added dedicated invariant test for `SetPredicted(true/false)`.
  - Added JSON default assertions for `predicted:false` and `scheduled:true` from `NewTripStatus()`.

Tracked as a follow-up from #627.

### Files Modified
- `internal/models/trip_details.go`
- `internal/models/trip_details_test.go`
- `internal/restapi/trips_helper.go`
- `internal/restapi/vehicles_for_agency_handler.go`

### Validation
- `make test` passed.