### PR TITLE
test:added route_search and spatial_index tests

### DIFF
--- a/internal/gtfs/route_search_test.go
+++ b/internal/gtfs/route_search_test.go
@@ -1,0 +1,157 @@
+package gtfs
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildRouteSearchQuery(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "SingleWord",
+			input:    "airport",
+			expected: `"airport"*`,
+		},
+		{
+			name:     "MultipleWords",
+			input:    "redding express",
+			expected: `"redding"* AND "express"*`,
+		},
+		{
+			name:     "InputIsLowered",
+			input:    "Airport Express",
+			expected: `"airport"* AND "express"*`,
+		},
+		{
+			name:     "EmptyString",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "WhitespaceOnly",
+			input:    "   \t  ",
+			expected: "",
+		},
+		{
+			name:     "SpecialCharactersBang",
+			input:    "route!",
+			expected: `"route!"*`,
+		},
+		{
+			name:     "SpecialCharactersAt",
+			input:    "stop@here",
+			expected: `"stop@here"*`,
+		},
+		{
+			name:     "SpecialCharactersSlash",
+			input:    "north/south",
+			expected: `"north/south"*`,
+		},
+		{
+			name:     "UnicodeAccented",
+			input:    "café",
+			expected: `"café"*`,
+		},
+		{
+			name:     "UnicodeCJK",
+			input:    "日本 電車",
+			expected: `"日本"* AND "電車"*`,
+		},
+		{
+			name:     "EmbeddedDoubleQuotes",
+			input:    `the "quick" route`,
+			expected: `"the"* AND """quick"""* AND "route"*`,
+		},
+		{
+			name:     "ExtraWhitespace",
+			input:    "  route   one  ",
+			expected: `"route"* AND "one"*`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildRouteSearchQuery(tt.input)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}
+
+func TestSearchRoutes_MatchingResults(t *testing.T) {
+	ctx := context.Background()
+	manager, _ := getSharedTestComponents(t)
+	require.NotNil(t, manager)
+
+	manager.RLock()
+	defer manager.RUnlock()
+
+	routes, err := manager.SearchRoutes(ctx, "1", 20)
+	require.NoError(t, err)
+	assert.NotEmpty(t, routes, "Should find routes matching short name '1'")
+
+	// Verify returned routes contain expected fields
+	for _, r := range routes {
+		assert.NotEmpty(t, r.ID, "Route ID should not be empty")
+		assert.NotEmpty(t, r.AgencyID, "AgencyID should not be empty")
+	}
+}
+
+func TestSearchRoutes_NoMatch(t *testing.T) {
+	ctx := context.Background()
+	manager, _ := getSharedTestComponents(t)
+	require.NotNil(t, manager)
+
+	manager.RLock()
+	defer manager.RUnlock()
+
+	routes, err := manager.SearchRoutes(ctx, "zzzyyyxxx_nomatch", 20)
+	require.NoError(t, err)
+	assert.Empty(t, routes, "Should return empty slice for non-matching query")
+}
+
+func TestSearchRoutes_EmptyInput(t *testing.T) {
+	ctx := context.Background()
+	manager, _ := getSharedTestComponents(t)
+	require.NotNil(t, manager)
+
+	manager.RLock()
+	defer manager.RUnlock()
+
+	routes, err := manager.SearchRoutes(ctx, "", 20)
+	require.NoError(t, err)
+	assert.Empty(t, routes, "Empty input should short-circuit and return empty slice")
+}
+
+func TestSearchRoutes_WhitespaceOnlyInput(t *testing.T) {
+	ctx := context.Background()
+	manager, _ := getSharedTestComponents(t)
+	require.NotNil(t, manager)
+
+	manager.RLock()
+	defer manager.RUnlock()
+
+	routes, err := manager.SearchRoutes(ctx, "   \t  ", 20)
+	require.NoError(t, err)
+	assert.Empty(t, routes, "Whitespace-only input should short-circuit and return empty slice")
+}
+
+func TestSearchRoutes_DefaultLimit(t *testing.T) {
+	ctx := context.Background()
+	manager, _ := getSharedTestComponents(t)
+	require.NotNil(t, manager)
+
+	manager.RLock()
+	defer manager.RUnlock()
+
+	// Pass maxCount=0 to trigger default limit of 20
+	routes, err := manager.SearchRoutes(ctx, "1", 0)
+	require.NoError(t, err)
+	assert.NotEmpty(t, routes, "Default limit should still return results")
+}

