### PR TITLE
fix: guard against nil vehicle.ID dereference in arrival and vehicle handlers

### DIFF
--- a/internal/gtfs/gtfs_manager_mock.go
+++ b/internal/gtfs/gtfs_manager_mock.go
@@ -35,7 +35,7 @@ func (m *Manager) MockAddVehicle(vehicleID, tripID, routeID string) {
 	defer m.realTimeMutex.Unlock()
 
 	for _, v := range m.realTimeVehicles {
-		if v.ID.ID == vehicleID {
+		if v.ID != nil && v.ID.ID == vehicleID {
 			return
 		}
 	}
@@ -110,7 +110,7 @@ func (m *Manager) MockAddVehicleWithOptions(vehicleID, tripID, routeID string, o
 	if vehicleID != "" && !opts.NoID {
 		m.realTimeVehicleLookupByVehicle[vehicleID] = idx
 	}
-	if tripID != "" {
+	if tripID != "" && !opts.NoTrip {
 		m.realTimeVehicleLookupByTrip[tripID] = idx
 	}
 }

--- a/internal/restapi/arrival_and_departure_for_stop_handler.go
+++ b/internal/restapi/arrival_and_departure_for_stop_handler.go
@@ -314,6 +314,8 @@ func (api *RestAPI) arrivalAndDepartureForStopHandler(w http.ResponseWriter, r *
 	if vehicle != nil && vehicle.Trip != nil {
 		if vehicle.ID != nil {
 			vehicleID = vehicle.ID.ID
+		} else {
+			api.Logger.Warn("vehicle with nil ID descriptor found for trip", "tripID", tripID)
 		}
 		predicted = true
 	}

--- a/internal/restapi/arrival_and_departure_for_stop_handler_test.go
+++ b/internal/restapi/arrival_and_departure_for_stop_handler_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"maglev.onebusaway.org/gtfsdb"
+	internalgtfs "maglev.onebusaway.org/internal/gtfs"
 	"maglev.onebusaway.org/internal/models"
 	"maglev.onebusaway.org/internal/utils"
 )
@@ -1075,4 +1076,58 @@ func TestArrivalAndDepartureForStopHandler_LoopRouteStopSequence(t *testing.T) {
 	entry2, ok := data2["entry"].(map[string]interface{})
 	require.True(t, ok)
 	assert.Equal(t, float64(14), entry2["stopSequence"], "expected zero-based index for stop_sequence=15")
+}
+
+func TestArrivalAndDepartureForStop_VehicleWithNilID(t *testing.T) {
+	api := createTestApi(t)
+	defer api.Shutdown()
+	t.Cleanup(api.GtfsManager.MockResetRealTimeData)
+
+	ctx := context.Background()
+
+	trips := api.GtfsManager.GetTrips()
+	require.NotEmpty(t, trips)
+
+	var validTripID, validStopID string
+	var stopSequence int64
+	for _, trip := range trips {
+		stopTimes, err := api.GtfsManager.GtfsDB.Queries.GetStopTimesForTrip(ctx, trip.ID)
+		if err == nil && len(stopTimes) > 0 {
+			validTripID = trip.ID
+			validStopID = stopTimes[0].StopID
+			stopSequence = stopTimes[0].StopSequence
+			break
+		}
+	}
+	require.NotEmpty(t, validTripID, "no trip with stop times found in test data")
+
+	agencies := api.GtfsManager.GetAgencies()
+	require.NotEmpty(t, agencies)
+	agencyID := agencies[0].Id
+
+	combinedStopID := utils.FormCombinedID(agencyID, validStopID)
+	combinedTripID := utils.FormCombinedID(agencyID, validTripID)
+	serviceDateMs := time.Now().UnixMilli()
+
+	api.GtfsManager.MockAddVehicleWithOptions("", validTripID, "", internalgtfs.MockVehicleOptions{
+		NoID: true,
+	})
+
+	endpoint := fmt.Sprintf(
+		"/api/where/arrival-and-departure-for-stop/%s.json?key=TEST&tripId=%s&serviceDate=%d&stopSequence=%d",
+		combinedStopID,
+		combinedTripID,
+		serviceDateMs,
+		stopSequence,
+	)
+
+	resp, model := serveApiAndRetrieveEndpoint(t, api, endpoint)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, 200, model.Code)
+
+	data, ok := model.Data.(map[string]interface{})
+	require.True(t, ok)
+	entry, ok := data["entry"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "", entry["vehicleId"], "vehicleId should be empty for vehicle with nil ID")
 }

--- a/internal/restapi/arrivals_and_departure_for_stop.go
+++ b/internal/restapi/arrivals_and_departure_for_stop.go
@@ -316,8 +316,12 @@ func (api *RestAPI) arrivalsAndDeparturesForStopHandler(w http.ResponseWriter, r
 
 		// Get vehicle if available
 		vehicle := api.GtfsManager.GetVehicleForTrip(ctx, st.TripID)
-		if vehicle != nil && vehicle.Trip != nil && vehicle.ID != nil {
-			vehicleID = vehicle.ID.ID
+		if vehicle != nil && vehicle.Trip != nil {
+			if vehicle.ID != nil {
+				vehicleID = vehicle.ID.ID
+			} else {
+				api.Logger.Warn("vehicle with nil ID descriptor found for trip", "tripID", st.TripID)
+			}
 		}
 
 		// Prepare scheduled times for the shared function

--- a/internal/restapi/arrivals_and_departures_for_stop_handler_test.go
+++ b/internal/restapi/arrivals_and_departures_for_stop_handler_test.go
@@ -1217,29 +1217,104 @@ func TestPluralArrivals_TripUpdateWithoutVehicle(t *testing.T) {
 }
 
 func TestArrivalsAndDeparturesForStop_VehicleWithNilID(t *testing.T) {
-	api := createTestApi(t)
+	loc, err := time.LoadLocation("America/Los_Angeles")
+	require.NoError(t, err)
+	mockClock := clock.NewMockClock(time.Date(2010, 1, 1, 8, 2, 0, 0, loc))
+
+	api := createTestApiWithClock(t, mockClock)
 	defer api.Shutdown()
 	t.Cleanup(api.GtfsManager.MockResetRealTimeData)
 
-	agencies := api.GtfsManager.GetAgencies()
-	require.NotEmpty(t, agencies)
-	agencyID := agencies[0].Id
+	ctx := context.Background()
+	queries := api.GtfsManager.GtfsDB.Queries
 
-	stops := api.GtfsManager.GetStops()
-	require.NotEmpty(t, stops)
-	combinedStopID := utils.FormCombinedID(agencyID, stops[0].Id)
+	const (
+		agencyID = "NilIDAgency"
+		stopID   = "NilIDStop"
+		routeID  = "NilIDRoute"
+		tripID   = "NilIDTrip"
+	)
 
-	trips := api.GtfsManager.GetTrips()
-	require.NotEmpty(t, trips)
-	rawRouteID := trips[0].Route.Id
+	_, err = queries.CreateAgency(ctx, gtfsdb.CreateAgencyParams{
+		ID:       agencyID,
+		Name:     "Nil ID Test Agency",
+		Url:      "http://nilid-agency.com",
+		Timezone: "America/Los_Angeles",
+	})
+	require.NoError(t, err)
 
-	api.GtfsManager.MockAddVehicleWithOptions("", trips[0].ID, rawRouteID, internalgtfs.MockVehicleOptions{
+	_, err = queries.CreateStop(ctx, gtfsdb.CreateStopParams{
+		ID:   stopID,
+		Name: sql.NullString{String: "Nil ID Test Stop", Valid: true},
+		Lat:  40.5865,
+		Lon:  -122.3917,
+	})
+	require.NoError(t, err)
+
+	_, err = queries.CreateRoute(ctx, gtfsdb.CreateRouteParams{
+		ID:       routeID,
+		AgencyID: agencyID,
+		Type:     3,
+	})
+	require.NoError(t, err)
+
+	_, err = queries.CreateCalendar(ctx, gtfsdb.CreateCalendarParams{
+		ID:        "nilid_service",
+		Monday:    1,
+		Tuesday:   1,
+		Wednesday: 1,
+		Thursday:  1,
+		Friday:    1,
+		Saturday:  1,
+		Sunday:    1,
+		StartDate: "20000101",
+		EndDate:   "20301231",
+	})
+	require.NoError(t, err)
+
+	_, err = queries.CreateTrip(ctx, gtfsdb.CreateTripParams{
+		ID:        tripID,
+		RouteID:   routeID,
+		ServiceID: "nilid_service",
+	})
+	require.NoError(t, err)
+
+	_, err = queries.CreateStopTime(ctx, gtfsdb.CreateStopTimeParams{
+		TripID:        tripID,
+		StopID:        stopID,
+		StopSequence:  1,
+		ArrivalTime:   29100 * 1e9, // 08:05:00 in nanoseconds
+		DepartureTime: 29400 * 1e9, // 08:10:00 in nanoseconds
+	})
+	require.NoError(t, err)
+
+	api.GtfsManager.MockAddVehicleWithOptions("", tripID, routeID, internalgtfs.MockVehicleOptions{
 		NoID: true,
 	})
 
+	combinedStopID := utils.FormCombinedID(agencyID, stopID)
 	resp, model := serveApiAndRetrieveEndpoint(t, api,
 		"/api/where/arrivals-and-departures-for-stop/"+combinedStopID+".json?key=TEST&minutesBefore=60&minutesAfter=60")
 
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, 200, model.Code)
+
+	data, ok := model.Data.(map[string]interface{})
+	require.True(t, ok)
+	entry, ok := data["entry"].(map[string]interface{})
+	require.True(t, ok)
+	arrivalsRaw, ok := entry["arrivalsAndDepartures"].([]interface{})
+	require.True(t, ok)
+
+	var found bool
+	for _, a := range arrivalsRaw {
+		arr := a.(map[string]interface{})
+		_, arrTripID, _ := utils.ExtractAgencyIDAndCodeID(arr["tripId"].(string))
+		if arrTripID == tripID {
+			assert.Equal(t, "", arr["vehicleId"], "vehicleId should be empty for vehicle with nil ID")
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "should find arrival for test trip %s", tripID)
 }

--- a/internal/restapi/vehicles_for_agency_handler.go
+++ b/internal/restapi/vehicles_for_agency_handler.go
@@ -69,10 +69,11 @@ func (api *RestAPI) vehiclesForAgencyHandler(w http.ResponseWriter, r *http.Requ
 			return
 		}
 
-		var vid string
-		if vehicle.ID != nil {
-			vid = vehicle.ID.ID
+		if vehicle.ID == nil {
+			api.Logger.Warn("skipping vehicle with nil ID descriptor", "agencyID", id)
+			continue
 		}
+		vid := vehicle.ID.ID
 		vehicleStatus := models.VehicleStatus{
 			VehicleID: vid,
 		}

--- a/internal/restapi/vehicles_for_agency_handler_test.go
+++ b/internal/restapi/vehicles_for_agency_handler_test.go
@@ -403,6 +403,15 @@ func TestVehiclesForAgencyHandler_VehicleWithNilID(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, 200, model.Code)
+
+	data, ok := model.Data.(map[string]interface{})
+	require.True(t, ok)
+	list, ok := data["list"].([]interface{})
+	require.True(t, ok)
+	for _, item := range list {
+		v := item.(map[string]interface{})
+		assert.NotEqual(t, "", v["vehicleId"], "vehicle with nil ID must be skipped, not returned with empty vehicleId")
+	}
 }
 
 // createTestApiWithRealTimeData creates a test API with real-time GTFS-RT data served from local files
@@ -510,10 +519,14 @@ func TestVehiclesForAgencyHandlerWithRealTimeData(t *testing.T) {
 		t.Log("Real-time vehicles are not matching the test agency. Debugging:")
 		for i, vehicle := range realTimeVehicles {
 			if i < 3 { // Log first 3 vehicles
+				vehicleID := ""
+				if vehicle.ID != nil {
+					vehicleID = vehicle.ID.ID
+				}
 				if vehicle.Trip != nil {
-					t.Logf("Vehicle %s: tripId=%s, routeId=%s", vehicle.ID.ID, vehicle.Trip.ID.ID, vehicle.Trip.ID.RouteID)
+					t.Logf("Vehicle %s: tripId=%s, routeId=%s", vehicleID, vehicle.Trip.ID.ID, vehicle.Trip.ID.RouteID)
 				} else {
-					t.Logf("Vehicle %s: no trip assigned", vehicle.ID.ID)
+					t.Logf("Vehicle %s: no trip assigned", vehicleID)
 				}
 			}
 		}


### PR DESCRIPTION
Closes #714 

## Summary
- Add nil guard for `vehicle.ID` in 3 handlers that accessed `vehicle.ID.ID` without checking,
  consistent with the existing safe pattern in `trips_helper.go`
- Add `NoID` option to `MockVehicleOptions` in `gtfs_manager_mock.go` for testing vehicles with nil ID
- Add regression tests in `vehicles_for_agency_handler_test.go` and
  `arrivals_and_departures_for_stop_handler_test.go`

## Test plan
- [x] `make test` passes (all 13 packages)
- [x] `make lint` passes (zero issues)
- [x] `go fmt ./...` produces no changes
- [x] New regression tests inject a vehicle with `ID == nil` and verify 200 OK (no panic)