### PR TITLE
fix(openapi): align arrivals-and-departures-for-stop time + arrival m…

### DIFF
--- a/internal/models/arrival_and_departure.go
+++ b/internal/models/arrival_and_departure.go
@@ -6,23 +6,23 @@ type ArrivalAndDeparture struct {
 	BlockTripSequence          int         `json:"blockTripSequence"`
 	DepartureEnabled           bool        `json:"departureEnabled"`
 	DistanceFromStop           float64     `json:"distanceFromStop"`
-	Frequency                  *Frequency  `json:"frequency"`
+	Frequency                  string      `json:"frequency,omitempty"`
 	HistoricalOccupancy        string      `json:"historicalOccupancy"`
 	LastUpdateTime             *int64      `json:"lastUpdateTime,omitempty"`
 	NumberOfStopsAway          int         `json:"numberOfStopsAway"`
 	OccupancyStatus            string      `json:"occupancyStatus"`
 	Predicted                  bool        `json:"predicted"`
-	PredictedArrivalInterval   interface{} `json:"predictedArrivalInterval"`
+	PredictedArrivalInterval   string      `json:"predictedArrivalInterval,omitempty"`
 	PredictedArrivalTime       int64       `json:"predictedArrivalTime"`
-	PredictedDepartureInterval interface{} `json:"predictedDepartureInterval"`
+	PredictedDepartureInterval string      `json:"predictedDepartureInterval,omitempty"`
 	PredictedDepartureTime     int64       `json:"predictedDepartureTime"`
 	PredictedOccupancy         string      `json:"predictedOccupancy"`
 	RouteID                    string      `json:"routeId"`
 	RouteLongName              string      `json:"routeLongName"`
 	RouteShortName             string      `json:"routeShortName"`
-	ScheduledArrivalInterval   interface{} `json:"scheduledArrivalInterval"`
+	ScheduledArrivalInterval   string      `json:"scheduledArrivalInterval,omitempty"`
 	ScheduledArrivalTime       int64       `json:"scheduledArrivalTime"`
-	ScheduledDepartureInterval interface{} `json:"scheduledDepartureInterval"`
+	ScheduledDepartureInterval string      `json:"scheduledDepartureInterval,omitempty"`
 	ScheduledDepartureTime     int64       `json:"scheduledDepartureTime"`
 	ScheduledTrack             string      `json:"scheduledTrack"`
 	ServiceDate                int64       `json:"serviceDate"`
@@ -54,23 +54,23 @@ func NewArrivalAndDeparture(
 		BlockTripSequence:          blockTripSequence,
 		DepartureEnabled:           departureEnabled,
 		DistanceFromStop:           distanceFromStop,
-		Frequency:                  nil,
+		Frequency:                  "",
 		HistoricalOccupancy:        historicalOccupancy,
 		LastUpdateTime:             lastUpdateTime,
 		NumberOfStopsAway:          numberOfStopsAway,
 		OccupancyStatus:            occupancyStatus,
 		Predicted:                  predicted,
-		PredictedArrivalInterval:   nil,
+		PredictedArrivalInterval:   "",
 		PredictedArrivalTime:       predictedArrivalTime,
-		PredictedDepartureInterval: nil,
+		PredictedDepartureInterval: "",
 		PredictedDepartureTime:     predictedDepartureTime,
 		PredictedOccupancy:         predictedOccupancy,
 		RouteID:                    routeID,
 		RouteLongName:              routeLongName,
 		RouteShortName:             routeShortName,
-		ScheduledArrivalInterval:   nil,
+		ScheduledArrivalInterval:   "",
 		ScheduledArrivalTime:       scheduledArrivalTime,
-		ScheduledDepartureInterval: nil,
+		ScheduledDepartureInterval: "",
 		ScheduledDepartureTime:     scheduledDepartureTime,
 		ScheduledTrack:             "",
 		ServiceDate:                serviceDate,

--- a/internal/models/arrival_and_departure_test.go
+++ b/internal/models/arrival_and_departure_test.go
@@ -79,11 +79,11 @@ func TestNewArrivalAndDeparture(t *testing.T) {
 	assert.Equal(t, situationIDs, arrival.SituationIDs)
 	assert.Equal(t, "", arrival.ActualTrack)
 	assert.Equal(t, "", arrival.ScheduledTrack)
-	assert.Nil(t, arrival.Frequency)
-	assert.Nil(t, arrival.PredictedArrivalInterval)
-	assert.Nil(t, arrival.PredictedDepartureInterval)
-	assert.Nil(t, arrival.ScheduledArrivalInterval)
-	assert.Nil(t, arrival.ScheduledDepartureInterval)
+	assert.Equal(t, "", arrival.Frequency)
+	assert.Equal(t, "", arrival.PredictedArrivalInterval)
+	assert.Equal(t, "", arrival.PredictedDepartureInterval)
+	assert.Equal(t, "", arrival.ScheduledArrivalInterval)
+	assert.Equal(t, "", arrival.ScheduledDepartureInterval)
 }
 
 func TestArrivalAndDepartureJSON(t *testing.T) {
@@ -98,23 +98,23 @@ func TestArrivalAndDepartureJSON(t *testing.T) {
 		BlockTripSequence:          2,
 		DepartureEnabled:           true,
 		DistanceFromStop:           500.75,
-		Frequency:                  nil,
+		Frequency:                  "",
 		HistoricalOccupancy:        "STANDING_ROOM_ONLY",
 		LastUpdateTime:             &lastUpdateTime,
 		NumberOfStopsAway:          3,
 		OccupancyStatus:            "MANY_SEATS_AVAILABLE",
 		Predicted:                  true,
-		PredictedArrivalInterval:   nil,
+		PredictedArrivalInterval:   "",
 		PredictedArrivalTime:       1609462850000,
-		PredictedDepartureInterval: nil,
+		PredictedDepartureInterval: "",
 		PredictedDepartureTime:     1609462950000,
 		PredictedOccupancy:         "FEW_SEATS_AVAILABLE",
 		RouteID:                    "unitrans_FMS",
 		RouteLongName:              "Fremont Station",
 		RouteShortName:             "FMS",
-		ScheduledArrivalInterval:   nil,
+		ScheduledArrivalInterval:   "",
 		ScheduledArrivalTime:       1609462800000,
-		ScheduledDepartureInterval: nil,
+		ScheduledDepartureInterval: "",
 		ScheduledDepartureTime:     1609462900000,
 		ScheduledTrack:             "",
 		ServiceDate:                1609459200000,
@@ -131,6 +131,26 @@ func TestArrivalAndDepartureJSON(t *testing.T) {
 
 	jsonData, err := json.Marshal(arrival)
 	assert.NoError(t, err)
+
+	// verify omitempty fields are not present
+	var jsonMap map[string]interface{}
+	err = json.Unmarshal(jsonData, &jsonMap)
+	assert.NoError(t, err)
+
+	_, ok := jsonMap["frequency"]
+	assert.False(t, ok)
+
+	_, ok = jsonMap["predictedArrivalInterval"]
+	assert.False(t, ok)
+
+	_, ok = jsonMap["predictedDepartureInterval"]
+	assert.False(t, ok)
+
+	_, ok = jsonMap["scheduledArrivalInterval"]
+	assert.False(t, ok)
+
+	_, ok = jsonMap["scheduledDepartureInterval"]
+	assert.False(t, ok)
 
 	var unmarshaledArrival ArrivalAndDeparture
 	err = json.Unmarshal(jsonData, &unmarshaledArrival)

--- a/internal/restapi/arrivals_and_departure_for_stop.go
+++ b/internal/restapi/arrivals_and_departure_for_stop.go
@@ -71,10 +71,10 @@ func (api *RestAPI) parseArrivalsAndDeparturesParams(r *http.Request) (ArrivalsS
 	}
 
 	if val := query.Get("time"); val != "" {
-		if timeMs, err := strconv.ParseInt(val, 10, 64); err == nil {
-			params.Time = time.Unix(timeMs/1000, (timeMs%1000)*1000000)
+		if parsed, err := time.Parse(time.RFC3339, val); err == nil {
+			params.Time = parsed
 		} else {
-			addError("time", "must be a valid Unix timestamp in milliseconds")
+			addError("time", "must be a valid RFC3339 date-time (e.g. 2026-01-01T00:00:00Z)")
 		}
 	}
 

--- a/internal/restapi/arrivals_and_departures_for_stop_handler_test.go
+++ b/internal/restapi/arrivals_and_departures_for_stop_handler_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strconv"
 	"testing"
 	"time"
@@ -225,10 +226,9 @@ func TestArrivalsAndDeparturesForStopHandlerWithSpecificTime(t *testing.T) {
 
 	tomorrow := time.Now().AddDate(0, 0, 1)
 	specificTime := time.Date(tomorrow.Year(), tomorrow.Month(), tomorrow.Day(), 9, 0, 0, 0, time.Local)
-	timeMs := specificTime.Unix() * 1000
 
 	resp, model := serveApiAndRetrieveEndpoint(t, api,
-		"/api/where/arrivals-and-departures-for-stop/"+stopID+".json?key=TEST&time="+strconv.FormatInt(timeMs, 10))
+		"/api/where/arrivals-and-departures-for-stop/"+stopID+".json?key=TEST&time="+url.QueryEscape(specificTime.Format(time.RFC3339)))
 
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, 200, model.Code)
@@ -293,10 +293,9 @@ func TestArrivalsAndDeparturesForStopHandlerNoActiveServices(t *testing.T) {
 	stopID := utils.FormCombinedID(agency.Id, stops[0].Id)
 
 	futureTime := time.Now().AddDate(10, 0, 0)
-	timeMs := futureTime.Unix() * 1000
 
 	resp, model := serveApiAndRetrieveEndpoint(t, api,
-		"/api/where/arrivals-and-departures-for-stop/"+stopID+".json?key=TEST&time="+strconv.FormatInt(timeMs, 10))
+		"/api/where/arrivals-and-departures-for-stop/"+stopID+".json?key=TEST&time="+url.QueryEscape(futureTime.Format(time.RFC3339)))
 
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, 200, model.Code)
@@ -394,7 +393,7 @@ func TestParseArrivalsAndDeparturesParams_AllParameters(t *testing.T) {
 	api := createTestApi(t)
 	defer api.Shutdown()
 
-	req := httptest.NewRequest("GET", "/test?minutesAfter=60&minutesBefore=15&time=1609459200000", nil)
+	req := httptest.NewRequest("GET", "/test?minutesAfter=60&minutesBefore=15&time=2021-01-01T00:00:00Z", nil)
 
 	params, errs := api.parseArrivalsAndDeparturesParams(req)
 
@@ -433,7 +432,7 @@ func TestParseArrivalsAndDeparturesParams_InvalidValues(t *testing.T) {
 
 	assert.Equal(t, "must be a valid integer", errs["minutesAfter"][0])
 	assert.Equal(t, "must be a valid integer", errs["minutesBefore"][0])
-	assert.Equal(t, "must be a valid Unix timestamp in milliseconds", errs["time"][0])
+	assert.Equal(t, "must be a valid RFC3339 date-time (e.g. 2026-01-01T00:00:00Z)", errs["time"][0])
 }
 
 func TestArrivalsAndDeparturesForStopHandlerWithInvalidParams(t *testing.T) {

--- a/internal/restapi/openapi_conformance_test.go
+++ b/internal/restapi/openapi_conformance_test.go
@@ -478,10 +478,21 @@ func TestOpenAPIConformance_RealTimeEndpoints(t *testing.T) {
 	vehicles := api.GtfsManager.VehiclesForAgencyID(agencyID)
 	require.NotEmpty(t, vehicles, "Real-time vehicles must be loaded for conformance testing")
 
+	stops := api.GtfsManager.GetStops()
+	require.NotEmpty(t, stops, "Test data must contain at least one stop")
+	stopID := utils.FormCombinedID(agencyID, stops[0].Id)
+
 	t.Run("vehicles-for-agency", func(t *testing.T) {
 		assertConformance(t, server.URL, doc,
 			"/api/where/vehicles-for-agency/"+agencyID+".json?key=TEST",
 			"/api/where/vehicles-for-agency/{agencyID}.json",
+		)
+	})
+
+	t.Run("arrivals-and-departures-for-stop", func(t *testing.T) {
+		assertConformance(t, server.URL, doc,
+			"/api/where/arrivals-and-departures-for-stop/"+stopID+".json?key=TEST&time=2026-01-01T00%3A00%3A00Z",
+			"/api/where/arrivals-and-departures-for-stop/{stopID}.json",
 		)
 	})
 }


### PR DESCRIPTION
## Align `arrivals-and-departures-for-stop` with OpenAPI spec + fix `ArrivalAndDeparture` schema drift

Fixes #724 

### Problem
- Handler parsed `time` as Unix milliseconds instead of RFC3339 `date-time` as the OpenAPI spec requires, breaking spec-compliant requests.
- `ArrivalAndDeparture` model had drifted from the OpenAPI `ArrivalDepartureForStop` schema (`interface{}`/null shapes, missing `omitempty` on optional fields).
- No conformance test coverage existed for this endpoint.

### Changes

**Handler** (`arrivals_and_departure_for_stop.go`)
- Parse `time` as RFC3339 only; return 400 on invalid input.

**Handler Tests** (`arrivals_and_departures_for_stop_handler_test.go`)
- Pass `time` as RFC3339 and URL-escape values so `+05:30` offsets aren't decoded as spaces.

**Model** (`arrival_and_departure.go`)
- Replace `interface{}`/null fields with `string`; add `omitempty` on optional fields to match spec.

**Model Tests** (`arrival_and_departure_test.go`)
- Assert optional fields are absent in marshaled JSON when empty.

**Conformance** (`openapi_conformance_test.go`)
- Add missing conformance test for this endpoint against `testdata/openapi.yml`.

### Notes
- `testdata/openapi.yml` is unchanged — all fixes are implementation-side only.

### Validation Passed
- `make test`