### PR TITLE
perf(gtfs): build alertIndex for O(1) alert lookups

### DIFF
--- a/internal/gtfs/gtfs_manager.go
+++ b/internal/gtfs/gtfs_manager.go
@@ -49,10 +49,10 @@ type Manager struct {
 	realTimeTrips                  []gtfs.Trip
 	realTimeVehicles               []gtfs.Vehicle
 	realTimeMutex                  sync.RWMutex
-	realTimeAlerts                 []gtfs.Alert
 	realTimeTripLookup             map[string]int
 	realTimeVehicleLookupByTrip    map[string]int
 	realTimeVehicleLookupByVehicle map[string]int
+	alertIdx                       alertIndex
 	agenciesMap                    map[string]*gtfs.Agency
 	routesMap                      map[string]*gtfs.Route
 	frequencyTripIDs               map[string]struct{}

--- a/internal/gtfs/gtfs_manager_mock.go
+++ b/internal/gtfs/gtfs_manager_mock.go
@@ -135,6 +135,17 @@ func (m *Manager) MockAddTripUpdate(tripID string, delay *time.Duration, stopTim
 	m.realTimeTripLookup[tripID] = len(m.realTimeTrips) - 1
 }
 
+func (m *Manager) MockAddAlert(feedID string, alert gtfs.Alert) {
+	m.realTimeMutex.Lock()
+	defer m.realTimeMutex.Unlock()
+
+	if m.feedAlerts == nil {
+		m.feedAlerts = make(map[string][]gtfs.Alert)
+	}
+	m.feedAlerts[feedID] = append(m.feedAlerts[feedID], alert)
+	m.rebuildMergedRealtimeLocked()
+}
+
 // MockResetRealTimeData clears all mock real-time vehicles and trip updates.
 func (m *Manager) MockResetRealTimeData() {
 	m.realTimeMutex.Lock()

--- a/internal/gtfs/realtime.go
+++ b/internal/gtfs/realtime.go
@@ -17,6 +17,15 @@ import (
 	"maglev.onebusaway.org/internal/logging"
 )
 
+// alertIndex holds pre-built maps for O(1) alert lookups, keyed by trip, route, agency, and stop IDs.
+// It is rebuilt on every call to rebuildMergedRealtimeLocked under the existing write lock.
+type alertIndex struct {
+	byTrip   map[string][]gtfs.Alert
+	byRoute  map[string][]gtfs.Alert
+	byAgency map[string][]gtfs.Alert
+	byStop   map[string][]gtfs.Alert
+}
+
 // staleVehicleTimeout is the duration after which a vehicle is considered stale
 const staleVehicleTimeout = 15 * time.Minute
 
@@ -114,32 +123,27 @@ func (manager *Manager) GetAlertsByIDs(tripID, routeID, agencyID string) []gtfs.
 	manager.realTimeMutex.RLock()
 	defer manager.realTimeMutex.RUnlock()
 
+	seen := make(map[string]bool)
 	var alerts []gtfs.Alert
-	for _, alert := range manager.realTimeAlerts {
-		if alert.InformedEntities == nil {
-			continue
-		}
-		for _, entity := range alert.InformedEntities {
-			if entity.TripID != nil && tripID != "" && entity.TripID.ID == tripID {
-				alerts = append(alerts, alert)
-				break
-			}
-			// Only match route-level entities that have no stop restriction.
-			// Entities with {routeId + stopId} are stop-specific alerts and should
-			// only appear when looking up a specific stop (matching Java's inverted
-			// index which files {routeId+stopId} entities in a separate bucket).
-			if entity.RouteID != nil && routeID != "" && *entity.RouteID == routeID &&
-				entity.StopID == nil {
-				alerts = append(alerts, alert)
-				break
-			}
-			// Only match agency-wide alerts: entity has agencyId but no route or trip restriction.
-			if entity.AgencyID != nil && agencyID != "" && *entity.AgencyID == agencyID &&
-				entity.RouteID == nil && entity.TripID == nil {
-				alerts = append(alerts, alert)
-				break
+	// Invariant: alertIdx only contains alerts with non-empty IDs (rebuildMergedRealtimeLocked
+	// skips any alert where alert.ID == ""), so seen[a.ID] is sufficient for deduplication.
+	addUnique := func(candidates []gtfs.Alert) {
+		for _, a := range candidates {
+			if !seen[a.ID] {
+				seen[a.ID] = true
+				alerts = append(alerts, a)
 			}
 		}
+	}
+
+	if tripID != "" {
+		addUnique(manager.alertIdx.byTrip[tripID])
+	}
+	if routeID != "" {
+		addUnique(manager.alertIdx.byRoute[routeID])
+	}
+	if agencyID != "" {
+		addUnique(manager.alertIdx.byAgency[agencyID])
 	}
 	return alerts
 }
@@ -175,22 +179,25 @@ func (manager *Manager) GetAlertsForTrip(ctx context.Context, tripID string) []g
 	return manager.GetAlertsByIDs(tripID, routeID, agencyID)
 }
 
+// GetAlertsForStop returns deduplicated alerts for the given stopID.
+// Deduplication by alert ID is done internally so callers never receive
+// duplicate entries even when the same alert ID appears in multiple feeds.
 func (manager *Manager) GetAlertsForStop(stopID string) []gtfs.Alert {
 	manager.realTimeMutex.RLock()
 	defer manager.realTimeMutex.RUnlock()
-
-	var alerts []gtfs.Alert
-	for _, alert := range manager.realTimeAlerts {
-		if alert.InformedEntities != nil {
-			for _, entity := range alert.InformedEntities {
-				if entity.StopID != nil && *entity.StopID == stopID {
-					alerts = append(alerts, alert)
-					break
-				}
-			}
+	src := manager.alertIdx.byStop[stopID]
+	if len(src) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(src))
+	out := make([]gtfs.Alert, 0, len(src))
+	for _, a := range src {
+		if _, ok := seen[a.ID]; !ok {
+			seen[a.ID] = struct{}{}
+			out = append(out, a)
 		}
 	}
-	return alerts
+	return out
 }
 
 // Fetches GTFS-RT data from a URL with per-feed headers.
@@ -610,17 +617,10 @@ func (manager *Manager) rebuildMergedRealtimeLocked() {
 	}
 
 	alertFeedIDs := make([]string, 0, len(manager.feedAlerts))
-	totalAlerts := 0
-	for id, alerts := range manager.feedAlerts {
+	for id := range manager.feedAlerts {
 		alertFeedIDs = append(alertFeedIDs, id)
-		totalAlerts += len(alerts)
 	}
 	sort.Strings(alertFeedIDs)
-
-	allAlerts := make([]gtfs.Alert, 0, totalAlerts)
-	for _, id := range alertFeedIDs {
-		allAlerts = append(allAlerts, manager.feedAlerts[id]...)
-	}
 
 	tripLookup := make(map[string]int, len(allTrips))
 	for i, trip := range allTrips {
@@ -639,12 +639,57 @@ func (manager *Manager) rebuildMergedRealtimeLocked() {
 			vehicleLookupByVehicle[vehicle.ID.ID] = i
 		}
 	}
+	idx := alertIndex{
+		byTrip:   make(map[string][]gtfs.Alert),
+		byRoute:  make(map[string][]gtfs.Alert),
+		byAgency: make(map[string][]gtfs.Alert),
+		byStop:   make(map[string][]gtfs.Alert),
+	}
+	for _, id := range alertFeedIDs {
+		for _, alert := range manager.feedAlerts[id] {
+			if alert.InformedEntities == nil || alert.ID == "" {
+				continue
+			}
+			// Per-alert per-bucket dedup: prevents the same alert from being appended
+			// to the same bucket more than once when it has multiple InformedEntities
+			// referencing the same key (e.g. two entities both pointing to stop "S1").
+			// Capacity is set to the entity count so the map never needs to grow.
+			n := len(alert.InformedEntities)
+			seenTrip := make(map[string]bool, n)
+			seenRoute := make(map[string]bool, n)
+			seenAgency := make(map[string]bool, n)
+			seenStop := make(map[string]bool, n)
+			for _, entity := range alert.InformedEntities {
+				if entity.TripID != nil && !seenTrip[entity.TripID.ID] {
+					seenTrip[entity.TripID.ID] = true
+					idx.byTrip[entity.TripID.ID] = append(idx.byTrip[entity.TripID.ID], alert)
+				}
+				// Only match route-level entities that have no stop or trip restriction.
+				// Entities with {routeId + stopId} are stop-specific alerts and are filed
+				// in byStop only (matching Java's inverted index bucket behaviour).
+				if entity.RouteID != nil && entity.StopID == nil && entity.TripID == nil && !seenRoute[*entity.RouteID] {
+					seenRoute[*entity.RouteID] = true
+					idx.byRoute[*entity.RouteID] = append(idx.byRoute[*entity.RouteID], alert)
+				}
+				// Only match agency-wide alerts: entity has agencyId but no route or trip restriction.
+				if entity.AgencyID != nil && entity.RouteID == nil && entity.TripID == nil && !seenAgency[*entity.AgencyID] {
+					seenAgency[*entity.AgencyID] = true
+					idx.byAgency[*entity.AgencyID] = append(idx.byAgency[*entity.AgencyID], alert)
+				}
+				if entity.StopID != nil && !seenStop[*entity.StopID] {
+					seenStop[*entity.StopID] = true
+					idx.byStop[*entity.StopID] = append(idx.byStop[*entity.StopID], alert)
+				}
+			}
+		}
+	}
+
 	manager.realTimeTrips = allTrips
 	manager.realTimeVehicles = allVehicles
-	manager.realTimeAlerts = allAlerts
 	manager.realTimeTripLookup = tripLookup
 	manager.realTimeVehicleLookupByTrip = vehicleLookupByTrip
 	manager.realTimeVehicleLookupByVehicle = vehicleLookupByVehicle
+	manager.alertIdx = idx
 }
 
 // calculateBackoff computes the next polling interval using exponential backoff with jitter

--- a/internal/gtfs/realtime_benchmark_test.go
+++ b/internal/gtfs/realtime_benchmark_test.go
@@ -70,3 +70,96 @@ func BenchmarkRebuildRealTimeVehicleLookupByVehicle(b *testing.B) {
 		manager.rebuildMergedRealtimeLocked()
 	}
 }
+
+func BenchmarkRebuildAlertIndex(b *testing.B) {
+	routeID := "route_0"
+	agencyID := "agency_0"
+	manager := &Manager{
+		realTimeMutex: sync.RWMutex{},
+		feedAlerts:    make(map[string][]gtfs.Alert),
+	}
+
+	feedAlerts := make([]gtfs.Alert, 1000)
+	for i := 0; i < 1000; i++ {
+		tripID := gtfs.TripID{ID: fmt.Sprintf("trip_%d", i)}
+		stopID := fmt.Sprintf("stop_%d", i)
+		feedAlerts[i] = gtfs.Alert{
+			ID: fmt.Sprintf("alert_%d", i),
+			InformedEntities: []gtfs.AlertInformedEntity{
+				{TripID: &tripID},
+				{RouteID: &routeID},
+				{AgencyID: &agencyID},
+				{StopID: &stopID},
+			},
+		}
+	}
+	manager.feedAlerts["feed-0"] = feedAlerts
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		manager.rebuildMergedRealtimeLocked()
+	}
+}
+
+func BenchmarkGetAlertsByIDs(b *testing.B) {
+	// Realistic distribution: 1000 alerts spread across 100 routes and 50 agencies
+	// (~10 alerts/route, ~20 alerts/agency), each with a unique trip.
+	manager := &Manager{
+		realTimeMutex: sync.RWMutex{},
+		feedAlerts:    make(map[string][]gtfs.Alert),
+	}
+
+	feedAlerts := make([]gtfs.Alert, 1000)
+	for i := 0; i < 1000; i++ {
+		tripID := gtfs.TripID{ID: fmt.Sprintf("trip_%d", i)}
+		routeID := fmt.Sprintf("route_%d", i%100)
+		agencyID := fmt.Sprintf("agency_%d", i%50)
+		stopID := fmt.Sprintf("stop_%d", i)
+		feedAlerts[i] = gtfs.Alert{
+			ID: fmt.Sprintf("alert_%d", i),
+			InformedEntities: []gtfs.AlertInformedEntity{
+				{TripID: &tripID},
+				{RouteID: &routeID},
+				{AgencyID: &agencyID},
+				{StopID: &stopID},
+			},
+		}
+	}
+	manager.feedAlerts["feed-0"] = feedAlerts
+	manager.rebuildMergedRealtimeLocked()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		n := i % 1000
+		_ = manager.GetAlertsByIDs(
+			fmt.Sprintf("trip_%d", n),
+			fmt.Sprintf("route_%d", n%100),
+			fmt.Sprintf("agency_%d", n%50),
+		)
+	}
+}
+
+func BenchmarkGetAlertsForStop(b *testing.B) {
+	manager := &Manager{
+		realTimeMutex: sync.RWMutex{},
+		feedAlerts:    make(map[string][]gtfs.Alert),
+	}
+
+	feedAlerts := make([]gtfs.Alert, 1000)
+	for i := 0; i < 1000; i++ {
+		stopID := fmt.Sprintf("stop_%d", i)
+		feedAlerts[i] = gtfs.Alert{
+			ID: fmt.Sprintf("alert_%d", i),
+			InformedEntities: []gtfs.AlertInformedEntity{
+				{StopID: &stopID},
+			},
+		}
+	}
+	manager.feedAlerts["feed-0"] = feedAlerts
+	manager.rebuildMergedRealtimeLocked()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = manager.GetAlertsForStop(fmt.Sprintf("stop_%d", i%1000))
+	}
+}

