### PR TITLE
perf: add in-memory cache for GetActiveServiceIDsForDate, invalidate on GTFS reload

### DIFF
--- a/internal/gtfs/gtfs_manager.go
+++ b/internal/gtfs/gtfs_manager.go
@@ -36,9 +36,11 @@ type RegionBounds struct {
 // Lock ordering policy (to prevent deadlocks):
 //
 //	staticMutex → realTimeMutex
+//	staticMutex → activeServiceIDsCacheMutex
 //
 // When both locks are needed, staticMutex MUST be acquired first.
 // Never acquire staticMutex while holding realTimeMutex.
+// Never acquire staticMutex while holding activeServiceIDsCacheMutex.
 type Manager struct {
 	gtfsData                       *gtfs.Static
 	GtfsDB                         *gtfsdb.Client
@@ -89,6 +91,15 @@ type Manager struct {
 
 	// Tracks the last successful update time per feed
 	feedLastUpdate map[string]time.Time
+
+	// activeServiceIDsCache caches GetActiveServiceIDsForDate results keyed by "YYYYMMDD" date string.
+	// Protected by activeServiceIDsCacheMutex. Cleared on every ForceUpdate.
+	activeServiceIDsCache      map[string][]string
+	activeServiceIDsCacheMutex sync.RWMutex
+	// cacheEpoch is incremented each time the cache is cleared (ForceUpdate or MockClearServiceIDsCache).
+	// GetActiveServiceIDsForDateCached snapshots it before the DB query and discards the result if
+	// it has advanced, preventing stale writes from a pre-swap DB into a freshly-cleared cache.
+	cacheEpoch atomic.Uint64
 }
 
 // clearFeedData removes stale data for a specific feed when the staleness threshold is crossed
@@ -251,6 +262,7 @@ func InitGTFSManager(ctx context.Context, config Config) (*Manager, error) {
 		feedVehicleLastSeen:            make(map[string]map[string]time.Time),
 		feedVehicleTimestamp:           make(map[string]uint64),
 		frequencyTripIDs:               make(map[string]struct{}),
+		activeServiceIDsCache:          make(map[string][]string),
 		Metrics:                        config.Metrics,
 	}
 
@@ -556,7 +568,7 @@ func (manager *Manager) GetStopsForLocation(
 			}
 
 			// Get active service IDs for current date
-			activeServiceIDs, err := manager.GtfsDB.Queries.GetActiveServiceIDsForDate(ctx, currentDate)
+			activeServiceIDs, err := manager.GetActiveServiceIDsForDateCached(ctx, currentDate)
 			if err != nil {
 				logger := slog.Default().With(slog.String("component", "gtfs_manager"))
 				logging.LogError(logger, "could not get active service IDs for date", err, slog.String("date", currentDate))
@@ -746,6 +758,55 @@ func (manager *Manager) GetAllTripUpdates() []gtfs.Trip {
 	manager.realTimeMutex.RLock()
 	defer manager.realTimeMutex.RUnlock()
 	return manager.realTimeTrips
+}
+
+// GetActiveServiceIDsForDateCached returns the active service IDs for the given date string
+// ("YYYYMMDD"), using an in-memory cache to avoid repeating the calendar CTE query within
+// the same GTFS dataset. The cache is invalidated on every ForceUpdate.
+// On a cache miss the query is executed with no lock held; on error nothing is cached.
+//
+// The returned slice is a defensive copy; callers may freely modify it.
+func (manager *Manager) GetActiveServiceIDsForDateCached(ctx context.Context, date string) ([]string, error) {
+	manager.activeServiceIDsCacheMutex.RLock()
+	cached, ok := manager.activeServiceIDsCache[date]
+	manager.activeServiceIDsCacheMutex.RUnlock()
+	if ok {
+		out := make([]string, len(cached))
+		copy(out, cached)
+		return out, nil
+	}
+
+	// Snapshot the epoch before querying the DB. ForceUpdate may swap manager.GtfsDB
+	// while our query is in-flight — results from the old DB must not populate the cache
+	// for the new dataset. The epoch detects this: ForceUpdate increments it (under
+	// activeServiceIDsCacheMutex) after the DB swap, so our snapshot will no longer match.
+	epochBefore := manager.cacheEpoch.Load()
+
+	// Read GtfsDB under staticMutex.RLock to avoid a data race with ForceUpdate, which
+	// writes the field under staticMutex.Lock. We release the lock before the query so
+	// ForceUpdate is never blocked by an in-flight DB call.
+	manager.staticMutex.RLock()
+	db := manager.GtfsDB
+	manager.staticMutex.RUnlock()
+	if db == nil {
+		return nil, fmt.Errorf("GTFS database is not available")
+	}
+	ids, err := db.Queries.GetActiveServiceIDsForDate(ctx, date)
+	if err != nil {
+		return nil, err
+	}
+
+	manager.activeServiceIDsCacheMutex.Lock()
+	if manager.cacheEpoch.Load() == epochBefore {
+		if _, ok := manager.activeServiceIDsCache[date]; !ok {
+			manager.activeServiceIDsCache[date] = ids
+		}
+	}
+	manager.activeServiceIDsCacheMutex.Unlock()
+
+	out := make([]string, len(ids))
+	copy(out, ids)
+	return out, nil
 }
 
 // IMPORTANT: Caller must hold manager.RLock() before calling this method.

--- a/internal/gtfs/gtfs_manager_mock.go
+++ b/internal/gtfs/gtfs_manager_mock.go
@@ -146,3 +146,16 @@ func (m *Manager) MockResetRealTimeData() {
 	m.realTimeTrips = nil
 	m.realTimeTripLookup = make(map[string]int)
 }
+
+// MockClearServiceIDsCache evicts all entries from the active-service-IDs cache.
+// Call this in tests that mutate the calendar tables of a shared Manager to ensure
+// the next request re-queries the database with the updated data.
+//
+// Safe to call without holding staticMutex. Acquires only activeServiceIDsCacheMutex,
+// consistent with the lock ordering: staticMutex → activeServiceIDsCacheMutex.
+func (m *Manager) MockClearServiceIDsCache() {
+	m.activeServiceIDsCacheMutex.Lock()
+	m.activeServiceIDsCache = make(map[string][]string)
+	m.cacheEpoch.Add(1)
+	m.activeServiceIDsCacheMutex.Unlock()
+}

--- a/internal/gtfs/gtfs_manager_test.go
+++ b/internal/gtfs/gtfs_manager_test.go
@@ -3,6 +3,7 @@ package gtfs
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"log/slog"
 	"sync"
@@ -646,4 +647,314 @@ func TestManager_DataFreshnessTracking(t *testing.T) {
 	feedTimes["feed-1"] = time.Now().Add(time.Hour)
 	feedTimes2 := manager.GetFeedUpdateTimes()
 	assert.Equal(t, now, feedTimes2["feed-1"])
+}
+
+func TestActiveServiceIDsCacheInvalidation(t *testing.T) {
+	ctx := context.Background()
+
+	tempDir := t.TempDir()
+	gtfsConfig := Config{
+		GtfsURL:      models.GetFixturePath(t, "raba.zip"),
+		GTFSDataPath: tempDir + "/gtfs.db",
+		Env:          appconf.Development,
+	}
+
+	manager, err := InitGTFSManager(ctx, gtfsConfig)
+	require.NoError(t, err)
+	defer manager.Shutdown()
+
+	// Use a fixed date that has known calendar data in the RABA fixture.
+	// The RABA feed covers weekdays; pick a Monday.
+	date := "20240101"
+
+	// First call should hit the DB and populate the cache.
+	ids1, err := manager.GetActiveServiceIDsForDateCached(ctx, date)
+	require.NoError(t, err)
+	require.NotEmpty(t, ids1, "RABA fixture must have active services on 20240101; check the test date or fixture")
+
+	manager.activeServiceIDsCacheMutex.RLock()
+	cached, ok := manager.activeServiceIDsCache[date]
+	manager.activeServiceIDsCacheMutex.RUnlock()
+	assert.True(t, ok, "cache entry should exist after first call")
+	assert.Equal(t, ids1, cached, "cached value should match returned value")
+
+	// Second call should return the same result from cache without hitting the DB.
+	ids2, err := manager.GetActiveServiceIDsForDateCached(ctx, date)
+	require.NoError(t, err)
+	assert.Equal(t, ids1, ids2, "cached result should match original result")
+
+	// ForceUpdate should clear the cache.
+	err = manager.ForceUpdate(ctx)
+	require.NoError(t, err)
+
+	manager.activeServiceIDsCacheMutex.RLock()
+	cacheLen := len(manager.activeServiceIDsCache)
+	manager.activeServiceIDsCacheMutex.RUnlock()
+	assert.Equal(t, 0, cacheLen, "cache should be empty after ForceUpdate")
+
+	// After ForceUpdate the cache should repopulate on the next call.
+	ids3, err := manager.GetActiveServiceIDsForDateCached(ctx, date)
+	require.NoError(t, err)
+	assert.Equal(t, ids1, ids3, "result after cache invalidation should match original")
+
+	manager.activeServiceIDsCacheMutex.RLock()
+	_, repopulated := manager.activeServiceIDsCache[date]
+	manager.activeServiceIDsCacheMutex.RUnlock()
+	assert.True(t, repopulated, "cache should be repopulated after post-ForceUpdate call")
+}
+
+func TestActiveServiceIDsCache_ErrorPathLeavesNothingCached(t *testing.T) {
+	// Use an isolated manager so the cache is guaranteed cold for this date,
+	// regardless of test execution order in the package.
+	gtfsConfig := Config{
+		GtfsURL:      models.GetFixturePath(t, "raba.zip"),
+		GTFSDataPath: ":memory:",
+		Env:          appconf.Test,
+	}
+	manager, err := InitGTFSManager(context.Background(), gtfsConfig)
+	require.NoError(t, err)
+	defer manager.Shutdown()
+
+	cancelledCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, queryErr := manager.GetActiveServiceIDsForDateCached(cancelledCtx, "20240101")
+
+	// mattn/go-sqlite3 (sqlite_fts5 build tag) propagates a cancelled context as an error.
+	// The pure-Go modernc driver (purego tag) may not; guard the assertion so the test
+	// remains valid if the build tag ever changes.
+	if errors.Is(queryErr, context.Canceled) || errors.Is(queryErr, context.DeadlineExceeded) {
+		manager.activeServiceIDsCacheMutex.RLock()
+		_, cached := manager.activeServiceIDsCache["20240101"]
+		manager.activeServiceIDsCacheMutex.RUnlock()
+		assert.False(t, cached, "cache must remain empty after a failed query")
+	} else {
+		t.Logf("driver did not propagate cancelled context as an error (%v); cache-pollution assertion skipped", queryErr)
+	}
+}
+
+func TestActiveServiceIDsCacheRace(t *testing.T) {
+	manager, _ := getSharedTestComponents(t)
+	ctx := context.Background()
+
+	// The primary goal is to exercise the race detector on the double-checked locking
+	// path; the equality assertions confirm all goroutines see consistent data.
+	const workers = 20
+	results := make([][]string, workers)
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for i := 0; i < workers; i++ {
+		go func(idx int) {
+			defer wg.Done()
+			results[idx], _ = manager.GetActiveServiceIDsForDateCached(ctx, "20240101")
+		}(i)
+	}
+	wg.Wait()
+
+	for i := 1; i < workers; i++ {
+		assert.Equal(t, results[0], results[i], "goroutine %d returned inconsistent result", i)
+	}
+}
+
+func TestActiveServiceIDsCacheNilDB(t *testing.T) {
+	manager := &Manager{
+		activeServiceIDsCache: make(map[string][]string),
+		// GtfsDB is intentionally nil.
+	}
+	_, err := manager.GetActiveServiceIDsForDateCached(context.Background(), "20240101")
+	require.Error(t, err, "nil GtfsDB should return an error, not panic")
+}
+
+func TestActiveServiceIDsCacheMutationSafety(t *testing.T) {
+	// Use an isolated manager so the cache is cold, guaranteeing the first call is a
+	// genuine cache miss and that we exercise both the miss-path and hit-path copies.
+	gtfsConfig := Config{
+		GtfsURL:      models.GetFixturePath(t, "raba.zip"),
+		GTFSDataPath: ":memory:",
+		Env:          appconf.Test,
+	}
+	manager, err := InitGTFSManager(context.Background(), gtfsConfig)
+	require.NoError(t, err)
+	defer manager.Shutdown()
+
+	ctx := context.Background()
+	date := "20240101"
+
+	// First call: cache miss path — result must be a defensive copy.
+	ids1, err := manager.GetActiveServiceIDsForDateCached(ctx, date)
+	require.NoError(t, err)
+	require.NotEmpty(t, ids1, "need at least one service ID to test mutation safety")
+
+	original := ids1[0]
+	ids1[0] = "mutated-miss-path"
+
+	// Second call: cache hit path — must return a fresh copy of the stored value.
+	ids2, err := manager.GetActiveServiceIDsForDateCached(ctx, date)
+	require.NoError(t, err)
+	assert.Equal(t, original, ids2[0], "miss-path: mutating first result must not corrupt the cache")
+
+	ids2[0] = "mutated-hit-path"
+
+	// Third call: still must return the original value.
+	ids3, err := manager.GetActiveServiceIDsForDateCached(ctx, date)
+	require.NoError(t, err)
+	assert.Equal(t, original, ids3[0], "hit-path: mutating second result must not corrupt the cache")
+}
+
+func TestActiveServiceIDsCacheEmptyDate(t *testing.T) {
+	manager, _ := getSharedTestComponents(t)
+	ctx := context.Background()
+
+	// An empty date string is syntactically invalid for the calendar CTE. The call must
+	// return an error or an empty slice; it must never panic or cache garbage.
+	ids, err := manager.GetActiveServiceIDsForDateCached(ctx, "")
+	if err != nil {
+		// Acceptable: DB returned an error for a malformed date.
+		manager.activeServiceIDsCacheMutex.RLock()
+		_, cached := manager.activeServiceIDsCache[""]
+		manager.activeServiceIDsCacheMutex.RUnlock()
+		assert.False(t, cached, "a failed query for empty date must not populate the cache")
+	} else {
+		// Also acceptable: DB returned an empty result set.
+		assert.Empty(t, ids, "empty date should yield no active service IDs")
+	}
+}
+
+func TestActiveServiceIDsCacheConcurrentForceUpdate(t *testing.T) {
+	ctx := context.Background()
+
+	tempDir := t.TempDir()
+	gtfsConfig := Config{
+		GtfsURL:      models.GetFixturePath(t, "raba.zip"),
+		GTFSDataPath: tempDir + "/gtfs.db",
+		Env:          appconf.Development,
+	}
+
+	manager, err := InitGTFSManager(ctx, gtfsConfig)
+	require.NoError(t, err)
+	defer manager.Shutdown()
+
+	date := "20240101"
+
+	// Warm the cache before the concurrent phase.
+	_, err = manager.GetActiveServiceIDsForDateCached(ctx, date)
+	require.NoError(t, err)
+
+	// Launch readers that race against ForceUpdate. With the epoch guard in place, no
+	// in-flight reader can write stale data from the old dataset into the freshly-cleared
+	// cache. The race detector will catch any unsynchronised access.
+	const readers = 10
+	var wg sync.WaitGroup
+	wg.Add(readers)
+	for i := 0; i < readers; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 5; j++ {
+				_, _ = manager.GetActiveServiceIDsForDateCached(ctx, date)
+			}
+		}()
+	}
+
+	err = manager.ForceUpdate(ctx)
+	require.NoError(t, err)
+
+	wg.Wait()
+
+	// The epoch must have advanced, confirming ForceUpdate cleared the cache.
+	assert.Greater(t, manager.cacheEpoch.Load(), uint64(0), "epoch should advance after ForceUpdate")
+
+	// Repeated queries after settling must return consistent results.
+	ids1, err := manager.GetActiveServiceIDsForDateCached(ctx, date)
+	require.NoError(t, err)
+	ids2, err := manager.GetActiveServiceIDsForDateCached(ctx, date)
+	require.NoError(t, err)
+	assert.Equal(t, ids1, ids2, "repeated queries after ForceUpdate must return consistent results")
+}
+
+func TestMockClearServiceIDsCache_IncrementsEpoch(t *testing.T) {
+	manager, _ := getSharedTestComponents(t)
+
+	before := manager.cacheEpoch.Load()
+	manager.MockClearServiceIDsCache()
+	after := manager.cacheEpoch.Load()
+
+	assert.Greater(t, after, before, "MockClearServiceIDsCache must increment cacheEpoch")
+}
+
+func TestActiveServiceIDsCacheConcurrentErrorAndReaders(t *testing.T) {
+	manager, _ := getSharedTestComponents(t)
+	// Clear the cache so the cancelled-context goroutine reaches the DB query path
+	// rather than returning a warm-cache hit before the context is inspected.
+	manager.MockClearServiceIDsCache()
+	ctx := context.Background()
+
+	cancelledCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	// One goroutine queries with a cancelled context; all others use a valid context.
+	// The error from the bad goroutine must not corrupt the cache for the rest.
+	const workers = 20
+	results := make([][]string, workers)
+	errs := make([]error, workers)
+
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for i := 0; i < workers; i++ {
+		go func(idx int) {
+			defer wg.Done()
+			c := ctx
+			if idx == 0 {
+				c = cancelledCtx
+			}
+			results[idx], errs[idx] = manager.GetActiveServiceIDsForDateCached(c, "20240101")
+		}(i)
+	}
+	wg.Wait()
+
+	// All goroutines using a valid context must have succeeded with consistent results.
+	var reference []string
+	for i := 1; i < workers; i++ {
+		require.NoError(t, errs[i], "goroutine %d should not have gotten an error", i)
+		if reference == nil {
+			reference = results[i]
+		} else {
+			assert.Equal(t, reference, results[i], "goroutine %d returned inconsistent result", i)
+		}
+	}
+	assert.NotEmpty(t, reference, "valid goroutines must return non-empty results")
+}
+
+func BenchmarkGetActiveServiceIDsForDate(b *testing.B) {
+	ctx := context.Background()
+
+	gtfsConfig := Config{
+		GtfsURL:      models.GetFixturePath(b, "raba.zip"),
+		GTFSDataPath: ":memory:",
+		Env:          appconf.Test,
+	}
+	manager, err := InitGTFSManager(ctx, gtfsConfig)
+	if err != nil {
+		b.Fatalf("Failed to initialize: %v", err)
+	}
+	defer manager.Shutdown()
+
+	date := "20240101"
+
+	b.Run("uncached", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			_, _ = manager.GtfsDB.Queries.GetActiveServiceIDsForDate(ctx, date)
+		}
+	})
+
+	// Warm the cache once before benchmarking the cached path.
+	_, _ = manager.GetActiveServiceIDsForDateCached(ctx, date)
+
+	b.Run("cached", func(b *testing.B) {
+		b.ResetTimer()
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			_, _ = manager.GetActiveServiceIDsForDateCached(ctx, date)
+		}
+	})
 }

