### PR TITLE
fix: add missing Stops field to schedule-for-route response

### DIFF
--- a/internal/models/schedule_for_route.go
+++ b/internal/models/schedule_for_route.go
@@ -29,4 +29,6 @@ type ScheduleForRouteEntry struct {
 	ScheduleDate      int64              `json:"scheduleDate"`
 	ServiceIDs        []string           `json:"serviceIds"`
 	StopTripGroupings []StopTripGrouping `json:"stopTripGroupings"`
+	Stops             []Stop             `json:"stops"`
+	Trips             []Trip             `json:"trips"`
 }

--- a/internal/restapi/schedule_for_route_handler.go
+++ b/internal/restapi/schedule_for_route_handler.go
@@ -82,6 +82,8 @@ func (api *RestAPI) scheduleForRouteHandler(w http.ResponseWriter, r *http.Reque
 			ScheduleDate:      scheduleDate,
 			ServiceIDs:        []string{},
 			StopTripGroupings: []models.StopTripGrouping{},
+			Stops:             []models.Stop{},
+			Trips:             []models.Trip{},
 		}
 		api.sendResponse(w, r, models.NewEntryResponse(entry, *models.NewEmptyReferences(), api.Clock))
 		return
@@ -109,6 +111,8 @@ func (api *RestAPI) scheduleForRouteHandler(w http.ResponseWriter, r *http.Reque
 			ScheduleDate:      scheduleDate,
 			ServiceIDs:        combinedServiceIDs,
 			StopTripGroupings: []models.StopTripGrouping{},
+			Stops:             []models.Stop{},
+			Trips:             []models.Trip{},
 		}
 		api.sendResponse(w, r, models.NewEntryResponse(entry, *models.NewEmptyReferences(), api.Clock))
 		return
@@ -302,6 +306,8 @@ func (api *RestAPI) scheduleForRouteHandler(w http.ResponseWriter, r *http.Reque
 		ScheduleDate:      scheduleDate,
 		ServiceIDs:        combinedServiceIDs,
 		StopTripGroupings: stopTripGroupings,
+		Stops:             references.Stops,
+		Trips:             references.Trips,
 	}
 	api.sendResponse(w, r, models.NewEntryResponse(entry, *references, api.Clock))
 }


### PR DESCRIPTION
**Description:**

### What does this PR do?

This PR resolves the OpenAPI schema validation failure in the `/api/where/schedule-for-route/{routeID}.json` endpoint that was causing the `TestOpenAPIConformance_StaticEndpoints/schedule-for-route` test to fail in CI.

### Why is this needed?

As outlined in , the OpenAPI specification requires the `ScheduleEntry` object to include a `stops` array (as well as a `trips` array). Previously, the endpoint omitted these properties from the response object, triggering strict schema violations (`property "stops" is missing`, `property "trips" is missing`).

### How does this fix the issue?

1. **Model Update:** Added `Stops` and `Trips` slice fields with the proper JSON tags to the `ScheduleForRouteEntry` struct in `internal/models/schedule_for_route.go`.
2. **Handler Update:** Modified `internal/restapi/schedule_for_route_handler.go` to populate the `stops` and `trips` lists in the response from the route's schedule data. Also ensured that valid "zero-data" states explicitly initialize and return empty arrays (`[]models.Stop{}`) rather than omitting the fields.

### Related Issues


### Acceptance Criteria Verified

* [x] `ScheduleForRouteEntry` includes a `Stops` field with proper JSON tag.
* [x] The handler populates stops from the route's schedule data.
* [x] `TestOpenAPIConformance_StaticEndpoints/schedule-for-route` passes.
* [x] Existing tests in `schedule_for_route_handler_test.go` continue to pass.
* [x] `make test` passes successfully.
* [x] `make lint` passes successfully.