### PR TITLE
 Added validation for maxCount

### DIFF
--- a/internal/restapi/search_stops_handler.go
+++ b/internal/restapi/search_stops_handler.go
@@ -50,11 +50,11 @@ func (api *RestAPI) searchStopsHandler(w http.ResponseWriter, r *http.Request) {
 	api.GtfsManager.RLock()
 	defer api.GtfsManager.RUnlock()
 
-	limit := 50
+	limit := 20
 	if maxCountStr := r.URL.Query().Get("maxCount"); maxCountStr != "" {
 		parsed, err := strconv.Atoi(maxCountStr)
-		if err != nil || parsed <= 0 || parsed > 50 {
-			api.validationErrorResponse(w, r, map[string][]string{"maxCount": {"need to be a positive integer"}})
+		if err != nil || parsed <= 0 {
+			api.validationErrorResponse(w, r, map[string][]string{"maxCount": {"must be a positive integer"}})
 			return
 		}
 		limit = parsed

--- a/internal/restapi/search_stops_handler.go
+++ b/internal/restapi/search_stops_handler.go
@@ -52,9 +52,12 @@ func (api *RestAPI) searchStopsHandler(w http.ResponseWriter, r *http.Request) {
 
 	limit := 50
 	if maxCountStr := r.URL.Query().Get("maxCount"); maxCountStr != "" {
-		if parsed, err := strconv.Atoi(maxCountStr); err == nil && parsed > 0 {
-			limit = parsed
+		parsed, err := strconv.Atoi(maxCountStr)
+		if err != nil || parsed <= 0 || parsed > 50 {
+			api.validationErrorResponse(w, r, map[string][]string{"maxCount": {"need to be a positive integer"}})
+			return
 		}
+		limit = parsed
 	}
 
 	// 2. Sanitize and construct FTS5 query

--- a/internal/restapi/search_stops_handler_test.go
+++ b/internal/restapi/search_stops_handler_test.go
@@ -226,7 +226,7 @@ func TestSearchStopsHandlerMaxCountBoundaries(t *testing.T) {
 	}{
 		{"zero", "0", http.StatusBadRequest},
 		{"negative", "-1", http.StatusBadRequest},
-		{"tooLarge", "101", http.StatusBadRequest},
+		{"largeRequest", "101", http.StatusOK},
 		{"invalid string", "abc", http.StatusBadRequest},
 	}
 	for _, tt := range tests {

--- a/internal/restapi/search_stops_handler_test.go
+++ b/internal/restapi/search_stops_handler_test.go
@@ -220,14 +220,15 @@ func TestSearchStopsHandlerMaxCountBoundaries(t *testing.T) {
 	query := url.QueryEscape(targetStop.Name)
 
 	tests := []struct {
-		name     string
-		maxCount string
+		name           string
+		maxCount       string
+		expectedStatus int
 	}{
-		{"zero", "0"},
-		{"negative", "-1"},
-		{"tooLarge", "101"},
+		{"zero", "0", http.StatusBadRequest},
+		{"negative", "-1", http.StatusBadRequest},
+		{"tooLarge", "101", http.StatusBadRequest},
+		{"invalid string", "abc", http.StatusBadRequest},
 	}
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			reqUrl := fmt.Sprintf(
@@ -238,15 +239,17 @@ func TestSearchStopsHandlerMaxCountBoundaries(t *testing.T) {
 
 			resp, model := serveApiAndRetrieveEndpoint(t, api, reqUrl)
 
-			assert.Equal(t, http.StatusOK, resp.StatusCode)
+			assert.Equal(t, tt.expectedStatus, resp.StatusCode)
 
-			data, ok := model.Data.(map[string]interface{})
-			require.True(t, ok)
+			if tt.expectedStatus == http.StatusOK {
+				data, ok := model.Data.(map[string]interface{})
+				require.True(t, ok)
 
-			list, ok := data["list"].([]interface{})
-			require.True(t, ok)
+				list, ok := data["list"].([]interface{})
+				require.True(t, ok)
 
-			assert.NotEmpty(t, list)
+				assert.NotEmpty(t, list)
+			}
 		})
 	}
 }


### PR DESCRIPTION
Fixes #771 
# Problem
The maxCount query parameter is parsed, but errors are ignored.

# Fix 
Added validation to the parameter checking for a positive integer sending a error for negative and values greater then the limit.  Also fixed test file to now accept the new requirements. 
