### PR TITLE
refactor: implement graceful shutdown for rate limiter goroutine

### DIFF
--- a/internal/restapi/rate_limit_middleware.go
+++ b/internal/restapi/rate_limit_middleware.go
@@ -33,6 +33,7 @@ type RateLimitMiddleware struct {
 	exemptKeys  map[string]bool
 	stopChan    chan struct{}
 	stopOnce    sync.Once
+	wg          sync.WaitGroup
 	clock       clock.Clock
 }
 
@@ -69,6 +70,7 @@ func NewRateLimitMiddleware(ratePerSecond int, interval time.Duration, exemptKey
 	}
 
 	// Start cleanup goroutine
+	middleware.wg.Add(1)
 	go middleware.cleanup()
 
 	return middleware
@@ -216,8 +218,10 @@ func (rl *RateLimitMiddleware) cleanupOnce() {
 	})
 }
 
-// cleanup periodically removes old, unused limiters to prevent memory leaks
+// cleanup periodically removes old, unused limiters to prevent memory leaks.
+// It decrements the WaitGroup when it exits so that Stop can await completion.
 func (rl *RateLimitMiddleware) cleanup() {
+	defer rl.wg.Done()
 	for {
 		select {
 		case <-rl.cleanupTick.C:
@@ -228,7 +232,7 @@ func (rl *RateLimitMiddleware) cleanup() {
 	}
 }
 
-// Stop stops the cleanup goroutine. It is safe to call multiple times.
+// Stop stops the cleanup goroutine and waits for it to exit. It is safe to call multiple times.
 // Note: This does not affect in-flight requests - it only stops the
 // background cleanup goroutine.
 func (rl *RateLimitMiddleware) Stop() {
@@ -238,4 +242,5 @@ func (rl *RateLimitMiddleware) Stop() {
 			rl.cleanupTick.Stop()
 		}
 	})
+	rl.wg.Wait()
 }

--- a/internal/restapi/rate_limit_shutdown_test.go
+++ b/internal/restapi/rate_limit_shutdown_test.go
@@ -76,7 +76,6 @@ func TestRateLimitMiddleware_GoroutineActuallyExits(t *testing.T) {
 	assert.Greater(t, afterCreate, initial, "cleanup goroutine should have started")
 
 	middleware.Stop()
-	time.Sleep(50 * time.Millisecond) // Give goroutine time to exit
 
 	afterStop := runtime.NumGoroutine()
 	assert.LessOrEqual(t, afterStop, initial, "cleanup goroutine should have exited")


### PR DESCRIPTION
# Description
This PR addresses potential resource leaks by ensuring the `RateLimitMiddleware` cleanup goroutine is properly awaited during application shutdown. By replacing non-deterministic `time.Sleep` calls in tests with a `sync.WaitGroup` synchronization primitive, we improve both the reliability of the shutdown sequence and the stability of the test suite.

- closes #673

## Changes
### `internal/restapi/rate_limit_middleware.go`
- Added `wg sync.WaitGroup` to the middleware struct.
- Instrumented `cleanup()` with `Add(1)` and `defer Done()`.
- Updated `Stop()` to call `Wait()`, making it a blocking call that guarantees the goroutine has exited.

### `internal/restapi/rate_limit_shutdown_test.go`
- Refactored shutdown tests to remove `50ms` sleeps.
- Tests now rely on the blocking behavior of `Stop()` to verify cleanup.