### PR TITLE
fix(openapi): align schedule-for-route schema with ScheduleForRouteEn…

### DIFF
--- a/testdata/openapi.yml
+++ b/testdata/openapi.yml
@@ -1810,21 +1810,11 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/StopTripGrouping'
-        stops:
-          type: array
-          items:
-            $ref: '#/components/schemas/Stop'
-        trips:
-          type: array
-          items:
-            $ref: '#/components/schemas/Trip'
       required:
         - routeId
         - scheduleDate
         - serviceIds
         - stopTripGroupings
-        - stops
-        - trips
 
     StopTripGrouping:
       type: object


### PR DESCRIPTION
This PR aligns OpenAPI schema with the current `schedule-for-route` response.

fixes #699 

### What changed
1. Updated `ScheduleEntry` in `testdata/openapi.yml`.
2. Removed `stops` and `trips` from:
   - `properties`
   - `required`

### Why
`stops`/`trips` were removed from `ScheduleForRouteEntry` and handler output, but `testdata/openapi.yml` still required them.

### Validation
`make test` passes
