### PR TITLE
Use simplelru.LRU for rate limiter cache to eliminate double-locking

### DIFF
--- a/internal/restapi/arrivals_and_departures_for_stop_handler_test.go
+++ b/internal/restapi/arrivals_and_departures_for_stop_handler_test.go
@@ -1233,6 +1233,9 @@ func TestArrivalsAndDeparturesForStop_VehicleWithNilID(t *testing.T) {
 	defer api.Shutdown()
 	t.Cleanup(api.GtfsManager.MockResetRealTimeData)
 
+	// Clear the service-IDs cache so the request sees the newly inserted calendar entry
+	api.GtfsManager.MockClearServiceIDsCache()
+
 	ctx := context.Background()
 	queries := api.GtfsManager.GtfsDB.Queries
 

--- a/internal/restapi/rate_limit_cleanup_test.go
+++ b/internal/restapi/rate_limit_cleanup_test.go
@@ -81,7 +81,9 @@ func TestRateLimitMiddleware_LazyEvictionResetsExhaustedLimiters(t *testing.T) {
 	assert.Equal(t, http.StatusTooManyRequests, w.Code)
 
 	// Capture the exhausted limiter
+	middleware.mu.Lock()
 	client, ok := middleware.limiters.Get("exhausted-user")
+	middleware.mu.Unlock()
 	require.True(t, ok)
 	exhaustedLimiter := client.limiter
 	assert.Less(t, exhaustedLimiter.Tokens(), 1.0,
@@ -98,7 +100,9 @@ func TestRateLimitMiddleware_LazyEvictionResetsExhaustedLimiters(t *testing.T) {
 		"Request after lazy eviction of exhausted limiter should succeed")
 
 	// Verify a new limiter was created
+	middleware.mu.Lock()
 	client, ok = middleware.limiters.Get("exhausted-user")
+	middleware.mu.Unlock()
 	require.True(t, ok)
 	assert.NotSame(t, exhaustedLimiter, client.limiter,
 		"Should have received a fresh limiter after idle threshold")
@@ -114,11 +118,14 @@ func TestRateLimitMiddleware_LRUEviction(t *testing.T) {
 	for i := 0; i < maxLRUSize; i++ {
 		middleware.getLimiter(fmt.Sprintf("key-%d", i))
 	}
+	middleware.mu.Lock()
 	assert.Equal(t, maxLRUSize, middleware.limiters.Len(),
 		"Cache should be at capacity")
+	middleware.mu.Unlock()
 
 	// Adding one more should evict the oldest (key-0)
 	middleware.getLimiter("overflow-key")
+	middleware.mu.Lock()
 	assert.Equal(t, maxLRUSize, middleware.limiters.Len(),
 		"Cache should not exceed capacity")
 
@@ -132,6 +139,7 @@ func TestRateLimitMiddleware_LRUEviction(t *testing.T) {
 
 	_, ok = middleware.limiters.Get(fmt.Sprintf("key-%d", maxLRUSize-1))
 	assert.True(t, ok, "Recently used key should still exist")
+	middleware.mu.Unlock()
 }
 
 // TestRateLimitMiddleware_LastSeenUpdateOnEveryRequest verifies lastSeen timestamp is updated on each request.
@@ -150,7 +158,9 @@ func TestRateLimitMiddleware_LastSeenUpdateOnEveryRequest(t *testing.T) {
 	w := httptest.NewRecorder()
 	limitedHandler.ServeHTTP(w, req)
 
+	middleware.mu.Lock()
 	client, ok := middleware.limiters.Get("timestamp-test")
+	middleware.mu.Unlock()
 	require.True(t, ok)
 	firstSeenNano := client.lastSeen.Load()
 	firstSeen := time.Unix(0, firstSeenNano)
@@ -163,7 +173,9 @@ func TestRateLimitMiddleware_LastSeenUpdateOnEveryRequest(t *testing.T) {
 	w = httptest.NewRecorder()
 	limitedHandler.ServeHTTP(w, req)
 
+	middleware.mu.Lock()
 	client, ok = middleware.limiters.Get("timestamp-test")
+	middleware.mu.Unlock()
 	require.True(t, ok)
 	secondSeenNano := client.lastSeen.Load()
 	secondSeen := time.Unix(0, secondSeenNano)
@@ -194,10 +206,12 @@ func TestRateLimitMiddleware_ConcurrentGetLimiterReturnsSameInstance(t *testing.
 	wg.Wait()
 
 	// All goroutines should get a valid limiter and the key should exist
-	for i := 0; i < goroutines; i++ {
-		assert.NotNil(t, limiters[i], "All goroutines should get a valid limiter")
+	for i := 1; i < goroutines; i++ {
+		assert.Same(t, limiters[0], limiters[i], "All goroutines should get the same limiter instance")
 	}
 
+	middleware.mu.Lock()
 	_, ok := middleware.limiters.Get("new-key")
+	middleware.mu.Unlock()
 	assert.True(t, ok, "Key should exist in cache after concurrent access")
 }

--- a/internal/restapi/rate_limit_middleware.go
+++ b/internal/restapi/rate_limit_middleware.go
@@ -11,7 +11,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	lru "github.com/hashicorp/golang-lru/v2"
+	"github.com/hashicorp/golang-lru/v2/simplelru"
 	"maglev.onebusaway.org/internal/clock"
 	"maglev.onebusaway.org/internal/logging"
 
@@ -34,7 +34,7 @@ type rateLimitClient struct {
 // RateLimitMiddleware provides per-API-key rate limiting using an LRU cache with lazy eviction.
 type RateLimitMiddleware struct {
 	mu         sync.Mutex
-	limiters   *lru.Cache[string, *rateLimitClient]
+	limiters   *simplelru.LRU[string, *rateLimitClient]
 	rateLimit  rate.Limit
 	burstSize  int
 	exemptKeys map[string]bool
@@ -64,7 +64,7 @@ func NewRateLimitMiddleware(ratePerSecond int, interval time.Duration, exemptKey
 		}
 	}
 
-	cache, _ := lru.New[string, *rateLimitClient](maxLRUSize)
+	cache, _ := simplelru.NewLRU[string, *rateLimitClient](maxLRUSize, nil)
 
 	middleware := &RateLimitMiddleware{
 		limiters:   cache,


### PR DESCRIPTION
## Summary

This PR replaces the use of `lru.Cache[string, *rateLimitClient]` with `simplelru.LRU[string, *rateLimitClient]` for the per-key rate limiter cache in the REST API middleware. This change eliminates unnecessary double-locking—previously, `getLimiter()` acquired an external `sync.Mutex` and `lru.Cache` acquired an internal `sync.RWMutex`, causing contention on the hot path for every API request.

## Details

- Uses `simplelru.LRU` from `github.com/hashicorp/golang-lru/v2/simplelru`, which is not thread-safe, so the external `sync.Mutex` now provides the only lock.
- Cache creation uses `simplelru.NewLRU[K, V](size, nil)`; no eviction callback is used as no resource cleanup is needed.
- All usages of `.Get()`, `.Add()`, and `.Purge()` are updated to the `simplelru.LRU` API.
- The rest of the API (`rateLimitClient`, limiter accounting, lazy eviction) is unchanged.

## Impact

- Every API request now acquires a single lock instead of two.
- Reduces serialization and contention under high concurrency.
- Fix originated from feedback on #749 and #722.

## Testing

- Existing tests pass.
- No change to public API or observable rate limiting behavior.

Closes #749
Follow-up to #722

The CI is failing due to other reason, which is fixed in the PR #754 