### PR TITLE
refactor: remove unused trip parameter from NewTripDetails

### DIFF
--- a/internal/models/trip_details.go
+++ b/internal/models/trip_details.go
@@ -9,7 +9,7 @@ type TripDetails struct {
 	TripID       string      `json:"tripId"`
 }
 
-func NewTripDetails(trip Trip, tripID string, serviceDate int64, frequency *Frequency, status *TripStatus, schedule *Schedule, situationIDs []string) *TripDetails {
+func NewTripDetails(tripID string, serviceDate int64, frequency *Frequency, status *TripStatus, schedule *Schedule, situationIDs []string) *TripDetails {
 	return &TripDetails{
 		TripID:       tripID,
 		ServiceDate:  serviceDate,

--- a/internal/models/trip_details_test.go
+++ b/internal/models/trip_details_test.go
@@ -23,7 +23,7 @@ func TestNewTripDetails(t *testing.T) {
 		TimeZone:       "America/Los_Angeles",
 	}
 
-	tripID := "trip_123"
+	tripID := trip.ID
 	serviceDate := int64(1609459200000)
 
 	frequency := &Frequency{
@@ -47,7 +47,7 @@ func TestNewTripDetails(t *testing.T) {
 
 	situationIDs := []string{"situation_1", "situation_2"}
 
-	tripDetails := NewTripDetails(trip, tripID, serviceDate, frequency, status, schedule, situationIDs)
+	tripDetails := NewTripDetails(tripID, serviceDate, frequency, status, schedule, situationIDs)
 
 	assert.Equal(t, tripID, tripDetails.TripID)
 	assert.Equal(t, serviceDate, tripDetails.ServiceDate)
@@ -115,9 +115,9 @@ func TestTripDetailsJSON(t *testing.T) {
 func TestTripDetailsWithNilValues(t *testing.T) {
 	trip := Trip{ID: "trip_123"}
 
-	tripDetails := NewTripDetails(trip, "trip_123", 1609459200000, nil, nil, nil, nil)
+	tripDetails := NewTripDetails(trip.ID, 1609459200000, nil, nil, nil, nil)
 
-	assert.Equal(t, "trip_123", tripDetails.TripID)
+	assert.Equal(t, trip.ID, tripDetails.TripID)
 	assert.Equal(t, int64(1609459200000), tripDetails.ServiceDate)
 	assert.Nil(t, tripDetails.Frequency)
 	assert.Nil(t, tripDetails.Status)


### PR DESCRIPTION
## Description
This PR addresses issue #640 by removing the unused `trip` parameter from the `NewTripDetails` function. 

## Changes
- Removed `trip models.Trip` parameter from `NewTripDetails` in `internal/models/trip_details.go`.
- Updated all call sites in `internal/models/trip_details_test.go` to remove the now-obsolete argument in:
  - `TestNewTripDetails`
  - `TestTripDetailsWithNilValues`

## Motivation and Context
The `trip` parameter was being passed but never utilized within the function body, leading to unnecessary complexity and potential confusion for future maintainers.

## How Has This Been Tested?
- [x] `make test` (Full suite passing)
- [x] `make lint` (Clean)

Fixes #640