### PR TITLE
refactor: use db query to fetch routes for agency

### DIFF
--- a/gtfsdb/db.go
+++ b/gtfsdb/db.go
@@ -216,6 +216,9 @@ func Prepare(ctx context.Context, db DBTX) (*Queries, error) {
 	if q.getRoutesByIDsStmt, err = db.PrepareContext(ctx, getRoutesByIDs); err != nil {
 		return nil, fmt.Errorf("error preparing query GetRoutesByIDs: %w", err)
 	}
+	if q.getRoutesForAgencyStmt, err = db.PrepareContext(ctx, getRoutesForAgency); err != nil {
+		return nil, fmt.Errorf("error preparing query GetRoutesForAgency: %w", err)
+	}
 	if q.getRoutesForStopStmt, err = db.PrepareContext(ctx, getRoutesForStop); err != nil {
 		return nil, fmt.Errorf("error preparing query GetRoutesForStop: %w", err)
 	}
@@ -676,6 +679,11 @@ func (q *Queries) Close() error {
 			err = fmt.Errorf("error closing getRoutesByIDsStmt: %w", cerr)
 		}
 	}
+	if q.getRoutesForAgencyStmt != nil {
+		if cerr := q.getRoutesForAgencyStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing getRoutesForAgencyStmt: %w", cerr)
+		}
+	}
 	if q.getRoutesForStopStmt != nil {
 		if cerr := q.getRoutesForStopStmt.Close(); cerr != nil {
 			err = fmt.Errorf("error closing getRoutesForStopStmt: %w", cerr)
@@ -1004,6 +1012,7 @@ type Queries struct {
 	getRouteIDsForStopStmt                        *sql.Stmt
 	getRouteIDsForStopsStmt                       *sql.Stmt
 	getRoutesByIDsStmt                            *sql.Stmt
+	getRoutesForAgencyStmt                        *sql.Stmt
 	getRoutesForStopStmt                          *sql.Stmt
 	getRoutesForStopsStmt                         *sql.Stmt
 	getRoutesInBlockTripIndicesStmt               *sql.Stmt
@@ -1119,6 +1128,7 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		getRouteIDsForStopStmt:                        q.getRouteIDsForStopStmt,
 		getRouteIDsForStopsStmt:                       q.getRouteIDsForStopsStmt,
 		getRoutesByIDsStmt:                            q.getRoutesByIDsStmt,
+		getRoutesForAgencyStmt:                        q.getRoutesForAgencyStmt,
 		getRoutesForStopStmt:                          q.getRoutesForStopStmt,
 		getRoutesForStopsStmt:                         q.getRoutesForStopsStmt,
 		getRoutesInBlockTripIndicesStmt:               q.getRoutesInBlockTripIndicesStmt,

--- a/gtfsdb/query.sql
+++ b/gtfsdb/query.sql
@@ -210,6 +210,21 @@ FROM
 WHERE
     stop_times.stop_id = ?;
 
+-- name: GetRoutesForAgency :many
+SELECT
+    routes.id,
+    routes.short_name,
+    routes.long_name,
+    routes."desc",
+    routes.type,
+    routes.url,
+    routes.color,
+    routes.text_color
+FROM
+    routes
+WHERE
+    routes.agency_id = ?;
+
 -- name: GetAgencyForStop :one
 SELECT DISTINCT
     a.id,

--- a/gtfsdb/query.sql.go
+++ b/gtfsdb/query.sql.go
@@ -2458,6 +2458,65 @@ func (q *Queries) GetRoutesByIDs(ctx context.Context, routeIds []string) ([]Rout
 	return items, nil
 }
 
+const getRoutesForAgency = `-- name: GetRoutesForAgency :many
+SELECT
+    routes.id,
+    routes.short_name,
+    routes.long_name,
+    routes."desc",
+    routes.type,
+    routes.url,
+    routes.color,
+    routes.text_color
+FROM
+    routes
+WHERE
+    routes.agency_id = ?
+`
+
+type GetRoutesForAgencyRow struct {
+	ID        string
+	ShortName sql.NullString
+	LongName  sql.NullString
+	Desc      sql.NullString
+	Type      int64
+	Url       sql.NullString
+	Color     sql.NullString
+	TextColor sql.NullString
+}
+
+func (q *Queries) GetRoutesForAgency(ctx context.Context, agencyID string) ([]GetRoutesForAgencyRow, error) {
+	rows, err := q.query(ctx, q.getRoutesForAgencyStmt, getRoutesForAgency, agencyID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []GetRoutesForAgencyRow
+	for rows.Next() {
+		var i GetRoutesForAgencyRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.ShortName,
+			&i.LongName,
+			&i.Desc,
+			&i.Type,
+			&i.Url,
+			&i.Color,
+			&i.TextColor,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const getRoutesForStop = `-- name: GetRoutesForStop :many
 SELECT DISTINCT
     routes.id,

--- a/internal/gtfs/advanced_direction_calculator_test.go
+++ b/internal/gtfs/advanced_direction_calculator_test.go
@@ -361,8 +361,8 @@ func TestCalculateOrientationAtStop_WithDistanceTraveled(t *testing.T) {
 	// Test with distance traveled
 	orientation, err := calc.calculateOrientationAtStop(ctx, "19_0_1", 100.0, 0, 0)
 	assert.NoError(t, err)
-		assert.GreaterOrEqual(t, orientation, -math.Pi)
-		assert.LessOrEqual(t, orientation, math.Pi)
+	assert.GreaterOrEqual(t, orientation, -math.Pi)
+	assert.LessOrEqual(t, orientation, math.Pi)
 }
 
 func TestCalculateOrientationAtStop_GeographicMatching(t *testing.T) {
@@ -380,9 +380,9 @@ func TestCalculateOrientationAtStop_GeographicMatching(t *testing.T) {
 	stopLon := shapes[0].Lon
 	orientation, err := calc.calculateOrientationAtStop(ctx, "19_0_1", -1.0, stopLat, stopLon)
 	assert.NoError(t, err)
-		assert.GreaterOrEqual(t, orientation, -math.Pi)
-		assert.LessOrEqual(t, orientation, math.Pi)
-	}
+	assert.GreaterOrEqual(t, orientation, -math.Pi)
+	assert.LessOrEqual(t, orientation, math.Pi)
+}
 
 func TestCalculateOrientationAtStop_NoShapePoints(t *testing.T) {
 	ctx := context.Background()
@@ -407,18 +407,18 @@ func TestCalculateOrientationAtStop_EdgeCases(t *testing.T) {
 	if len(shapes) > 0 && shapes[0].ShapeDistTraveled.Valid {
 		orientation, err := calc.calculateOrientationAtStop(ctx, "19_0_1", shapes[0].ShapeDistTraveled.Float64, 0, 0)
 		assert.NoError(t, err)
-			assert.GreaterOrEqual(t, orientation, -math.Pi)
-			assert.LessOrEqual(t, orientation, math.Pi)
-		}
+		assert.GreaterOrEqual(t, orientation, -math.Pi)
+		assert.LessOrEqual(t, orientation, math.Pi)
+	}
 
 	// Test at the very end of the shape
 	if len(shapes) > 1 && shapes[len(shapes)-1].ShapeDistTraveled.Valid {
 		orientation, err := calc.calculateOrientationAtStop(ctx, "19_0_1", shapes[len(shapes)-1].ShapeDistTraveled.Float64, 0, 0)
 		assert.NoError(t, err)
-			assert.GreaterOrEqual(t, orientation, -math.Pi)
-			assert.LessOrEqual(t, orientation, math.Pi)
-		}
+		assert.GreaterOrEqual(t, orientation, -math.Pi)
+		assert.LessOrEqual(t, orientation, math.Pi)
 	}
+}
 
 func TestGetAngleAsDirection_EdgeCases(t *testing.T) {
 	calc := &AdvancedDirectionCalculator{}

--- a/internal/gtfs/concurrency_test.go
+++ b/internal/gtfs/concurrency_test.go
@@ -207,68 +207,6 @@ func TestSafeGTFSDataAccess(t *testing.T) {
 	})
 }
 
-func TestConcurrentVehicleUpdates(t *testing.T) {
-	// Test that real-time data updates are already safe (they use realTimeMutex)
-	manager := &Manager{
-		gtfsData: &gtfs.Static{
-			Routes: []gtfs.Route{},
-		},
-		realTimeVehicles: []gtfs.Vehicle{},
-		realTimeMutex:    sync.RWMutex{},
-		staticMutex:      sync.RWMutex{},
-	}
-
-	var wg sync.WaitGroup
-	done := make(chan struct{})
-
-	// Start readers
-	for i := 0; i < 5; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			for {
-				select {
-				case <-done:
-					return
-				default:
-					_ = manager.VehiclesForAgencyID("test")
-					time.Sleep(time.Microsecond)
-				}
-			}
-		}()
-	}
-
-	// Start writers
-	for i := 0; i < 3; i++ {
-		wg.Add(1)
-		go func(index int) {
-			defer wg.Done()
-			for j := 0; j < 10; j++ {
-				select {
-				case <-done:
-					return
-				default:
-					// Use direct assignment to realTimeVehicles for testing
-					manager.realTimeMutex.Lock()
-					testVehicleID := gtfs.VehicleID{ID: "test-vehicle"}
-					manager.realTimeVehicles = []gtfs.Vehicle{
-						{ID: &testVehicleID},
-					}
-					manager.realTimeMutex.Unlock()
-					time.Sleep(time.Millisecond)
-				}
-			}
-		}(i)
-	}
-
-	// Let it run for a short time
-	time.Sleep(50 * time.Millisecond)
-	close(done)
-	wg.Wait()
-
-	// Should complete without races (tested with race detector)
-}
-
 // Helper methods for testing - these simulate the unsafe operations
 func (manager *Manager) unsafeSetStaticGTFS(staticData *gtfs.Static) {
 	// This is the current unsafe implementation

--- a/internal/gtfs/gtfs_manager.go
+++ b/internal/gtfs/gtfs_manager.go
@@ -44,7 +44,6 @@ type RegionBounds struct {
 type Manager struct {
 	gtfsData                       *gtfs.Static
 	GtfsDB                         *gtfsdb.Client
-	routesByAgencyID               map[string][]*gtfs.Route
 	lastUpdated                    time.Time
 	lastUpdatedUnixNanos           atomic.Int64 // Lock-free freshness tracking
 	isLocalFile                    bool
@@ -60,7 +59,7 @@ type Manager struct {
 	routesMap                      map[string]*gtfs.Route
 	frequencyTripIDs               map[string]struct{}
 	staticUpdateMutex              sync.Mutex   // Protects against concurrent ForceUpdate calls
-	staticMutex                    sync.RWMutex // Protects gtfsData and lastUpdated
+	staticMutex                    sync.RWMutex // Protects GtfsDB, gtfsData, and lastUpdated
 	config                         Config
 	shutdownChan                   chan struct{}
 	wg                             sync.WaitGroup
@@ -456,12 +455,8 @@ func (manager *Manager) GetRoutes() []gtfs.Route {
 
 // RoutesForAgencyID retrieves all routes associated with the specified agency ID from the GTFS data.
 // IMPORTANT: Caller must hold manager.RLock() before calling this method.
-func (manager *Manager) RoutesForAgencyID(agencyID string) []*gtfs.Route {
-	if routes, ok := manager.routesByAgencyID[agencyID]; ok {
-		return routes
-	}
-
-	return []*gtfs.Route{}
+func (manager *Manager) RoutesForAgencyID(ctx context.Context, agencyID string) ([]gtfsdb.GetRoutesForAgencyRow, error) {
+	return manager.GtfsDB.Queries.GetRoutesForAgency(ctx, agencyID)
 }
 
 type stopWithDistance struct {
@@ -636,15 +631,18 @@ func (manager *Manager) GetStopsForLocation(
 // VehiclesForAgencyID returns all real-time vehicles serving routes that belong
 // to the given agency. It manages its own locking internally; callers must NOT
 // hold any Manager locks.
-func (manager *Manager) VehiclesForAgencyID(agencyID string) []gtfs.Vehicle {
-	// Step 1: Acquire static lock, collect route IDs, then release.
+func (manager *Manager) VehiclesForAgencyID(ctx context.Context, agencyID string) ([]gtfs.Vehicle, error) {
 	manager.staticMutex.RLock()
-	routes := manager.RoutesForAgencyID(agencyID)
+	routes, err := manager.RoutesForAgencyID(ctx, agencyID)
+	manager.staticMutex.RUnlock()
+	if err != nil {
+		return nil, err
+	}
+
 	routeIDs := make(map[string]bool, len(routes))
 	for _, route := range routes {
-		routeIDs[route.Id] = true
+		routeIDs[route.ID] = true
 	}
-	manager.staticMutex.RUnlock()
 
 	// Step 2: Acquire real-time lock independently to read vehicles.
 	rtVehicles := manager.GetRealTimeVehicles()
@@ -656,7 +654,7 @@ func (manager *Manager) VehiclesForAgencyID(agencyID string) []gtfs.Vehicle {
 		}
 	}
 
-	return vehicles
+	return vehicles, nil
 }
 
 // GetDuplicatedVehiclesForRoute returns real-time vehicles serving DUPLICATED trips

--- a/internal/gtfs/gtfs_manager_test.go
+++ b/internal/gtfs/gtfs_manager_test.go
@@ -42,13 +42,13 @@ func TestManager_RoutesForAgencyID(t *testing.T) {
 	assert.NotNil(t, manager)
 
 	manager.RLock()
-	routes := manager.RoutesForAgencyID("25")
+	routes, err := manager.RoutesForAgencyID(t.Context(), "25")
 	manager.RUnlock()
+	assert.Nil(t, err)
 	assert.Equal(t, 13, len(routes))
 
 	route := routes[0]
-	assert.Equal(t, "1", route.ShortName)
-	assert.Equal(t, "25", route.Agency.Id)
+	assert.Equal(t, "1", route.ShortName.String)
 }
 
 func TestManager_GetStopsForLocation_UsesSpatialIndex(t *testing.T) {
@@ -397,7 +397,24 @@ func TestManager_FindRoute_UsesMap(t *testing.T) {
 	assert.Nil(t, result)
 }
 
-func TestRoutesForAgencyID_MapOptimization(t *testing.T) {
+func TestRoutesForAgencyID_NonexistentId(t *testing.T) {
+	ctx := context.Background()
+
+	gtfsConfig := Config{
+		GtfsURL:      models.GetFixturePath(t, "raba.zip"),
+		GTFSDataPath: ":memory:",
+		Env:          appconf.Test,
+	}
+	manager, err := InitGTFSManager(ctx, gtfsConfig)
+	require.NoError(t, err, "Failed to initialize manager")
+	defer manager.Shutdown()
+
+	emptyRoutes, err := manager.RoutesForAgencyID(ctx, "nonexistent")
+	assert.Nil(t, err)
+	assert.Empty(t, emptyRoutes, "Non-existent agency should return empty slice")
+}
+
+func TestRoutesForAgencyID_ValidId(t *testing.T) {
 	ctx := context.Background()
 
 	gtfsConfig := Config{
@@ -412,26 +429,9 @@ func TestRoutesForAgencyID_MapOptimization(t *testing.T) {
 	targetAgencyID := "25"
 	expectedRouteCount := 13
 
-	// Consolidated lock region
-	manager.RLock()
-	assert.NotNil(t, manager.routesByAgencyID, "routesByAgencyID map should be initialized")
-
-	cachedRoutes, exists := manager.routesByAgencyID[targetAgencyID]
-	assert.True(t, exists, "Agency %s should exist in cache map", targetAgencyID)
-	assert.Len(t, cachedRoutes, expectedRouteCount, "Map should contain correct number of routes")
-
-	publicRoutes := manager.RoutesForAgencyID(targetAgencyID)
-	emptyRoutes := manager.RoutesForAgencyID("nonexistent")
-	manager.RUnlock()
-
+	publicRoutes, err := manager.RoutesForAgencyID(ctx, targetAgencyID)
+	assert.Nil(t, err)
 	assert.Len(t, publicRoutes, expectedRouteCount, "Public API should return correct route count")
-
-	for _, route := range publicRoutes {
-		assert.Equal(t, targetAgencyID, route.Agency.Id,
-			"Route %s should belong to agency %s", route.Id, targetAgencyID)
-	}
-
-	assert.Empty(t, emptyRoutes, "Non-existent agency should return empty slice")
 }
 
 func TestRoutesForAgencyID_ConcurrentAccess(t *testing.T) {
@@ -450,7 +450,7 @@ func TestRoutesForAgencyID_ConcurrentAccess(t *testing.T) {
 	defer cancel()
 
 	var wg sync.WaitGroup
-	errors := make(chan error, 10)
+	errorChan := make(chan error, 10)
 
 	// Spawn concurrent readers
 	for i := range 5 {
@@ -463,11 +463,17 @@ func TestRoutesForAgencyID_ConcurrentAccess(t *testing.T) {
 					return
 				default:
 					manager.RLock()
-					routes := manager.RoutesForAgencyID("25")
+					routes, err := manager.RoutesForAgencyID(ctx, "25")
 					manager.RUnlock()
+					if errors.Is(err, context.DeadlineExceeded) {
+						return
+					} else if err != nil {
+						errorChan <- err
+						return
+					}
 
 					if routes == nil {
-						errors <- fmt.Errorf("reader %d: got nil routes slice", id)
+						errorChan <- fmt.Errorf("reader %d: got nil routes slice", id)
 						return
 					}
 					time.Sleep(1 * time.Microsecond)
@@ -498,9 +504,9 @@ func TestRoutesForAgencyID_ConcurrentAccess(t *testing.T) {
 	}()
 
 	wg.Wait()
-	close(errors)
+	close(errorChan)
 
-	for err := range errors {
+	for err := range errorChan {
 		t.Error(err)
 	}
 }
@@ -523,7 +529,7 @@ func BenchmarkRoutesForAgencyID_MapLookup(b *testing.B) {
 
 	for i := 0; i < b.N; i++ {
 		manager.RLock()
-		_ = manager.RoutesForAgencyID("25")
+		_, _ = manager.RoutesForAgencyID(ctx, "25")
 		manager.RUnlock()
 	}
 }

--- a/internal/gtfs/static.go
+++ b/internal/gtfs/static.go
@@ -385,8 +385,6 @@ func (manager *Manager) ForceUpdate(ctx context.Context) error {
 	manager.cacheEpoch.Add(1)
 	manager.activeServiceIDsCacheMutex.Unlock()
 
-	manager.routesByAgencyID = buildRouteIndex(newStaticData)
-
 	if newCache, freqErr := buildFrequencyCache(ctx, client.Queries); freqErr == nil {
 		manager.frequencyTripIDs = newCache
 	} else {
@@ -413,8 +411,7 @@ func (manager *Manager) ForceUpdate(ctx context.Context) error {
 
 	logging.LogOperation(logger, "gtfs_static_data_updated_hot_swap",
 		slog.String("source", manager.config.GtfsURL),
-		slog.String("db_path", finalDBPath),
-		slog.Int("route_index_agencies", len(manager.routesByAgencyID)))
+		slog.String("db_path", finalDBPath))
 
 	manager.parseAndLogFeedExpiryLocked(ctx, logger)
 
@@ -435,8 +432,6 @@ func (manager *Manager) setStaticGTFS(staticData *gtfs.Static) {
 	manager.isHealthy = true
 
 	manager.agenciesMap, manager.routesMap = buildLookupMaps(staticData)
-
-	manager.routesByAgencyID = buildRouteIndex(staticData)
 
 	manager.blockLayoverIndices = buildBlockLayoverIndices(staticData)
 	manager.regionBounds = ComputeRegionBounds(staticData.Shapes, staticData.Stops)
@@ -478,8 +473,7 @@ func (manager *Manager) setStaticGTFS(staticData *gtfs.Static) {
 		logger := slog.Default().With(slog.String("component", "gtfs_manager"))
 		logging.LogOperation(logger, "gtfs_data_set_successfully",
 			slog.String("source", manager.config.GtfsURL),
-			slog.Int("layover_indices_built", len(manager.blockLayoverIndices)),
-			slog.Int("route_index_agencies", len(manager.routesByAgencyID)))
+			slog.Int("layover_indices_built", len(manager.blockLayoverIndices)))
 	}
 }
 
@@ -495,19 +489,6 @@ func buildLookupMaps(data *gtfs.Static) (map[string]*gtfs.Agency, map[string]*gt
 		routes[data.Routes[i].Id] = &data.Routes[i]
 	}
 	return agencies, routes
-}
-
-func buildRouteIndex(staticData *gtfs.Static) map[string][]*gtfs.Route {
-	index := make(map[string][]*gtfs.Route, len(staticData.Agencies))
-
-	for i := range staticData.Routes {
-		route := &staticData.Routes[i]
-		agencyID := route.Agency.Id
-
-		index[agencyID] = append(index[agencyID], route)
-	}
-
-	return index
 }
 
 // buildFrequencyCache queries the DB for frequency trip IDs and returns a set.

--- a/internal/restapi/openapi_conformance_test.go
+++ b/internal/restapi/openapi_conformance_test.go
@@ -475,7 +475,8 @@ func TestOpenAPIConformance_RealTimeEndpoints(t *testing.T) {
 	require.NotEmpty(t, agencies)
 	agencyID := agencies[0].Id
 
-	vehicles := api.GtfsManager.VehiclesForAgencyID(agencyID)
+	vehicles, err := api.GtfsManager.VehiclesForAgencyID(ctx, agencyID)
+	require.Nil(t, err)
 	require.NotEmpty(t, vehicles, "Real-time vehicles must be loaded for conformance testing")
 
 	t.Run("vehicles-for-agency", func(t *testing.T) {

--- a/internal/restapi/routes_for_agency_handler.go
+++ b/internal/restapi/routes_for_agency_handler.go
@@ -24,19 +24,28 @@ func (api *RestAPI) routesForAgencyHandler(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	routesForAgency := api.GtfsManager.RoutesForAgencyID(id)
+	routesForAgency, err := api.GtfsManager.RoutesForAgencyID(r.Context(), id)
+	if err != nil {
+		api.serverErrorResponse(w, r, err)
+		return
+	}
 
 	// Apply pagination
 	offset, limit := utils.ParsePaginationParams(r)
 	routesForAgency, limitExceeded := utils.PaginateSlice(routesForAgency, offset, limit)
-	// Safe allocation logic
 	routesList := make([]models.Route, 0, len(routesForAgency))
 
 	for _, route := range routesForAgency {
 		routesList = append(routesList, models.NewRoute(
-			utils.FormCombinedID(route.Agency.Id, route.Id), route.Agency.Id, route.ShortName, route.LongName,
-			route.Description, models.RouteType(route.Type),
-			route.Url, route.Color, route.TextColor))
+			utils.FormCombinedID(agency.Id, route.ID),
+			agency.Id,
+			utils.NullStringOrEmpty(route.ShortName),
+			utils.NullStringOrEmpty(route.LongName),
+			utils.NullStringOrEmpty(route.Desc),
+			models.RouteType(route.Type),
+			utils.NullStringOrEmpty(route.Url),
+			utils.NullStringOrEmpty(route.Color),
+			utils.NullStringOrEmpty(route.TextColor)))
 	}
 
 	references := models.NewEmptyReferences()

--- a/internal/restapi/vehicles_for_agency_handler.go
+++ b/internal/restapi/vehicles_for_agency_handler.go
@@ -30,7 +30,11 @@ func (api *RestAPI) vehiclesForAgencyHandler(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	vehiclesForAgency := api.GtfsManager.VehiclesForAgencyID(id)
+	vehiclesForAgency, err := api.GtfsManager.VehiclesForAgencyID(ctx, id)
+	if err != nil {
+		api.serverErrorResponse(w, r, err)
+		return
+	}
 
 	// Apply pagination
 	offset, limit := utils.ParsePaginationParams(r)

--- a/internal/restapi/vehicles_for_agency_handler_test.go
+++ b/internal/restapi/vehicles_for_agency_handler_test.go
@@ -512,7 +512,8 @@ func TestVehiclesForAgencyHandlerWithRealTimeData(t *testing.T) {
 	t.Logf("Loaded %d real-time vehicles", len(realTimeVehicles))
 
 	// Debug vehicle-to-agency matching
-	vehiclesForAgency := api.GtfsManager.VehiclesForAgencyID(agencyId)
+	vehiclesForAgency, err := api.GtfsManager.VehiclesForAgencyID(context.Background(), agencyId)
+	require.Nil(t, err)
 	t.Logf("Found %d vehicles for agency %s", len(vehiclesForAgency), agencyId)
 
 	if len(realTimeVehicles) > 0 && len(vehiclesForAgency) == 0 {
@@ -531,11 +532,12 @@ func TestVehiclesForAgencyHandlerWithRealTimeData(t *testing.T) {
 			}
 		}
 
-		routes := api.GtfsManager.RoutesForAgencyID(agencyId)
+		routes, err := api.GtfsManager.RoutesForAgencyID(t.Context(), agencyId)
+		require.Nil(t, err)
 		t.Logf("Agency %s has %d routes:", agencyId, len(routes))
 		for i, route := range routes {
 			if i < 3 { // Log first 3 routes
-				t.Logf("Route: %s (agency: %s)", route.Id, route.Agency.Id)
+				t.Logf("Route: %s", route.ID)
 			}
 		}
 	}


### PR DESCRIPTION
Instead of building an in-memory index use the existing route information in the SQL database as well as the existing index on agency ID to query routes by agency.