--- a/internal/gtfs/spatial_index_test.go
+++ b/internal/gtfs/spatial_index_test.go
@@ -1,0 +1,181 @@
+package gtfs
+
+import (
+	"database/sql"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/rtree"
+	"maglev.onebusaway.org/gtfsdb"
+	"maglev.onebusaway.org/internal/utils"
+)
+
+// buildTestTree creates an R-tree with the provided stops for testing.
+func buildTestTree(stops []gtfsdb.Stop) *rtree.RTree {
+	tree := &rtree.RTree{}
+	for _, stop := range stops {
+		tree.Insert(
+			[2]float64{stop.Lat, stop.Lon},
+			[2]float64{stop.Lat, stop.Lon},
+			stop,
+		)
+	}
+	return tree
+}
+
+// testStops returns a fixed set of stops used across spatial index tests.
+func testStops() []gtfsdb.Stop {
+	return []gtfsdb.Stop{
+		{ID: "stop1", Lat: 40.58, Lon: -122.39, Name: sql.NullString{String: "Downtown", Valid: true}},
+		{ID: "stop2", Lat: 40.59, Lon: -122.38, Name: sql.NullString{String: "Midtown", Valid: true}},
+		{ID: "stop3", Lat: 40.60, Lon: -122.37, Name: sql.NullString{String: "Uptown", Valid: true}},
+		{ID: "stop4", Lat: 41.00, Lon: -122.00, Name: sql.NullString{String: "Faraway", Valid: true}},
+	}
+}
+
+func TestQueryStopsInBounds(t *testing.T) {
+	stops := testStops()
+	tree := buildTestTree(stops)
+
+	tests := []struct {
+		name          string
+		bounds        utils.CoordinateBounds
+		expectedCount int
+		expectedIDs   []string 
+	}{
+		{
+			name: "NormalBoundingBox_SomeStops",
+			bounds: utils.CoordinateBounds{
+				MinLat: 40.57, MaxLat: 40.595,
+				MinLon: -122.40, MaxLon: -122.37,
+			},
+			expectedCount: 2,
+			expectedIDs:   []string{"stop1", "stop2"},
+		},
+		{
+			name: "BoundingBox_NoStops",
+			bounds: utils.CoordinateBounds{
+				MinLat: 50.00, MaxLat: 51.00,
+				MinLon: -80.00, MaxLon: -79.00,
+			},
+			expectedCount: 0,
+		},
+		{
+			name: "BoundingBox_AllStops",
+			bounds: utils.CoordinateBounds{
+				MinLat: 40.00, MaxLat: 42.00,
+				MinLon: -123.00, MaxLon: -121.00,
+			},
+			expectedCount: 4,
+		},
+		{
+			name: "ZeroSizeBoundingBox_PointQuery",
+			bounds: utils.CoordinateBounds{
+				MinLat: 40.58, MaxLat: 40.58,
+				MinLon: -122.39, MaxLon: -122.39,
+			},
+			expectedCount: 1,
+			expectedIDs:   []string{"stop1"},
+		},
+		{
+			name: "ExtremelyLargeBoundingBox",
+			bounds: utils.CoordinateBounds{
+				MinLat: -90.0, MaxLat: 90.0,
+				MinLon: -180.0, MaxLon: 180.0,
+			},
+			expectedCount: 4,
+		},
+		{
+			name: "SwappedMinMax_HandledByNormalization",
+			bounds: utils.CoordinateBounds{
+				MinLat: 40.595, MaxLat: 40.57,
+				MinLon: -122.37, MaxLon: -122.40,
+			},
+			expectedCount: 2,
+			expectedIDs:   []string{"stop1", "stop2"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			results := queryStopsInBounds(tree, tt.bounds)
+			assert.Len(t, results, tt.expectedCount)
+
+			if len(tt.expectedIDs) > 0 {
+				gotIDs := make([]string, len(results))
+				for i, s := range results {
+					gotIDs[i] = s.ID
+				}
+				for _, expectedID := range tt.expectedIDs {
+					assert.Contains(t, gotIDs, expectedID)
+				}
+			}
+		})
+	}
+}
+
+func TestQueryStopsInBounds_NilTree(t *testing.T) {
+	bounds := utils.CoordinateBounds{
+		MinLat: 40.0, MaxLat: 41.0,
+		MinLon: -123.0, MaxLon: -122.0,
+	}
+
+	results := queryStopsInBounds(nil, bounds)
+	assert.Empty(t, results, "Nil tree should return empty slice")
+	assert.NotNil(t, results, "Should return non-nil empty slice, not nil")
+}
+
+func TestQueryStopsInBounds_EmptyTree(t *testing.T) {
+	tree := &rtree.RTree{}
+	bounds := utils.CoordinateBounds{
+		MinLat: -90.0, MaxLat: 90.0,
+		MinLon: -180.0, MaxLon: 180.0,
+	}
+
+	results := queryStopsInBounds(tree, bounds)
+	assert.Empty(t, results, "Empty tree should return no results")
+}
+
+func TestBuildStopSpatialIndex_WithRABA(t *testing.T) {
+	manager, _ := getSharedTestComponents(t)
+	require.NotNil(t, manager)
+	require.NotNil(t, manager.stopSpatialIndex, "Spatial index should be built during initialization")
+
+	// Query a bounding box around the RABA service area (Redding, CA)
+	bounds := utils.CoordinateBounds{
+		MinLat: 40.50, MaxLat: 40.70,
+		MinLon: -122.50, MaxLon: -122.30,
+	}
+
+	results := queryStopsInBounds(manager.stopSpatialIndex, bounds)
+	assert.NotEmpty(t, results, "Should find stops in the RABA service area")
+
+	for _, stop := range results {
+		assert.NotEmpty(t, stop.ID, "Stop ID should not be empty")
+		assert.NotZero(t, stop.Lat, "Stop latitude should not be zero")
+		assert.NotZero(t, stop.Lon, "Stop longitude should not be zero")
+	}
+}
+
+func TestMinMaxHelpers(t *testing.T) {
+	tests := []struct {
+		name        string
+		a, b        float64
+		expectedMin float64
+		expectedMax float64
+	}{
+		{"PositiveValues", 3.0, 5.0, 3.0, 5.0},
+		{"NegativeValues", -5.0, -3.0, -5.0, -3.0},
+		{"MixedSigns", -1.0, 1.0, -1.0, 1.0},
+		{"EqualValues", 4.0, 4.0, 4.0, 4.0},
+		{"ZeroAndPositive", 0.0, 7.0, 0.0, 7.0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expectedMin, min(tt.a, tt.b))
+			assert.Equal(t, tt.expectedMax, max(tt.a, tt.b))
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Adds unit tests for two previously untested modules: [route_search.go](cci:7://file:///c:/Users/hiros/Desktop/gsoc/open-transit/maglev/internal/gtfs/route_search.go:0:0-0:0) and [spatial_index.go](cci:7://file:///c:/Users/hiros/Desktop/gsoc/open-transit/maglev/internal/gtfs/spatial_index.go:0:0-0:0) in `internal/gtfs/`.

Closes #697

## Changes

### `internal/gtfs/route_search_test.go` (new)

- **`TestBuildRouteSearchQuery`** — 12-case table-driven test for the FTS5 query builder covering: single/multi-word input, empty/whitespace, special characters (`!`, `@`, `/`), unicode (`café`, `日本`), embedded double-quotes, and extra whitespace.
- **`TestSearchRoutes_MatchingResults`** — integration test using RABA fixture data, verifies matching routes are returned.
- **`TestSearchRoutes_NoMatch`** — verifies empty result for non-matching input.
- **`TestSearchRoutes_EmptyInput`** — verifies empty string short-circuits to empty slice.
- **`TestSearchRoutes_WhitespaceOnlyInput`** — verifies whitespace-only input short-circuits.
- **`TestSearchRoutes_DefaultLimit`** — verifies `maxCount=0` falls back to the default limit.

### `internal/gtfs/spatial_index_test.go` (new)

- **`TestQueryStopsInBounds`** — 6-case table-driven test: normal bounding box, no stops, all stops, zero-size (point query), extremely large bounds, and swapped min/max bounds.
- **`TestQueryStopsInBounds_NilTree`** — verifies nil tree returns empty slice.
- **`TestQueryStopsInBounds_EmptyTree`** — verifies empty tree returns no results.
- **`TestBuildStopSpatialIndex_WithRABA`** — integration test using RABA fixture data, verifies the spatial index is populated with real stops.
- **`TestMinMaxHelpers`** — 5-case table-driven test for the `min`/`max` helper functions.

## Testing

- No existing files were modified — only new test files were added.
- All tests follow existing conventions: `package gtfs`, testify assertions, table-driven tests with `t.Run`, and the shared `getSharedTestComponents` singleton pattern.
