### PR TITLE
fix: prevent timer leak in GTFS retry loop

### DIFF
--- a/internal/gtfs/gtfs_manager.go
+++ b/internal/gtfs/gtfs_manager.go
@@ -170,10 +170,12 @@ func InitGTFSManager(ctx context.Context, config Config) (*Manager, error) {
 					)
 
 					// Cancellable sleep
+					retryTimer := time.NewTimer(delay)
 					select {
 					case <-ctx.Done():
+						retryTimer.Stop()
 						return nil, ctx.Err()
-					case <-time.After(delay):
+					case <-retryTimer.C:
 					}
 					continue
 				}
@@ -194,10 +196,12 @@ func InitGTFSManager(ctx context.Context, config Config) (*Manager, error) {
 					staticData = nil
 
 					// Cancellable sleep
+					retryTimer := time.NewTimer(delay)
 					select {
 					case <-ctx.Done():
+						retryTimer.Stop()
 						return nil, ctx.Err()
-					case <-time.After(delay):
+					case <-retryTimer.C:
 					}
 					continue
 				}
@@ -228,10 +232,12 @@ func InitGTFSManager(ctx context.Context, config Config) (*Manager, error) {
 					)
 
 					// Cancellable sleep
+					retryTimer := time.NewTimer(delay)
 					select {
 					case <-ctx.Done():
+						retryTimer.Stop()
 						return nil, ctx.Err()
-					case <-time.After(delay):
+					case <-retryTimer.C:
 					}
 					continue
 				}

--- a/internal/gtfs/spatial_index_test.go
+++ b/internal/gtfs/spatial_index_test.go
@@ -42,7 +42,7 @@ func TestQueryStopsInBounds(t *testing.T) {
 		name          string
 		bounds        utils.CoordinateBounds
 		expectedCount int
-		expectedIDs   []string 
+		expectedIDs   []string
 	}{
 		{
 			name: "NormalBoundingBox_SomeStops",

--- a/internal/restapi/trips_for_location_handler.go
+++ b/internal/restapi/trips_for_location_handler.go
@@ -708,7 +708,6 @@ func (rb *referenceBuilder) createRoute(route gtfsdb.Route) models.Route {
 
 }
 
-
 func (rb *referenceBuilder) buildTripReferences() error {
 	rb.tripsRefList = make([]models.Trip, 0, len(rb.presentTrips))
 

--- a/internal/restapi/trips_for_route_handler.go
+++ b/internal/restapi/trips_for_route_handler.go
@@ -635,7 +635,7 @@ func buildTripReferences(
 					TripHeadsign:  trip.TripHeadsign,
 					TripShortName: trip.TripShortName,
 					DirectionID:   trip.DirectionID,
-					BlockID: utils.FormCombinedID(currentAgency, trip.BlockID),
+					BlockID:       utils.FormCombinedID(currentAgency, trip.BlockID),
 					ShapeID:       utils.FormCombinedID(currentAgency, trip.ShapeID),
 					PeakOffPeak:   0,
 					TimeZone:      "",


### PR DESCRIPTION
##  SUMMARY

This PR fixes a timer lifecycle issue in `InitGTFSManager` where retry backoff used `time.After`, which cannot be stopped on context cancellation. It replaces those calls with `time.NewTimer` to ensure proper cleanup.

The changes affect `internal/gtfs/gtfs_manager.go`, specifically the retry sleep logic in the GTFS initialization flow. 

---

## FIX

```go
// Before
select {
case <-ctx.Done():
    return nil, ctx.Err()
case <-time.After(delay):
}

// After
retryTimer := time.NewTimer(delay)
select {
case <-ctx.Done():
    retryTimer.Stop()
    return nil, ctx.Err()
case <-retryTimer.C:
}
```

---

##  VERIFICATION 

Test by starting the service with a failing GTFS endpoint so it enters the retry loop, then cancel the context (e.g., send SIGTERM) while it is sleeping. The function should exit immediately with `ctx.Err()` instead of waiting for the delay. Retry behavior should remain unchanged when the context is not cancelled, with no lingering timers.
