### PR TITLE
fix(test): clear service ID cache in VehicleWithNilID arrivals test

### DIFF
--- a/internal/restapi/arrivals_and_departures_for_stop_handler_test.go
+++ b/internal/restapi/arrivals_and_departures_for_stop_handler_test.go
@@ -1280,6 +1280,10 @@ func TestArrivalsAndDeparturesForStop_VehicleWithNilID(t *testing.T) {
 	})
 	require.NoError(t, err)
 
+	// Clear the service-IDs cache so the upcoming request sees the newly inserted
+	// calendar entry rather than a result cached by an earlier test in this package.
+	api.GtfsManager.MockClearServiceIDsCache()
+
 	_, err = queries.CreateTrip(ctx, gtfsdb.CreateTripParams{
 		ID:        tripID,
 		RouteID:   routeID,


### PR DESCRIPTION
Closes #764 

## Summary

- `TestArrivalsAndDeparturesForStop_VehicleWithNilID` was failing because it inserts its own `nilid_service` calendar entry but never cleared the `GetActiveServiceIDsForDate` in-memory cache.
- When the full `internal/restapi` package runs, an earlier test populates the cache with stale service IDs, so `nilid_service` is never seen as active and the handler returns zero arrivals.
- Added `api.GtfsManager.MockClearServiceIDsCache()` after `CreateCalendar` — the same pattern already used in two other tests in this file.

## Test plan

- [ ] Run the fixed test in isolation: `go test -tags "sqlite_fts5" -count=1 ./internal/restapi/... -run TestArrivalsAndDeparturesForStop_VehicleWithNilID -v`
- [ ] Run the full restapi package fresh: `go test -tags "sqlite_fts5" -count=1 ./internal/restapi/...`
- [ ] Confirm `--- PASS: TestArrivalsAndDeparturesForStop_VehicleWithNilID`

