### PR TITLE
fix: nil guard in tripsForLocationHandler

### DIFF
--- a/internal/restapi/trips_for_location_handler.go
+++ b/internal/restapi/trips_for_location_handler.go
@@ -57,7 +57,7 @@ func (api *RestAPI) tripsForLocationHandler(w http.ResponseWriter, r *http.Reque
 			return
 		}
 
-		if vehicle.Position == nil {
+		if vehicle.Position == nil || vehicle.Position.Latitude == nil || vehicle.Position.Longitude == nil {
 			continue
 		}
 		vLat, vLon := float64(*vehicle.Position.Latitude), float64(*vehicle.Position.Longitude)


### PR DESCRIPTION
## SUMMARY

This PR fixes a potential nil pointer dereference in `trips_for_location_handler.go` when accessing vehicle position data. It ensures safe handling of partially populated GTFS-RT `Position` fields by validating `Latitude` and `Longitude` before dereferencing.

---

## FIX 

```go
// Before
if vehicle.Position == nil {
    continue
}
vLat, vLon := float64(*vehicle.Position.Latitude), float64(*vehicle.Position.Longitude)

// After
if vehicle.Position == nil || vehicle.Position.Latitude == nil || vehicle.Position.Longitude == nil {
    continue
}
vLat, vLon := float64(*vehicle.Position.Latitude), float64(*vehicle.Position.Longitude)
```

---

## VERIFICATION

1. Call `/api/where/trips-for-location.json` with a GTFS-RT feed containing:

   * A vehicle with `Position != nil`
   * But `Latitude == nil` or `Longitude == nil`
2. Observe handler behavior before and after the fix.