### PR TITLE
fix: use route.AgencyID for route reference ID in trip handler

### DIFF
--- a/internal/restapi/trip_handler.go
+++ b/internal/restapi/trip_handler.go
@@ -71,7 +71,7 @@ func (api *RestAPI) tripHandler(w http.ResponseWriter, r *http.Request) {
 	references := models.NewEmptyReferences()
 
 	references.Routes = append(references.Routes, models.NewRoute(
-		utils.FormCombinedID(agencyID, trip.RouteID),
+		utils.FormCombinedID(route.AgencyID, trip.RouteID),
 		route.AgencyID,
 		route.ShortName.String,
 		route.LongName.String,


### PR DESCRIPTION
## 1. SUMMARY

This PR fixes inconsistent route reference ID construction in the `tripHandler` by ensuring the combined route ID uses the database-backed `route.AgencyID` instead of the URL-provided `agencyID`. The issue affects `internal/restapi/trip_handler.go` within the route reference creation logic.

This aligns route ID generation with other handlers and ensures internal consistency between `id` and `agencyId` fields.

---

## 2. FIX

```go
// Before (bug)
utils.FormCombinedID(agencyID, trip.RouteID),

// After (fix)
utils.FormCombinedID(route.AgencyID, trip.RouteID),
```

---

## 3. VERIFICATION

Call `/api/where/trip/{id}` using a multi agency dataset where the route’s actual agency differs from the one in the URL. Before the fix, the response contains mismatched values (e.g., `id: "25_routeID"` and `agencyId: "40"`). After the fix, both fields are consistent, and the route reference is correctly formed.
