### PR TITLE
fix: ensure BlockID uses FormCombinedID in trips-for-route response

### DIFF
--- a/internal/restapi/trips_for_route_handler.go
+++ b/internal/restapi/trips_for_route_handler.go
@@ -634,7 +634,7 @@ func buildTripReferences(
 					TripHeadsign:  trip.TripHeadsign,
 					TripShortName: trip.TripShortName,
 					DirectionID:   trip.DirectionID,
-					BlockID:       trip.BlockID,
+					BlockID: utils.FormCombinedID(currentAgency, trip.BlockID),
 					ShapeID:       utils.FormCombinedID(currentAgency, trip.ShapeID),
 					PeakOffPeak:   0,
 					TimeZone:      "",


### PR DESCRIPTION
## 1. SUMMARY

This PR fixes inconsistent ID formatting in the `trips-for-route` endpoint by ensuring `BlockID` follows the `{agencyID}_{codeID}` format. The issue affects `internal/restapi/trips_for_route_handler.go` within the trip reference construction logic.

This aligns `BlockID` handling with other ID fields and with the correct implementation already present in similar modules. 

---

## 2. FIX

```go
// Before (bug)
BlockID: trip.BlockID,

// After (fix)
BlockID: utils.FormCombinedID(currentAgency, trip.BlockID),
```

---

## 3. VERIFICATION 

Call `/api/where/trips-for-route/{routeId}.json` and check `blockId` in the response. Before the fix, it shows a raw value like `BLK001` and fails (404) when used in the block endpoint. After the fix, it’s properly formatted (e.g., `RABA_BLK001`) and works as expected.