--- a/internal/gtfs/realtime_test.go
+++ b/internal/gtfs/realtime_test.go
@@ -25,17 +25,20 @@ func TestGetAlertsForTrip(t *testing.T) {
 	tripID := gtfs.TripID{ID: "trip123"}
 	manager := &Manager{
 		realTimeMutex: sync.RWMutex{},
-		realTimeAlerts: []gtfs.Alert{
-			{
-				ID: "alert1",
-				InformedEntities: []gtfs.AlertInformedEntity{
-					{
-						TripID: &tripID,
+		feedAlerts: map[string][]gtfs.Alert{
+			"feed-0": {
+				{
+					ID: "alert1",
+					InformedEntities: []gtfs.AlertInformedEntity{
+						{
+							TripID: &tripID,
+						},
 					},
 				},
 			},
 		},
 	}
+	manager.rebuildMergedRealtimeLocked()
 
 	alerts := manager.GetAlertsForTrip(context.Background(), "trip123")
 
@@ -47,17 +50,20 @@ func TestGetAlertsForStop(t *testing.T) {
 	stopID := "stop123"
 	manager := &Manager{
 		realTimeMutex: sync.RWMutex{},
-		realTimeAlerts: []gtfs.Alert{
-			{
-				ID: "alert1",
-				InformedEntities: []gtfs.AlertInformedEntity{
-					{
-						StopID: &stopID,
+		feedAlerts: map[string][]gtfs.Alert{
+			"feed-0": {
+				{
+					ID: "alert1",
+					InformedEntities: []gtfs.AlertInformedEntity{
+						{
+							StopID: &stopID,
+						},
 					},
 				},
 			},
 		},
 	}
+	manager.rebuildMergedRealtimeLocked()
 
 	alerts := manager.GetAlertsForStop("stop123")
 
@@ -699,6 +705,11 @@ func TestGetAlertsByIDs_RouteScoping(t *testing.T) {
 			expectMatch: true,
 		},
 		{
+			name:        "route+trip entity does not match route query",
+			entities:    []gtfs.AlertInformedEntity{{RouteID: &routeID, TripID: &gtfs.TripID{ID: "t1"}}},
+			expectMatch: false,
+		},
+		{
 			name:        "different route does not match",
 			entities:    []gtfs.AlertInformedEntity{{RouteID: &otherRoute}},
 			expectMatch: false,
@@ -708,9 +719,12 @@ func TestGetAlertsByIDs_RouteScoping(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			manager := &Manager{
-				realTimeMutex:  sync.RWMutex{},
-				realTimeAlerts: []gtfs.Alert{{ID: "alert1", InformedEntities: tt.entities}},
+				realTimeMutex: sync.RWMutex{},
+				feedAlerts: map[string][]gtfs.Alert{
+					"feed-0": {{ID: "alert1", InformedEntities: tt.entities}},
+				},
 			}
+			manager.rebuildMergedRealtimeLocked()
 			alerts := manager.GetAlertsByIDs("", routeID, "")
 			if tt.expectMatch {
 				assert.Len(t, alerts, 1)
@@ -719,6 +733,35 @@ func TestGetAlertsByIDs_RouteScoping(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestAlertIndex_RouteTripEntityIndexedUnderByTrip verifies the positive path of the
+// {routeID+tripID} scoping rule: such an entity is excluded from byRoute (covered by
+// TestGetAlertsByIDs_RouteScoping) but must still appear in byTrip so trip-scoped
+// lookups find it.
+func TestAlertIndex_RouteTripEntityIndexedUnderByTrip(t *testing.T) {
+	routeID := "route123"
+	tripID := gtfs.TripID{ID: "trip456"}
+
+	manager := &Manager{
+		realTimeMutex: sync.RWMutex{},
+		feedAlerts: map[string][]gtfs.Alert{
+			"feed-0": {
+				{
+					ID:               "alert1",
+					InformedEntities: []gtfs.AlertInformedEntity{{RouteID: &routeID, TripID: &tripID}},
+				},
+			},
+		},
+	}
+	manager.rebuildMergedRealtimeLocked()
+
+	tripAlerts := manager.GetAlertsByIDs(tripID.ID, "", "")
+	assert.Len(t, tripAlerts, 1, "{routeID+tripID} entity should be indexed under byTrip")
+	assert.Equal(t, "alert1", tripAlerts[0].ID)
+
+	routeAlerts := manager.GetAlertsByIDs("", routeID, "")
+	assert.Empty(t, routeAlerts, "{routeID+tripID} entity must NOT appear in byRoute")
 }
 
 // TestGetAlertsByIDs_AgencyScoping verifies that agency-wide matching only fires
@@ -748,14 +791,24 @@ func TestGetAlertsByIDs_AgencyScoping(t *testing.T) {
 			entities:    []gtfs.AlertInformedEntity{{AgencyID: &agencyID, TripID: &tripID}},
 			expectMatch: false,
 		},
+		{
+			// {agencyID+stopID} has no route/trip restriction, so it is filed in byAgency
+			// AND byStop. An agency-only lookup should therefore still match.
+			name:        "agency+stop entity matches agency-only query",
+			entities:    []gtfs.AlertInformedEntity{{AgencyID: &agencyID, StopID: func() *string { s := "stop99"; return &s }()}},
+			expectMatch: true,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			manager := &Manager{
-				realTimeMutex:  sync.RWMutex{},
-				realTimeAlerts: []gtfs.Alert{{ID: "alert1", InformedEntities: tt.entities}},
+				realTimeMutex: sync.RWMutex{},
+				feedAlerts: map[string][]gtfs.Alert{
+					"feed-0": {{ID: "alert1", InformedEntities: tt.entities}},
+				},
 			}
+			manager.rebuildMergedRealtimeLocked()
 			alerts := manager.GetAlertsByIDs("", "", agencyID)
 			if tt.expectMatch {
 				assert.Len(t, alerts, 1)
@@ -764,6 +817,316 @@ func TestGetAlertsByIDs_AgencyScoping(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestAlertIndex_ByTripID(t *testing.T) {
+	tripID := gtfs.TripID{ID: "trip1"}
+	manager := &Manager{
+		realTimeMutex: sync.RWMutex{},
+		feedAlerts: map[string][]gtfs.Alert{
+			"feed-0": {
+				{
+					ID:               "alert1",
+					InformedEntities: []gtfs.AlertInformedEntity{{TripID: &tripID}},
+				},
+			},
+		},
+	}
+	manager.rebuildMergedRealtimeLocked()
+
+	alerts := manager.GetAlertsByIDs("trip1", "", "")
+
+	require.Len(t, alerts, 1)
+	assert.Equal(t, "alert1", alerts[0].ID)
+}
+
+func TestAlertIndex_ByRouteID(t *testing.T) {
+	routeID := "route1"
+	manager := &Manager{
+		realTimeMutex: sync.RWMutex{},
+		feedAlerts: map[string][]gtfs.Alert{
+			"feed-0": {
+				{
+					ID:               "alert1",
+					InformedEntities: []gtfs.AlertInformedEntity{{RouteID: &routeID}},
+				},
+			},
+		},
+	}
+	manager.rebuildMergedRealtimeLocked()
+
+	alerts := manager.GetAlertsByIDs("", "route1", "")
+
+	require.Len(t, alerts, 1)
+	assert.Equal(t, "alert1", alerts[0].ID)
+}
+
+func TestAlertIndex_ByAgencyID(t *testing.T) {
+	agencyID := "agency1"
+	manager := &Manager{
+		realTimeMutex: sync.RWMutex{},
+		feedAlerts: map[string][]gtfs.Alert{
+			"feed-0": {
+				{
+					ID:               "alert1",
+					InformedEntities: []gtfs.AlertInformedEntity{{AgencyID: &agencyID}},
+				},
+			},
+		},
+	}
+	manager.rebuildMergedRealtimeLocked()
+
+	alerts := manager.GetAlertsByIDs("", "", "agency1")
+
+	require.Len(t, alerts, 1)
+	assert.Equal(t, "alert1", alerts[0].ID)
+}
+
+func TestAlertIndex_ByStopID(t *testing.T) {
+	stopID := "stop1"
+	manager := &Manager{
+		realTimeMutex: sync.RWMutex{},
+		feedAlerts: map[string][]gtfs.Alert{
+			"feed-0": {
+				{
+					ID:               "alert1",
+					InformedEntities: []gtfs.AlertInformedEntity{{StopID: &stopID}},
+				},
+			},
+		},
+	}
+	manager.rebuildMergedRealtimeLocked()
+
+	alerts := manager.GetAlertsForStop("stop1")
+
+	require.Len(t, alerts, 1)
+	assert.Equal(t, "alert1", alerts[0].ID)
+}
+
+func TestAlertIndex_Deduplication(t *testing.T) {
+	tripID := gtfs.TripID{ID: "trip1"}
+	routeID := "route1"
+	manager := &Manager{
+		realTimeMutex: sync.RWMutex{},
+		feedAlerts: map[string][]gtfs.Alert{
+			"feed-0": {
+				{
+					ID: "alert1",
+					InformedEntities: []gtfs.AlertInformedEntity{
+						{TripID: &tripID},
+						{RouteID: &routeID},
+					},
+				},
+			},
+		},
+	}
+	manager.rebuildMergedRealtimeLocked()
+
+	// Querying by both trip and route should return the alert exactly once.
+	alerts := manager.GetAlertsByIDs("trip1", "route1", "")
+
+	require.Len(t, alerts, 1)
+	assert.Equal(t, "alert1", alerts[0].ID)
+}
+
+func TestAlertIndex_EmptyAlerts(t *testing.T) {
+	manager := &Manager{
+		realTimeMutex: sync.RWMutex{},
+		feedAlerts:    map[string][]gtfs.Alert{},
+	}
+	manager.rebuildMergedRealtimeLocked()
+
+	assert.Empty(t, manager.GetAlertsByIDs("trip1", "route1", "agency1"))
+	assert.Empty(t, manager.GetAlertsForStop("stop1"))
+}
+
+func TestAlertIndex_NoDuplicatesFromRepeatedEntityKeys(t *testing.T) {
+	stopID := "stop1"
+	routeID := "route1"
+	tripID := gtfs.TripID{ID: "trip1"}
+	agencyID := "agency1"
+
+	manager := &Manager{
+		realTimeMutex: sync.RWMutex{},
+		feedAlerts: map[string][]gtfs.Alert{
+			"feed-0": {
+				{
+					ID: "alert1",
+					InformedEntities: []gtfs.AlertInformedEntity{
+						{StopID: &stopID},
+						{StopID: &stopID},
+						{RouteID: &routeID},
+						{RouteID: &routeID},
+						{TripID: &tripID},
+						{TripID: &tripID},
+						{AgencyID: &agencyID},
+						{AgencyID: &agencyID},
+					},
+				},
+			},
+		},
+	}
+	manager.rebuildMergedRealtimeLocked()
+
+	assert.Len(t, manager.GetAlertsForStop("stop1"), 1)
+	assert.Len(t, manager.GetAlertsByIDs("trip1", "route1", "agency1"), 1)
+}
+
+func TestAlertIndex_EmptyIDAlertExcluded(t *testing.T) {
+	stopID := "stop1"
+	tripID := gtfs.TripID{ID: "trip1"}
+
+	manager := &Manager{
+		realTimeMutex: sync.RWMutex{},
+		feedAlerts: map[string][]gtfs.Alert{
+			"feed-0": {
+				{
+					ID:               "",
+					InformedEntities: []gtfs.AlertInformedEntity{{StopID: &stopID}, {TripID: &tripID}},
+				},
+				{
+					ID:               "alert-valid",
+					InformedEntities: []gtfs.AlertInformedEntity{{StopID: &stopID}},
+				},
+			},
+		},
+	}
+	manager.rebuildMergedRealtimeLocked()
+
+	stopAlerts := manager.GetAlertsForStop("stop1")
+	require.Len(t, stopAlerts, 1)
+	assert.Equal(t, "alert-valid", stopAlerts[0].ID)
+
+	tripAlerts := manager.GetAlertsByIDs("trip1", "", "")
+	assert.Empty(t, tripAlerts)
+}
+
+// TestAlertIndex_AgencyStopEntityAlsoIndexedByStop verifies the symmetric half
+// of the agency+stop scoping rule: an entity with both agencyID and stopID is
+// filed in byStop (so stop-scoped lookups find it) in addition to byAgency.
+func TestAlertIndex_AgencyStopEntityAlsoIndexedByStop(t *testing.T) {
+	agencyID := "agency40"
+	stopID := "stop99"
+
+	manager := &Manager{
+		realTimeMutex: sync.RWMutex{},
+		feedAlerts: map[string][]gtfs.Alert{
+			"feed-0": {
+				{
+					ID:               "alert1",
+					InformedEntities: []gtfs.AlertInformedEntity{{AgencyID: &agencyID, StopID: &stopID}},
+				},
+			},
+		},
+	}
+	manager.rebuildMergedRealtimeLocked()
+
+	stopAlerts := manager.GetAlertsForStop(stopID)
+	assert.Len(t, stopAlerts, 1, "agency+stop entity should appear in byStop")
+	assert.Equal(t, "alert1", stopAlerts[0].ID)
+
+	agencyAlerts := manager.GetAlertsByIDs("", "", agencyID)
+	assert.Len(t, agencyAlerts, 1, "agency+stop entity should also appear in byAgency")
+	assert.Equal(t, "alert1", agencyAlerts[0].ID)
+}
+
+// TestAlertIndex_AllEmptyArgsReturnsNil verifies that GetAlertsByIDs returns nil
+// (not an allocated empty slice) when all three arguments are empty strings.
+func TestAlertIndex_AllEmptyArgsReturnsNil(t *testing.T) {
+	stopID := "stop1"
+	manager := &Manager{
+		realTimeMutex: sync.RWMutex{},
+		feedAlerts: map[string][]gtfs.Alert{
+			"feed-0": {
+				{ID: "alert1", InformedEntities: []gtfs.AlertInformedEntity{{StopID: &stopID}}},
+			},
+		},
+	}
+	manager.rebuildMergedRealtimeLocked()
+
+	result := manager.GetAlertsByIDs("", "", "")
+	assert.Nil(t, result, "GetAlertsByIDs with all empty args should return nil")
+}
+
+func TestMockAddAlert_IndexIsImmediatelySynced(t *testing.T) {
+	stopID := "stop-mock"
+	routeID := "route-mock"
+	tripID := gtfs.TripID{ID: "trip-mock"}
+	agencyID := "agency-mock"
+
+	manager := &Manager{realTimeMutex: sync.RWMutex{}}
+	manager.MockAddAlert("feed-0", gtfs.Alert{
+		ID: "alert-synced",
+		InformedEntities: []gtfs.AlertInformedEntity{
+			{StopID: &stopID},
+			{RouteID: &routeID},
+			{TripID: &tripID},
+			{AgencyID: &agencyID},
+		},
+	})
+
+	t.Run("byStop bucket is populated", func(t *testing.T) {
+		alerts := manager.GetAlertsForStop(stopID)
+		require.Len(t, alerts, 1)
+		assert.Equal(t, "alert-synced", alerts[0].ID)
+	})
+
+	t.Run("byTrip bucket is populated", func(t *testing.T) {
+		alerts := manager.GetAlertsByIDs(tripID.ID, "", "")
+		require.Len(t, alerts, 1)
+		assert.Equal(t, "alert-synced", alerts[0].ID)
+	})
+
+	t.Run("byRoute bucket is populated", func(t *testing.T) {
+		alerts := manager.GetAlertsByIDs("", routeID, "")
+		require.Len(t, alerts, 1)
+		assert.Equal(t, "alert-synced", alerts[0].ID)
+	})
+
+	t.Run("byAgency bucket is populated", func(t *testing.T) {
+		alerts := manager.GetAlertsByIDs("", "", agencyID)
+		require.Len(t, alerts, 1)
+		assert.Equal(t, "alert-synced", alerts[0].ID)
+	})
+}
+
+func TestAlertIndex_NilInformedEntitiesExcludedFromAllBuckets(t *testing.T) {
+	// Two different code paths both produce empty buckets:
+	//   - nil InformedEntities: hits the `continue` guard in rebuildMergedRealtimeLocked
+	//   - non-nil but empty slice: falls through to an inner loop that never executes
+	// Both are tested here to guard against regressions in either branch.
+	manager := &Manager{
+		realTimeMutex: sync.RWMutex{},
+		feedAlerts: map[string][]gtfs.Alert{
+			"feed-0": {
+				{ID: "alert-nil-entities", InformedEntities: nil},
+				{ID: "alert-empty-entities", InformedEntities: []gtfs.AlertInformedEntity{}},
+			},
+		},
+	}
+	manager.rebuildMergedRealtimeLocked()
+
+	assert.Empty(t, manager.GetAlertsForStop("any-stop"))
+	assert.Empty(t, manager.GetAlertsByIDs("any-trip", "any-route", "any-agency"))
+}
+
+func TestAlertIndex_CrossFeedDeduplication(t *testing.T) {
+	stopID := "stop1"
+	// The same alert ID appears in two feeds. GetAlertsForStop deduplicates
+	// by alert ID internally, so the caller always receives exactly one entry
+	// regardless of how many feeds contributed the same alert.
+	manager := &Manager{
+		realTimeMutex: sync.RWMutex{},
+		feedAlerts: map[string][]gtfs.Alert{
+			"feed-0": {{ID: "alert1", InformedEntities: []gtfs.AlertInformedEntity{{StopID: &stopID}}}},
+			"feed-1": {{ID: "alert1", InformedEntities: []gtfs.AlertInformedEntity{{StopID: &stopID}}}},
+		},
+	}
+	manager.rebuildMergedRealtimeLocked()
+
+	stopAlerts := manager.GetAlertsForStop(stopID)
+	assert.Len(t, stopAlerts, 1, "GetAlertsForStop deduplicates by alert ID across feeds")
+	assert.Equal(t, "alert1", stopAlerts[0].ID)
 }
 
 // encodeVehicleFeed constructs a GTFS-RT protobuf payload containing


### PR DESCRIPTION
Closes #728

## Summary

Replaces O(n×m) linear alert scans with a pre-built `alertIndex` of four hash maps, giving O(1) lookup at read time. The index is rebuilt once per feed refresh under the existing write lock — the same pattern already used for `realTimeTripLookup` and `realTimeVehicleLookupByTrip`.

## Changes

- **`gtfs_manager.go`** — adds `alertIdx alertIndex` field alongside the existing lookup maps
- **`realtime.go`**
  - New `alertIndex` struct with `byTrip`, `byRoute`, `byAgency`, `byStop` maps
  - Index built in `rebuildMergedRealtimeLocked()` via direct two-level feed iteration (no intermediate slice allocation)
  - `GetAlertsByIDs` now does O(1) map lookups with cross-category dedup via `addUnique`
  - `GetAlertsForStop` now does an O(1) map lookup with internal dedup by alert ID, consistent with `GetAlertsByIDs`
  - Per-alert `seen*` maps pre-sized to avoid internal growth
  - Route-entity scoping aligned with Java OBA: `{routeID+tripID}` entities go into `byTrip` only, not `byRoute`
- **`realtime_test.go`** — 4 existing tests updated to use `feedAlerts` + `rebuildMergedRealtimeLocked`; 13 new tests covering each bucket, scoping rules, dedup, and edge cases
- **`realtime_benchmark_test.go`** — benchmarks for `RebuildAlertIndex`, `GetAlertsByIDs`, and `GetAlertsForStop`

## Scoping rules

| Entity shape | Indexed in |
|---|---|
| `{tripID}` | `byTrip` |
| `{routeID}` (no stop, no trip) | `byRoute` |
| `{routeID + tripID}` | `byTrip` only |
| `{routeID + stopID}` | `byStop` only |
| `{agencyID}` (no route, no trip) | `byAgency` |
| `{agencyID + stopID}` | `byAgency` + `byStop` |
| `{stopID}` | `byStop` |

## Benchmarks

Apple M4, 1000 alerts across 100 routes and 50 agencies, `-count=5 -benchmem`:

| Benchmark | Before | After | Speedup |
|---|---|---|---|
| `GetAlertsByIDs` | 13.40 µs/op | 2.43 µs/op | **5.5x** |
| `GetAlertsForStop` | 4.61 µs/op | 102.5 ns/op | **45x** |

`GetAlertsForStop` sees the biggest gain — the old code scanned every alert on every call, so the improvement scales linearly with alert count. `GetAlertsByIDs` picks up 5.5x with a realistic spread of alerts per route/agency. Both are called per arrival in `arrivals-and-departures-for-stop`, so with 50 arrivals per request the savings add up.