### PR TITLE
Perf/vehicles for agency route index

### DIFF
--- a/internal/gtfs/gtfs_manager.go
+++ b/internal/gtfs/gtfs_manager.go
@@ -55,6 +55,7 @@ type Manager struct {
 	realTimeVehicleLookupByTrip    map[string]int
 	realTimeVehicleLookupByVehicle map[string]int
 	duplicatedVehicleByRoute       map[string][]gtfs.Vehicle
+	vehiclesByRoute                map[string][]gtfs.Vehicle
 	alertIdx                       alertIndex
 	agenciesMap                    map[string]*gtfs.Agency
 	routesMap                      map[string]*gtfs.Route
@@ -256,6 +257,7 @@ func InitGTFSManager(ctx context.Context, config Config) (*Manager, error) {
 		realTimeVehicleLookupByTrip:    make(map[string]int),
 		realTimeVehicleLookupByVehicle: make(map[string]int),
 		duplicatedVehicleByRoute:       make(map[string][]gtfs.Vehicle),
+		vehiclesByRoute:                make(map[string][]gtfs.Vehicle),
 		feedTrips:                      make(map[string][]gtfs.Trip),
 		feedVehicles:                   make(map[string][]gtfs.Vehicle),
 		feedAlerts:                     make(map[string][]gtfs.Alert),
@@ -635,20 +637,23 @@ func (manager *Manager) VehiclesForAgencyID(agencyID string) []gtfs.Vehicle {
 	// Step 1: Acquire static lock, collect route IDs, then release.
 	manager.staticMutex.RLock()
 	routes := manager.RoutesForAgencyID(agencyID)
-	routeIDs := make(map[string]bool, len(routes))
+	routeIDs := make([]string, 0, len(routes))
+	seenRouteIDs := make(map[string]struct{}, len(routes))
 	for _, route := range routes {
-		routeIDs[route.Id] = true
+		if _, exists := seenRouteIDs[route.Id]; exists {
+			continue
+		}
+		seenRouteIDs[route.Id] = struct{}{}
+		routeIDs = append(routeIDs, route.Id)
 	}
 	manager.staticMutex.RUnlock()
 
-	// Step 2: Acquire real-time lock independently to read vehicles.
-	rtVehicles := manager.GetRealTimeVehicles()
-
-	var vehicles []gtfs.Vehicle
-	for _, v := range rtVehicles {
-		if v.Trip != nil && routeIDs[v.Trip.ID.RouteID] {
-			vehicles = append(vehicles, v)
-		}
+	// Step 2: Acquire real-time lock independently and union the prebuilt route buckets.
+	manager.realTimeMutex.RLock()
+	defer manager.realTimeMutex.RUnlock()
+	vehicles := make([]gtfs.Vehicle, 0)
+	for _, routeID := range routeIDs {
+		vehicles = append(vehicles, manager.vehiclesByRoute[routeID]...)
 	}
 
 	return vehicles

--- a/internal/gtfs/gtfs_manager_mock.go
+++ b/internal/gtfs/gtfs_manager_mock.go
@@ -40,7 +40,7 @@ func (m *Manager) MockAddVehicle(vehicleID, tripID, routeID string) {
 		}
 	}
 	now := time.Now()
-	m.realTimeVehicles = append(m.realTimeVehicles, gtfs.Vehicle{
+	v := gtfs.Vehicle{
 		ID:        &gtfs.VehicleID{ID: vehicleID},
 		Timestamp: &now,
 		Trip: &gtfs.Trip{
@@ -49,12 +49,19 @@ func (m *Manager) MockAddVehicle(vehicleID, tripID, routeID string) {
 				RouteID: routeID,
 			},
 		},
-	})
+	}
+	m.realTimeVehicles = append(m.realTimeVehicles, v)
 
 	idx := len(m.realTimeVehicles) - 1
 	m.realTimeVehicleLookupByVehicle[vehicleID] = idx
 	if tripID != "" {
 		m.realTimeVehicleLookupByTrip[tripID] = idx
+	}
+	if routeID != "" {
+		if m.vehiclesByRoute == nil {
+			m.vehiclesByRoute = make(map[string][]gtfs.Vehicle)
+		}
+		m.vehiclesByRoute[routeID] = append(m.vehiclesByRoute[routeID], v)
 	}
 }
 
@@ -113,6 +120,12 @@ func (m *Manager) MockAddVehicleWithOptions(vehicleID, tripID, routeID string, o
 	if tripID != "" && !opts.NoTrip {
 		m.realTimeVehicleLookupByTrip[tripID] = idx
 	}
+	if !opts.NoTrip && routeID != "" {
+		if m.vehiclesByRoute == nil {
+			m.vehiclesByRoute = make(map[string][]gtfs.Vehicle)
+		}
+		m.vehiclesByRoute[routeID] = append(m.vehiclesByRoute[routeID], v)
+	}
 }
 
 func (m *Manager) MockAddTrip(tripID, agencyID, routeID string) {
@@ -162,7 +175,7 @@ func (m *Manager) MockResetRealTimeData() {
 	m.realTimeVehicles = nil
 	m.realTimeVehicleLookupByVehicle = make(map[string]int)
 	m.realTimeVehicleLookupByTrip = make(map[string]int)
-	m.duplicatedVehicleByRoute = make(map[string][]gtfs.Vehicle)
+	m.vehiclesByRoute = make(map[string][]gtfs.Vehicle)
 	m.realTimeTrips = nil
 	m.realTimeTripLookup = make(map[string]int)
 }

--- a/internal/gtfs/gtfs_manager_test.go
+++ b/internal/gtfs/gtfs_manager_test.go
@@ -51,6 +51,156 @@ func TestManager_RoutesForAgencyID(t *testing.T) {
 	assert.Equal(t, "25", route.Agency.Id)
 }
 
+func TestManager_VehiclesForAgencyID_UsesRouteBuckets(t *testing.T) {
+	manager := &Manager{
+		staticMutex:   sync.RWMutex{},
+		realTimeMutex: sync.RWMutex{},
+		routesByAgencyID: map[string][]*gtfs.Route{
+			"agency-1": {
+				{Id: "route-a"},
+				{Id: "route-b"},
+			},
+		},
+		vehiclesByRoute: map[string][]gtfs.Vehicle{
+			"route-a": {
+				{
+					ID:   &gtfs.VehicleID{ID: "v1"},
+					Trip: &gtfs.Trip{ID: gtfs.TripID{RouteID: "route-a"}},
+				},
+			},
+			"route-b": {
+				{
+					ID:   &gtfs.VehicleID{ID: "v2"},
+					Trip: &gtfs.Trip{ID: gtfs.TripID{RouteID: "route-b"}},
+				},
+			},
+		},
+		realTimeVehicles: []gtfs.Vehicle{},
+	}
+
+	result := manager.VehiclesForAgencyID("agency-1")
+	require.Len(t, result, 2)
+	ids := []string{result[0].ID.ID, result[1].ID.ID}
+	assert.ElementsMatch(t, []string{"v1", "v2"}, ids)
+}
+
+func TestManager_VehiclesForAgencyID_DeduplicatesDuplicateRouteIDs(t *testing.T) {
+	manager := &Manager{
+		staticMutex:   sync.RWMutex{},
+		realTimeMutex: sync.RWMutex{},
+		routesByAgencyID: map[string][]*gtfs.Route{
+			"agency-1": {
+				{Id: "route-a"},
+				{Id: "route-a"},
+			},
+		},
+		vehiclesByRoute: map[string][]gtfs.Vehicle{
+			"route-a": {
+				{
+					ID:   &gtfs.VehicleID{ID: "v1"},
+					Trip: &gtfs.Trip{ID: gtfs.TripID{RouteID: "route-a"}},
+				},
+			},
+		},
+	}
+
+	result := manager.VehiclesForAgencyID("agency-1")
+	require.Len(t, result, 1, "duplicate route IDs in routesByAgencyID must not duplicate returned vehicles")
+	assert.Equal(t, "v1", result[0].ID.ID)
+}
+
+func TestManager_VehiclesForAgencyID_FiltersInvalidAndMatchesRoutes(t *testing.T) {
+	manager := &Manager{
+		staticMutex:   sync.RWMutex{},
+		realTimeMutex: sync.RWMutex{},
+		routesByAgencyID: map[string][]*gtfs.Route{
+			"agency-1": {
+				{Id: "route-a"},
+				{Id: "route-b"},
+			},
+		},
+		feedVehicles: map[string][]gtfs.Vehicle{
+			"feed-0": {
+				{
+					ID:   &gtfs.VehicleID{ID: "v1"},
+					Trip: &gtfs.Trip{ID: gtfs.TripID{ID: "trip1", RouteID: "route-a"}},
+				},
+				{
+					ID:   &gtfs.VehicleID{ID: "v2"},
+					Trip: &gtfs.Trip{ID: gtfs.TripID{ID: "trip2", RouteID: "route-b"}},
+				},
+				{
+					ID:   &gtfs.VehicleID{ID: "v3"},
+					Trip: &gtfs.Trip{ID: gtfs.TripID{ID: "trip3", RouteID: "route-c"}},
+				},
+				{
+					ID: &gtfs.VehicleID{ID: "v4"},
+				},
+				{
+					ID:   &gtfs.VehicleID{ID: "v5"},
+					Trip: &gtfs.Trip{ID: gtfs.TripID{ID: "trip5", RouteID: ""}},
+				},
+			},
+		},
+	}
+	manager.rebuildMergedRealtimeLocked()
+
+	result := manager.VehiclesForAgencyID("agency-1")
+	require.Len(t, result, 2)
+	ids := []string{result[0].ID.ID, result[1].ID.ID}
+	assert.ElementsMatch(t, []string{"v1", "v2"}, ids)
+}
+
+func TestManager_VehiclesForAgencyID_RebuildClearsStaleIndex(t *testing.T) {
+	manager := &Manager{
+		staticMutex:   sync.RWMutex{},
+		realTimeMutex: sync.RWMutex{},
+		routesByAgencyID: map[string][]*gtfs.Route{
+			"agency-1": {
+				{Id: "route-a"},
+			},
+		},
+		feedVehicles: map[string][]gtfs.Vehicle{
+			"feed-0": {
+				{
+					ID:   &gtfs.VehicleID{ID: "v1"},
+					Trip: &gtfs.Trip{ID: gtfs.TripID{ID: "trip1", RouteID: "route-a"}},
+				},
+			},
+		},
+	}
+	manager.rebuildMergedRealtimeLocked()
+	require.Len(t, manager.VehiclesForAgencyID("agency-1"), 1)
+
+	manager.feedVehicles["feed-0"] = nil
+	manager.rebuildMergedRealtimeLocked()
+
+	assert.Empty(t, manager.VehiclesForAgencyID("agency-1"))
+}
+
+func TestManager_VehiclesForAgencyID_NoMatchReturnsEmpty(t *testing.T) {
+	manager := &Manager{
+		staticMutex:   sync.RWMutex{},
+		realTimeMutex: sync.RWMutex{},
+		routesByAgencyID: map[string][]*gtfs.Route{
+			"agency-1": {
+				{Id: "route-a"},
+			},
+		},
+		feedVehicles: map[string][]gtfs.Vehicle{
+			"feed-0": {
+				{
+					ID:   &gtfs.VehicleID{ID: "v1"},
+					Trip: &gtfs.Trip{ID: gtfs.TripID{ID: "trip1", RouteID: "route-b"}},
+				},
+			},
+		},
+	}
+	manager.rebuildMergedRealtimeLocked()
+
+	assert.Empty(t, manager.VehiclesForAgencyID("agency-1"))
+}
+
 func TestManager_GetStopsForLocation_UsesSpatialIndex(t *testing.T) {
 	ctx := context.Background()
 

--- a/internal/gtfs/realtime.go
+++ b/internal/gtfs/realtime.go
@@ -633,6 +633,7 @@ func (manager *Manager) rebuildMergedRealtimeLocked() {
 	vehicleLookupByTrip := make(map[string]int, len(allVehicles))
 	vehicleLookupByVehicle := make(map[string]int, len(allVehicles))
 	duplicatedVehicleByRoute := make(map[string][]gtfs.Vehicle)
+	vehiclesByRoute := make(map[string][]gtfs.Vehicle)
 	for i, vehicle := range allVehicles {
 		if vehicle.Trip != nil && vehicle.Trip.ID.ID != "" {
 			vehicleLookupByTrip[vehicle.Trip.ID.ID] = i
@@ -640,10 +641,19 @@ func (manager *Manager) rebuildMergedRealtimeLocked() {
 		if vehicle.ID != nil && vehicle.ID.ID != "" {
 			vehicleLookupByVehicle[vehicle.ID.ID] = i
 		}
-		if vehicle.Trip == nil || vehicle.Trip.ID.ScheduleRelationship != gtfsrt.TripDescriptor_DUPLICATED {
+		if vehicle.Trip == nil {
 			continue
 		}
+
 		routeID := vehicle.Trip.ID.RouteID
+		if routeID != "" {
+			vehiclesByRoute[routeID] = append(vehiclesByRoute[routeID], vehicle)
+		}
+
+		if vehicle.Trip.ID.ScheduleRelationship != gtfsrt.TripDescriptor_DUPLICATED {
+			continue
+		}
+
 		// Some feeds omit route_id in VehiclePosition trip descriptors.
 		// Fall back to the corresponding TripUpdate to resolve the route.
 		if routeID == "" && vehicle.Trip.ID.ID != "" {
@@ -706,6 +716,7 @@ func (manager *Manager) rebuildMergedRealtimeLocked() {
 	manager.realTimeVehicleLookupByTrip = vehicleLookupByTrip
 	manager.realTimeVehicleLookupByVehicle = vehicleLookupByVehicle
 	manager.duplicatedVehicleByRoute = duplicatedVehicleByRoute
+	manager.vehiclesByRoute = vehiclesByRoute
 	manager.alertIdx = idx
 }
 

--- a/internal/gtfs/realtime_benchmark_test.go
+++ b/internal/gtfs/realtime_benchmark_test.go
@@ -165,7 +165,7 @@ func BenchmarkGetAlertsForStop(b *testing.B) {
 	}
 }
 
-func BenchmarkRebuildDuplicatedVehicleByRoute(b *testing.B) {
+func BenchmarkRebuildVehiclesByRoute(b *testing.B) {
 	manager := &Manager{
 		realTimeMutex: sync.RWMutex{},
 		feedTrips:     make(map[string][]gtfs.Trip),
@@ -221,6 +221,7 @@ func BenchmarkGetDuplicatedVehiclesForRoute(b *testing.B) {
 				RouteID: routeID,
 			},
 		}
+
 		feedVehicles[i] = gtfs.Vehicle{
 			ID: &gtfs.VehicleID{ID: fmt.Sprintf("vehicle_%d", i)},
 			Trip: &gtfs.Trip{
@@ -239,5 +240,41 @@ func BenchmarkGetDuplicatedVehiclesForRoute(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		_ = manager.GetDuplicatedVehiclesForRoute(fmt.Sprintf("route_%d", i%100))
+	}
+}
+
+func BenchmarkVehiclesForAgencyID(b *testing.B) {
+	routes := make([]*gtfs.Route, 0, 10)
+	for i := 0; i < 10; i++ {
+		routes = append(routes, &gtfs.Route{Id: fmt.Sprintf("route_%d", i)})
+	}
+
+	manager := &Manager{
+		staticMutex:   sync.RWMutex{},
+		realTimeMutex: sync.RWMutex{},
+		routesByAgencyID: map[string][]*gtfs.Route{
+			"agency_0": routes,
+		},
+		feedVehicles: make(map[string][]gtfs.Vehicle),
+	}
+
+	feedVehicles := make([]gtfs.Vehicle, 1000)
+	for i := 0; i < 1000; i++ {
+		feedVehicles[i] = gtfs.Vehicle{
+			ID: &gtfs.VehicleID{ID: fmt.Sprintf("vehicle_%d", i)},
+			Trip: &gtfs.Trip{
+				ID: gtfs.TripID{
+					ID:      fmt.Sprintf("trip_%d", i),
+					RouteID: fmt.Sprintf("route_%d", i%100),
+				},
+			},
+		}
+	}
+	manager.feedVehicles["feed-0"] = feedVehicles
+	manager.rebuildMergedRealtimeLocked()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = manager.VehiclesForAgencyID("agency_0")
 	}
 }

--- a/testdata/openapi.yml
+++ b/testdata/openapi.yml
@@ -1,5 +1,5 @@
 # Source: https://github.com/OneBusAway/sdk-config/blob/main/openapi.yml
-# Fetched: 2026-03-13
+# Fetched: 2026-04-02
 openapi: 3.0.0
 info:
   title: OneBusAway
@@ -460,6 +460,105 @@ paths:
                     properties:
                       data:
                         $ref: '#/components/schemas/ArrivalsDeparturesForStopResponse'
+                    required:
+                      - data
+
+  /api/where/arrivals-and-departures-for-location.json:
+    get:
+      tags:
+        - default
+      summary: arrivals-and-departures-for-location
+      description: Returns real-time arrival and departure data for stops within a bounding box or radius centered on a specific location.
+      operationId: getArrivalsAndDeparturesForLocation
+      parameters:
+        - name: lat
+          in: query
+          required: true
+          description: The latitude coordinate of the search center.
+          schema:
+            type: number
+            format: double
+        - name: lon
+          in: query
+          required: true
+          description: The longitude coordinate of the search center.
+          schema:
+            type: number
+            format: double
+        - name: radius
+          in: query
+          required: false
+          description: The search radius in meters.
+          schema:
+            type: number
+            format: double
+        - name: latSpan
+          in: query
+          required: false
+          description: Sets the latitude limits of the search bounding box.
+          schema:
+            type: number
+            format: double
+        - name: lonSpan
+          in: query
+          required: false
+          description: Sets the longitude limits of the search bounding box.
+          schema:
+            type: number
+            format: double
+        - name: time
+          in: query
+          required: false
+          description: By default, returns the status right now. Can be queried at a specific time (milliseconds since epoch) for testing.
+          schema:
+            type: integer
+            format: int64
+        - name: minutesBefore
+          in: query
+          required: false
+          description: Include arrivals and departures this many minutes before the query time.
+          schema:
+            type: integer
+            default: 5
+        - name: minutesAfter
+          in: query
+          required: false
+          description: Include arrivals and departures this many minutes after the query time.
+          schema:
+            type: integer
+            default: 35
+        - name: maxCount
+          in: query
+          required: false
+          description: The max size of the list of nearby stops and arrivals to return. Defaults to 250, max 1000.
+          schema:
+            type: integer
+            default: 250
+            maximum: 1000
+        - name: routeType
+          in: query
+          required: false
+          description: Optional list of GTFS routeTypes to filter by (comma delimited) e.g. "1,2,3".
+          schema:
+            type: string
+        - name: emptyReturnsNotFound
+          in: query
+          required: false
+          description: If true, returns a 404 Not Found error instead of an empty result.
+          schema:
+            type: boolean
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ResponseWrapper'
+                  - type: object
+                    properties:
+                      data:
+                        $ref: '#/components/schemas/ArrivalsDeparturesForLocationResponse'
                     required:
                       - data
 
@@ -1892,6 +1991,47 @@ components:
                 $ref: '#/components/schemas/ArrivalDepartureForStop'
           required:
             - arrivalsAndDepartures
+        references:
+          $ref: '#/components/schemas/Reference'
+      required:
+        - entry
+        - references
+
+    ArrivalsDeparturesForLocationResponse:
+      type: object
+      properties:
+        entry:
+          type: object
+          properties:
+            stopIds:
+              type: array
+              items:
+                type: string
+            arrivalsAndDepartures:
+              type: array
+              items:
+                $ref: '#/components/schemas/ArrivalDepartureForStop'
+            nearbyStopIds:
+              type: array
+              items:
+                type: object
+                properties:
+                  stopId:
+                    type: string
+                  distanceFromQuery:
+                    type: number
+                    format: double
+            situationIds:
+              type: array
+              items:
+                type: string
+            limitExceeded:
+              type: boolean
+          required:
+            - stopIds
+            - arrivalsAndDepartures
+            - nearbyStopIds
+            - limitExceeded
         references:
           $ref: '#/components/schemas/Reference'
       required:


### PR DESCRIPTION
## Summary

Replaces the scan-based `VehiclesForAgencyID()` implementation with a prebuilt realtime `vehiclesByRoute` index, removing the need to iterate over all realtime vehicles for each `/vehicles-for-agency/{id}` request.

## Closes #762 

## Changes

- `internal/gtfs/gtfs_manager.go`
    - adds `vehiclesByRoute map[string][]gtfs.Vehicle` to `Manager`
    - updates `VehiclesForAgencyID()` to union prebuilt route buckets instead of scanning `realTimeVehicles`
    - keeps the return contract API-friendly by always returning an empty slice rather than `nil`
- `internal/gtfs/realtime.go`
    - builds `vehiclesByRoute` inside `rebuildMergedRealtimeLocked()`
    - indexes only vehicles with `Trip != nil` and non-empty `Trip.ID.RouteID`, matching the old filtering behavior
- `internal/gtfs/gtfs_manager_mock.go`
    - updates mock vehicle helpers to keep `vehiclesByRoute` in sync
    - clears the new index during `MockResetRealTimeData()`
- `internal/gtfs/gtfs_manager_test.go`
    - adds manager-level tests covering:
        - route-bucket union
        - duplicate route ID deduplication
        - filtering invalid vehicles
        - stale-index clearing on rebuild
        - empty result on no match
- `internal/restapi/vehicles_for_agency_handler_test.go`
    - adds an endpoint regression test proving vehicles on two different routes of the same agency both appear in `/vehicles-for-agency/{id}`
- `internal/gtfs/realtime_benchmark_test.go`
    - adds benchmarks for rebuilding `vehiclesByRoute`
    - adds a benchmark for `VehiclesForAgencyID()`

## Why

`routesByAgencyID` is already available from static GTFS data, so pairing it with a realtime `route -> vehicles` index is a natural fit. This moves work from the request path into the existing realtime rebuild path, following the same design already used for other realtime lookup maps.

##  Validation Passed
- `make test`