### PR TITLE
fix(metrics): keep DB pool metrics accurate across GTFS hot-swap

### DIFF
--- a/cmd/api/app.go
+++ b/cmd/api/app.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"fmt"
 	"log/slog"
@@ -120,9 +121,16 @@ func BuildApplication(ctx context.Context, cfg appconf.Config, gtfsCfg gtfs.Conf
 		Metrics:             appMetrics,
 	}
 
-	// Start DB stats collector if database is available
-	if gtfsManager != nil && gtfsManager.GtfsDB != nil && gtfsManager.GtfsDB.DB != nil {
-		appMetrics.StartDBStatsCollector(gtfsManager.GtfsDB.DB, 15*time.Second)
+	// Start DB stats collector using a provider so metrics follow DB hot-swap.
+	if gtfsManager != nil {
+		appMetrics.StartDBStatsCollector(func() *sql.DB {
+			gtfsManager.RLock()
+			defer gtfsManager.RUnlock()
+			if gtfsManager.GtfsDB == nil {
+				return nil
+			}
+			return gtfsManager.GtfsDB.DB
+		}, 15*time.Second)
 	}
 
 	return coreApp, nil

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -164,8 +164,8 @@ func NewWithLogger(logger *slog.Logger) *Metrics {
 // The interval specifies how often to collect stats.
 // This method is idempotent - calling it multiple times has no effect after the first call.
 // Call Shutdown() to stop the collector.
-func (m *Metrics) StartDBStatsCollector(db *sql.DB, interval time.Duration) {
-	if db == nil {
+func (m *Metrics) StartDBStatsCollector(dbProvider func() *sql.DB, interval time.Duration) {
+	if dbProvider == nil {
 		return
 	}
 
@@ -176,6 +176,7 @@ func (m *Metrics) StartDBStatsCollector(db *sql.DB, interval time.Duration) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 
+	var currentDB *sql.DB
 	var lastWaitDuration time.Duration
 
 	// Add to WaitGroup BEFORE exposing cancel to avoid race with Shutdown
@@ -198,10 +199,28 @@ func (m *Metrics) StartDBStatsCollector(db *sql.DB, interval time.Duration) {
 		for {
 			select {
 			case <-ticker.C:
+				db := dbProvider()
+				if db == nil {
+					m.DBConnectionsOpen.Set(0)
+					m.DBConnectionsInUse.Set(0)
+					m.DBConnectionsIdle.Set(0)
+					currentDB = nil
+					lastWaitDuration = 0
+					continue
+				}
+
 				stats := db.Stats()
 				m.DBConnectionsOpen.Set(float64(stats.OpenConnections))
 				m.DBConnectionsInUse.Set(float64(stats.InUse))
 				m.DBConnectionsIdle.Set(float64(stats.Idle))
+
+				// WaitDuration is cumulative per *sql.DB pool. If hot-swap changed
+				// the DB pointer, reset baseline to this pool's current counter.
+				if db != currentDB {
+					currentDB = db
+					lastWaitDuration = stats.WaitDuration
+					continue
+				}
 
 				// Add the delta of wait duration since last check
 				waitDelta := stats.WaitDuration - lastWaitDuration

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -1,7 +1,9 @@
 package metrics
 
 import (
+	"context"
 	"database/sql"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -34,12 +36,27 @@ func TestNewWithLogger(t *testing.T) {
 	assert.Nil(t, m.logger)
 }
 
-func TestStartDBStatsCollector_NilDB(t *testing.T) {
+func TestStartDBStatsCollector_NilProvider(t *testing.T) {
 	m := New()
-	// Should not panic with nil DB
+	// Should not panic with nil provider
 	m.StartDBStatsCollector(nil, time.Second)
 	// Collector should not be marked as started
 	assert.False(t, m.collectorStarted.Load())
+}
+
+func TestStartDBStatsCollector_ProviderCanReturnNilDB(t *testing.T) {
+	m := New()
+	m.StartDBStatsCollector(func() *sql.DB { return nil }, 20*time.Millisecond)
+	defer m.Shutdown()
+
+	assert.True(t, m.collectorStarted.Load())
+
+	require.Eventually(t, func() bool {
+		openConns := testutil.ToFloat64(m.DBConnectionsOpen)
+		inUse := testutil.ToFloat64(m.DBConnectionsInUse)
+		idle := testutil.ToFloat64(m.DBConnectionsIdle)
+		return openConns == 0 && inUse == 0 && idle == 0
+	}, time.Second, 20*time.Millisecond)
 }
 
 func TestStartDBStatsCollector_Idempotent(t *testing.T) {
@@ -50,11 +67,11 @@ func TestStartDBStatsCollector_Idempotent(t *testing.T) {
 	m := New()
 
 	// Start collector first time
-	m.StartDBStatsCollector(db, 100*time.Millisecond)
+	m.StartDBStatsCollector(func() *sql.DB { return db }, 100*time.Millisecond)
 	assert.True(t, m.collectorStarted.Load())
 
 	// Second call should be no-op
-	m.StartDBStatsCollector(db, 100*time.Millisecond)
+	m.StartDBStatsCollector(func() *sql.DB { return db }, 100*time.Millisecond)
 	assert.True(t, m.collectorStarted.Load())
 
 	m.Shutdown()
@@ -66,7 +83,7 @@ func TestStartDBStatsCollector_CollectsStats(t *testing.T) {
 	defer func() { _ = db.Close() }()
 
 	m := New()
-	m.StartDBStatsCollector(db, 50*time.Millisecond)
+	m.StartDBStatsCollector(func() *sql.DB { return db }, 50*time.Millisecond)
 
 	// Wait for at least one collection cycle
 	time.Sleep(100 * time.Millisecond)
@@ -90,7 +107,7 @@ func TestShutdown_StopsGoroutine(t *testing.T) {
 	defer func() { _ = db.Close() }()
 
 	m := New()
-	m.StartDBStatsCollector(db, 50*time.Millisecond)
+	m.StartDBStatsCollector(func() *sql.DB { return db }, 50*time.Millisecond)
 
 	// Shutdown should block until goroutine exits
 	done := make(chan struct{})
@@ -105,6 +122,38 @@ func TestShutdown_StopsGoroutine(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("Shutdown did not complete within timeout")
 	}
+}
+
+func TestStartDBStatsCollector_FollowsDBSwap(t *testing.T) {
+	db1, err := sql.Open(gtfsdb.DriverName, ":memory:")
+	require.NoError(t, err)
+	defer func() { _ = db1.Close() }()
+
+	db2, err := sql.Open(gtfsdb.DriverName, ":memory:")
+	require.NoError(t, err)
+	defer func() { _ = db2.Close() }()
+
+	// Hold one active transaction so db2 reports an in-use connection.
+	tx, err := db2.BeginTx(context.Background(), nil)
+	require.NoError(t, err)
+	defer func() { _ = tx.Rollback() }()
+
+	var dbPtr atomic.Pointer[sql.DB]
+	dbPtr.Store(db1)
+
+	m := New()
+	m.StartDBStatsCollector(func() *sql.DB { return dbPtr.Load() }, 20*time.Millisecond)
+	defer m.Shutdown()
+
+	require.Eventually(t, func() bool {
+		return testutil.ToFloat64(m.DBConnectionsInUse) == 0
+	}, time.Second, 20*time.Millisecond)
+
+	dbPtr.Store(db2)
+
+	require.Eventually(t, func() bool {
+		return testutil.ToFloat64(m.DBConnectionsInUse) >= 1
+	}, time.Second, 20*time.Millisecond)
 }
 
 func TestShutdown_SafeToCallMultipleTimes(t *testing.T) {


### PR DESCRIPTION
### Summary

Fixes #675 

Fix DB pool Prometheus metrics becoming stale after static GTFS hot-swap.

Previously, `StartDBStatsCollector` captured the initial `*sql.DB` at startup, so after `ForceUpdate` replaced `GtfsDB`, collector stats could reflect the old/closed pool.

### What changed

1. **Updated metrics collector API** to accept a DB provider callback:
   - `StartDBStatsCollector(dbProvider func() *sql.DB, interval time.Duration)`

2. **Updated collector loop** to fetch current DB on each tick:
   - If provider returns `nil`, set DB gauges (`open`, `in_use`, `idle`) to `0`.
   - If DB pointer changes, reset wait-duration baseline for the new pool.

3. **Updated app wiring:**
   - In `cmd/api/app.go`, pass a lock-safe provider closure (`GtfsManager.RLock`/`RUnlock`) that returns the current `GtfsDB.DB`.

4. **Added/updated tests** in `internal/metrics/metrics_test.go`:
   - `nil` provider
   - Provider returning `nil` DB
   - Idempotent start behavior
   - DB swap regression test (`TestStartDBStatsCollector_FollowsDBSwap`)

### Why

`sql.DBStats.WaitDuration` is cumulative per pool, and GTFS hot-swap replaces the pool pointer. Reading a fixed pointer after swap gives stale metrics and can incorrectly show zero/old values while traffic uses the new DB.

### Validation
```bash
make fmt
make test
```
