### PR TITLE
Add godoc comments to all REST API handler functions

### DIFF
--- a/internal/restapi/agencies_with_coverage_handler.go
+++ b/internal/restapi/agencies_with_coverage_handler.go
@@ -7,6 +7,7 @@ import (
 	"maglev.onebusaway.org/internal/utils"
 )
 
+// agenciesWithCoverageHandler returns all transit agencies along with their geographic coverage areas.
 func (api *RestAPI) agenciesWithCoverageHandler(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 

--- a/internal/restapi/agency_handler.go
+++ b/internal/restapi/agency_handler.go
@@ -6,6 +6,7 @@ import (
 	"maglev.onebusaway.org/internal/models"
 )
 
+// agencyHandler returns details for a single transit agency identified by its path ID.
 func (api *RestAPI) agencyHandler(w http.ResponseWriter, r *http.Request) {
 	id, ok := api.extractAndValidateID(w, r)
 	if !ok {

--- a/internal/restapi/arrival_and_departure_for_stop_handler.go
+++ b/internal/restapi/arrival_and_departure_for_stop_handler.go
@@ -116,6 +116,9 @@ func (api *RestAPI) parseArrivalAndDepartureParams(r *http.Request, loc ...*time
 	return params, nil
 }
 
+// arrivalAndDepartureForStopHandler returns arrival and departure information for a stop.
+// It handles both the single arrival-and-departure and the list arrivals-and-departures endpoints,
+// merging scheduled stop times with real-time predictions when available.
 func (api *RestAPI) arrivalAndDepartureForStopHandler(w http.ResponseWriter, r *http.Request) {
 	stopAgencyID, stopCode, ok := api.extractAndValidateAgencyCodeID(w, r)
 	if !ok {

--- a/internal/restapi/block_handler.go
+++ b/internal/restapi/block_handler.go
@@ -12,6 +12,8 @@ import (
 	"maglev.onebusaway.org/internal/utils"
 )
 
+// blockHandler returns the block configuration for a given block ID, including
+// the ordered sequence of trips and their stop times within the block.
 func (api *RestAPI) blockHandler(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	if ctx.Err() != nil {

--- a/internal/restapi/config_handler.go
+++ b/internal/restapi/config_handler.go
@@ -7,6 +7,7 @@ import (
 	"maglev.onebusaway.org/internal/models"
 )
 
+// configHandler returns server configuration metadata, including the Git commit hash and build info.
 func (api *RestAPI) configHandler(w http.ResponseWriter, r *http.Request) {
 	shortHash := "unknown"
 	if len(buildinfo.CommitHash) >= 7 {

--- a/internal/restapi/current_time_handler.go
+++ b/internal/restapi/current_time_handler.go
@@ -6,8 +6,7 @@ import (
 	"maglev.onebusaway.org/internal/models"
 )
 
-// Declare a handler which writes a JSON response with information about the
-// current time.
+// currentTimeHandler returns the server's current time as a JSON response.
 func (api *RestAPI) currentTimeHandler(w http.ResponseWriter, r *http.Request) {
 	// Health Check: fail if GTFS data is invalid
 	if !api.GtfsManager.IsHealthy() {

--- a/internal/restapi/problem_reports_for_stop_handler.go
+++ b/internal/restapi/problem_reports_for_stop_handler.go
@@ -6,6 +6,7 @@ import (
 	"maglev.onebusaway.org/internal/models"
 )
 
+// problemReportsForStopHandler returns all user-submitted problem reports for a given stop.
 func (api *RestAPI) problemReportsForStopHandler(w http.ResponseWriter, r *http.Request) {
 	_, stopID, ok := api.extractAndValidateAgencyCodeID(w, r)
 	if !ok {

--- a/internal/restapi/problem_reports_for_trip_handler.go
+++ b/internal/restapi/problem_reports_for_trip_handler.go
@@ -6,6 +6,7 @@ import (
 	"maglev.onebusaway.org/internal/models"
 )
 
+// problemReportsForTripHandler returns all user-submitted problem reports for a given trip.
 func (api *RestAPI) problemReportsForTripHandler(w http.ResponseWriter, r *http.Request) {
 	_, tripID, ok := api.extractAndValidateAgencyCodeID(w, r)
 	if !ok {

--- a/internal/restapi/report_problem_with_stop_handler.go
+++ b/internal/restapi/report_problem_with_stop_handler.go
@@ -10,6 +10,8 @@ import (
 	"maglev.onebusaway.org/internal/utils"
 )
 
+// reportProblemWithStopHandler accepts a user-submitted problem report for a specific stop
+// and persists it to the database.
 func (api *RestAPI) reportProblemWithStopHandler(w http.ResponseWriter, r *http.Request) {
 	logger := api.Logger
 	if logger == nil {

--- a/internal/restapi/report_problem_with_trip_handler.go
+++ b/internal/restapi/report_problem_with_trip_handler.go
@@ -10,6 +10,8 @@ import (
 	"maglev.onebusaway.org/internal/utils"
 )
 
+// reportProblemWithTripHandler accepts a user-submitted problem report for a specific trip
+// and persists it to the database.
 func (api *RestAPI) reportProblemWithTripHandler(w http.ResponseWriter, r *http.Request) {
 	logger := api.Logger
 	if logger == nil {

--- a/internal/restapi/route_handler.go
+++ b/internal/restapi/route_handler.go
@@ -7,6 +7,7 @@ import (
 	"maglev.onebusaway.org/internal/utils"
 )
 
+// routeHandler returns details for a single transit route identified by its combined agency_routeID.
 func (api *RestAPI) routeHandler(w http.ResponseWriter, r *http.Request) {
 	agencyID, routeID, ok := api.extractAndValidateAgencyCodeID(w, r)
 	if !ok {

--- a/internal/restapi/route_ids_for_agency_handler.go
+++ b/internal/restapi/route_ids_for_agency_handler.go
@@ -7,6 +7,7 @@ import (
 	"maglev.onebusaway.org/internal/utils"
 )
 
+// routeIDsForAgencyHandler returns a list of route IDs belonging to a given agency.
 func (api *RestAPI) routeIDsForAgencyHandler(w http.ResponseWriter, r *http.Request) {
 	id, ok := api.extractAndValidateID(w, r)
 	if !ok {

--- a/internal/restapi/route_search_handler.go
+++ b/internal/restapi/route_search_handler.go
@@ -8,6 +8,8 @@ import (
 	"maglev.onebusaway.org/internal/utils"
 )
 
+// routeSearchHandler searches for routes matching a user-provided query string,
+// with optional geographic bounds filtering via lat, lon, and radius parameters.
 func (api *RestAPI) routeSearchHandler(w http.ResponseWriter, r *http.Request) {
 	queryParams := r.URL.Query()
 

--- a/internal/restapi/routes_for_agency_handler.go
+++ b/internal/restapi/routes_for_agency_handler.go
@@ -7,6 +7,7 @@ import (
 	"maglev.onebusaway.org/internal/utils"
 )
 
+// routesForAgencyHandler returns all routes operated by a given agency.
 func (api *RestAPI) routesForAgencyHandler(w http.ResponseWriter, r *http.Request) {
 	id, ok := api.extractAndValidateID(w, r)
 	if !ok {

--- a/internal/restapi/routes_for_location_handler.go
+++ b/internal/restapi/routes_for_location_handler.go
@@ -9,6 +9,8 @@ import (
 	"maglev.onebusaway.org/internal/utils"
 )
 
+// routesForLocationHandler returns routes serving stops near a geographic location,
+// specified by lat/lon coordinates with an optional radius or latSpan/lonSpan bounding box.
 func (api *RestAPI) routesForLocationHandler(w http.ResponseWriter, r *http.Request) {
 	queryParams := r.URL.Query()
 

--- a/internal/restapi/schedule_for_route_handler.go
+++ b/internal/restapi/schedule_for_route_handler.go
@@ -11,6 +11,8 @@ import (
 	"maglev.onebusaway.org/internal/utils"
 )
 
+// scheduleForRouteHandler returns the full schedule for a route on a given date,
+// organized by stop-trip groupings with associated service IDs.
 func (api *RestAPI) scheduleForRouteHandler(w http.ResponseWriter, r *http.Request) {
 	agencyID, routeID, ok := api.extractAndValidateAgencyCodeID(w, r)
 	if !ok {

--- a/internal/restapi/schedule_for_stop_handler.go
+++ b/internal/restapi/schedule_for_stop_handler.go
@@ -11,6 +11,8 @@ import (
 	"maglev.onebusaway.org/internal/utils"
 )
 
+// scheduleForStopHandler returns the full schedule for a stop on a given date,
+// including arrival and departure times grouped by route.
 func (api *RestAPI) scheduleForStopHandler(w http.ResponseWriter, r *http.Request) {
 	agencyID, stopID, ok := api.extractAndValidateAgencyCodeID(w, r)
 	if !ok {

--- a/internal/restapi/search_stops_handler.go
+++ b/internal/restapi/search_stops_handler.go
@@ -35,6 +35,8 @@ func sanitizeFTS5Query(input string) string {
 	return sanitized
 }
 
+// searchStopsHandler searches for stops matching a user-provided query string
+// using full-text search, with optional geographic bounds filtering.
 func (api *RestAPI) searchStopsHandler(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 

--- a/internal/restapi/shapes_handler.go
+++ b/internal/restapi/shapes_handler.go
@@ -7,6 +7,7 @@ import (
 	"maglev.onebusaway.org/internal/models"
 )
 
+// shapesHandler returns the encoded polyline shape for a route's geographic path.
 func (api *RestAPI) shapesHandler(w http.ResponseWriter, r *http.Request) {
 	agencyID, shapeCode, ok := api.extractAndValidateAgencyCodeID(w, r)
 	if !ok {

--- a/internal/restapi/stop-ids-for-agency_handler.go
+++ b/internal/restapi/stop-ids-for-agency_handler.go
@@ -7,6 +7,7 @@ import (
 	"maglev.onebusaway.org/internal/utils"
 )
 
+// stopIDsForAgencyHandler returns a list of stop IDs belonging to a given agency.
 func (api *RestAPI) stopIDsForAgencyHandler(w http.ResponseWriter, r *http.Request) {
 
 	id, ok := api.extractAndValidateID(w, r)

--- a/internal/restapi/stop_handler.go
+++ b/internal/restapi/stop_handler.go
@@ -7,6 +7,7 @@ import (
 	"maglev.onebusaway.org/internal/utils"
 )
 
+// stopHandler returns details for a single stop, including its location and the routes that serve it.
 func (api *RestAPI) stopHandler(w http.ResponseWriter, r *http.Request) {
 	agencyID, stopID, ok := api.extractAndValidateAgencyCodeID(w, r)
 	if !ok {

--- a/internal/restapi/stops_for_agency_handler.go
+++ b/internal/restapi/stops_for_agency_handler.go
@@ -8,6 +8,7 @@ import (
 	"maglev.onebusaway.org/internal/utils"
 )
 
+// stopsForAgencyHandler returns all stops belonging to a given agency with full stop details.
 func (api *RestAPI) stopsForAgencyHandler(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 

--- a/internal/restapi/stops_for_location_handler.go
+++ b/internal/restapi/stops_for_location_handler.go
@@ -12,6 +12,8 @@ import (
 	"maglev.onebusaway.org/internal/utils"
 )
 
+// stopsForLocationHandler returns stops near a geographic location, specified by
+// lat/lon coordinates with an optional radius or latSpan/lonSpan bounding box.
 func (api *RestAPI) stopsForLocationHandler(w http.ResponseWriter, r *http.Request) {
 	queryParams := r.URL.Query()
 

--- a/internal/restapi/stops_for_route_handler.go
+++ b/internal/restapi/stops_for_route_handler.go
@@ -37,6 +37,8 @@ func (api *RestAPI) parseStopsForRouteParams(r *http.Request) stopsForRouteParam
 	return params
 }
 
+// stopsForRouteHandler returns all stops served by a route, grouped by direction
+// with optional encoded polyline shapes.
 func (api *RestAPI) stopsForRouteHandler(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 

--- a/internal/restapi/trip_details_handler.go
+++ b/internal/restapi/trip_details_handler.go
@@ -102,6 +102,8 @@ func (api *RestAPI) parseTripParams(r *http.Request, includeScheduleDefault bool
 	return params, nil
 }
 
+// tripDetailsHandler returns extended information for a trip, including its schedule,
+// real-time status, and optionally the full stop time sequence.
 func (api *RestAPI) tripDetailsHandler(w http.ResponseWriter, r *http.Request) {
 	agencyID, tripID, ok := api.extractAndValidateAgencyCodeID(w, r)
 	if !ok {

--- a/internal/restapi/trip_for_vehicle_handler.go
+++ b/internal/restapi/trip_for_vehicle_handler.go
@@ -13,6 +13,7 @@ import (
 	"maglev.onebusaway.org/internal/utils"
 )
 
+// tripForVehicleHandler returns trip details for the trip currently being served by a given vehicle.
 func (api *RestAPI) tripForVehicleHandler(w http.ResponseWriter, r *http.Request) {
 	agencyID, vehicleID, ok := api.extractAndValidateAgencyCodeID(w, r)
 	if !ok {

--- a/internal/restapi/trip_handler.go
+++ b/internal/restapi/trip_handler.go
@@ -8,6 +8,7 @@ import (
 	"maglev.onebusaway.org/internal/utils"
 )
 
+// tripHandler returns details for a single trip, including its route, stop times, and shape.
 func (api *RestAPI) tripHandler(w http.ResponseWriter, r *http.Request) {
 	agencyID, id, ok := api.extractAndValidateAgencyCodeID(w, r)
 	if !ok {

--- a/internal/restapi/trips_for_location_handler.go
+++ b/internal/restapi/trips_for_location_handler.go
@@ -15,6 +15,8 @@ import (
 	"maglev.onebusaway.org/internal/utils"
 )
 
+// tripsForLocationHandler returns active trips near a geographic location, specified by
+// lat/lon coordinates with latSpan/lonSpan bounds, including real-time status and schedule data.
 func (api *RestAPI) tripsForLocationHandler(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 

--- a/internal/restapi/trips_for_route_handler.go
+++ b/internal/restapi/trips_for_route_handler.go
@@ -17,6 +17,8 @@ import (
 	"maglev.onebusaway.org/internal/utils"
 )
 
+// tripsForRouteHandler returns all active trips for a route, including their real-time
+// status, schedule, and vehicle positions when available.
 func (api *RestAPI) tripsForRouteHandler(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 

--- a/internal/restapi/vehicles_for_agency_handler.go
+++ b/internal/restapi/vehicles_for_agency_handler.go
@@ -9,6 +9,7 @@ import (
 	"maglev.onebusaway.org/internal/utils"
 )
 
+// vehiclesForAgencyHandler returns real-time vehicle positions for all vehicles operated by a given agency.
 func (api *RestAPI) vehiclesForAgencyHandler(w http.ResponseWriter, r *http.Request) {
 	id, ok := api.extractAndValidateID(w, r)
 	if !ok {


### PR DESCRIPTION
Every handler in internal/restapi/ now has a godoc comment describing its purpose, improving IDE support and code discoverability. Also includes a go fmt fix in trips_helper_test.go.