### PR TITLE
Add stops field to schedule-for-route response

### DIFF
--- a/internal/models/schedule_for_route.go
+++ b/internal/models/schedule_for_route.go
@@ -29,4 +29,5 @@ type ScheduleForRouteEntry struct {
 	ScheduleDate      int64              `json:"scheduleDate"`
 	ServiceIDs        []string           `json:"serviceIds"`
 	StopTripGroupings []StopTripGrouping `json:"stopTripGroupings"`
+	Stops             []Stop             `json:"stops"`
 }

--- a/internal/restapi/schedule_for_route_handler.go
+++ b/internal/restapi/schedule_for_route_handler.go
@@ -270,8 +270,10 @@ func (api *RestAPI) scheduleForRouteHandler(w http.ResponseWriter, r *http.Reque
 	for sid := range globalStopIDSet {
 		uniqueStopIDs = append(uniqueStopIDs, sid)
 	}
+	modelStops := []models.Stop{}
 
 	if len(uniqueStopIDs) > 0 {
+		var err error
 		modelStops, _, err := BuildStopReferencesAndRouteIDsForStops(api, ctx, agencyID, uniqueStopIDs)
 		if err != nil {
 			api.serverErrorResponse(w, r, err)
@@ -284,11 +286,13 @@ func (api *RestAPI) scheduleForRouteHandler(w http.ResponseWriter, r *http.Reque
 		references.StopTimes = append(references.StopTimes, sref...)
 	}
 
+
 	entry := models.ScheduleForRouteEntry{
 		RouteID:           utils.FormCombinedID(agencyID, routeID),
 		ScheduleDate:      scheduleDate,
 		ServiceIDs:        combinedServiceIDs,
 		StopTripGroupings: stopTripGroupings,
+		Stops:             modelStops,
 	}
 	api.sendResponse(w, r, models.NewEntryResponse(entry, *references, api.Clock))
 }


### PR DESCRIPTION
## Summary
Adds a `stops` field to the `schedule-for-route` API response to expose stop-level data directly within the response entry.

## Motivation
Currently, stop data is only available through the `references` section, which makes it harder for clients to access and use stops directly when working with route schedules.

This change simplifies client-side usage by including stops directly in the response entry.

## Changes
- Added `Stops []Stop` field to `ScheduleForRouteEntry` model
- Updated `schedule_for_route_handler.go` to populate the stops field using `BuildStopReferencesAndRouteIDsForStops`
- Ensured stops are still included in `references.Stops` for backward compatibility

## Testing
- Ran:go test ./internal/restapi -run ScheduleForRoute -v
 - Verified behavior matches existing API structure
- Confirmed tests pass locally

## Notes
This change is non-breaking since existing clients can continue using the `references` section.