### PR TITLE
Fix: Return 404 instead of 500 when agency does not exist

### DIFF
--- a/internal/restapi/arrival_and_departure_for_stop_handler.go
+++ b/internal/restapi/arrival_and_departure_for_stop_handler.go
@@ -172,7 +172,11 @@ func (api *RestAPI) arrivalAndDepartureForStopHandler(w http.ResponseWriter, r *
 
 	stopAgency, err := api.GtfsManager.GtfsDB.Queries.GetAgency(ctx, stopAgencyID)
 	if err != nil {
-		api.serverErrorResponse(w, r, err)
+		if errors.Is(err, sql.ErrNoRows) {
+			api.sendNotFound(w, r)
+		} else {
+			api.serverErrorResponse(w, r, err)
+		}
 		return
 	}
 

--- a/internal/restapi/arrivals_and_departure_for_stop.go
+++ b/internal/restapi/arrivals_and_departure_for_stop.go
@@ -2,6 +2,8 @@ package restapi
 
 import (
 	"context"
+	"database/sql"
+	"errors"
 	"log/slog"
 	"net/http"
 	"strconv"
@@ -108,7 +110,11 @@ func (api *RestAPI) arrivalsAndDeparturesForStopHandler(w http.ResponseWriter, r
 
 	agency, err := api.GtfsManager.GtfsDB.Queries.GetAgency(ctx, stopAgencyID)
 	if err != nil {
-		api.serverErrorResponse(w, r, err)
+		if errors.Is(err, sql.ErrNoRows) {
+			api.sendNotFound(w, r)
+		} else {
+			api.serverErrorResponse(w, r, err)
+		}
 		return
 	}
 

--- a/internal/restapi/trip_details_handler.go
+++ b/internal/restapi/trip_details_handler.go
@@ -2,6 +2,8 @@ package restapi
 
 import (
 	"context"
+	"database/sql"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -129,7 +131,11 @@ func (api *RestAPI) tripDetailsHandler(w http.ResponseWriter, r *http.Request) {
 
 	agency, err := api.GtfsManager.GtfsDB.Queries.GetAgency(ctx, route.AgencyID)
 	if err != nil {
-		api.serverErrorResponse(w, r, err)
+		if errors.Is(err, sql.ErrNoRows) {
+			api.sendNotFound(w, r)
+		} else {
+			api.serverErrorResponse(w, r, err)
+		}
 		return
 	}
 

--- a/internal/restapi/trip_for_vehicle_handler.go
+++ b/internal/restapi/trip_for_vehicle_handler.go
@@ -45,7 +45,11 @@ func (api *RestAPI) tripForVehicleHandler(w http.ResponseWriter, r *http.Request
 
 	agency, err := api.GtfsManager.GtfsDB.Queries.GetAgency(ctx, agencyID)
 	if err != nil {
-		api.serverErrorResponse(w, r, err)
+		if errors.Is(err, sql.ErrNoRows) {
+			api.sendNotFound(w, r)
+		} else {
+			api.serverErrorResponse(w, r, err)
+		}
 		return
 	}
 


### PR DESCRIPTION
Handle sql.ErrNoRows explicitly in GetAgency calls across multiple handlers. When an agency is not found, return 404 Not Found instead of 500 Internal Server Error to improve REST API correctness.

Changes:
- Added sql.ErrNoRows check in arrival_and_departure_for_stop_handler
- Added sql.ErrNoRows check in arrivals_and_departure_for_stop
- Added sql.ErrNoRows check in trip_for_vehicle_handler
- Added sql.ErrNoRows check in trip_details_handler
- Added missing imports (database/sql, errors) where needed

Impact:
- Improves REST API correctness for missing resources
- Avoids misleading server error responses
- Aligns with existing test expectations

Fixes #769 