### PR TITLE
Fix/block sequence fallback

### DIFF
--- a/internal/restapi/arrivals_and_departures_for_stop_handler_test.go
+++ b/internal/restapi/arrivals_and_departures_for_stop_handler_test.go
@@ -1232,6 +1232,7 @@ func TestArrivalsAndDeparturesForStop_VehicleWithNilID(t *testing.T) {
 	api := createTestApiWithClock(t, mockClock)
 	defer api.Shutdown()
 	t.Cleanup(api.GtfsManager.MockResetRealTimeData)
+	t.Cleanup(api.GtfsManager.MockClearServiceIDsCache)
 
 	ctx := context.Background()
 	queries := api.GtfsManager.GtfsDB.Queries
@@ -1279,6 +1280,10 @@ func TestArrivalsAndDeparturesForStop_VehicleWithNilID(t *testing.T) {
 		EndDate:   "20301231",
 	})
 	require.NoError(t, err)
+
+	// Clear the service-IDs cache so the upcoming request sees the newly inserted
+	// calendar entry rather than a result cached by an earlier test in this package.
+	api.GtfsManager.MockClearServiceIDsCache()
 
 	_, err = queries.CreateTrip(ctx, gtfsdb.CreateTripParams{
 		ID:        tripID,

--- a/internal/restapi/arrivals_and_departures_for_stop_handler_test.go
+++ b/internal/restapi/arrivals_and_departures_for_stop_handler_test.go
@@ -462,6 +462,7 @@ func TestArrivalsAndDeparturesForStopHandler_MultiAgency_Regression(t *testing.T
 
 	api := createTestApiWithClock(t, mockClock)
 	defer api.Shutdown()
+	t.Cleanup(api.GtfsManager.MockClearServiceIDsCache)
 
 	ctx := context.Background()
 	queries := api.GtfsManager.GtfsDB.Queries
@@ -534,6 +535,10 @@ func TestArrivalsAndDeparturesForStopHandler_MultiAgency_Regression(t *testing.T
 		DepartureTime: 29100 * 1e9, // 08:05:00 converted to nanoseconds
 	})
 	require.NoError(t, err)
+
+	// Clear the service-IDs cache so the upcoming request sees the newly inserted
+	// calendar entry rather than a result cached by an earlier test in this package.
+	api.GtfsManager.MockClearServiceIDsCache()
 
 	combinedStopID := utils.FormCombinedID(agencyA, stopID)
 

--- a/internal/restapi/block_sequence_helper.go
+++ b/internal/restapi/block_sequence_helper.go
@@ -17,7 +17,7 @@ func (api *RestAPI) getBlockSequenceForStopSequence(ctx context.Context, tripID 
 
 	blockTrips, err := api.GtfsManager.GtfsDB.Queries.GetTripsByBlockID(ctx, blockID)
 	if err != nil {
-		return 0
+		return stopSequence
 	}
 
 	type TripWithDetails struct {


### PR DESCRIPTION
## 1. SUMMARY

Fixes a bug where the function returned `0` on DB error instead of the given `stopSequence`.
Keeps fallback behavior consistent.

---

## 2. FIX


```go
// before
if err != nil {
    return 0
}

// after
if err != nil {
    return stopSequence
}
```

---

## 3. VERIFICATION

* Simulate DB error
* Call function

**Result:** returns `stopSequence` (not `0`)