--- a/internal/gtfs/static.go
+++ b/internal/gtfs/static.go
@@ -319,6 +319,13 @@ func (manager *Manager) ForceUpdate(ctx context.Context) error {
 			manager.isHealthy = false
 		}
 
+		// The DB was briefly closed and may have been reopened. Flush the cache so the next
+		// caller re-queries against whichever DB is now active rather than using stale entries.
+		manager.activeServiceIDsCacheMutex.Lock()
+		manager.activeServiceIDsCache = make(map[string][]string)
+		manager.cacheEpoch.Add(1)
+		manager.activeServiceIDsCacheMutex.Unlock()
+
 		return err
 	}
 
@@ -332,6 +339,10 @@ func (manager *Manager) ForceUpdate(ctx context.Context) error {
 		manager.GtfsDB = nil
 
 		manager.isHealthy = false
+		// Intentionally skip cache invalidation here. GtfsDB is now nil, so any cache
+		// miss would immediately hit the nil-DB guard and return an error. Keeping stale
+		// entries means cached callers continue receiving answers rather than errors —
+		// the least-bad outcome until the next successful ForceUpdate clears the cache.
 		return fmt.Errorf("failed to update GTFS database client: %w", err)
 	}
 
@@ -341,6 +352,17 @@ func (manager *Manager) ForceUpdate(ctx context.Context) error {
 	manager.blockLayoverIndices = newBlockLayoverIndices
 	manager.stopSpatialIndex = newStopSpatialIndex
 	manager.regionBounds = newRegionBounds
+
+	// Note: the epoch is incremented after GtfsDB is assigned. A narrow race exists where
+	// a reader snapshots epochBefore, then reads the new DB pointer (already live), queries
+	// the new DB, and writes to the cache before the epoch advances — only for this clear
+	// to immediately evict it. The outcome is one extra DB round-trip, not data corruption.
+	// Moving the epoch increment earlier would break the epoch guard's correctness guarantee,
+	// so this ordering is intentional.
+	manager.activeServiceIDsCacheMutex.Lock()
+	manager.activeServiceIDsCache = make(map[string][]string)
+	manager.cacheEpoch.Add(1)
+	manager.activeServiceIDsCacheMutex.Unlock()
 
 	manager.routesByAgencyID = buildRouteIndex(newStaticData)
 

--- a/internal/restapi/arrivals_and_departure_for_stop.go
+++ b/internal/restapi/arrivals_and_departure_for_stop.go
@@ -153,7 +153,7 @@ func (api *RestAPI) arrivalsAndDeparturesForStopHandler(w http.ResponseWriter, r
 		serviceMidnight := time.Date(targetDate.Year(), targetDate.Month(), targetDate.Day(), 0, 0, 0, 0, loc)
 		serviceDateStr := targetDate.Format("20060102")
 
-		activeServiceIDs, err := api.GtfsManager.GtfsDB.Queries.GetActiveServiceIDsForDate(ctx, serviceDateStr)
+		activeServiceIDs, err := api.GtfsManager.GetActiveServiceIDsForDateCached(ctx, serviceDateStr)
 		if err != nil {
 			api.Logger.Warn("failed to query active service IDs",
 				slog.String("date", serviceDateStr),

--- a/internal/restapi/arrivals_and_departures_for_stop_handler_test.go
+++ b/internal/restapi/arrivals_and_departures_for_stop_handler_test.go
@@ -707,6 +707,10 @@ func setupDelayPropTestData(t *testing.T, api *RestAPI, stopSeq int64) (stopCode
 	combinedStopID = utils.FormCombinedID(agencyID, stopCode)
 	serviceMidnight := time.Date(2010, 1, 1, 0, 0, 0, 0, time.UTC)
 	scheduledArrivalMs = serviceMidnight.Add(time.Duration(arrivalNanos)).UnixMilli()
+
+	// Clear the service-IDs cache so the upcoming request sees the newly inserted
+	// calendar entry rather than a result cached by an earlier test in this package.
+	api.GtfsManager.MockClearServiceIDsCache()
 	return
 }
 
@@ -1166,6 +1170,10 @@ func TestPluralArrivals_TripUpdateWithoutVehicle(t *testing.T) {
 		DepartureTime: 29400 * 1e9, // 08:10:00 in nanoseconds
 	})
 	require.NoError(t, err)
+
+	// Clear the service-IDs cache so the upcoming request sees the newly inserted
+	// calendar entry rather than a result cached by an earlier test in this package.
+	api.GtfsManager.MockClearServiceIDsCache()
 
 	// Add a trip update WITHOUT any vehicle position.
 	delayDuration := 120 * time.Second

--- a/internal/restapi/schedule_for_route_handler.go
+++ b/internal/restapi/schedule_for_route_handler.go
@@ -70,7 +70,7 @@ func (api *RestAPI) scheduleForRouteHandler(w http.ResponseWriter, r *http.Reque
 		scheduleDate = startOfDay.UnixMilli()
 	}
 
-	serviceIDs, err := api.GtfsManager.GtfsDB.Queries.GetActiveServiceIDsForDate(ctx, targetDate)
+	serviceIDs, err := api.GtfsManager.GetActiveServiceIDsForDateCached(ctx, targetDate)
 	if err != nil {
 		api.serverErrorResponse(w, r, err)
 		return

--- a/internal/restapi/servicedate_timezone_regression_test.go
+++ b/internal/restapi/servicedate_timezone_regression_test.go
@@ -227,6 +227,9 @@ func TestServiceDateTimezoneRegression_BlockTripSequence(t *testing.T) {
 			defer api.Shutdown()
 
 			setupTzTestGTFS(t, api.GtfsManager.GtfsDB.Queries, td, days)
+			// Clear the service-IDs cache so the request below sees the newly
+			// inserted calendar entry rather than a result cached by an earlier test.
+			api.GtfsManager.MockClearServiceIDsCache()
 
 			combinedTrip := utils.FormCombinedID(td.AgencyID, td.TripID2)
 			endpoint := fmt.Sprintf(

--- a/internal/restapi/stops_for_location_handler.go
+++ b/internal/restapi/stops_for_location_handler.go
@@ -145,7 +145,7 @@ func (api *RestAPI) stopsForLocationHandler(w http.ResponseWriter, r *http.Reque
 
 	// Get active service IDs for the requested queryTime
 	currentDate := queryTime.Format("20060102")
-	activeServiceIDs, err := api.GtfsManager.GtfsDB.Queries.GetActiveServiceIDsForDate(ctx, currentDate)
+	activeServiceIDs, err := api.GtfsManager.GetActiveServiceIDsForDateCached(ctx, currentDate)
 	if err != nil {
 		api.serverErrorResponse(w, r, err)
 		return

--- a/internal/restapi/stops_for_route_handler.go
+++ b/internal/restapi/stops_for_route_handler.go
@@ -83,7 +83,7 @@ func (api *RestAPI) stopsForRouteHandler(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	serviceIDs, err := api.GtfsManager.GtfsDB.Queries.GetActiveServiceIDsForDate(ctx, formattedDate)
+	serviceIDs, err := api.GtfsManager.GetActiveServiceIDsForDateCached(ctx, formattedDate)
 	if err != nil {
 		api.serverErrorResponse(w, r, err)
 		return

--- a/internal/restapi/trips_for_location_handler.go
+++ b/internal/restapi/trips_for_location_handler.go
@@ -296,7 +296,7 @@ func (api *RestAPI) buildTripsForLocationEntries(
 			}
 
 			dateStr := serviceDate.Format("20060102")
-			activeServiceIDs, err := api.GtfsManager.GtfsDB.Queries.GetActiveServiceIDsForDate(ctx, dateStr)
+			activeServiceIDs, err := api.GtfsManager.GetActiveServiceIDsForDateCached(ctx, dateStr)
 			if err != nil {
 				activeServiceIDs = []string{}
 				api.Logger.Warn("failed to fetch active service IDs for block logic", "error", err)

--- a/internal/restapi/trips_for_route_handler.go
+++ b/internal/restapi/trips_for_route_handler.go
@@ -52,7 +52,7 @@ func (api *RestAPI) tripsForRouteHandler(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	serviceIDs, err := api.GtfsManager.GtfsDB.Queries.GetActiveServiceIDsForDate(ctx, formattedDate)
+	serviceIDs, err := api.GtfsManager.GetActiveServiceIDsForDateCached(ctx, formattedDate)
 	if err != nil {
 		api.serverErrorResponse(w, r, err)
 		return

--- a/internal/restapi/trips_helper.go
+++ b/internal/restapi/trips_helper.go
@@ -525,7 +525,7 @@ func (api *RestAPI) calculateBlockTripSequence(ctx context.Context, tripID strin
 	}
 
 	formattedDate := serviceDate.Format("20060102")
-	activeServiceIDs, err := api.GtfsManager.GtfsDB.Queries.GetActiveServiceIDsForDate(ctx, formattedDate)
+	activeServiceIDs, err := api.GtfsManager.GetActiveServiceIDsForDateCached(ctx, formattedDate)
 	if err != nil {
 		slog.Warn("calculateBlockTripSequence: failed to get active service IDs",
 			slog.String("trip_id", tripID),


### PR DESCRIPTION
Closes #742

## What this does

`GetActiveServiceIDsForDate` runs a calendar CTE query on every request that needs active service IDs — arrivals, trips for route, stops for route, schedule, and more. With 8 call sites all hitting the DB independently, the same query executes multiple times per request for the same date.

Since GTFS calendar data only changes on a feed reload, the result is safe to cache in memory keyed by `"YYYYMMDD"` date string. This PR adds that cache on `*Manager`, migrates all 8 call sites to the cached path, and invalidates the cache on every `ForceUpdate`.

## Implementation

- **Cache**: `map[string][]string` on `*Manager`, protected by `activeServiceIDsCacheMutex` (RWMutex)
- **Invalidation**: cache cleared and epoch incremented on every `ForceUpdate` (GTFS reload)
- **Epoch guard**: atomic `cacheEpoch` counter prevents stale writes if `ForceUpdate` swaps the DB while a query is in-flight
- **Race safety**: `GtfsDB` read under `staticMutex.RLock` to avoid a data race with `ForceUpdate`
- **Defensive copy**: returned slices are copies so callers cannot silently corrupt the cache
- **Call sites migrated**: 7 REST API handlers + 1 internal call in `gtfs_manager.go`

## Benchmark (Apple M4)

| | ns/op | B/op | allocs/op |
|---|---|---|---|
| `uncached` (DB round-trip) | 31,878 | 744 | 27 |
| `cached` (memory hit) | 18.61 | 32 | 1 |

Cache hit is **~1,712× faster** with **27× fewer allocations**. Since `GetActiveServiceIDsForDate` is called on every arrivals/trips/stops/schedule request, this reduces per-request latency and GC pressure noticeably under load.

---

> **Note on test coverage:** This PR includes extended test coverage for the cache (nil DB guard, defensive-copy mutation safety, empty date handling, mock epoch assertion, and a concurrent-error-with-readers scenario) beyond the core four tests (invalidation, error path, race detector, concurrent ForceUpdate). Happy to trim to just the essentials if you'd prefer a leaner test suite — let me know.