### PR TITLE
Add reusable query parameter validation middleware

### DIFF
--- a/internal/restapi/n success, calls next.ServeHTTP(w, r) [NEW]  validation_middleware.go
+++ b/internal/restapi/n success, calls next.ServeHTTP(w, r) [NEW]  validation_middleware.go
@@ -1,0 +1,94 @@
+package restapi
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+)
+
+// QueryParamRule defines a validation rule for a single query parameter.
+// If the parameter is absent from the request, the rule is skipped (optional params).
+// The Validate function receives the raw string value and returns an error message
+// and a boolean indicating whether validation passed.
+type QueryParamRule struct {
+	Param    string
+	Validate func(value string) (errMsg string, ok bool)
+}
+
+// PositiveIntRule returns a rule that validates a query parameter is a positive integer (> 0).
+func PositiveIntRule(param string) QueryParamRule {
+	return QueryParamRule{
+		Param: param,
+		Validate: func(value string) (string, bool) {
+			n, err := strconv.Atoi(value)
+			if err != nil {
+				return "must be a valid integer", false
+			}
+			if n <= 0 {
+				return "must be a positive integer", false
+			}
+			return "", true
+		},
+	}
+}
+
+// IntRangeRule returns a rule that validates a query parameter is an integer within [min, max].
+func IntRangeRule(param string, min, max int) QueryParamRule {
+	return QueryParamRule{
+		Param: param,
+		Validate: func(value string) (string, bool) {
+			n, err := strconv.Atoi(value)
+			if err != nil {
+				return "must be a valid integer", false
+			}
+			if n < min || n > max {
+				return fmt.Sprintf("must be between %d and %d", min, max), false
+			}
+			return "", true
+		},
+	}
+}
+
+// NonNegativeIntRule returns a rule that validates a query parameter is a non-negative integer (>= 0).
+func NonNegativeIntRule(param string) QueryParamRule {
+	return QueryParamRule{
+		Param: param,
+		Validate: func(value string) (string, bool) {
+			n, err := strconv.Atoi(value)
+			if err != nil {
+				return "must be a valid integer", false
+			}
+			if n < 0 {
+				return "must be a non-negative integer", false
+			}
+			return "", true
+		},
+	}
+}
+
+// ValidateQueryParams applies validation rules to query parameters
+// and returns 400 if validation fails before invoking the next handler.
+// Parameters not present in the request are skipped (all rules are optional-param-safe).
+func ValidateQueryParams(api *RestAPI, rules []QueryParamRule, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		query := r.URL.Query()
+		fieldErrors := make(map[string][]string)
+
+		for _, rule := range rules {
+			value := query.Get(rule.Param)
+			if value == "" {
+				continue // param not provided, skip
+			}
+			if errMsg, ok := rule.Validate(value); !ok {
+				fieldErrors[rule.Param] = append(fieldErrors[rule.Param], errMsg)
+			}
+		}
+
+		if len(fieldErrors) > 0 {
+			api.validationErrorResponse(w, r, fieldErrors)
+			return
+		}
+
+		next.ServeHTTP(w, r)
+	})
+}

