### PR TITLE
fix: propagate ctx to gtfstidy subprocess

### DIFF
--- a/internal/gtfs/static.go
+++ b/internal/gtfs/static.go
@@ -69,7 +69,7 @@ func rawGtfsData(ctx context.Context, source string, isLocalFile bool, config Co
 	// Process through gtfstidy if enabled
 	if config.EnableGTFSTidy {
 		logging.LogOperation(logger, "gtfstidy_enabled_processing_gtfs_data")
-		tidiedData, err := tidyGTFSData(b, logger)
+		tidiedData, err := tidyGTFSData(ctx, b, logger)
 		if err != nil {
 			logging.LogError(logger, "Failed to tidy GTFS data, using original data", err)
 		} else {

--- a/internal/gtfs/tidy.go
+++ b/internal/gtfs/tidy.go
@@ -2,6 +2,7 @@ package gtfs
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"log/slog"
 	"os"
@@ -51,7 +52,7 @@ func checkGTFSTidyAvailable() (string, error) {
 
 // tidyGTFSData processes GTFS data through gtfstidy with flags -OscRCSmeD
 // Returns the tidied GTFS zip data or an error
-func tidyGTFSData(inputZip []byte, logger *slog.Logger) ([]byte, error) {
+func tidyGTFSData(ctx context.Context, inputZip []byte, logger *slog.Logger) ([]byte, error) {
 	gtfstidyPath, err := checkGTFSTidyAvailable()
 	if err != nil {
 		return nil, err
@@ -82,7 +83,7 @@ func tidyGTFSData(inputZip []byte, logger *slog.Logger) ([]byte, error) {
 		slog.Int("input_size_bytes", len(inputZip)))
 
 	// -o: output file
-	cmd := exec.Command(gtfstidyPath, "-OscRCSmeD", "-o", outputZipPath, pristineZipPath)
+	cmd := exec.CommandContext(ctx, gtfstidyPath, "-OscRCSmeD", "-o", outputZipPath, pristineZipPath)
 	cmd.Dir = tempDir
 
 	var stdout, stderr bytes.Buffer

--- a/internal/gtfs/tidy_test.go
+++ b/internal/gtfs/tidy_test.go
@@ -3,6 +3,7 @@ package gtfs
 import (
 	"archive/zip"
 	"bytes"
+	"context"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -37,7 +38,7 @@ func TestTidyGTFSData(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 
 	// Run tidy
-	outputData, err := tidyGTFSData(inputData, logger)
+	outputData, err := tidyGTFSData(context.Background(), inputData, logger)
 	if err != nil {
 		t.Fatalf("tidyGTFSData failed: %v", err)
 	}


### PR DESCRIPTION
##  SUMMARY

This PR fixes a context propagation issue in the GTFS tidy pipeline where subprocesses could not be canceled, leading to hangs during shutdown or timeout. It updates `tidyGTFSData` to accept a `context.Context` and uses `exec.CommandContext` instead of `exec.Command`.

Primary changes are in `internal/gtfs/tidy.go`, with call-site updates in `internal/gtfs/static.go` and test adjustments in `internal/gtfs/tidy_test.go`.

---

##  FIX

```go
// Before
func tidyGTFSData(inputZip []byte, logger *slog.Logger) ([]byte, error) {
    cmd := exec.Command(gtfstidyPath, "-OscRCSmeD", "-o", outputZipPath, pristineZipPath)
}

// After
func tidyGTFSData(ctx context.Context, inputZip []byte, logger *slog.Logger) ([]byte, error) {
    cmd := exec.CommandContext(ctx, gtfstidyPath, "-OscRCSmeD", "-o", outputZipPath, pristineZipPath)
}
```

---

##  VERIFICATION

Tested by enabling GTFS tidy, triggering a feed update, and sending a SIGTERM while the tidy process was running. The service now shuts down cleanly without hanging, and the subprocess exits immediately on cancellation. Builds and existing tests pass with no regressions.

