### PR TITLE
refactor(restapi): remove redundant SetPredicted(false) in vehicles-f…

### DIFF
--- a/internal/restapi/vehicles_for_agency_handler.go
+++ b/internal/restapi/vehicles_for_agency_handler.go
@@ -102,7 +102,6 @@ func (api *RestAPI) vehiclesForAgencyHandler(w http.ResponseWriter, r *http.Requ
 			tripStatus := models.NewTripStatus()
 			tripStatus.ActiveTripID = utils.FormCombinedID(id, vehicle.Trip.ID.ID)
 			tripStatus.BlockTripSequence = 0
-			tripStatus.SetPredicted(false)
 			tripStatus.Phase = vehicleStatus.Phase
 			tripStatus.Status = vehicleStatus.Status
 


### PR DESCRIPTION
Removed a redundant `tripStatus.SetPredicted(false)` call in `vehicles_for_agency_handler`.

`models.NewTripStatus()` already sets the default predicted/scheduled state, so this keeps constructor defaults as the single source of truth and avoids confusion. Behavior is unchanged.

fixes #692 