### PR TITLE
perf: resolve N+1 query patterns in schedule and route handlers

### DIFF
--- a/gtfsdb/db.go
+++ b/gtfsdb/db.go
@@ -141,6 +141,9 @@ func Prepare(ctx context.Context, db DBTX) (*Queries, error) {
 	if q.getBlockIDByTripIDStmt, err = db.PrepareContext(ctx, getBlockIDByTripID); err != nil {
 		return nil, fmt.Errorf("error preparing query GetBlockIDByTripID: %w", err)
 	}
+	if q.getBlockIDsByTripIDsStmt, err = db.PrepareContext(ctx, getBlockIDsByTripIDs); err != nil {
+		return nil, fmt.Errorf("error preparing query GetBlockIDsByTripIDs: %w", err)
+	}
 	if q.getBlockTripIndexIDsForBlocksStmt, err = db.PrepareContext(ctx, getBlockTripIndexIDsForBlocks); err != nil {
 		return nil, fmt.Errorf("error preparing query GetBlockTripIndexIDsForBlocks: %w", err)
 	}
@@ -233,6 +236,9 @@ func Prepare(ctx context.Context, db DBTX) (*Queries, error) {
 	}
 	if q.getShapePointsByTripIDStmt, err = db.PrepareContext(ctx, getShapePointsByTripID); err != nil {
 		return nil, fmt.Errorf("error preparing query GetShapePointsByTripID: %w", err)
+	}
+	if q.getShapePointsByTripIDsStmt, err = db.PrepareContext(ctx, getShapePointsByTripIDs); err != nil {
+		return nil, fmt.Errorf("error preparing query GetShapePointsByTripIDs: %w", err)
 	}
 	if q.getShapePointsForTripStmt, err = db.PrepareContext(ctx, getShapePointsForTrip); err != nil {
 		return nil, fmt.Errorf("error preparing query GetShapePointsForTrip: %w", err)
@@ -539,6 +545,11 @@ func (q *Queries) Close() error {
 			err = fmt.Errorf("error closing getBlockIDByTripIDStmt: %w", cerr)
 		}
 	}
+	if q.getBlockIDsByTripIDsStmt != nil {
+		if cerr := q.getBlockIDsByTripIDsStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing getBlockIDsByTripIDsStmt: %w", cerr)
+		}
+	}
 	if q.getBlockTripIndexIDsForBlocksStmt != nil {
 		if cerr := q.getBlockTripIndexIDsForBlocksStmt.Close(); cerr != nil {
 			err = fmt.Errorf("error closing getBlockTripIndexIDsForBlocksStmt: %w", cerr)
@@ -692,6 +703,11 @@ func (q *Queries) Close() error {
 	if q.getShapePointsByTripIDStmt != nil {
 		if cerr := q.getShapePointsByTripIDStmt.Close(); cerr != nil {
 			err = fmt.Errorf("error closing getShapePointsByTripIDStmt: %w", cerr)
+		}
+	}
+	if q.getShapePointsByTripIDsStmt != nil {
+		if cerr := q.getShapePointsByTripIDsStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing getShapePointsByTripIDsStmt: %w", cerr)
 		}
 	}
 	if q.getShapePointsForTripStmt != nil {
@@ -947,6 +963,7 @@ type Queries struct {
 	getArrivalsAndDeparturesForStopStmt           *sql.Stmt
 	getBlockDetailsStmt                           *sql.Stmt
 	getBlockIDByTripIDStmt                        *sql.Stmt
+	getBlockIDsByTripIDsStmt                      *sql.Stmt
 	getBlockTripIndexIDsForBlocksStmt             *sql.Stmt
 	getBlockTripIndexIDsForRouteStmt              *sql.Stmt
 	getBlockTripSequenceStmt                      *sql.Stmt
@@ -978,6 +995,7 @@ type Queries struct {
 	getShapePointWindowStmt                       *sql.Stmt
 	getShapePointsByIDsStmt                       *sql.Stmt
 	getShapePointsByTripIDStmt                    *sql.Stmt
+	getShapePointsByTripIDsStmt                   *sql.Stmt
 	getShapePointsForTripStmt                     *sql.Stmt
 	getShapePointsWithDistanceStmt                *sql.Stmt
 	getShapesGroupedByTripHeadSignStmt            *sql.Stmt
@@ -1058,6 +1076,7 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		getArrivalsAndDeparturesForStopStmt:           q.getArrivalsAndDeparturesForStopStmt,
 		getBlockDetailsStmt:                           q.getBlockDetailsStmt,
 		getBlockIDByTripIDStmt:                        q.getBlockIDByTripIDStmt,
+		getBlockIDsByTripIDsStmt:                      q.getBlockIDsByTripIDsStmt,
 		getBlockTripIndexIDsForBlocksStmt:             q.getBlockTripIndexIDsForBlocksStmt,
 		getBlockTripIndexIDsForRouteStmt:              q.getBlockTripIndexIDsForRouteStmt,
 		getBlockTripSequenceStmt:                      q.getBlockTripSequenceStmt,
@@ -1089,6 +1108,7 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		getShapePointWindowStmt:                       q.getShapePointWindowStmt,
 		getShapePointsByIDsStmt:                       q.getShapePointsByIDsStmt,
 		getShapePointsByTripIDStmt:                    q.getShapePointsByTripIDStmt,
+		getShapePointsByTripIDsStmt:                   q.getShapePointsByTripIDsStmt,
 		getShapePointsForTripStmt:                     q.getShapePointsForTripStmt,
 		getShapePointsWithDistanceStmt:                q.getShapePointsWithDistanceStmt,
 		getShapesGroupedByTripHeadSignStmt:            q.getShapesGroupedByTripHeadSignStmt,

--- a/gtfsdb/query.sql
+++ b/gtfsdb/query.sql
@@ -808,6 +808,32 @@ WHERE
 ORDER BY
     t.id, st.stop_sequence;
 
+-- name: GetBlockIDsByTripIDs :many
+SELECT
+    id AS trip_id,
+    block_id
+FROM
+    trips
+WHERE
+    id IN (sqlc.slice('trip_ids'));
+
+-- name: GetShapePointsByTripIDs :many
+SELECT
+    t.id AS trip_id,
+    s.id,
+    s.shape_id,
+    s.lat,
+    s.lon,
+    s.shape_pt_sequence,
+    s.shape_dist_traveled
+FROM
+    shapes s
+    JOIN trips t ON t.shape_id = s.shape_id
+WHERE
+    t.id IN (sqlc.slice('trip_ids'))
+ORDER BY
+    t.id, s.shape_pt_sequence ASC;
+
 -- name: GetStopTimesByStopIDs :many
 SELECT
     *

--- a/gtfsdb/query.sql.go
+++ b/gtfsdb/query.sql.go
@@ -1459,6 +1459,54 @@ func (q *Queries) GetBlockIDByTripID(ctx context.Context, id string) (sql.NullSt
 	return block_id, err
 }
 
+const getBlockIDsByTripIDs = `-- name: GetBlockIDsByTripIDs :many
+SELECT
+    id AS trip_id,
+    block_id
+FROM
+    trips
+WHERE
+    id IN (/*SLICE:trip_ids*/?)
+`
+
+type GetBlockIDsByTripIDsRow struct {
+	TripID  string
+	BlockID sql.NullString
+}
+
+func (q *Queries) GetBlockIDsByTripIDs(ctx context.Context, tripIds []string) ([]GetBlockIDsByTripIDsRow, error) {
+	query := getBlockIDsByTripIDs
+	var queryParams []interface{}
+	if len(tripIds) > 0 {
+		for _, v := range tripIds {
+			queryParams = append(queryParams, v)
+		}
+		query = strings.Replace(query, "/*SLICE:trip_ids*/?", strings.Repeat(",?", len(tripIds))[1:], 1)
+	} else {
+		query = strings.Replace(query, "/*SLICE:trip_ids*/?", "NULL", 1)
+	}
+	rows, err := q.query(ctx, nil, query, queryParams...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []GetBlockIDsByTripIDsRow
+	for rows.Next() {
+		var i GetBlockIDsByTripIDsRow
+		if err := rows.Scan(&i.TripID, &i.BlockID); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const getBlockTripIndexIDsForBlocks = `-- name: GetBlockTripIndexIDsForBlocks :many
 SELECT DISTINCT bte.block_trip_index_id
 FROM block_trip_entry bte
@@ -2844,6 +2892,75 @@ func (q *Queries) GetShapePointsByTripID(ctx context.Context, id string) ([]Shap
 	for rows.Next() {
 		var i Shape
 		if err := rows.Scan(
+			&i.ID,
+			&i.ShapeID,
+			&i.Lat,
+			&i.Lon,
+			&i.ShapePtSequence,
+			&i.ShapeDistTraveled,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const getShapePointsByTripIDs = `-- name: GetShapePointsByTripIDs :many
+SELECT
+    t.id AS trip_id,
+    s.id,
+    s.shape_id,
+    s.lat,
+    s.lon,
+    s.shape_pt_sequence,
+    s.shape_dist_traveled
+FROM
+    shapes s
+    JOIN trips t ON t.shape_id = s.shape_id
+WHERE
+    t.id IN (/*SLICE:trip_ids*/?)
+ORDER BY
+    t.id, s.shape_pt_sequence ASC
+`
+
+type GetShapePointsByTripIDsRow struct {
+	TripID            string
+	ID                int64
+	ShapeID           string
+	Lat               float64
+	Lon               float64
+	ShapePtSequence   int64
+	ShapeDistTraveled sql.NullFloat64
+}
+
+func (q *Queries) GetShapePointsByTripIDs(ctx context.Context, tripIds []string) ([]GetShapePointsByTripIDsRow, error) {
+	query := getShapePointsByTripIDs
+	var queryParams []interface{}
+	if len(tripIds) > 0 {
+		for _, v := range tripIds {
+			queryParams = append(queryParams, v)
+		}
+		query = strings.Replace(query, "/*SLICE:trip_ids*/?", strings.Repeat(",?", len(tripIds))[1:], 1)
+	} else {
+		query = strings.Replace(query, "/*SLICE:trip_ids*/?", "NULL", 1)
+	}
+	rows, err := q.query(ctx, nil, query, queryParams...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []GetShapePointsByTripIDsRow
+	for rows.Next() {
+		var i GetShapePointsByTripIDsRow
+		if err := rows.Scan(
+			&i.TripID,
 			&i.ID,
 			&i.ShapeID,
 			&i.Lat,

--- a/internal/restapi/arrival_and_departure_for_stop_handler.go
+++ b/internal/restapi/arrival_and_departure_for_stop_handler.go
@@ -340,7 +340,7 @@ func (api *RestAPI) arrivalAndDepartureForStopHandler(w http.ResponseWriter, r *
 		}
 
 		if vehicle != nil && vehicle.Position != nil {
-			distanceFromStop = api.getBlockDistanceToStop(ctx, tripID, stopCode, vehicle, serviceDate)
+			distanceFromStop = api.getBlockDistanceToStop(ctx, tripID, stopCode, vehicle, serviceDate, nil)
 
 			numberOfStopsAwayPtr := api.getNumberOfStopsAway(ctx, tripID, int(targetStopTime.StopSequence), vehicle, serviceDate)
 			if numberOfStopsAwayPtr != nil {

--- a/internal/restapi/arrival_and_departure_for_stop_handler_test.go
+++ b/internal/restapi/arrival_and_departure_for_stop_handler_test.go
@@ -565,7 +565,7 @@ func TestGetBlockDistanceToStop_NilVehicle(t *testing.T) {
 	defer api.Shutdown()
 	ctx := context.Background()
 
-	result := api.getBlockDistanceToStop(ctx, "test_trip", "test_stop", nil, time.Now())
+	result := api.getBlockDistanceToStop(ctx, "test_trip", "test_stop", nil, time.Now(), nil)
 
 	assert.Equal(t, 0.0, result)
 }
@@ -579,7 +579,7 @@ func TestGetBlockDistanceToStop_NoPosition(t *testing.T) {
 		Position: nil,
 	}
 
-	result := api.getBlockDistanceToStop(ctx, "test_trip", "test_stop", vehicle, time.Now())
+	result := api.getBlockDistanceToStop(ctx, "test_trip", "test_stop", vehicle, time.Now(), nil)
 
 	assert.Equal(t, 0.0, result)
 }

--- a/internal/restapi/arrivals_and_departure_for_stop.go
+++ b/internal/restapi/arrivals_and_departure_for_stop.go
@@ -274,6 +274,8 @@ func (api *RestAPI) arrivalsAndDeparturesForStopHandler(w http.ResponseWriter, r
 	distanceHelperCache := &DistanceHelperCache{
 		stopTimesByTrip:   make(map[string][]gtfsdb.StopTime),
 		shapePointsByTrip: make(map[string][]gtfsdb.GetShapePointsByTripIDsRow),
+		blockIDByTrip:     make(map[string]string),
+		tripsByBlock:      make(map[string][]gtfsdb.GetTripsByBlockIDRow),
 	}
 
 	if len(uniqueTripIDs) > 0 {
@@ -285,6 +287,7 @@ func (api *RestAPI) arrivalsAndDeparturesForStopHandler(w http.ResponseWriter, r
 			for _, m := range blockTripMappings {
 				if m.BlockID.Valid && m.BlockID.String != "" {
 					uniqueBlockIDsMap[m.BlockID.String] = true
+					distanceHelperCache.blockIDByTrip[m.TripID] = m.BlockID.String
 				}
 			}
 
@@ -313,6 +316,21 @@ func (api *RestAPI) arrivalsAndDeparturesForStopHandler(w http.ResponseWriter, r
 					blockTripIDsMap := make(map[string]bool)
 					for _, bt := range blockTrips {
 						blockTripIDsMap[bt.ID] = true
+
+						mappedRow := gtfsdb.GetTripsByBlockIDRow{
+							ID:            bt.ID,
+							RouteID:       bt.RouteID,
+							ServiceID:     bt.ServiceID,
+							TripHeadsign:  bt.TripHeadsign,
+							TripShortName: bt.TripShortName,
+							DirectionID:   bt.DirectionID,
+							BlockID:       bt.BlockID,
+							ShapeID:       bt.ShapeID,
+						}
+
+						if bt.BlockID.Valid {
+							distanceHelperCache.tripsByBlock[bt.BlockID.String] = append(distanceHelperCache.tripsByBlock[bt.BlockID.String], mappedRow)
+						}
 					}
 
 					blockTripIDs := make([]string, 0, len(blockTripIDsMap))

--- a/internal/restapi/arrivals_and_departure_for_stop.go
+++ b/internal/restapi/arrivals_and_departure_for_stop.go
@@ -2,6 +2,7 @@ package restapi
 
 import (
 	"context"
+	"database/sql"
 	"log/slog"
 	"net/http"
 	"strconv"
@@ -269,6 +270,83 @@ func (api *RestAPI) arrivalsAndDeparturesForStopHandler(w http.ResponseWriter, r
 			}
 		}
 	}
+	// Batch-fetch block data for DistanceHelperCache
+	distanceHelperCache := &DistanceHelperCache{
+		stopTimesByTrip:   make(map[string][]gtfsdb.StopTime),
+		shapePointsByTrip: make(map[string][]gtfsdb.GetShapePointsByTripIDsRow),
+	}
+
+	if len(uniqueTripIDs) > 0 {
+		blockTripMappings, err := api.GtfsManager.GtfsDB.Queries.GetBlockIDsByTripIDs(ctx, uniqueTripIDs)
+		if err != nil {
+			api.Logger.Warn("failed to batch fetch block IDs for caching", slog.Any("error", err))
+		} else {
+			uniqueBlockIDsMap := make(map[string]bool)
+			for _, m := range blockTripMappings {
+				if m.BlockID.Valid && m.BlockID.String != "" {
+					uniqueBlockIDsMap[m.BlockID.String] = true
+				}
+			}
+
+			if len(uniqueBlockIDsMap) > 0 {
+				uniqueBlockIDs := make([]sql.NullString, 0, len(uniqueBlockIDsMap))
+				for bid := range uniqueBlockIDsMap {
+					uniqueBlockIDs = append(uniqueBlockIDs, sql.NullString{String: bid, Valid: true})
+				}
+
+				// re-collect active service IDs
+				activeServiceIDSet := make(map[string]bool)
+				for _, ast := range allActiveStopTimes {
+					activeServiceIDSet[ast.ServiceID] = true
+				}
+				activeServiceIDsArray := make([]string, 0, len(activeServiceIDSet))
+				for sid := range activeServiceIDSet {
+					activeServiceIDsArray = append(activeServiceIDsArray, sid)
+				}
+
+				blockTrips, err := api.GtfsManager.GtfsDB.Queries.GetTripsByBlockIDs(ctx, gtfsdb.GetTripsByBlockIDsParams{
+					BlockIds:   uniqueBlockIDs,
+					ServiceIds: activeServiceIDsArray,
+				})
+
+				if err == nil {
+					blockTripIDsMap := make(map[string]bool)
+					for _, bt := range blockTrips {
+						blockTripIDsMap[bt.ID] = true
+					}
+
+					blockTripIDs := make([]string, 0, len(blockTripIDsMap))
+					for tid := range blockTripIDsMap {
+						blockTripIDs = append(blockTripIDs, tid)
+					}
+
+					if len(blockTripIDs) > 0 {
+						stForBlocks, err := api.GtfsManager.GtfsDB.Queries.GetStopTimesForTripIDs(ctx, blockTripIDs)
+						if err == nil {
+							for _, st := range stForBlocks {
+								distanceHelperCache.stopTimesByTrip[st.TripID] = append(distanceHelperCache.stopTimesByTrip[st.TripID], st)
+							}
+						} else {
+							api.Logger.Warn("failed to batch fetch stop times for block trips", slog.Any("error", err))
+						}
+
+						spForBlocks, err := api.GtfsManager.GtfsDB.Queries.GetShapePointsByTripIDs(ctx, blockTripIDs)
+						if err == nil {
+							for _, sp := range spForBlocks {
+								distanceHelperCache.shapePointsByTrip[sp.TripID] = append(distanceHelperCache.shapePointsByTrip[sp.TripID], sp)
+							}
+						} else {
+							api.Logger.Warn("failed to batch fetch shape points for block trips", slog.Any("error", err))
+						}
+					}
+				} else {
+					api.Logger.Warn("failed to batch fetch trips by block IDs for caching", slog.Any("error", err))
+				}
+			}
+		}
+	}
+
+	missingActiveTripIDs := make(map[string]bool)
 
 	for _, ast := range allActiveStopTimes {
 		st := ast.GetStopTimesForStopInWindowRow
@@ -363,9 +441,9 @@ func (api *RestAPI) arrivalsAndDeparturesForStopHandler(w http.ResponseWriter, r
 				}
 
 				if vehicle.Position != nil {
-					distanceFromStop = api.getBlockDistanceToStop(ctx, st.TripID, stopCode, vehicle, params.Time)
+					distanceFromStop = api.getBlockDistanceToStop(ctx, st.TripID, stopCode, vehicle, serviceMidnight, distanceHelperCache)
 
-					numberOfStopsAwayPtr := api.getNumberOfStopsAway(ctx, st.TripID, int(st.StopSequence), vehicle, params.Time)
+					numberOfStopsAwayPtr := api.getNumberOfStopsAway(ctx, st.TripID, int(st.StopSequence), vehicle, serviceMidnight)
 					if numberOfStopsAwayPtr != nil {
 						numberOfStopsAway = *numberOfStopsAwayPtr
 					} else {
@@ -377,24 +455,9 @@ func (api *RestAPI) arrivalsAndDeparturesForStopHandler(w http.ResponseWriter, r
 				if status.ActiveTripID != "" {
 					_, activeTripID, err := utils.ExtractAgencyIDAndCodeID(status.ActiveTripID)
 					if err == nil && activeTripID != st.TripID {
-						// Check cache for active trip
+						// Deferred fetch: just record that we need this trip
 						if _, exists := tripIDSet[activeTripID]; !exists {
-							activeTrip, err := api.GtfsManager.GtfsDB.Queries.GetTrip(ctx, activeTripID)
-							if err != nil {
-								api.Logger.Debug("skipping active trip reference: trip not found",
-									slog.String("activeTripID", activeTripID),
-									slog.String("scheduledTripID", st.TripID),
-									slog.Any("error", err))
-							} else {
-								tripIDSet[activeTrip.ID] = &activeTrip
-								activeRoute, err := api.GtfsManager.GtfsDB.Queries.GetRoute(ctx, activeTrip.RouteID)
-								if err == nil {
-									routeIDSet[activeRoute.ID] = &activeRoute
-								} else {
-									api.Logger.Warn("failed to fetch route for active trip reference",
-										"tripID", activeTripID, "routeID", activeTrip.RouteID, "error", err)
-								}
-							}
+							missingActiveTripIDs[activeTripID] = true
 						}
 					}
 				}
@@ -464,6 +527,49 @@ func (api *RestAPI) arrivalsAndDeparturesForStopHandler(w http.ResponseWriter, r
 		)
 
 		arrivals = append(arrivals, *arrival)
+	}
+
+	// Batch-fetch missing active trips
+	if len(missingActiveTripIDs) > 0 {
+		tripIDsToFetch := make([]string, 0, len(missingActiveTripIDs))
+		for tid := range missingActiveTripIDs {
+			tripIDsToFetch = append(tripIDsToFetch, tid)
+		}
+
+		fetchedTrips, err := api.GtfsManager.GtfsDB.Queries.GetTripsByIDs(ctx, tripIDsToFetch)
+		if err == nil {
+			for i := range fetchedTrips {
+				trip := fetchedTrips[i]
+				tripIDSet[trip.ID] = &trip
+			}
+		} else {
+			api.Logger.Warn("failed to batch fetch active trips", slog.Any("error", err))
+		}
+	}
+
+	// Batch-fetch missing routes for both the scheduled trips and the newly added active trips
+	missingRouteIDs := make(map[string]bool)
+	for _, trip := range tripIDSet {
+		if _, exists := routeIDSet[trip.RouteID]; !exists {
+			missingRouteIDs[trip.RouteID] = true
+		}
+	}
+
+	if len(missingRouteIDs) > 0 {
+		routeIDsToFetch := make([]string, 0, len(missingRouteIDs))
+		for rid := range missingRouteIDs {
+			routeIDsToFetch = append(routeIDsToFetch, rid)
+		}
+
+		fetchedRoutes, err := api.GtfsManager.GtfsDB.Queries.GetRoutesByIDs(ctx, routeIDsToFetch)
+		if err == nil {
+			for i := range fetchedRoutes {
+				route := fetchedRoutes[i]
+				routeIDSet[route.ID] = &route
+			}
+		} else {
+			api.Logger.Warn("failed to batch fetch missing routes", slog.Any("error", err))
+		}
 	}
 
 	for _, trip := range tripIDSet {

--- a/internal/restapi/block_distance_helper.go
+++ b/internal/restapi/block_distance_helper.go
@@ -7,10 +7,11 @@ import (
 	"time"
 
 	"github.com/OneBusAway/go-gtfs"
+	"maglev.onebusaway.org/gtfsdb"
 )
 
 // IMPORTANT: Caller must hold manager.RLock() before calling this method.
-func (api *RestAPI) getBlockDistanceToStop(ctx context.Context, targetTripID, targetStopID string, vehicle *gtfs.Vehicle, serviceDate time.Time) float64 {
+func (api *RestAPI) getBlockDistanceToStop(ctx context.Context, targetTripID, targetStopID string, vehicle *gtfs.Vehicle, serviceDate time.Time, cache *DistanceHelperCache) float64 {
 	if vehicle == nil || vehicle.Position == nil || vehicle.Trip == nil {
 		return 0
 	}
@@ -19,8 +20,8 @@ func (api *RestAPI) getBlockDistanceToStop(ctx context.Context, targetTripID, ta
 	if err != nil || !blockID.Valid || blockID.String == "" {
 		// Fallback to single trip logic if no block
 		if vehicle.Trip.ID.ID == targetTripID {
-			targetDist := api.getStopDistanceAlongShape(ctx, targetTripID, targetStopID)
-			vehicleDist := api.getVehicleDistanceAlongShapeContextual(ctx, targetTripID, vehicle)
+			targetDist := api.getStopDistanceAlongShape(ctx, targetTripID, targetStopID, cache)
+			vehicleDist := api.getVehicleDistanceAlongShapeContextual(ctx, targetTripID, vehicle, cache)
 			return targetDist - vehicleDist
 		}
 		return 0
@@ -44,7 +45,12 @@ func (api *RestAPI) getBlockDistanceToStop(ctx context.Context, targetTripID, ta
 			continue
 		}
 
-		stopTimes, err := api.GtfsManager.GtfsDB.Queries.GetStopTimesForTrip(ctx, blockTrip.ID)
+		var stopTimes []gtfsdb.StopTime
+		if cache != nil && cache.stopTimesByTrip[blockTrip.ID] != nil {
+			stopTimes = cache.stopTimesByTrip[blockTrip.ID]
+		} else {
+			stopTimes, err = api.GtfsManager.GtfsDB.Queries.GetStopTimesForTrip(ctx, blockTrip.ID)
+		}
 		if err != nil || len(stopTimes) == 0 {
 			continue
 		}
@@ -56,10 +62,20 @@ func (api *RestAPI) getBlockDistanceToStop(ctx context.Context, targetTripID, ta
 			}
 		}
 
-		shapeRows, _ := api.GtfsManager.GtfsDB.Queries.GetShapePointsByTripID(ctx, blockTrip.ID)
+		var shapeRows []gtfsdb.Shape
+		var shapePoints []gtfs.ShapePoint
+		if cache != nil && cache.shapePointsByTrip[blockTrip.ID] != nil {
+			cachedShapeRows := cache.shapePointsByTrip[blockTrip.ID]
+			shapePoints = shapePointsRowsToPoints(cachedShapeRows)
+		} else {
+			shapeRows, _ = api.GtfsManager.GtfsDB.Queries.GetShapePointsByTripID(ctx, blockTrip.ID)
+			if len(shapeRows) > 1 {
+				shapePoints = shapeRowsToPoints(shapeRows)
+			}
+		}
+
 		totalDist := 0.0
-		if len(shapeRows) > 1 {
-			shapePoints := shapeRowsToPoints(shapeRows)
+		if len(shapePoints) > 1 {
 			totalDist = preCalculateCumulativeDistances(shapePoints)[len(shapePoints)-1]
 		}
 
@@ -80,11 +96,11 @@ func (api *RestAPI) getBlockDistanceToStop(ctx context.Context, targetTripID, ta
 
 	for _, trip := range activeTrips {
 		if trip.TripID == vehicle.Trip.ID.ID {
-			vehicleDist := api.getVehicleDistanceAlongShapeContextual(ctx, trip.TripID, vehicle)
+			vehicleDist := api.getVehicleDistanceAlongShapeContextual(ctx, trip.TripID, vehicle, cache)
 			vehicleBlockDist = cumulativeDist + vehicleDist
 		}
 		if trip.TripID == targetTripID {
-			targetDist := api.getStopDistanceAlongShape(ctx, trip.TripID, targetStopID)
+			targetDist := api.getStopDistanceAlongShape(ctx, trip.TripID, targetStopID, cache)
 			targetBlockDist = cumulativeDist + targetDist
 		}
 

--- a/internal/restapi/block_distance_helper.go
+++ b/internal/restapi/block_distance_helper.go
@@ -2,6 +2,7 @@ package restapi
 
 import (
 	"context"
+	"database/sql"
 	"math"
 	"sort"
 	"time"
@@ -16,20 +17,32 @@ func (api *RestAPI) getBlockDistanceToStop(ctx context.Context, targetTripID, ta
 		return 0
 	}
 
-	blockID, err := api.GtfsManager.GtfsDB.Queries.GetBlockIDByTripID(ctx, targetTripID)
-	if err != nil || !blockID.Valid || blockID.String == "" {
-		// Fallback to single trip logic if no block
-		if vehicle.Trip.ID.ID == targetTripID {
-			targetDist := api.getStopDistanceAlongShape(ctx, targetTripID, targetStopID, cache)
-			vehicleDist := api.getVehicleDistanceAlongShapeContextual(ctx, targetTripID, vehicle, cache)
-			return targetDist - vehicleDist
+	var blockIDStr string
+	if cache != nil && cache.blockIDByTrip != nil && cache.blockIDByTrip[targetTripID] != "" {
+		blockIDStr = cache.blockIDByTrip[targetTripID]
+	} else {
+		blockID, err := api.GtfsManager.GtfsDB.Queries.GetBlockIDByTripID(ctx, targetTripID)
+		if err != nil || !blockID.Valid || blockID.String == "" {
+			// Fallback to single trip logic if no block
+			if vehicle.Trip.ID.ID == targetTripID {
+				targetDist := api.getStopDistanceAlongShape(ctx, targetTripID, targetStopID, cache)
+				vehicleDist := api.getVehicleDistanceAlongShapeContextual(ctx, targetTripID, vehicle, cache)
+				return targetDist - vehicleDist
+			}
+			return 0
 		}
-		return 0
+		blockIDStr = blockID.String
 	}
 
-	blockTrips, err := api.GtfsManager.GtfsDB.Queries.GetTripsByBlockID(ctx, blockID)
-	if err != nil {
-		return 0
+	var blockTrips []gtfsdb.GetTripsByBlockIDRow
+	if cache != nil && cache.tripsByBlock != nil && len(cache.tripsByBlock[blockIDStr]) > 0 {
+		blockTrips = cache.tripsByBlock[blockIDStr]
+	} else {
+		var err error
+		blockTrips, err = api.GtfsManager.GtfsDB.Queries.GetTripsByBlockID(ctx, sql.NullString{String: blockIDStr, Valid: true})
+		if err != nil {
+			return 0
+		}
 	}
 
 	type TripInfo struct {
@@ -49,9 +62,13 @@ func (api *RestAPI) getBlockDistanceToStop(ctx context.Context, targetTripID, ta
 		if cache != nil && cache.stopTimesByTrip[blockTrip.ID] != nil {
 			stopTimes = cache.stopTimesByTrip[blockTrip.ID]
 		} else {
-			stopTimes, err = api.GtfsManager.GtfsDB.Queries.GetStopTimesForTrip(ctx, blockTrip.ID)
+			var fetchErr error
+			stopTimes, fetchErr = api.GtfsManager.GtfsDB.Queries.GetStopTimesForTrip(ctx, blockTrip.ID)
+			if fetchErr != nil {
+				continue
+			}
 		}
-		if err != nil || len(stopTimes) == 0 {
+		if len(stopTimes) == 0 {
 			continue
 		}
 
@@ -66,7 +83,9 @@ func (api *RestAPI) getBlockDistanceToStop(ctx context.Context, targetTripID, ta
 		var shapePoints []gtfs.ShapePoint
 		if cache != nil && cache.shapePointsByTrip[blockTrip.ID] != nil {
 			cachedShapeRows := cache.shapePointsByTrip[blockTrip.ID]
-			shapePoints = shapePointsRowsToPoints(cachedShapeRows)
+			if len(cachedShapeRows) > 1 {
+				shapePoints = shapePointsRowsToPoints(cachedShapeRows)
+			}
 		} else {
 			shapeRows, _ = api.GtfsManager.GtfsDB.Queries.GetShapePointsByTripID(ctx, blockTrip.ID)
 			if len(shapeRows) > 1 {

--- a/internal/restapi/shape_distance_helpers.go
+++ b/internal/restapi/shape_distance_helpers.go
@@ -27,8 +27,10 @@ func shapePointsRowsToPoints(rows []gtfsdb.GetShapePointsByTripIDsRow) []gtfs.Sh
 }
 
 type DistanceHelperCache struct {
-	stopTimesByTrip map[string][]gtfsdb.StopTime
+	stopTimesByTrip   map[string][]gtfsdb.StopTime
 	shapePointsByTrip map[string][]gtfsdb.GetShapePointsByTripIDsRow
+	blockIDByTrip     map[string]string
+	tripsByBlock      map[string][]gtfsdb.GetTripsByBlockIDRow
 }
 
 // IMPORTANT: Caller must hold manager.RLock() before calling this method.

--- a/internal/restapi/shape_distance_helpers.go
+++ b/internal/restapi/shape_distance_helpers.go
@@ -18,9 +18,30 @@ func shapeRowsToPoints(rows []gtfsdb.Shape) []gtfs.ShapePoint {
 	return pts
 }
 
+func shapePointsRowsToPoints(rows []gtfsdb.GetShapePointsByTripIDsRow) []gtfs.ShapePoint {
+	pts := make([]gtfs.ShapePoint, len(rows))
+	for i, sp := range rows {
+		pts[i] = gtfs.ShapePoint{Latitude: sp.Lat, Longitude: sp.Lon}
+	}
+	return pts
+}
+
+type DistanceHelperCache struct {
+	stopTimesByTrip map[string][]gtfsdb.StopTime
+	shapePointsByTrip map[string][]gtfsdb.GetShapePointsByTripIDsRow
+}
+
 // IMPORTANT: Caller must hold manager.RLock() before calling this method.
-func (api *RestAPI) getStopDistanceAlongShape(ctx context.Context, tripID, stopID string) float64 {
-	stopTimes, err := api.GtfsManager.GtfsDB.Queries.GetStopTimesForTrip(ctx, tripID)
+func (api *RestAPI) getStopDistanceAlongShape(ctx context.Context, tripID, stopID string, cache *DistanceHelperCache) float64 {
+	var stopTimes []gtfsdb.StopTime
+	var err error
+
+	if cache != nil && cache.stopTimesByTrip[tripID] != nil {
+		stopTimes = cache.stopTimesByTrip[tripID]
+	} else {
+		stopTimes, err = api.GtfsManager.GtfsDB.Queries.GetStopTimesForTrip(ctx, tripID)
+	}
+
 	if err == nil {
 		for _, st := range stopTimes {
 			if st.StopID == stopID && st.ShapeDistTraveled.Valid {
@@ -29,9 +50,20 @@ func (api *RestAPI) getStopDistanceAlongShape(ctx context.Context, tripID, stopI
 		}
 	}
 
-	shapeRows, err := api.GtfsManager.GtfsDB.Queries.GetShapePointsByTripID(ctx, tripID)
-	if err != nil || len(shapeRows) < 2 {
-		return 0
+	var shapePoints []gtfs.ShapePoint
+
+	if cache != nil && cache.shapePointsByTrip[tripID] != nil {
+		shapeRows := cache.shapePointsByTrip[tripID]
+		if len(shapeRows) < 2 {
+			return 0
+		}
+		shapePoints = shapePointsRowsToPoints(shapeRows)
+	} else {
+		shapeRows, err := api.GtfsManager.GtfsDB.Queries.GetShapePointsByTripID(ctx, tripID)
+		if err != nil || len(shapeRows) < 2 {
+			return 0
+		}
+		shapePoints = shapeRowsToPoints(shapeRows)
 	}
 
 	stop, err := api.GtfsManager.GtfsDB.Queries.GetStop(ctx, stopID)
@@ -39,29 +71,44 @@ func (api *RestAPI) getStopDistanceAlongShape(ctx context.Context, tripID, stopI
 		return 0
 	}
 
-	shapePoints := shapeRowsToPoints(shapeRows)
-
 	return getDistanceAlongShape(stop.Lat, stop.Lon, shapePoints)
 }
 
 // IMPORTANT: Caller must hold manager.RLock() before calling this method.
-func (api *RestAPI) getVehicleDistanceAlongShapeContextual(ctx context.Context, tripID string, vehicle *gtfs.Vehicle) float64 {
+func (api *RestAPI) getVehicleDistanceAlongShapeContextual(ctx context.Context, tripID string, vehicle *gtfs.Vehicle, cache *DistanceHelperCache) float64 {
 	if vehicle == nil || vehicle.Position == nil || vehicle.Position.Latitude == nil || vehicle.Position.Longitude == nil {
 		return 0
 	}
 
-	shapeRows, err := api.GtfsManager.GtfsDB.Queries.GetShapePointsByTripID(ctx, tripID)
-	if err != nil || len(shapeRows) < 2 {
-		return 0
-	}
+	var shapePoints []gtfs.ShapePoint
 
-	shapePoints := shapeRowsToPoints(shapeRows)
+	if cache != nil && cache.shapePointsByTrip[tripID] != nil {
+		shapeRows := cache.shapePointsByTrip[tripID]
+		if len(shapeRows) < 2 {
+			return 0
+		}
+		shapePoints = shapePointsRowsToPoints(shapeRows)
+	} else {
+		shapeRows, err := api.GtfsManager.GtfsDB.Queries.GetShapePointsByTripID(ctx, tripID)
+		if err != nil || len(shapeRows) < 2 {
+			return 0
+		}
+		shapePoints = shapeRowsToPoints(shapeRows)
+	}
 
 	lat := float64(*vehicle.Position.Latitude)
 	lon := float64(*vehicle.Position.Longitude)
 
 	if vehicle.CurrentStopSequence != nil {
-		stopTimes, err := api.GtfsManager.GtfsDB.Queries.GetStopTimesForTrip(ctx, tripID)
+		var stopTimes []gtfsdb.StopTime
+		var err error
+
+		if cache != nil && cache.stopTimesByTrip[tripID] != nil {
+			stopTimes = cache.stopTimesByTrip[tripID]
+		} else {
+			stopTimes, err = api.GtfsManager.GtfsDB.Queries.GetStopTimesForTrip(ctx, tripID)
+		}
+
 		if err == nil && len(stopTimes) > 0 {
 			currentSeq := int64(*vehicle.CurrentStopSequence)
 			var prevStopDist, nextStopDist float64
@@ -72,13 +119,13 @@ func (api *RestAPI) getVehicleDistanceAlongShapeContextual(ctx context.Context, 
 					if st.ShapeDistTraveled.Valid {
 						nextStopDist = st.ShapeDistTraveled.Float64
 					} else {
-						nextStopDist = api.getStopDistanceAlongShape(ctx, tripID, st.StopID)
+						nextStopDist = api.getStopDistanceAlongShape(ctx, tripID, st.StopID, cache)
 					}
 					if i > 0 {
 						if stopTimes[i-1].ShapeDistTraveled.Valid {
 							prevStopDist = stopTimes[i-1].ShapeDistTraveled.Float64
 						} else {
-							prevStopDist = api.getStopDistanceAlongShape(ctx, tripID, stopTimes[i-1].StopID)
+							prevStopDist = api.getStopDistanceAlongShape(ctx, tripID, stopTimes[i-1].StopID, cache)
 						}
 					}
 					foundNext = true

--- a/internal/restapi/stops_for_route_handler_test.go
+++ b/internal/restapi/stops_for_route_handler_test.go
@@ -141,17 +141,20 @@ func TestStopsForRouteHandlerEndToEnd(t *testing.T) {
 }
 
 func TestStopsForRouteHandlerInvalidRouteID(t *testing.T) {
-	_, resp, _ := serveAndRetrieveEndpoint(t, "/api/where/stops-for-route/invalid_route.json?key=TEST")
+	api, resp, _ := serveAndRetrieveEndpoint(t, "/api/where/stops-for-route/invalid_route.json?key=TEST")
+	defer api.Shutdown()
 	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
 }
 
 func TestStopsForRouteHandlerMissingRouteIDComponent(t *testing.T) {
-	_, resp, _ := serveAndRetrieveEndpoint(t, "/api/where/stops-for-route/_FMS.json?key=TEST")
+	api, resp, _ := serveAndRetrieveEndpoint(t, "/api/where/stops-for-route/_FMS.json?key=TEST")
+	defer api.Shutdown()
 	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
 }
 
 func TestStopsForRouteHandlerNonExistentAgency(t *testing.T) {
-	_, resp, _ := serveAndRetrieveEndpoint(t, "/api/where/stops-for-route/fake_Raba.json?key=TEST")
+	api, resp, _ := serveAndRetrieveEndpoint(t, "/api/where/stops-for-route/fake_Raba.json?key=TEST")
+	defer api.Shutdown()
 	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
 }
 
@@ -165,7 +168,8 @@ func TestStopsForRouteHandlerWithInvalidTimeFormats(t *testing.T) {
 
 	for _, format := range invalidFormats {
 		t.Run("Invalid format: "+format, func(t *testing.T) {
-			_, resp, _ := serveAndRetrieveEndpoint(t, "/api/where/stops-for-route/25-151.json?key=TEST&time="+format)
+			api, resp, _ := serveAndRetrieveEndpoint(t, "/api/where/stops-for-route/25-151.json?key=TEST&time="+format)
+			defer api.Shutdown()
 
 			assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 		})

--- a/internal/restapi/trips_helper.go
+++ b/internal/restapi/trips_helper.go
@@ -134,7 +134,7 @@ func (api *RestAPI) BuildTripStatus(
 		if vehicle != nil && vehicle.Position != nil && vehicle.Position.Latitude != nil && vehicle.Position.Longitude != nil {
 			// Refine the raw GPS position (set by BuildVehicleStatus) by projecting
 			// it onto the route shape. Reuses the already-fetched shapePoints.
-			actualDistance := api.getVehicleDistanceAlongShapeContextual(ctx, activeTripRawID, vehicle)
+			actualDistance := api.getVehicleDistanceAlongShapeContextual(ctx, activeTripRawID, vehicle, nil)
 			status.DistanceAlongTrip = actualDistance
 
 			if status.LastKnownLocation != nil {


### PR DESCRIPTION
#### Description
- closes #719 

This pull request addresses severe N+1 database query patterns identified REST API handlers, specifically targeting `arrivals_and_departure_for_stop.go` and its associated distance helpers.

Previously, handlers fetched related data iteratively within large loops, resulting in a significant increase in database load per request. By implementing deferred pre-fetch batching and in-memory caching contexts, this PR removes these in-loop database lookups, drastically reducing latency and database contention.

#### Changes

**1. Arrivals and Departures (`arrivals_and_departure_for_stop.go`)**
* **Active Trip & Route Fetching:** Removed loop-based `GtfsDB.Queries.GetTrip` and `GtfsDB.Queries.GetRoute` calls.
* **Deferred Batching:** Introduced a deferred pre-fetch mechanism using `GetTripsByIDs` and `GetRoutesByIDs`. Active trips discovered during loop iterations are now deferred, batched, and resolved simultaneously at the end of the execution block to populate reference sets.
* **Block Context Caching:** Consolidated the block distances calculation. Injected pre-fetched block contexts, allowing distance helpers to compute metrics entirely in memory rather than triggering multiple sequential database lookups per stop iteration.

**2. Distance Helpers (`block_distance_helper.go` / `shape_distance_helpers.go`)**
* **In-Memory Lookups:** Modified distance helper signatures to accept in-memory representations of `StopTimes` and `ShapePoints`.
* **Query Reduction:** These are now pre-fetched by the handlers grouping the trips, preventing multiple sequential trip and stop lookups on `GtfsManager.GtfsDB.Queries`.

**3. Stops For Route (`stops_for_route_handler.go`)**
* **Directional Loop Analysis:** Analyzed the directional fetching loops and confirmed iterations are strictly bounded by the number of unique headsigns/directions on a route (typically N <= 2).
* **Validation:** Verified that standard array grouping and current data access do not trigger an N+1 scaling issue in this context.
* **Test Patching:** Patched related tests to ensure valid `GtfsManager` initialization flows.
