### PR TITLE
parse YYYY-MM-DD time params in agency timezone

### DIFF
--- a/internal/utils/api.go
+++ b/internal/utils/api.go
@@ -198,7 +198,7 @@ func ParseTimeParameter(timeParam string, currentLocation *time.Location) (strin
 		validFormat = true
 	} else if strings.Contains(timeParam, "-") {
 		// Assume YYYY-MM-DD format
-		parsedTime, err = time.Parse("2006-01-02", timeParam)
+		parsedTime, err = time.ParseInLocation("2006-01-02", timeParam, currentLocation)
 		if err == nil {
 			validFormat = true
 		}

--- a/internal/utils/api_test.go
+++ b/internal/utils/api_test.go
@@ -589,6 +589,21 @@ func TestParseTimeParameter_EdgeCases(t *testing.T) {
 	})
 }
 
+func TestParseTimeParameter_DateStringUsesProvidedLocation(t *testing.T) {
+	loc, err := time.LoadLocation("America/Los_Angeles")
+	require.NoError(t, err)
+
+	dateStr, parsedTime, fieldErrors, valid := ParseTimeParameter("2026-03-12", loc)
+
+	require.True(t, valid)
+	require.Nil(t, fieldErrors)
+	assert.Equal(t, "20260312", dateStr)
+
+	expected := time.Date(2026, 3, 12, 0, 0, 0, 0, loc)
+	assert.True(t, parsedTime.Equal(expected), "parsed time should represent midnight in the provided location")
+	assert.Equal(t, loc.String(), parsedTime.Location().String())
+}
+
 func TestParseMaxCount(t *testing.T) {
 	tests := []struct {
 		name             string


### PR DESCRIPTION
This PR fixes #681 : Timezone handling for date-only time query input in `ParseTimeParameter`.

**What changed:**
1. Replaced `time.Parse("2006-01-02", ...)` with `time.ParseInLocation("2006-01-02", ..., currentLocation)`.
2. Added regression test `TestParseTimeParameter_DateStringUsesProvidedLocation`.

**Why:** Date-only input should align with agency-local service semantics. Parsing in UTC could shift behavior for non-UTC agencies.

**Validation:**
1. Ran `make test`.
2. Regression test confirms returned `time.Time` keeps the provided location and local midnight semantics.