### PR TITLE
fix(metrics): guard non-positive DB stats collector interval

### DIFF
--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -168,6 +168,12 @@ func (m *Metrics) StartDBStatsCollector(dbProvider func() *sql.DB, interval time
 	if dbProvider == nil {
 		return
 	}
+	if interval <= 0 {
+		if m.logger != nil {
+			m.logger.Error("invalid DB stats collector interval", "interval", interval)
+		}
+		return
+	}
 
 	// Prevent spawning multiple collectors
 	if !m.collectorStarted.CompareAndSwap(false, true) {

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -59,6 +59,26 @@ func TestStartDBStatsCollector_ProviderCanReturnNilDB(t *testing.T) {
 	}, time.Second, 20*time.Millisecond)
 }
 
+func TestStartDBStatsCollector_NonPositiveInterval(t *testing.T) {
+	db, err := sql.Open(gtfsdb.DriverName, ":memory:")
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	m := New()
+
+	m.StartDBStatsCollector(func() *sql.DB { return db }, 0)
+	assert.False(t, m.collectorStarted.Load(), "collector should not start with zero interval")
+
+	m.StartDBStatsCollector(func() *sql.DB { return db }, -time.Second)
+	assert.False(t, m.collectorStarted.Load(), "collector should not start with negative interval")
+
+	// A later valid start must still work.
+	m.StartDBStatsCollector(func() *sql.DB { return db }, 20*time.Millisecond)
+	assert.True(t, m.collectorStarted.Load(), "collector should start with a positive interval")
+
+	m.Shutdown()
+}
+
 func TestStartDBStatsCollector_Idempotent(t *testing.T) {
 	db, err := sql.Open(gtfsdb.DriverName, ":memory:")
 	require.NoError(t, err)


### PR DESCRIPTION
Fixes #677 

### Summary

Adds explicit validation in DB stats collector for non-positive intervals and a regression test.

### What changed

1. **`internal/metrics/metrics.go`:**
   - Added early return for `interval <= 0` in `StartDBStatsCollector`.
   - Logs an error (if logger is configured).
   - Validation happens before `collectorStarted.CompareAndSwap(...)`.

2. **`internal/metrics/metrics_test.go`:**
   - Added `TestStartDBStatsCollector_NonPositiveInterval`.
   - Confirms:
     - `interval == 0` does not start collector.
     - `interval < 0` does not start collector.
     - Subsequent valid interval starts collector successfully.

### Why

Avoids relying on panic/recover for input validation and keeps `StartDBStatsCollector`  restartable.

### Validation
```bash
make test
```