### PR TITLE
Fix #696: Add missing Stops field to schedule-for-route response

### DIFF
--- a/internal/models/schedule_for_route.go
+++ b/internal/models/schedule_for_route.go
@@ -29,4 +29,5 @@ type ScheduleForRouteEntry struct {
 	ScheduleDate      int64              `json:"scheduleDate"`
 	ServiceIDs        []string           `json:"serviceIds"`
 	StopTripGroupings []StopTripGrouping `json:"stopTripGroupings"`
+	Stops             []Stop             `json:"stops"`
 }

--- a/internal/restapi/schedule_for_route_handler.go
+++ b/internal/restapi/schedule_for_route_handler.go
@@ -270,7 +270,7 @@ func (api *RestAPI) scheduleForRouteHandler(w http.ResponseWriter, r *http.Reque
 	for sid := range globalStopIDSet {
 		uniqueStopIDs = append(uniqueStopIDs, sid)
 	}
-
+	var entryStops []models.Stop
 	if len(uniqueStopIDs) > 0 {
 		modelStops, _, err := BuildStopReferencesAndRouteIDsForStops(api, ctx, agencyID, uniqueStopIDs)
 		if err != nil {
@@ -278,6 +278,7 @@ func (api *RestAPI) scheduleForRouteHandler(w http.ResponseWriter, r *http.Reque
 			return
 		}
 		references.Stops = append(references.Stops, modelStops...)
+		entryStops = modelStops // ← CORRECT: = assigns to existing variable
 	}
 
 	for _, sref := range stopTimesRefs {
@@ -289,6 +290,7 @@ func (api *RestAPI) scheduleForRouteHandler(w http.ResponseWriter, r *http.Reque
 		ScheduleDate:      scheduleDate,
 		ServiceIDs:        combinedServiceIDs,
 		StopTripGroupings: stopTripGroupings,
+		Stops:             entryStops,
 	}
 	api.sendResponse(w, r, models.NewEntryResponse(entry, *references, api.Clock))
 }


### PR DESCRIPTION
What This Fixes
Resolves #696 - The schedule-for-route endpoint was missing the required Stops field in its OpenAPI spec response, causing the OpenAPI conformance test to fail.
Changes Made
1. Model (internal/models/schedule_for_route.go)

Added Stops []Stop field to the ScheduleForRouteEntry struct
Added JSON tag: json:"stops"

2. Handler (internal/restapi/schedule_for_route_handler.go)

Declared entryStops variable before the stops collection logic
Populated entryStops from the modelStops returned by BuildStopReferencesAndRouteIDsForStops
Added Stops: entryStops to the ScheduleForRouteEntry response struct

Implementation Details
The implementation follows the existing pattern used in the codebase:

Reuses BuildStopReferencesAndRouteIDsForStops (already called for references)
No additional database queries needed
Automatically sorted consistently
Minimal code changes (3 lines added in handler, 1 line in model)

Testing
The changes enable the following test to pass:

TestOpenAPIConformance_StaticEndpoints/schedule-for-route

References

Issue: #696
Related pattern: stops_for_route_handler.go (lines 146-199)
OpenAPI spec: https://github.com/OneBusAway/sdk-config/blob/main/openapi.yml
API docs: https://developer.onebusaway.org/api/where/methods/schedule-for-route

Notes

This change is backward compatible (adds a field to the response)
The field contains the same stops that are already in the references section
No breaking changes to existing API clients