--- a/internal/restapi/validation_middleware.go
+++ b/internal/restapi/validation_middleware.go
@@ -69,16 +69,19 @@ func NonNegativeIntRule(param string) QueryParamRule {
 // ValidateQueryParams applies validation rules to query parameters
 // and returns 400 if validation fails before invoking the next handler.
 // Parameters not present in the request are skipped (all rules are optional-param-safe).
+// Parameters present but empty (e.g. ?maxCount=) are validated normally.
 func ValidateQueryParams(api *RestAPI, rules []QueryParamRule, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		query := r.URL.Query()
 		fieldErrors := make(map[string][]string)
 
 		for _, rule := range rules {
-			value := query.Get(rule.Param)
-			if value == "" {
-				continue // param not provided, skip
+			if !query.Has(rule.Param) {
+				continue // truly absent, skip
 			}
+
+			value := query.Get(rule.Param)
+
 			if errMsg, ok := rule.Validate(value); !ok {
 				fieldErrors[rule.Param] = append(fieldErrors[rule.Param], errMsg)
 			}

--- a/internal/restapi/validation_middleware_test.go
+++ b/internal/restapi/validation_middleware_test.go
@@ -1,0 +1,220 @@
+package restapi
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPositiveIntRule(t *testing.T) {
+	rule := PositiveIntRule("maxCount")
+
+	tests := []struct {
+		name  string
+		value string
+		ok    bool
+	}{
+		{"valid positive", "10", true},
+		{"valid one", "1", true},
+		{"zero is invalid", "0", false},
+		{"negative is invalid", "-5", false},
+		{"non-numeric is invalid", "abc", false},
+		{"float is invalid", "3.14", false},
+		{"large valid", "999999", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			errMsg, ok := rule.Validate(tt.value)
+			assert.Equal(t, tt.ok, ok)
+			if !ok {
+				assert.NotEmpty(t, errMsg)
+			}
+		})
+	}
+}
+
+func TestIntRangeRule(t *testing.T) {
+	rule := IntRangeRule("minutesAfter", 0, 240)
+
+	tests := []struct {
+		name  string
+		value string
+		ok    bool
+	}{
+		{"within range", "35", true},
+		{"at minimum", "0", true},
+		{"at maximum", "240", true},
+		{"below minimum", "-1", false},
+		{"above maximum", "241", false},
+		{"non-numeric", "abc", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			errMsg, ok := rule.Validate(tt.value)
+			assert.Equal(t, tt.ok, ok)
+			if !ok {
+				assert.NotEmpty(t, errMsg)
+			}
+		})
+	}
+}
+
+func TestNonNegativeIntRule(t *testing.T) {
+	rule := NonNegativeIntRule("offset")
+
+	tests := []struct {
+		name  string
+		value string
+		ok    bool
+	}{
+		{"positive", "5", true},
+		{"zero", "0", true},
+		{"negative", "-1", false},
+		{"non-numeric", "xyz", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			errMsg, ok := rule.Validate(tt.value)
+			assert.Equal(t, tt.ok, ok)
+			if !ok {
+				assert.NotEmpty(t, errMsg)
+			}
+		})
+	}
+}
+
+func TestValidateQueryParams(t *testing.T) {
+	api := createTestApi(t)
+	defer api.Shutdown()
+
+	// A simple handler that returns 200 OK when reached
+	okHandler := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"status":"ok"}`))
+	}
+
+	rules := []QueryParamRule{
+		PositiveIntRule("maxCount"),
+	}
+
+	wrapped := ValidateQueryParams(api, rules, http.HandlerFunc(okHandler))
+
+	t.Run("valid param passes through", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/test?maxCount=10", nil)
+		rec := httptest.NewRecorder()
+		wrapped.ServeHTTP(rec, req)
+		assert.Equal(t, http.StatusOK, rec.Code)
+	})
+
+	t.Run("absent param passes through", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/test", nil)
+		rec := httptest.NewRecorder()
+		wrapped.ServeHTTP(rec, req)
+		assert.Equal(t, http.StatusOK, rec.Code)
+	})
+
+	t.Run("invalid param returns 400", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/test?maxCount=-1", nil)
+		rec := httptest.NewRecorder()
+		wrapped.ServeHTTP(rec, req)
+		assert.Equal(t, http.StatusBadRequest, rec.Code)
+
+		body, err := io.ReadAll(rec.Body)
+		require.NoError(t, err)
+		assert.Contains(t, string(body), "maxCount")
+	})
+
+	t.Run("non-numeric param returns 400", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/test?maxCount=abc", nil)
+		rec := httptest.NewRecorder()
+		wrapped.ServeHTTP(rec, req)
+		assert.Equal(t, http.StatusBadRequest, rec.Code)
+	})
+
+	t.Run("zero param returns 400", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/test?maxCount=0", nil)
+		rec := httptest.NewRecorder()
+		wrapped.ServeHTTP(rec, req)
+		assert.Equal(t, http.StatusBadRequest, rec.Code)
+	})
+
+	t.Run("response matches validationErrorResponse format", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/test?maxCount=bad", nil)
+		rec := httptest.NewRecorder()
+		wrapped.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusBadRequest, rec.Code)
+		assert.Equal(t, "application/json", rec.Header().Get("Content-Type"))
+
+		var resp struct {
+			Code int `json:"code"`
+			Text string `json:"text"`
+			Data struct {
+				FieldErrors map[string][]string `json:"fieldErrors"`
+			} `json:"data"`
+		}
+		err := json.NewDecoder(rec.Body).Decode(&resp)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusBadRequest, resp.Code)
+		assert.NotEmpty(t, resp.Data.FieldErrors["maxCount"])
+	})
+}
+
+func TestValidateQueryParamsMultipleRules(t *testing.T) {
+	api := createTestApi(t)
+	defer api.Shutdown()
+
+	okHandler := func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}
+
+	rules := []QueryParamRule{
+		PositiveIntRule("maxCount"),
+		NonNegativeIntRule("offset"),
+	}
+
+	wrapped := ValidateQueryParams(api, rules, http.HandlerFunc(okHandler))
+
+	t.Run("both valid", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/test?maxCount=10&offset=0", nil)
+		rec := httptest.NewRecorder()
+		wrapped.ServeHTTP(rec, req)
+		assert.Equal(t, http.StatusOK, rec.Code)
+	})
+
+	t.Run("first invalid", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/test?maxCount=-1&offset=0", nil)
+		rec := httptest.NewRecorder()
+		wrapped.ServeHTTP(rec, req)
+		assert.Equal(t, http.StatusBadRequest, rec.Code)
+	})
+
+	t.Run("second invalid", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/test?maxCount=10&offset=-5", nil)
+		rec := httptest.NewRecorder()
+		wrapped.ServeHTTP(rec, req)
+		assert.Equal(t, http.StatusBadRequest, rec.Code)
+	})
+
+	t.Run("both invalid collects all errors", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/test?maxCount=-1&offset=-5", nil)
+		rec := httptest.NewRecorder()
+		wrapped.ServeHTTP(rec, req)
+		assert.Equal(t, http.StatusBadRequest, rec.Code)
+
+		body, err := io.ReadAll(rec.Body)
+		require.NoError(t, err)
+		bodyStr := string(body)
+		assert.Contains(t, bodyStr, "maxCount")
+		assert.Contains(t, bodyStr, "offset")
+	})
+}

--- a/internal/restapi/validation_middleware_test.go
+++ b/internal/restapi/validation_middleware_test.go
@@ -122,6 +122,17 @@ func TestValidateQueryParams(t *testing.T) {
 		assert.Equal(t, http.StatusOK, rec.Code)
 	})
 
+	t.Run("empty param value returns 400", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/test?maxCount=", nil)
+		rec := httptest.NewRecorder()
+		wrapped.ServeHTTP(rec, req)
+		assert.Equal(t, http.StatusBadRequest, rec.Code)
+
+		body, err := io.ReadAll(rec.Body)
+		require.NoError(t, err)
+		assert.Contains(t, string(body), "maxCount")
+	})
+
 	t.Run("invalid param returns 400", func(t *testing.T) {
 		req := httptest.NewRequest("GET", "/test?maxCount=-1", nil)
 		rec := httptest.NewRecorder()


### PR DESCRIPTION
## Summary
Introduces a reusable query parameter validation middleware for the REST API.

## Problem
Validation logic for query parameters is currently implemented inconsistently across handlers, with some cases duplicating logic and others silently ignoring invalid input.

## Solution
Added a centralized middleware that applies validation rules to query parameters before the request reaches the handler. The middleware uses a composable rule-based approach, allowing each parameter to define its own validation logic.

## Changes
- Added `QueryParamRule` abstraction for defining validation rules
- Implemented reusable rules:
  - `PositiveIntRule`
  - `IntRangeRule`
  - `NonNegativeIntRule`
- Added `ValidateQueryParams` middleware to enforce validation
- Added comprehensive unit tests covering valid, invalid, and edge cases

## Scope
This PR only introduces the validation middleware and tests.  
No existing handlers or routes are modified to keep the change minimal and safe for review.

## Future Work
- Apply this middleware incrementally to existing endpoints
- Remove duplicated inline validation logic across handlers

## Benefits
- Improves API consistency and reliability
- Prevents silent failures on invalid input
- Reduces duplicated validation logic
- Provides a scalable foundation for future validation needs