### PR TITLE
Clarify VehiclesForAgencyID lock ownership and fix test locking

### DIFF
--- a/internal/gtfs/concurrency_test.go
+++ b/internal/gtfs/concurrency_test.go
@@ -231,7 +231,9 @@ func TestConcurrentVehicleUpdates(t *testing.T) {
 				case <-done:
 					return
 				default:
+					manager.RLock()
 					_ = manager.VehiclesForAgencyID("test")
+					manager.RUnlock()
 					time.Sleep(time.Microsecond)
 				}
 			}

--- a/internal/gtfs/gtfs_manager.go
+++ b/internal/gtfs/gtfs_manager.go
@@ -629,19 +629,18 @@ func (manager *Manager) GetStopsForLocation(
 }
 
 // VehiclesForAgencyID returns all real-time vehicles serving routes that belong
-// to the given agency. It manages its own locking internally; callers must NOT
-// hold any Manager locks.
+// to the given agency.
+// IMPORTANT: Caller must hold manager.RLock() before calling this method.
+// The method acquires the real-time lock internally while reading vehicles.
 func (manager *Manager) VehiclesForAgencyID(agencyID string) []gtfs.Vehicle {
-	// Step 1: Acquire static lock, collect route IDs, then release.
-	manager.staticMutex.RLock()
+	// Step 1: Get route IDs for the agency from static data.
 	routes := manager.RoutesForAgencyID(agencyID)
 	routeIDs := make(map[string]bool, len(routes))
 	for _, route := range routes {
 		routeIDs[route.Id] = true
 	}
-	manager.staticMutex.RUnlock()
 
-	// Step 2: Acquire real-time lock independently to read vehicles.
+	// Step 2: Get real-time vehicles and filter by route IDs.
 	rtVehicles := manager.GetRealTimeVehicles()
 
 	var vehicles []gtfs.Vehicle

--- a/internal/restapi/openapi_conformance_test.go
+++ b/internal/restapi/openapi_conformance_test.go
@@ -164,6 +164,8 @@ func TestOpenAPIConformance_StaticEndpoints(t *testing.T) {
 	doc := loadOpenAPISpec(t)
 
 	// Gather test data IDs from the RABA fixture
+	api.GtfsManager.RLock()
+	defer api.GtfsManager.RUnlock()
 	agencies := api.GtfsManager.GetAgencies()
 	require.NotEmpty(t, agencies, "Test data must contain at least one agency")
 	agencyID := agencies[0].Id
@@ -471,6 +473,8 @@ func TestOpenAPIConformance_RealTimeEndpoints(t *testing.T) {
 
 	doc := loadOpenAPISpec(t)
 
+	api.GtfsManager.RLock()
+	defer api.GtfsManager.RUnlock()
 	agencies := api.GtfsManager.GetAgencies()
 	require.NotEmpty(t, agencies)
 	agencyID := agencies[0].Id

--- a/internal/restapi/vehicles_for_agency_handler.go
+++ b/internal/restapi/vehicles_for_agency_handler.go
@@ -16,13 +16,12 @@ func (api *RestAPI) vehiclesForAgencyHandler(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
+	api.GtfsManager.RLock()
+	defer api.GtfsManager.RUnlock()
+
 	ctx := r.Context()
 
-	// Acquire static lock only for the agency lookup; release immediately.
-	// VehiclesForAgencyID manages its own locking internally.
-	api.GtfsManager.RLock()
 	agency := api.GtfsManager.FindAgency(id)
-	api.GtfsManager.RUnlock()
 
 	if agency == nil {
 		// return an empty list response.

--- a/internal/restapi/vehicles_for_agency_handler_test.go
+++ b/internal/restapi/vehicles_for_agency_handler_test.go
@@ -512,7 +512,9 @@ func TestVehiclesForAgencyHandlerWithRealTimeData(t *testing.T) {
 	t.Logf("Loaded %d real-time vehicles", len(realTimeVehicles))
 
 	// Debug vehicle-to-agency matching
+	api.GtfsManager.RLock()
 	vehiclesForAgency := api.GtfsManager.VehiclesForAgencyID(agencyId)
+	api.GtfsManager.RUnlock()
 	t.Logf("Found %d vehicles for agency %s", len(vehiclesForAgency), agencyId)
 
 	if len(realTimeVehicles) > 0 && len(vehiclesForAgency) == 0 {


### PR DESCRIPTION
## Summary

Clarifies static lock ownership for `vehicles-for-agency` and fixes missing test-side locking for static GTFS manager access.

## Changes

- Hold `api.GtfsManager.RLock()` for the full duration of `vehiclesForAgencyHandler`
- Make `VehiclesForAgencyID` require caller-held `manager.RLock()`
- Update direct `VehiclesForAgencyID` test call sites to follow that contract
- Add missing `RLock()` in the OpenAPI conformance tests before static manager reads

## Why

Previously, `vehiclesForAgencyHandler` only held `RLock()` for the initial agency lookup, then released it before continuing with other static-dependent work such as `VehiclesForAgencyID` and DB-backed route/reference reads.

This split the handler's static reads across multiple lock windows instead of one clear snapshot boundary. During `ForceUpdate`, static data, lookup maps, indexes, and `GtfsDB` are swapped under the write lock, so different parts of a single response could otherwise be built from different static snapshots.

This change makes lock ownership explicit:

- The handler owns the static read lock for its full duration
- `VehiclesForAgencyID` assumes the caller already holds it
- Tests now follow the same contract

## Validation Passed
```
~ make test
```

### Fixes #795 