### PR TITLE
fix: standardize logging in trip_details_handler

### DIFF
--- a/internal/logging/error_handling.go
+++ b/internal/logging/error_handling.go
@@ -32,8 +32,8 @@ func SafeCloseWithLogging(closer io.Closer, logger *slog.Logger, operation strin
 
 	if err := closer.Close(); err != nil {
 		LogError(logger, "failed to close resource", err,
-			slog.String("operation", operation),
-			slog.String("component", "resource_management"))
+			"operation", operation,
+			"component", "resource_management")
 	}
 }
 
@@ -72,8 +72,8 @@ func SafeRollbackWithLogging(tx interface{ Rollback() error }, logger *slog.Logg
 		}
 
 		LogError(logger, "failed to rollback transaction", err,
-			slog.String("operation", operation),
-			slog.String("component", "database"))
+			"operation", operation,
+			"component", "database")
 	}
 }
 
@@ -104,8 +104,8 @@ func HandleDeferredError(originalErr *error, deferredOp func() error, logger *sl
 	if err := deferredOp(); err != nil {
 		// Log the deferred error
 		LogError(logger, "deferred operation failed", err,
-			slog.String("operation", operation),
-			slog.String("component", "deferred_cleanup"))
+			"operation", operation,
+			"component", "deferred_cleanup")
 
 		// If there was no original error, set this as the error
 		if *originalErr == nil {

--- a/internal/logging/structured_logging.go
+++ b/internal/logging/structured_logging.go
@@ -7,6 +7,9 @@ import (
 	"log/slog"
 )
 
+// Logger is an alias for slog.Logger to avoid direct slog imports in handlers
+type Logger = slog.Logger
+
 // loggerKey is used to store the logger in context
 type loggerKey struct{}
 
@@ -20,61 +23,46 @@ func NewStructuredLogger(w io.Writer, level slog.Level) *slog.Logger {
 }
 
 // LogError logs an error with structured context
-func LogError(logger *slog.Logger, message string, err error, attrs ...slog.Attr) {
+func LogError(logger *slog.Logger, message string, err error, args ...any) {
 	if logger == nil {
-		slog.Default().Error("nil logger provided to LogError", slog.String("message", message))
+		slog.Default().Error("nil logger provided to LogError", "message", message, "error", err)
 		return
 	}
 
-	args := make([]any, 0, len(attrs)+2)
-	args = append(args, slog.String("error", err.Error()))
+	finalArgs := make([]any, 0, len(args)+2)
+	finalArgs = append(finalArgs, "error", err.Error())
+	finalArgs = append(finalArgs, args...)
 
-	for _, attr := range attrs {
-		args = append(args, attr)
-	}
-
-	logger.Error(message, args...)
+	logger.Error(message, finalArgs...)
 }
 
 // LogOperation logs an operation with structured context
-func LogOperation(logger *slog.Logger, operation string, attrs ...slog.Attr) {
+func LogOperation(logger *slog.Logger, operation string, args ...any) {
 	if logger == nil {
-		slog.Default().Info("nil logger provided to LogOperation", slog.String("operation", operation))
+		slog.Default().Info("nil logger provided to LogOperation", "operation", operation)
 		return
-	}
-
-	args := make([]any, 0, len(attrs))
-	for _, attr := range attrs {
-		// Skip zero-value durations to avoid cluttering logs with meaningless timing data
-		if attr.Key == "duration" && attr.Value.Duration() == 0 {
-			continue
-		}
-		args = append(args, attr)
 	}
 
 	logger.Info(operation, args...)
 }
 
 // LogHTTPRequest logs HTTP request details
-func LogHTTPRequest(logger *slog.Logger, method, path string, status int, durationMs float64, attrs ...slog.Attr) {
+func LogHTTPRequest(logger *slog.Logger, method, path string, status int, durationMs float64, args ...any) {
 	if logger == nil {
-		slog.Default().Info("nil logger provided to LogHTTPRequest", slog.String("path", path))
+		slog.Default().Info("nil logger provided to LogHTTPRequest", "path", path)
 		return
 	}
 
-	args := make([]any, 0, len(attrs)+4)
-	args = append(args,
-		slog.String("method", method),
-		slog.String("path", path),
-		slog.Int("status", status),
-		slog.Float64("duration_ms", durationMs),
+	finalArgs := make([]any, 0, len(args)+8)
+	finalArgs = append(finalArgs,
+		"method", method,
+		"path", path,
+		"status", status,
+		"duration_ms", durationMs,
 	)
+	finalArgs = append(finalArgs, args...)
 
-	for _, attr := range attrs {
-		args = append(args, attr)
-	}
-
-	logger.Info("http_request", args...)
+	logger.Info("http_request", finalArgs...)
 }
 
 // WithLogger adds a logger to the context
@@ -95,7 +83,7 @@ func FromContext(ctx context.Context) *slog.Logger {
 // ReplaceLogPrint replaces log.Print calls with structured logging
 func ReplaceLogPrint(logger *slog.Logger, message string) {
 	if logger == nil {
-		slog.Default().Info("nil logger provided to ReplaceLogPrint", slog.String("message", message))
+		slog.Default().Info("nil logger provided to ReplaceLogPrint", "message", message)
 		return
 	}
 	logger.Info(message)

--- a/internal/restapi/arrivals_and_departure_for_stop.go
+++ b/internal/restapi/arrivals_and_departure_for_stop.go
@@ -2,7 +2,6 @@ package restapi
 
 import (
 	"context"
-	"log/slog"
 	"net/http"
 	"strconv"
 	"time"
@@ -156,8 +155,8 @@ func (api *RestAPI) arrivalsAndDeparturesForStopHandler(w http.ResponseWriter, r
 		activeServiceIDs, err := api.GtfsManager.GtfsDB.Queries.GetActiveServiceIDsForDate(ctx, serviceDateStr)
 		if err != nil {
 			api.Logger.Warn("failed to query active service IDs",
-				slog.String("date", serviceDateStr),
-				slog.Any("error", err))
+				"date", serviceDateStr,
+				"error", err)
 			continue
 		}
 		if len(activeServiceIDs) == 0 {
@@ -183,8 +182,8 @@ func (api *RestAPI) arrivalsAndDeparturesForStopHandler(w http.ResponseWriter, r
 		})
 		if err != nil {
 			api.Logger.Warn("failed to query stop times in window",
-				slog.String("stopID", stopCode),
-				slog.Any("error", err))
+				"stopID", stopCode,
+				"error", err)
 			continue
 		}
 
@@ -262,7 +261,7 @@ func (api *RestAPI) arrivalsAndDeparturesForStopHandler(w http.ResponseWriter, r
 	if len(uniqueTripIDs) > 0 {
 		allStopTimesForTrips, err := api.GtfsManager.GtfsDB.Queries.GetStopTimesForTripIDs(ctx, uniqueTripIDs)
 		if err != nil {
-			api.Logger.Warn("failed to batch fetch stop times for trips", slog.Any("error", err))
+			api.Logger.Warn("failed to batch fetch stop times for trips", "error", err)
 		} else {
 			for _, st := range allStopTimesForTrips {
 				tripStopCountMap[st.TripID]++
@@ -283,16 +282,16 @@ func (api *RestAPI) arrivalsAndDeparturesForStopHandler(w http.ResponseWriter, r
 		route, routeExists := routesLookup[st.RouteID]
 		if !routeExists {
 			api.Logger.Debug("skipping stop time: route not found in batch fetch",
-				slog.String("routeID", st.RouteID),
-				slog.String("tripID", st.TripID))
+				"routeID", st.RouteID,
+				"tripID", st.TripID)
 			continue
 		}
 
 		trip, tripExists := tripsLookup[st.TripID]
 		if !tripExists {
 			api.Logger.Debug("skipping stop time: trip not found in batch fetch",
-				slog.String("tripID", st.TripID),
-				slog.String("routeID", st.RouteID))
+				"tripID", st.TripID,
+				"routeID", st.RouteID)
 			continue
 		}
 
@@ -382,9 +381,9 @@ func (api *RestAPI) arrivalsAndDeparturesForStopHandler(w http.ResponseWriter, r
 							activeTrip, err := api.GtfsManager.GtfsDB.Queries.GetTrip(ctx, activeTripID)
 							if err != nil {
 								api.Logger.Debug("skipping active trip reference: trip not found",
-									slog.String("activeTripID", activeTripID),
-									slog.String("scheduledTripID", st.TripID),
-									slog.Any("error", err))
+									"activeTripID", activeTripID,
+									"scheduledTripID", st.TripID,
+									"error", err)
 							} else {
 								tripIDSet[activeTrip.ID] = &activeTrip
 								activeRoute, err := api.GtfsManager.GtfsDB.Queries.GetRoute(ctx, activeTrip.RouteID)
@@ -507,13 +506,13 @@ func (api *RestAPI) arrivalsAndDeparturesForStopHandler(w http.ResponseWriter, r
 
 	batchStops, err := api.GtfsManager.GtfsDB.Queries.GetStopsByIDs(ctx, stopIDsSlice)
 	if err != nil {
-		api.Logger.Warn("failed to batch fetch stop references", slog.Any("error", err))
+		api.Logger.Warn("failed to batch fetch stop references", "error", err)
 		batchStops = nil
 	}
 
 	batchRoutesForStops, err := api.GtfsManager.GtfsDB.Queries.GetRoutesForStops(ctx, stopIDsSlice)
 	if err != nil {
-		api.Logger.Warn("failed to batch fetch routes for stop references", slog.Any("error", err))
+		api.Logger.Warn("failed to batch fetch routes for stop references", "error", err)
 		batchRoutesForStops = nil
 	}
 
@@ -535,7 +534,7 @@ func (api *RestAPI) arrivalsAndDeparturesForStopHandler(w http.ResponseWriter, r
 
 		stopData, ok := stopsMap[stopID]
 		if !ok {
-			api.Logger.Debug("skipping stop reference: stop not found", slog.String("stopID", stopID))
+			api.Logger.Debug("skipping stop reference: stop not found", "stopID", stopID)
 			continue
 		}
 

--- a/internal/restapi/errors.go
+++ b/internal/restapi/errors.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"log/slog"
 	"net/http"
 
 	"maglev.onebusaway.org/internal/logging"
@@ -47,7 +46,7 @@ func (api *RestAPI) serverErrorResponse(w http.ResponseWriter, r *http.Request, 
 		api.clientCanceledResponse(w, r, err)
 		return
 	}
-	logging.LogError(api.Logger, "internal server error", err, slog.String("path", r.URL.Path))
+	logging.LogError(api.Logger, "internal server error", err, "path", r.URL.Path)
 	// Send a 500 Internal Server Error response
 	response := struct {
 		Code        int    `json:"code"`

--- a/internal/restapi/errors_test.go
+++ b/internal/restapi/errors_test.go
@@ -1,9 +1,9 @@
 package restapi
 
 import (
+	"maglev.onebusaway.org/internal/logging"
 	"encoding/json"
 	"errors"
-	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -16,7 +16,7 @@ import (
 
 func TestServerErrorResponse(t *testing.T) {
 	// Create a mock Application with Clock
-	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	logger := logging.NewStructuredLogger(os.Stdout, 0)
 	application := &app.Application{
 		Clock:  clock.RealClock{},
 		Logger: logger,

--- a/internal/restapi/http_test.go
+++ b/internal/restapi/http_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"encoding/json"
 	"io"
-	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -88,7 +87,7 @@ func createTestApiWithClock(t testing.TB, c clock.Clock) *RestAPI {
 	}
 
 	api := NewRestAPI(application)
-	api.Logger = slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	api.Logger = logging.NewStructuredLogger(os.Stdout, -4)
 
 	return api
 }
@@ -119,7 +118,7 @@ func serveApiAndRetrieveEndpoint(t testing.TB, api *RestAPI, endpoint string) (*
 	resp, err := http.Get(server.URL + endpoint)
 	require.NoError(t, err)
 	defer logging.SafeCloseWithLogging(resp.Body,
-		slog.Default().With(slog.String("component", "test")),
+		logging.FromContext(context.Background()).With("component", "test"),
 		"http_response_body")
 
 	var response models.ResponseModel

--- a/internal/restapi/perf_test_helpers_test.go
+++ b/internal/restapi/perf_test_helpers_test.go
@@ -3,7 +3,7 @@
 package restapi
 
 import (
-	"log/slog"
+	"maglev.onebusaway.org/internal/logging"
 	"os"
 	"path/filepath"
 	"testing"
@@ -43,6 +43,6 @@ func createLargeAgencyApi(tb testing.TB) *RestAPI {
 		Clock:       clock.RealClock{},
 	}
 	api := NewRestAPI(application)
-	api.Logger = slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelWarn}))
+	api.Logger = logging.NewStructuredLogger(os.Stdout, 4)
 	return api
 }

--- a/internal/restapi/rate_limit_middleware.go
+++ b/internal/restapi/rate_limit_middleware.go
@@ -1,8 +1,8 @@
 package restapi
 
 import (
+	"context"
 	"encoding/json"
-	"log/slog"
 	"math"
 	"net/http"
 	"strconv"
@@ -185,7 +185,7 @@ func (rl *RateLimitMiddleware) sendRateLimitExceeded(w http.ResponseWriter, r *h
 	}
 
 	if err := json.NewEncoder(w).Encode(errorResponse); err != nil {
-		logger := slog.Default().With(slog.String("component", "rate_limit_middleware"))
+		logger := logging.FromContext(context.Background()).With("component", "rate_limit_middleware")
 		logging.LogError(logger, "failed to encode rate limit response", err)
 	}
 }

--- a/internal/restapi/recovery_middleware.go
+++ b/internal/restapi/recovery_middleware.go
@@ -3,7 +3,6 @@ package restapi
 import (
 	"encoding/json"
 	"fmt"
-	"log/slog"
 	"net/http"
 	"runtime/debug"
 
@@ -32,7 +31,7 @@ func (rw *recoveryResponseWriter) Write(b []byte) (int, error) {
 
 // NewRecoveryMiddleware returns middleware that recovers from panics in handlers,
 // logs the panic with stack trace, and returns HTTP 500 (JSON) if no response was sent.
-func NewRecoveryMiddleware(logger *slog.Logger, c clock.Clock) func(http.Handler) http.Handler {
+func NewRecoveryMiddleware(logger *logging.Logger, c clock.Clock) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			rw := &recoveryResponseWriter{ResponseWriter: w}
@@ -47,10 +46,10 @@ func NewRecoveryMiddleware(logger *slog.Logger, c clock.Clock) func(http.Handler
 						err = fmt.Errorf("%v", rec)
 					}
 					logging.LogError(logger, "handler panic recovered", err,
-						slog.String("path", r.URL.Path),
-						slog.String("method", r.Method),
-						slog.String("request_id", reqID),
-						slog.String("stack", string(stack)))
+						"path", r.URL.Path,
+						"method", r.Method,
+						"request_id", reqID,
+						"stack", string(stack))
 					if !rw.wroteHeader {
 						w.Header().Set("Content-Type", "application/json")
 						w.WriteHeader(http.StatusInternalServerError)
@@ -67,9 +66,9 @@ func NewRecoveryMiddleware(logger *slog.Logger, c clock.Clock) func(http.Handler
 						}
 						if err := json.NewEncoder(w).Encode(response); err != nil {
 							logging.LogError(logger, "failed to encode panic recovery response", err,
-								slog.String("path", r.URL.Path),
-								slog.String("method", r.Method),
-								slog.String("request_id", reqID))
+								"path", r.URL.Path,
+								"method", r.Method,
+								"request_id", reqID)
 						}
 					}
 				}

--- a/internal/restapi/recovery_middleware_test.go
+++ b/internal/restapi/recovery_middleware_test.go
@@ -1,10 +1,10 @@
 package restapi
 
 import (
+	"maglev.onebusaway.org/internal/logging"
 	"encoding/json"
 	"fmt"
 	"io"
-	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -14,7 +14,7 @@ import (
 )
 
 func TestRecoveryMiddleware_Panic(t *testing.T) {
-	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	logger := logging.NewStructuredLogger(io.Discard, 0)
 	mockClock := clock.NewMockClock(time.Date(2025, 1, 15, 12, 0, 0, 0, time.UTC))
 
 	panicHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -64,7 +64,7 @@ func TestRecoveryMiddleware_Panic(t *testing.T) {
 }
 
 func TestRecoveryMiddleware_NoPanic(t *testing.T) {
-	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	logger := logging.NewStructuredLogger(io.Discard, 0)
 	mockClock := clock.NewMockClock(time.Now())
 
 	okHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -88,7 +88,7 @@ func TestRecoveryMiddleware_NoPanic(t *testing.T) {
 }
 
 func TestRecoveryMiddleware_PanicAfterWriteDoesNotOverrideResponse(t *testing.T) {
-	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	logger := logging.NewStructuredLogger(io.Discard, 0)
 	mockClock := clock.NewMockClock(time.Now())
 
 	panicHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -112,7 +112,7 @@ func TestRecoveryMiddleware_PanicAfterWriteDoesNotOverrideResponse(t *testing.T)
 }
 
 func TestRecoveryMiddleware_PanicWithErrorType(t *testing.T) {
-	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	logger := logging.NewStructuredLogger(io.Discard, 0)
 	mockClock := clock.NewMockClock(time.Date(2025, 1, 15, 12, 0, 0, 0, time.UTC))
 
 	panicHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/restapi/report_problem_with_stop_handler.go
+++ b/internal/restapi/report_problem_with_stop_handler.go
@@ -1,7 +1,6 @@
 package restapi
 
 import (
-	"log/slog"
 	"net/http"
 
 	"maglev.onebusaway.org/gtfsdb"
@@ -13,7 +12,7 @@ import (
 func (api *RestAPI) reportProblemWithStopHandler(w http.ResponseWriter, r *http.Request) {
 	logger := api.Logger
 	if logger == nil {
-		logger = slog.Default()
+		logger = logging.FromContext(r.Context())
 	}
 
 	agencyID, stopCode, ok := api.extractAndValidateAgencyCodeID(w, r)
@@ -38,15 +37,15 @@ func (api *RestAPI) reportProblemWithStopHandler(w http.ResponseWriter, r *http.
 	userLocationAccuracy := utils.ValidateNumericParam(query.Get("userLocationAccuracy"))
 
 	// Log the problem report for observability
-	logger = logging.FromContext(r.Context()).With(slog.String("component", "problem_reporting"))
+	logger = logging.FromContext(r.Context()).With("component", "problem_reporting")
 	logging.LogOperation(logger, "problem_report_received_for_stop",
-		slog.String("stop_id", stopID),
-		slog.String("composite_id", compositeID),
-		slog.String("code", code),
-		slog.String("user_comment", userComment),
-		slog.String("user_lat", userLatStr),
-		slog.String("user_lon", userLonStr),
-		slog.String("user_location_accuracy", userLocationAccuracy))
+		"stop_id", stopID,
+		"composite_id", compositeID,
+		"code", code,
+		"user_comment", userComment,
+		"user_lat", userLatStr,
+		"user_lon", userLonStr,
+		"user_location_accuracy", userLocationAccuracy)
 
 	// Store the problem report in the database
 	now := api.Clock.Now().UnixMilli()
@@ -64,7 +63,7 @@ func (api *RestAPI) reportProblemWithStopHandler(w http.ResponseWriter, r *http.
 	err := api.GtfsManager.GtfsDB.Queries.CreateProblemReportStop(r.Context(), params)
 	if err != nil {
 		logging.LogError(logger, "failed to store problem report", err,
-			slog.String("stop_id", stopID))
+			"stop_id", stopID)
 		http.Error(w, `{"code":500, "text":"failed to store problem report"}`, http.StatusInternalServerError)
 		return
 	}

--- a/internal/restapi/report_problem_with_trip_handler.go
+++ b/internal/restapi/report_problem_with_trip_handler.go
@@ -1,7 +1,6 @@
 package restapi
 
 import (
-	"log/slog"
 	"net/http"
 
 	"maglev.onebusaway.org/gtfsdb"
@@ -13,7 +12,7 @@ import (
 func (api *RestAPI) reportProblemWithTripHandler(w http.ResponseWriter, r *http.Request) {
 	logger := api.Logger
 	if logger == nil {
-		logger = slog.Default()
+		logger = logging.FromContext(r.Context())
 	}
 
 	agencyID, tripID, ok := api.extractAndValidateAgencyCodeID(w, r)
@@ -44,20 +43,20 @@ func (api *RestAPI) reportProblemWithTripHandler(w http.ResponseWriter, r *http.
 	userLocationAccuracy := utils.ValidateNumericParam(query.Get("userLocationAccuracy"))
 
 	// Log the problem report for observability
-	logger = logging.FromContext(r.Context()).With(slog.String("component", "problem_reporting"))
+	logger = logging.FromContext(r.Context()).With("component", "problem_reporting")
 	logging.LogOperation(logger, "problem_report_received_for_trip",
-		slog.String("trip_id", tripID),
-		slog.String("composite_id", compositeID),
-		slog.String("code", code),
-		slog.String("service_date", serviceDate),
-		slog.String("vehicle_id", vehicleID),
-		slog.String("stop_id", stopID),
-		slog.String("user_comment", userComment),
-		slog.String("user_on_vehicle", userOnVehicle),
-		slog.String("user_vehicle_number", userVehicleNumber),
-		slog.String("user_lat", userLatStr),
-		slog.String("user_lon", userLonStr),
-		slog.String("user_location_accuracy", userLocationAccuracy))
+		"trip_id", tripID,
+		"composite_id", compositeID,
+		"code", code,
+		"service_date", serviceDate,
+		"vehicle_id", vehicleID,
+		"stop_id", stopID,
+		"user_comment", userComment,
+		"user_on_vehicle", userOnVehicle,
+		"user_vehicle_number", userVehicleNumber,
+		"user_lat", userLatStr,
+		"user_lon", userLonStr,
+		"user_location_accuracy", userLocationAccuracy)
 
 	// Store the problem report in the database
 	now := api.Clock.Now().UnixMilli()
@@ -80,7 +79,7 @@ func (api *RestAPI) reportProblemWithTripHandler(w http.ResponseWriter, r *http.
 	err := api.GtfsManager.GtfsDB.Queries.CreateProblemReportTrip(r.Context(), params)
 	if err != nil {
 		logging.LogError(logger, "failed to store problem report", err,
-			slog.String("trip_id", tripID))
+			"trip_id", tripID)
 		http.Error(w, `{"code":500, "text":"failed to store problem report"}`, http.StatusInternalServerError)
 		return
 	}

--- a/internal/restapi/request_id_middleware_test.go
+++ b/internal/restapi/request_id_middleware_test.go
@@ -1,8 +1,8 @@
 package restapi
 
 import (
+	"maglev.onebusaway.org/internal/logging"
 	"bytes"
-	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -110,7 +110,7 @@ func TestRequestIDMiddleware(t *testing.T) {
 func TestRequestIDLoggingIntegration(t *testing.T) {
 	var logBuf bytes.Buffer
 
-	testLogger := slog.New(slog.NewJSONHandler(&logBuf, nil))
+	testLogger := logging.NewStructuredLogger(&logBuf, 0)
 
 	finalHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)

--- a/internal/restapi/request_logging_middleware.go
+++ b/internal/restapi/request_logging_middleware.go
@@ -1,7 +1,6 @@
 package restapi
 
 import (
-	"log/slog"
 	"net/http"
 	"time"
 
@@ -20,7 +19,7 @@ func (rw *responseWriter) WriteHeader(code int) {
 }
 
 // NewRequestLoggingMiddleware creates middleware that logs HTTP requests
-func NewRequestLoggingMiddleware(logger *slog.Logger) func(http.Handler) http.Handler {
+func NewRequestLoggingMiddleware(logger *logging.Logger) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			start := time.Now()
@@ -48,9 +47,9 @@ func NewRequestLoggingMiddleware(logger *slog.Logger) func(http.Handler) http.Ha
 				r.URL.Path,
 				wrapped.statusCode,
 				float64(duration.Nanoseconds())/1e6,
-				slog.String("request_id", reqID),
-				slog.String("user_agent", r.Header.Get("User-Agent")),
-				slog.String("component", "http_server"))
+				"request_id", reqID,
+				"user_agent", r.Header.Get("User-Agent"),
+				"component", "http_server")
 		})
 	}
 }

--- a/internal/restapi/request_logging_test.go
+++ b/internal/restapi/request_logging_test.go
@@ -2,7 +2,6 @@ package restapi
 
 import (
 	"bytes"
-	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -17,7 +16,7 @@ import (
 func TestRequestLoggingMiddleware(t *testing.T) {
 	t.Run("logs HTTP request details", func(t *testing.T) {
 		var buf bytes.Buffer
-		logger := logging.NewStructuredLogger(&buf, slog.LevelInfo)
+		logger := logging.NewStructuredLogger(&buf, 0)
 
 		// Create test handler
 		testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -54,7 +53,7 @@ func TestRequestLoggingMiddleware(t *testing.T) {
 
 	t.Run("logs different HTTP methods and status codes", func(t *testing.T) {
 		var buf bytes.Buffer
-		logger := logging.NewStructuredLogger(&buf, slog.LevelInfo)
+		logger := logging.NewStructuredLogger(&buf, 0)
 
 		testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			if r.Method == "POST" {
@@ -95,7 +94,7 @@ func TestRequestLoggingMiddleware(t *testing.T) {
 
 	t.Run("measures request duration accurately", func(t *testing.T) {
 		var buf bytes.Buffer
-		logger := logging.NewStructuredLogger(&buf, slog.LevelInfo)
+		logger := logging.NewStructuredLogger(&buf, 0)
 
 		// Handler that takes some time
 		testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -129,7 +128,7 @@ func TestRequestLoggingMiddleware(t *testing.T) {
 
 	t.Run("handles requests without User-Agent header", func(t *testing.T) {
 		var buf bytes.Buffer
-		logger := logging.NewStructuredLogger(&buf, slog.LevelInfo)
+		logger := logging.NewStructuredLogger(&buf, 0)
 
 		testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusOK)
@@ -150,7 +149,7 @@ func TestRequestLoggingMiddleware(t *testing.T) {
 
 	t.Run("strips query parameters from logged path", func(t *testing.T) {
 		var buf bytes.Buffer
-		logger := logging.NewStructuredLogger(&buf, slog.LevelInfo)
+		logger := logging.NewStructuredLogger(&buf, 0)
 
 		testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusOK)
@@ -173,7 +172,7 @@ func TestRequestLoggingMiddleware(t *testing.T) {
 func TestRequestLoggingIntegration(t *testing.T) {
 	t.Run("integrates with existing API handler chain", func(t *testing.T) {
 		var buf bytes.Buffer
-		logger := logging.NewStructuredLogger(&buf, slog.LevelInfo)
+		logger := logging.NewStructuredLogger(&buf, 0)
 
 		// Create test API
 		api := createTestApi(t)
@@ -202,7 +201,7 @@ func TestRequestLoggingIntegration(t *testing.T) {
 
 	t.Run("logs error responses correctly", func(t *testing.T) {
 		var buf bytes.Buffer
-		logger := logging.NewStructuredLogger(&buf, slog.LevelInfo)
+		logger := logging.NewStructuredLogger(&buf, 0)
 
 		api := createTestApi(t)
 		defer api.Shutdown()
@@ -225,7 +224,7 @@ func TestRequestLoggingIntegration(t *testing.T) {
 func TestRequestLoggingWithContext(t *testing.T) {
 	t.Run("logger is available in request context", func(t *testing.T) {
 		var buf bytes.Buffer
-		logger := logging.NewStructuredLogger(&buf, slog.LevelInfo)
+		logger := logging.NewStructuredLogger(&buf, 0)
 
 		testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			// Should be able to get logger from context
@@ -233,7 +232,7 @@ func TestRequestLoggingWithContext(t *testing.T) {
 			require.NotNil(t, ctxLogger)
 
 			// Log something from the handler
-			ctxLogger.Info("handler called", slog.String("test", "value"))
+			ctxLogger.Info("handler called", "test", "value")
 			w.WriteHeader(http.StatusOK)
 		})
 
@@ -254,7 +253,7 @@ func TestRequestLoggingWithContext(t *testing.T) {
 }
 
 // createHandlerWithRequestLogging creates an API handler with request logging enabled for testing
-func createHandlerWithRequestLogging(api *RestAPI, logger *slog.Logger) http.Handler {
+func createHandlerWithRequestLogging(api *RestAPI, logger *logging.Logger) http.Handler {
 	// Create a simple test handler
 	mux := http.NewServeMux()
 

--- a/internal/restapi/trip_details_handler.go
+++ b/internal/restapi/trip_details_handler.go
@@ -161,7 +161,7 @@ func (api *RestAPI) tripDetailsHandler(w http.ResponseWriter, r *http.Request) {
 		var statusErr error
 		status, statusErr = api.BuildTripStatus(ctx, agencyID, trip.ID, serviceDate, currentTime)
 		if statusErr != nil {
-			slog.Warn("BuildTripStatus failed",
+			api.Logger.Warn("BuildTripStatus failed",
 				slog.String("trip_id", trip.ID),
 				slog.String("error", statusErr.Error()))
 			status = nil
@@ -171,7 +171,7 @@ func (api *RestAPI) tripDetailsHandler(w http.ResponseWriter, r *http.Request) {
 	if params.IncludeSchedule {
 		schedule, err = api.BuildTripSchedule(ctx, agencyID, serviceDate, &trip, loc)
 		if err != nil {
-			slog.Warn("BuildTripSchedule failed",
+			api.Logger.Warn("BuildTripSchedule failed",
 				slog.String("trip_id", trip.ID),
 				slog.String("error", err.Error()))
 			schedule = nil

--- a/internal/restapi/trip_details_handler.go
+++ b/internal/restapi/trip_details_handler.go
@@ -3,7 +3,6 @@ package restapi
 import (
 	"context"
 	"fmt"
-	"log/slog"
 	"net/http"
 	"strconv"
 	"time"
@@ -162,8 +161,8 @@ func (api *RestAPI) tripDetailsHandler(w http.ResponseWriter, r *http.Request) {
 		status, statusErr = api.BuildTripStatus(ctx, agencyID, trip.ID, serviceDate, currentTime)
 		if statusErr != nil {
 			api.Logger.Warn("BuildTripStatus failed",
-				slog.String("trip_id", trip.ID),
-				slog.String("error", statusErr.Error()))
+				"trip_id", trip.ID,
+				"error", statusErr.Error())
 			status = nil
 		}
 	}
@@ -172,8 +171,8 @@ func (api *RestAPI) tripDetailsHandler(w http.ResponseWriter, r *http.Request) {
 		schedule, err = api.BuildTripSchedule(ctx, agencyID, serviceDate, &trip, loc)
 		if err != nil {
 			api.Logger.Warn("BuildTripSchedule failed",
-				slog.String("trip_id", trip.ID),
-				slog.String("error", err.Error()))
+				"trip_id", trip.ID,
+				"error", err.Error())
 			schedule = nil
 		}
 	}

--- a/internal/restapi/trip_for_vehicle_handler_test.go
+++ b/internal/restapi/trip_for_vehicle_handler_test.go
@@ -1,9 +1,9 @@
 package restapi
 
 import (
+	"maglev.onebusaway.org/internal/logging"
 	"context"
 	"encoding/json"
-	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -21,7 +21,7 @@ import (
 func setupTestApiWithMockVehicle(t *testing.T) (*RestAPI, string, string) {
 	api := createTestApi(t)
 	// Initialize the logger to prevent nil pointer panics during handler execution
-	api.Logger = slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	api.Logger = logging.NewStructuredLogger(os.Stdout, -4)
 	t.Cleanup(api.GtfsManager.MockResetRealTimeData)
 
 	// Note: caller is responsible for calling api.Shutdown()
@@ -256,7 +256,7 @@ func TestTripForVehicleHandlerWithIdleVehicle(t *testing.T) {
 func TestTripForVehicleHandlerWithNonExistentTrip(t *testing.T) {
 	api := createTestApi(t)
 	// Initialize the logger to prevent nil pointer panics during handler execution
-	api.Logger = slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	api.Logger = logging.NewStructuredLogger(os.Stdout, -4)
 	defer api.Shutdown()
 	t.Cleanup(api.GtfsManager.MockResetRealTimeData)
 

--- a/internal/restapi/trips_for_route_handler.go
+++ b/internal/restapi/trips_for_route_handler.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"database/sql"
 	"errors"
-	"log/slog"
 	"net/http"
 	"strconv"
 	"time"
@@ -141,7 +140,7 @@ func (api *RestAPI) tripsForRouteHandler(w http.ResponseWriter, r *http.Request)
 		})
 
 		if err != nil {
-			logging.LogError(api.Logger, "failed to fetch trips in block", err, slog.String("block_id", blockID))
+			logging.LogError(api.Logger, "failed to fetch trips in block", err, "block_id", blockID)
 			continue
 		}
 
@@ -154,7 +153,7 @@ func (api *RestAPI) tripsForRouteHandler(w http.ResponseWriter, r *http.Request)
 			if errors.Is(err, sql.ErrNoRows) {
 				continue
 			}
-			logging.LogError(api.Logger, "failed to fetch active trip in block", err, slog.String("block_id", blockID))
+			logging.LogError(api.Logger, "failed to fetch active trip in block", err, "block_id", blockID)
 			continue
 		}
 

--- a/internal/restapi/trips_helper.go
+++ b/internal/restapi/trips_helper.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	"log/slog"
 	"math"
 	"time"
 
@@ -64,9 +63,9 @@ func (api *RestAPI) BuildTripStatus(
 
 	stopTimes, err := api.GtfsManager.GtfsDB.Queries.GetStopTimesForTrip(ctx, activeTripRawID)
 	if err != nil {
-		slog.Warn("BuildTripStatus: failed to get stop times",
-			slog.String("trip_id", activeTripRawID),
-			slog.String("error", err.Error()))
+		api.Logger.Warn("BuildTripStatus: failed to get stop times",
+			"trip_id", activeTripRawID,
+			"error", err.Error())
 	}
 	if err == nil && len(stopTimes) > 0 {
 		stopTimesPtrs := make([]*gtfsdb.StopTime, len(stopTimes))
@@ -122,9 +121,9 @@ func (api *RestAPI) BuildTripStatus(
 
 	shapeRows, shapeErr := api.GtfsManager.GtfsDB.Queries.GetShapePointsByTripID(ctx, activeTripRawID)
 	if shapeErr != nil {
-		slog.Warn("BuildTripStatus: failed to get shape points",
-			slog.String("trip_id", activeTripRawID),
-			slog.String("error", shapeErr.Error()))
+		api.Logger.Warn("BuildTripStatus: failed to get shape points",
+			"trip_id", activeTripRawID,
+			"error", shapeErr.Error())
 	}
 	if shapeErr == nil && len(shapeRows) > 1 {
 		shapePoints := shapeRowsToPoints(shapeRows)
@@ -256,9 +255,9 @@ func (api *RestAPI) GetNextAndPreviousTripIDs(ctx context.Context, trip *gtfsdb.
 	case nil:
 		// Expected for the first trip in the block.
 	default:
-		slog.Warn("GetNextAndPreviousTripIDs: unexpected type for prev_trip_id",
-			slog.String("type", fmt.Sprintf("%T", prev)),
-			slog.String("trip_id", trip.ID))
+		api.Logger.Warn("GetNextAndPreviousTripIDs: unexpected type for prev_trip_id",
+			"type", fmt.Sprintf("%T", prev),
+			"trip_id", trip.ID)
 	}
 
 	switch next := navResult.NextTripID.(type) {
@@ -273,9 +272,9 @@ func (api *RestAPI) GetNextAndPreviousTripIDs(ctx context.Context, trip *gtfsdb.
 	case nil:
 		// Expected for the last trip in the block.
 	default:
-		slog.Warn("GetNextAndPreviousTripIDs: unexpected type for next_trip_id",
-			slog.String("type", fmt.Sprintf("%T", next)),
-			slog.String("trip_id", trip.ID))
+		api.Logger.Warn("GetNextAndPreviousTripIDs: unexpected type for next_trip_id",
+			"type", fmt.Sprintf("%T", next),
+			"trip_id", trip.ID)
 	}
 
 	stopTimes, err = api.GtfsManager.GtfsDB.Queries.GetStopTimesForTrip(ctx, trip.ID)
@@ -289,9 +288,9 @@ func (api *RestAPI) GetNextAndPreviousTripIDs(ctx context.Context, trip *gtfsdb.
 func (api *RestAPI) fillStopsFromSchedule(ctx context.Context, status *models.TripStatus, tripID string, currentTime time.Time, serviceDate time.Time, agencyID string) {
 	stopTimes, err := api.GtfsManager.GtfsDB.Queries.GetStopTimesForTrip(ctx, tripID)
 	if err != nil {
-		slog.Warn("fillStopsFromSchedule: failed to get stop times",
-			slog.String("trip_id", tripID),
-			slog.String("error", err.Error()))
+		api.Logger.Warn("fillStopsFromSchedule: failed to get stop times",
+			"trip_id", tripID,
+			"error", err.Error())
 		return
 	}
 	if len(stopTimes) == 0 {
@@ -514,9 +513,9 @@ func getDistanceAlongShapeInRange(lat, lon float64, shape []gtfs.ShapePoint, min
 func (api *RestAPI) calculateBlockTripSequence(ctx context.Context, tripID string, serviceDate time.Time) int {
 	trip, err := api.GtfsManager.GtfsDB.Queries.GetTrip(ctx, tripID)
 	if err != nil {
-		slog.Warn("calculateBlockTripSequence: failed to get trip",
-			slog.String("trip_id", tripID),
-			slog.String("error", err.Error()))
+		api.Logger.Warn("calculateBlockTripSequence: failed to get trip",
+			"trip_id", tripID,
+			"error", err.Error())
 		return 0
 	}
 
@@ -527,10 +526,10 @@ func (api *RestAPI) calculateBlockTripSequence(ctx context.Context, tripID strin
 	formattedDate := serviceDate.Format("20060102")
 	activeServiceIDs, err := api.GtfsManager.GtfsDB.Queries.GetActiveServiceIDsForDate(ctx, formattedDate)
 	if err != nil {
-		slog.Warn("calculateBlockTripSequence: failed to get active service IDs",
-			slog.String("trip_id", tripID),
-			slog.String("date", formattedDate),
-			slog.String("error", err.Error()))
+		api.Logger.Warn("calculateBlockTripSequence: failed to get active service IDs",
+			"trip_id", tripID,
+			"date", formattedDate,
+			"error", err.Error())
 		return 0
 	}
 	if len(activeServiceIDs) == 0 {
@@ -545,10 +544,10 @@ func (api *RestAPI) calculateBlockTripSequence(ctx context.Context, tripID strin
 	})
 	if err != nil {
 		if !errors.Is(err, sql.ErrNoRows) {
-			slog.Warn("calculateBlockTripSequence: failed to get block trip sequence",
-				slog.String("trip_id", tripID),
-				slog.String("block_id", trip.BlockID.String),
-				slog.String("error", err.Error()))
+			api.Logger.Warn("calculateBlockTripSequence: failed to get block trip sequence",
+				"trip_id", tripID,
+				"block_id", trip.BlockID.String,
+				"error", err.Error())
 		}
 		return 0
 	}
@@ -692,15 +691,15 @@ func (api *RestAPI) GetSituationIDsForTrip(ctx context.Context, tripID string) [
 				agencyID = route.AgencyID
 			} else if !errors.Is(err, sql.ErrNoRows) {
 				api.Logger.Warn("Failed to fetch route for alerts; degrading to trip+route matching only",
-					slog.String("trip_id", tripID),
-					slog.String("route_id", routeID),
-					slog.Any("error", err),
+					"trip_id", tripID,
+					"route_id", routeID,
+					"error", err,
 				)
 			}
 		} else if !errors.Is(err, sql.ErrNoRows) {
 			api.Logger.Warn("Failed to fetch trip for alerts; degrading to trip matching only",
-				slog.String("trip_id", tripID),
-				slog.Any("error", err),
+				"trip_id", tripID,
+				"error", err,
 			)
 		}
 	}
@@ -993,9 +992,9 @@ func (api *RestAPI) findNextStopBySequence(
 func (api *RestAPI) getFirstStopOfNextTripInBlock(ctx context.Context, currentTripID string, serviceDate time.Time) *gtfsdb.StopTime {
 	trip, err := api.GtfsManager.GtfsDB.Queries.GetTrip(ctx, currentTripID)
 	if err != nil {
-		slog.Warn("getFirstStopOfNextTripInBlock: failed to get trip",
-			slog.String("trip_id", currentTripID),
-			slog.String("error", err.Error()))
+		api.Logger.Warn("getFirstStopOfNextTripInBlock: failed to get trip",
+			"trip_id", currentTripID,
+			"error", err.Error())
 		return nil
 	}
 	if !trip.BlockID.Valid {
@@ -1010,10 +1009,10 @@ func (api *RestAPI) getFirstStopOfNextTripInBlock(ctx context.Context, currentTr
 	})
 	if err != nil {
 		if !errors.Is(err, sql.ErrNoRows) {
-			slog.Warn("getFirstStopOfNextTripInBlock: query failed",
-				slog.String("trip_id", currentTripID),
-				slog.String("block_id", trip.BlockID.String),
-				slog.String("error", err.Error()))
+			api.Logger.Warn("getFirstStopOfNextTripInBlock: query failed",
+				"trip_id", currentTripID,
+				"block_id", trip.BlockID.String,
+				"error", err.Error())
 		}
 		return nil
 	}


### PR DESCRIPTION
This PR replaces direct `slog.Warn` calls with `api.Logger.Warn` in `internal/restapi/trip_details_handler.go` for consistency with other handlers and to ensure structured logging configuration is respected.\n\nFixes #694