### PR TITLE
fix: propagate context to static GTFS download for proper cancellation

### DIFF
--- a/internal/gtfs/gtfs_manager.go
+++ b/internal/gtfs/gtfs_manager.go
@@ -147,7 +147,7 @@ func InitGTFSManager(ctx context.Context, config Config) (*Manager, error) {
 		attemptsMade = attempt
 		// Attempt to load in-memory static data if we haven't already succeeded
 		if staticData == nil {
-			staticData, err = loadGTFSData(config.GtfsURL, isLocalFile, config)
+			staticData, err = loadGTFSData(ctx, config.GtfsURL, isLocalFile, config)
 			if err != nil {
 				if attempt < maxAttempts {
 					delay := backoffs[attempt-1]

--- a/internal/gtfs/static.go
+++ b/internal/gtfs/static.go
@@ -15,7 +15,7 @@ import (
 	"maglev.onebusaway.org/internal/logging"
 )
 
-func rawGtfsData(source string, isLocalFile bool, config Config) ([]byte, error) {
+func rawGtfsData(ctx context.Context, source string, isLocalFile bool, config Config) ([]byte, error) {
 	var b []byte
 	var err error
 
@@ -27,7 +27,7 @@ func rawGtfsData(source string, isLocalFile bool, config Config) ([]byte, error)
 			return nil, fmt.Errorf("error reading local GTFS file: %w", err)
 		}
 	} else {
-		req, err := http.NewRequest("GET", source, nil)
+		req, err := http.NewRequestWithContext(ctx, "GET", source, nil)
 		if err != nil {
 			return nil, fmt.Errorf("error creating GTFS request: %w", err)
 		}
@@ -121,8 +121,8 @@ func buildGtfsDB(ctx context.Context, config Config, isLocalFile bool, dbPath st
 }
 
 // loadGTFSData loads and parses GTFS data from either a URL or a local file
-func loadGTFSData(source string, isLocalFile bool, config Config) (*gtfs.Static, error) {
-	b, err := rawGtfsData(source, isLocalFile, config)
+func loadGTFSData(ctx context.Context, source string, isLocalFile bool, config Config) (*gtfs.Static, error) {
+	b, err := rawGtfsData(ctx, source, isLocalFile, config)
 	if err != nil {
 		return nil, fmt.Errorf("error reading GTFS data: %w", err)
 	}
@@ -216,7 +216,7 @@ func (manager *Manager) ForceUpdate(ctx context.Context) error {
 
 	logger := slog.Default().With(slog.String("component", "gtfs_updater"))
 
-	newStaticData, err := loadGTFSData(manager.config.GtfsURL, manager.isLocalFile, manager.config)
+	newStaticData, err := loadGTFSData(ctx, manager.config.GtfsURL, manager.isLocalFile, manager.config)
 	if err != nil {
 		logging.LogError(logger, "Error updating GTFS data", err,
 			slog.String("source", manager.config.GtfsURL))


### PR DESCRIPTION
### 1. SUMMARY

This PR fixes non cancellable GTFS static downloads by propagating `context.Context` through the loading pipeline and attaching it to HTTP requests. The issue affects `internal/gtfs/static.go` and `internal/gtfs/gtfs_manager.go`, where context was available but not used during request creation.

This ensures downloads respect timeouts and shutdown signals, preventing long running operations from blocking graceful shutdown and aligning with realtime data handling.

---

### 2. FIX

```go
// Before (bug)
req, err := http.NewRequest("GET", source, nil)

// After (fix)
req, err := http.NewRequestWithContext(ctx, "GET", source, nil)
```
### 3. VERIFICATION

Run the service with a large GTFS feed and trigger a shutdown (SIGTERM) or use a short timeout via `context.WithTimeout`. Before the fix, the download continues until the HTTP timeout, delaying shutdown. After the fix, the request is cancelled immediately and the service exits promptly.
