### PR TITLE
refactor: remove routesMap and migrate route lookups to DB

### DIFF
--- a/internal/restapi/trips_for_route_handler.go
+++ b/internal/restapi/trips_for_route_handler.go
@@ -281,9 +281,11 @@ func (api *RestAPI) tripsForRouteHandler(w http.ResponseWriter, r *http.Request)
 	fetchedTrips = fetchedTrips[:n]
 
 	tripAgencyMap := make(map[string]string)
-	for _, trip := range fetchedTrips {
-		if route, err := api.GtfsManager.GtfsDB.Queries.GetRoute(ctx, trip.RouteID); err == nil {
-			tripAgencyMap[trip.ID] = route.AgencyID
+	if len(fetchedTrips) > 0 {
+		if route, err := api.GtfsManager.GtfsDB.Queries.GetRoute(ctx, routeID); err == nil {
+			for _, trip := range fetchedTrips {
+				tripAgencyMap[trip.ID] = route.AgencyID
+			}
 		}
 	}
 


### PR DESCRIPTION
Fixes: #814 

## Summary
- Removes `routesMap map[string]*gtfs.Route` from the `Manager` struct
- `FindRoute()` now delegates to `GtfsDB.Queries.GetRoute()`
- Agency filter functions (`filterTripsByAgency`, `filterVehiclesByAgency`, `filterAlertsByAgency`) are now pure functions no Manager receiver, no `staticMutex`. A single `buildRouteAgencyMap()` batch-fetches route --> agency data from DB before filtering runs
- `trips_for_route_handler` uses one `GetRoute` DB call instead of `FindRoute`
- `buildLookupMaps` now only builds the agency map
