### PR TITLE
fix: Graceful Shutdown Timeout for GTFS Manager

### DIFF
--- a/cmd/api/app.go
+++ b/cmd/api/app.go
@@ -256,7 +256,11 @@ func Run(ctx context.Context, srv *http.Server, coreApp *app.Application, api *r
 
 	// Then shutdown GTFS manager (stops data fetching - the lowest-level dependency)
 	if coreApp.GtfsManager != nil {
-		coreApp.GtfsManager.Shutdown()
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 25*time.Second)
+		defer cancel()
+		if err := coreApp.GtfsManager.Shutdown(shutdownCtx); err != nil {
+			logger.Warn("gtfs manager shutdown incomplete", "error", err)
+		}
 	}
 
 	logger.Info("server exited")

--- a/internal/gtfs/advanced_direction_calculator_test.go
+++ b/internal/gtfs/advanced_direction_calculator_test.go
@@ -570,7 +570,7 @@ func TestMain(m *testing.M) {
 	// Global Teardown
 	// If sharedManager was initialized during tests, shut it down now.
 	if sharedManager != nil {
-		sharedManager.Shutdown(context.Background())
+		_ = sharedManager.Shutdown(context.Background())
 	}
 
 	// Exit with the test result code

--- a/internal/gtfs/advanced_direction_calculator_test.go
+++ b/internal/gtfs/advanced_direction_calculator_test.go
@@ -570,7 +570,7 @@ func TestMain(m *testing.M) {
 	// Global Teardown
 	// If sharedManager was initialized during tests, shut it down now.
 	if sharedManager != nil {
-		sharedManager.Shutdown()
+		sharedManager.Shutdown(context.Background())
 	}
 
 	// Exit with the test result code

--- a/internal/gtfs/gtfs_manager.go
+++ b/internal/gtfs/gtfs_manager.go
@@ -64,6 +64,7 @@ type Manager struct {
 	shutdownChan                   chan struct{}
 	wg                             sync.WaitGroup
 	shutdownOnce                   sync.Once
+	dbCloseOnce                    sync.Once
 	stopSpatialIndex               *rtree.RTree
 	blockLayoverIndices            map[string][]*BlockLayoverIndex
 	regionBounds                   *RegionBounds
@@ -389,6 +390,15 @@ func (manager *Manager) Shutdown(ctx context.Context) error {
 		close(manager.shutdownChan)
 	})
 
+	defer manager.dbCloseOnce.Do(func() {
+		if manager.GtfsDB != nil {
+			if err := manager.GtfsDB.Close(); err != nil {
+				logger := slog.Default().With(slog.String("component", "gtfs_manager"))
+				logging.LogError(logger, "failed to close GTFS database", err)
+			}
+		}
+	})
+
 	done := make(chan struct{})
 	go func() {
 		manager.wg.Wait()
@@ -397,21 +407,8 @@ func (manager *Manager) Shutdown(ctx context.Context) error {
 
 	select {
 	case <-done:
-		if manager.GtfsDB != nil {
-			if err := manager.GtfsDB.Close(); err != nil {
-				logger := slog.Default().With(slog.String("component", "gtfs_manager"))
-				logging.LogError(logger, "failed to close GTFS database", err)
-			}
-		}
 		return nil
 	case <-ctx.Done():
-		// close DB even on timeout
-		if manager.GtfsDB != nil {
-			if err := manager.GtfsDB.Close(); err != nil {
-				logger := slog.Default().With(slog.String("component", "gtfs_manager"))
-				logging.LogError(logger, "failed to close GTFS database during timeout", err)
-			}
-		}
 		return fmt.Errorf("shutdown timeout exceeded: %w", ctx.Err())
 	}
 }

--- a/internal/gtfs/gtfs_manager.go
+++ b/internal/gtfs/gtfs_manager.go
@@ -383,18 +383,37 @@ func (manager *Manager) SetGtfsURL(url string) {
 	manager.isLocalFile = !strings.HasPrefix(url, "http://") && !strings.HasPrefix(url, "https://")
 }
 
-// Shutdown gracefully shuts down the manager and its background goroutines
-func (manager *Manager) Shutdown() {
+// Shutdown gracefully shuts down the manager and its background goroutines.
+func (manager *Manager) Shutdown(ctx context.Context) error {
 	manager.shutdownOnce.Do(func() {
 		close(manager.shutdownChan)
+	})
+
+	done := make(chan struct{})
+	go func() {
 		manager.wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
 		if manager.GtfsDB != nil {
 			if err := manager.GtfsDB.Close(); err != nil {
 				logger := slog.Default().With(slog.String("component", "gtfs_manager"))
 				logging.LogError(logger, "failed to close GTFS database", err)
 			}
 		}
-	})
+		return nil
+	case <-ctx.Done():
+		// close DB even on timeout
+		if manager.GtfsDB != nil {
+			if err := manager.GtfsDB.Close(); err != nil {
+				logger := slog.Default().With(slog.String("component", "gtfs_manager"))
+				logging.LogError(logger, "failed to close GTFS database during timeout", err)
+			}
+		}
+		return fmt.Errorf("shutdown timeout exceeded: %w", ctx.Err())
+	}
 }
 
 // RLock acquires the static data read lock.

--- a/internal/gtfs/gtfs_manager_test.go
+++ b/internal/gtfs/gtfs_manager_test.go
@@ -407,7 +407,7 @@ func TestRoutesForAgencyID_NonexistentId(t *testing.T) {
 	}
 	manager, err := InitGTFSManager(ctx, gtfsConfig)
 	require.NoError(t, err, "Failed to initialize manager")
-	defer manager.Shutdown()
+	defer func() { _ = manager.Shutdown(context.Background()) }()
 
 	emptyRoutes, err := manager.RoutesForAgencyID(ctx, "nonexistent")
 	assert.Nil(t, err)
@@ -667,7 +667,7 @@ func TestActiveServiceIDsCacheInvalidation(t *testing.T) {
 
 	manager, err := InitGTFSManager(ctx, gtfsConfig)
 	require.NoError(t, err)
-	defer manager.Shutdown()
+	defer func() { _ = manager.Shutdown(context.Background()) }()
 
 	// Use a fixed date that has known calendar data in the RABA fixture.
 	// The RABA feed covers weekdays; pick a Monday.
@@ -719,7 +719,7 @@ func TestActiveServiceIDsCache_ErrorPathLeavesNothingCached(t *testing.T) {
 	}
 	manager, err := InitGTFSManager(context.Background(), gtfsConfig)
 	require.NoError(t, err)
-	defer manager.Shutdown()
+	defer func() { _ = manager.Shutdown(context.Background()) }()
 
 	cancelledCtx, cancel := context.WithCancel(context.Background())
 	cancel()
@@ -781,7 +781,7 @@ func TestActiveServiceIDsCacheMutationSafety(t *testing.T) {
 	}
 	manager, err := InitGTFSManager(context.Background(), gtfsConfig)
 	require.NoError(t, err)
-	defer manager.Shutdown()
+	defer func() { _ = manager.Shutdown(context.Background()) }()
 
 	ctx := context.Background()
 	date := "20240101"
@@ -838,7 +838,7 @@ func TestActiveServiceIDsCacheConcurrentForceUpdate(t *testing.T) {
 
 	manager, err := InitGTFSManager(ctx, gtfsConfig)
 	require.NoError(t, err)
-	defer manager.Shutdown()
+	defer func() { _ = manager.Shutdown(context.Background()) }()
 
 	date := "20240101"
 
@@ -942,7 +942,7 @@ func BenchmarkGetActiveServiceIDsForDate(b *testing.B) {
 	if err != nil {
 		b.Fatalf("Failed to initialize: %v", err)
 	}
-	defer manager.Shutdown()
+	defer func() { _ = manager.Shutdown(context.Background()) }()
 
 	date := "20240101"
 

--- a/internal/gtfs/gtfs_manager_test.go
+++ b/internal/gtfs/gtfs_manager_test.go
@@ -305,7 +305,7 @@ func TestManager_GetVehicleForTrip(t *testing.T) {
 	// We use isolated GTFSManager here instead of shared test components because we want to control the real-time vehicles for this test.
 	manager, err := InitGTFSManager(ctx, gtfsConfig)
 	assert.Nil(t, err)
-	defer manager.Shutdown()
+	defer manager.Shutdown(context.Background())
 
 	trip := &gtfs.Trip{
 		ID: gtfs.TripID{ID: "5735633"},
@@ -424,7 +424,7 @@ func TestRoutesForAgencyID_ValidId(t *testing.T) {
 	}
 	manager, err := InitGTFSManager(ctx, gtfsConfig)
 	require.NoError(t, err, "Failed to initialize manager")
-	defer manager.Shutdown()
+	defer manager.Shutdown(context.Background())
 
 	targetAgencyID := "25"
 	expectedRouteCount := 13
@@ -444,7 +444,7 @@ func TestRoutesForAgencyID_ConcurrentAccess(t *testing.T) {
 	}
 	manager, err := InitGTFSManager(ctx, gtfsConfig)
 	require.NoError(t, err)
-	defer manager.Shutdown()
+	defer manager.Shutdown(context.Background())
 
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
@@ -523,7 +523,7 @@ func BenchmarkRoutesForAgencyID_MapLookup(b *testing.B) {
 	if err != nil {
 		b.Fatalf("Failed to initialize: %v", err)
 	}
-	defer manager.Shutdown()
+	defer manager.Shutdown(context.Background())
 
 	b.ReportAllocs()
 

--- a/internal/gtfs/gtfs_manager_test.go
+++ b/internal/gtfs/gtfs_manager_test.go
@@ -305,7 +305,7 @@ func TestManager_GetVehicleForTrip(t *testing.T) {
 	// We use isolated GTFSManager here instead of shared test components because we want to control the real-time vehicles for this test.
 	manager, err := InitGTFSManager(ctx, gtfsConfig)
 	assert.Nil(t, err)
-	defer manager.Shutdown(context.Background())
+	defer func() { _ = manager.Shutdown(context.Background()) }()
 
 	trip := &gtfs.Trip{
 		ID: gtfs.TripID{ID: "5735633"},
@@ -424,7 +424,7 @@ func TestRoutesForAgencyID_ValidId(t *testing.T) {
 	}
 	manager, err := InitGTFSManager(ctx, gtfsConfig)
 	require.NoError(t, err, "Failed to initialize manager")
-	defer manager.Shutdown(context.Background())
+	defer func() { _ = manager.Shutdown(context.Background()) }()
 
 	targetAgencyID := "25"
 	expectedRouteCount := 13
@@ -444,7 +444,7 @@ func TestRoutesForAgencyID_ConcurrentAccess(t *testing.T) {
 	}
 	manager, err := InitGTFSManager(ctx, gtfsConfig)
 	require.NoError(t, err)
-	defer manager.Shutdown(context.Background())
+	defer func() { _ = manager.Shutdown(context.Background()) }()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
@@ -523,7 +523,7 @@ func BenchmarkRoutesForAgencyID_MapLookup(b *testing.B) {
 	if err != nil {
 		b.Fatalf("Failed to initialize: %v", err)
 	}
-	defer manager.Shutdown(context.Background())
+	defer func() { _ = manager.Shutdown(context.Background()) }()
 
 	b.ReportAllocs()
 

--- a/internal/gtfs/hot_swap_test.go
+++ b/internal/gtfs/hot_swap_test.go
@@ -39,7 +39,7 @@ func TestHotSwap_QueriesCompleteDuringSwap(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to init manager: %v", err)
 	}
-	defer manager.Shutdown(context.Background())
+	defer func() { _ = manager.Shutdown(context.Background()) }()
 
 	agencies := manager.GetAgencies()
 	assert.Equal(t, 1, len(agencies))
@@ -122,7 +122,7 @@ func TestHotSwap_FailureRecovery(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to init manager: %v", err)
 	}
-	defer manager.Shutdown(context.Background())
+	defer func() { _ = manager.Shutdown(context.Background()) }()
 
 	agencies, err := manager.GtfsDB.Queries.ListAgencies(context.Background())
 	if err != nil {
@@ -175,7 +175,7 @@ func TestHotSwap_OldDatabaseCleanup(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to init manager: %v", err)
 	}
-	defer manager.Shutdown(context.Background())
+	defer func() { _ = manager.Shutdown(context.Background()) }()
 
 	manager.SetGtfsURL(gtfsNew)
 	err = manager.ForceUpdate(context.Background())
@@ -217,7 +217,7 @@ func TestHotSwap_MutexProtectedSwap(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to init manager: %v", err)
 	}
-	defer manager.Shutdown(context.Background())
+	defer func() { _ = manager.Shutdown(context.Background()) }()
 
 	// Verify initial state
 	manager.RLock()
@@ -271,7 +271,7 @@ func TestHotSwap_ConcurrentForceUpdate(t *testing.T) {
 
 	manager, err := InitGTFSManager(ctx, gtfsConfig)
 	require.NoError(t, err)
-	defer manager.Shutdown(context.Background())
+	defer func() { _ = manager.Shutdown(context.Background()) }()
 
 	// Verify initial state
 	manager.RLock()

--- a/internal/gtfs/hot_swap_test.go
+++ b/internal/gtfs/hot_swap_test.go
@@ -39,7 +39,7 @@ func TestHotSwap_QueriesCompleteDuringSwap(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to init manager: %v", err)
 	}
-	defer manager.Shutdown()
+	defer manager.Shutdown(context.Background())
 
 	agencies := manager.GetAgencies()
 	assert.Equal(t, 1, len(agencies))
@@ -122,7 +122,7 @@ func TestHotSwap_FailureRecovery(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to init manager: %v", err)
 	}
-	defer manager.Shutdown()
+	defer manager.Shutdown(context.Background())
 
 	agencies, err := manager.GtfsDB.Queries.ListAgencies(context.Background())
 	if err != nil {
@@ -175,7 +175,7 @@ func TestHotSwap_OldDatabaseCleanup(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to init manager: %v", err)
 	}
-	defer manager.Shutdown()
+	defer manager.Shutdown(context.Background())
 
 	manager.SetGtfsURL(gtfsNew)
 	err = manager.ForceUpdate(context.Background())
@@ -217,7 +217,7 @@ func TestHotSwap_MutexProtectedSwap(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to init manager: %v", err)
 	}
-	defer manager.Shutdown()
+	defer manager.Shutdown(context.Background())
 
 	// Verify initial state
 	manager.RLock()
@@ -271,7 +271,7 @@ func TestHotSwap_ConcurrentForceUpdate(t *testing.T) {
 
 	manager, err := InitGTFSManager(ctx, gtfsConfig)
 	require.NoError(t, err)
-	defer manager.Shutdown()
+	defer manager.Shutdown(context.Background())
 
 	// Verify initial state
 	manager.RLock()

--- a/internal/gtfs/shutdown_test.go
+++ b/internal/gtfs/shutdown_test.go
@@ -146,5 +146,5 @@ func TestManagerShutdown_TimeoutPath(t *testing.T) {
 	assert.Contains(t, err.Error(), "shutdown timeout exceeded")
 
 	close(stuck)
-	
+
 }

--- a/internal/gtfs/shutdown_test.go
+++ b/internal/gtfs/shutdown_test.go
@@ -2,6 +2,7 @@ package gtfs
 
 import (
 	"context"
+	"errors"
 	"path/filepath"
 	"testing"
 	"time"
@@ -32,20 +33,12 @@ func TestManagerShutdown(t *testing.T) {
 	agencies := manager.GetAgencies()
 	assert.Greater(t, len(agencies), 0, "Should have loaded agencies")
 
-	// Test shutdown
-	done := make(chan struct{})
-	go func() {
-		manager.Shutdown()
-		close(done)
-	}()
+	// Test shutdown with generous context
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
 
-	// Shutdown should complete within a reasonable time
-	select {
-	case <-done:
-		// Success
-	case <-time.After(5 * time.Second):
-		t.Fatal("Shutdown took too long")
-	}
+	err = manager.Shutdown(ctx)
+	assert.NoError(t, err, "Shutdown should complete without error")
 }
 
 func TestManagerShutdownWithRealtime(t *testing.T) {
@@ -77,20 +70,12 @@ func TestManagerShutdownWithRealtime(t *testing.T) {
 	// Give the real-time goroutine a moment to start
 	time.Sleep(100 * time.Millisecond)
 
-	// Test shutdown
-	done := make(chan struct{})
-	go func() {
-		manager.Shutdown()
-		close(done)
-	}()
+	// Test shutdown with generous context
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
 
-	// Shutdown should complete within a reasonable time even with real-time goroutine
-	select {
-	case <-done:
-		// Success
-	case <-time.After(5 * time.Second):
-		t.Fatal("Shutdown took too long")
-	}
+	err = manager.Shutdown(ctx)
+	assert.NoError(t, err, "Shutdown should complete without error even with real-time goroutine")
 }
 
 func TestManagerShutdownIdempotent(t *testing.T) {
@@ -110,6 +95,56 @@ func TestManagerShutdownIdempotent(t *testing.T) {
 	require.NoError(t, err, "Failed to initialize GTFS manager")
 
 	// Call shutdown multiple times - should not panic or hang
-	manager.Shutdown()
-	manager.Shutdown() // Second call should be safe
+	err = manager.Shutdown(context.Background())
+	assert.NoError(t, err)
+
+	err = manager.Shutdown(context.Background()) // Second call should be safe
+	assert.NoError(t, err)
+}
+
+// TestManagerShutdown_CleanPath verifies that Shutdown returns nil when all
+// goroutines exit promptly before the context deadline.
+func TestManagerShutdown_CleanPath(t *testing.T) {
+	manager := &Manager{
+		shutdownChan: make(chan struct{}),
+	}
+
+	manager.wg.Add(1)
+	go func() {
+		defer manager.wg.Done()
+		<-manager.shutdownChan
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	err := manager.Shutdown(ctx)
+	assert.NoError(t, err, "Shutdown should succeed when goroutines exit promptly")
+}
+
+// TestManagerShutdown_TimeoutPath verifies that Shutdown returns an error wrapping
+// context.DeadlineExceeded when a goroutine is stuck and ignores shutdownChan.
+func TestManagerShutdown_TimeoutPath(t *testing.T) {
+	manager := &Manager{
+		shutdownChan: make(chan struct{}),
+	}
+
+	manager.wg.Add(1)
+	stuck := make(chan struct{})
+	go func() {
+		defer manager.wg.Done()
+		<-stuck
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	err := manager.Shutdown(ctx)
+	require.Error(t, err, "Shutdown should return an error when context expires")
+	assert.True(t, errors.Is(err, context.DeadlineExceeded),
+		"error should wrap context.DeadlineExceeded, got: %v", err)
+	assert.Contains(t, err.Error(), "shutdown timeout exceeded")
+
+	close(stuck)
+	
 }

--- a/internal/restapi/openapi_conformance_test.go
+++ b/internal/restapi/openapi_conformance_test.go
@@ -447,7 +447,7 @@ func TestOpenAPIConformance_RealTimeEndpoints(t *testing.T) {
 
 	gtfsManager, err := gtfs.InitGTFSManager(ctx, gtfsConfig)
 	require.NoError(t, err)
-	defer gtfsManager.Shutdown()
+	defer gtfsManager.Shutdown(context.Background())
 
 	dirCalc := gtfs.NewAdvancedDirectionCalculator(gtfsManager.GtfsDB.Queries)
 

--- a/internal/restapi/openapi_conformance_test.go
+++ b/internal/restapi/openapi_conformance_test.go
@@ -447,7 +447,7 @@ func TestOpenAPIConformance_RealTimeEndpoints(t *testing.T) {
 
 	gtfsManager, err := gtfs.InitGTFSManager(ctx, gtfsConfig)
 	require.NoError(t, err)
-	defer gtfsManager.Shutdown(context.Background())
+	defer func() { _ = gtfsManager.Shutdown(context.Background()) }()
 
 	dirCalc := gtfs.NewAdvancedDirectionCalculator(gtfsManager.GtfsDB.Queries)
 

--- a/internal/restapi/stops_for_route_handler_test.go
+++ b/internal/restapi/stops_for_route_handler_test.go
@@ -277,7 +277,7 @@ func createTestApiWithNullDirectionID(t *testing.T) *RestAPI {
 
 	gtfsManager, err := gtfs.InitGTFSManager(ctx, gtfsConfig)
 	require.NoError(t, err)
-	t.Cleanup(gtfsManager.Shutdown)
+	t.Cleanup(func() { _ = gtfsManager.Shutdown(context.Background()) })
 
 	dirCalc := gtfs.NewAdvancedDirectionCalculator(gtfsManager.GtfsDB.Queries)
 

--- a/internal/restapi/vehicles_for_agency_handler_test.go
+++ b/internal/restapi/vehicles_for_agency_handler_test.go
@@ -489,7 +489,7 @@ func createTestApiWithRealTimeData(t testing.TB) (*RestAPI, func()) {
 	cleanup := func() {
 		api.Shutdown()
 		server.Close()
-		gtfsManager.Shutdown(context.Background())
+		_ = gtfsManager.Shutdown(context.Background())
 	}
 
 	return api, cleanup

--- a/internal/restapi/vehicles_for_agency_handler_test.go
+++ b/internal/restapi/vehicles_for_agency_handler_test.go
@@ -489,7 +489,7 @@ func createTestApiWithRealTimeData(t testing.TB) (*RestAPI, func()) {
 	cleanup := func() {
 		api.Shutdown()
 		server.Close()
-		gtfsManager.Shutdown()
+		gtfsManager.Shutdown(context.Background())
 	}
 
 	return api, cleanup


### PR DESCRIPTION
 ## Description
- Closes #736

`Manager.Shutdown()` called `wg.Wait()` with no timeout. A stuck real-time feed goroutine would block shutdown indefinitely.

### Solution
Updated `Shutdown` to accept a `context.Context` and race `wg.Wait()` against `ctx.Done()`. The production call site in `app.go` uses a **25s timeout**, keeping a 5s safety margin inside Kubernetes' default SIGTERM window. Timeouts
log a warning instead of fatally erroring, preserving liveness.

### Changes
- `gtfs_manager.go` new signature `Shutdown(ctx context.Context) error` with context-select pattern
- `app.go` 25s shutdown context with structured warning log on timeout
- 15+ call sites across 7 test files updated; zero uses of old 0-arg signature remain
- 2 new unit tests: clean path (`nil`) and timeout path (`context.DeadlineExceeded`)

### Tests
`go build ./...`  &nbsp; `make test` &nbsp; `make lint` &nbsp; `go fmt ./...` 