### PR TITLE
fix: inconsistent route ID format in vehicles-for-agency response

### DIFF
--- a/internal/restapi/vehicles_for_agency_handler.go
+++ b/internal/restapi/vehicles_for_agency_handler.go
@@ -193,8 +193,9 @@ func (api *RestAPI) vehiclesForAgencyHandler(w http.ResponseWriter, r *http.Requ
 					textColor = route.TextColor.String
 				}
 
-				routeRefs[route.ID] = models.NewRoute(
-					route.ID, route.AgencyID, shortName, longName,
+				combinedRouteID := utils.FormCombinedID(route.AgencyID, route.ID)
+				routeRefs[combinedRouteID] = models.NewRoute(
+					combinedRouteID, route.AgencyID, shortName, longName,
 					desc, models.RouteType(route.Type),
 					url, color, textColor)
 

--- a/internal/restapi/vehicles_for_agency_handler_test.go
+++ b/internal/restapi/vehicles_for_agency_handler_test.go
@@ -16,6 +16,7 @@ import (
 	"maglev.onebusaway.org/internal/appconf"
 	"maglev.onebusaway.org/internal/clock"
 	"maglev.onebusaway.org/internal/gtfs"
+	"maglev.onebusaway.org/internal/utils"
 )
 
 func TestVehiclesForAgencyHandlerRequiresValidApiKey(t *testing.T) {
@@ -670,5 +671,16 @@ func TestVehiclesForAgencyHandlerWithRealTimeData(t *testing.T) {
 	} else {
 		t.Log("No real-time vehicles loaded - testing empty case")
 		assert.Len(t, vehiclesList, 0)
+	}
+}
+
+func TestVehiclesForAgency_RouteIDUsesCombinedID(t *testing.T) {
+	agencyID := "25"
+	routeID := "1"
+
+	expected := utils.FormCombinedID(agencyID, routeID)
+
+	if expected != "25_1" {
+		t.Fatalf("expected combined ID 25_1, got %s", expected)
 	}
 }

--- a/internal/restapi/vehicles_for_agency_handler_test.go
+++ b/internal/restapi/vehicles_for_agency_handler_test.go
@@ -16,7 +16,6 @@ import (
 	"maglev.onebusaway.org/internal/appconf"
 	"maglev.onebusaway.org/internal/clock"
 	"maglev.onebusaway.org/internal/gtfs"
-	"maglev.onebusaway.org/internal/utils"
 )
 
 func TestVehiclesForAgencyHandlerRequiresValidApiKey(t *testing.T) {
@@ -675,12 +674,36 @@ func TestVehiclesForAgencyHandlerWithRealTimeData(t *testing.T) {
 }
 
 func TestVehiclesForAgency_RouteIDUsesCombinedID(t *testing.T) {
-	agencyID := "25"
-	routeID := "1"
+	api := createTestApi(t)
+	defer api.Shutdown()
+	t.Cleanup(api.GtfsManager.MockResetRealTimeData)
 
-	expected := utils.FormCombinedID(agencyID, routeID)
+	agencies := mustGetAgencies(t, api)
+	require.NotEmpty(t, agencies)
+	agencyID := agencies[0].ID
 
-	if expected != "25_1" {
-		t.Fatalf("expected combined ID 25_1, got %s", expected)
-	}
+	trip := mustGetTrip(t, api)
+	rawRouteID := trip.RouteID
+	tripID := trip.ID
+
+	api.GtfsManager.MockAddVehicleWithOptions("v_route_id_test", tripID, rawRouteID, gtfs.MockVehicleOptions{})
+
+	_, model := serveApiAndRetrieveEndpoint(t, api, "/api/where/vehicles-for-agency/"+agencyID+".json?key=TEST")
+
+	data, ok := model.Data.(map[string]interface{})
+	require.True(t, ok)
+
+	refs, ok := data["references"].(map[string]interface{})
+	require.True(t, ok)
+
+	tripRefs, ok := refs["trips"].([]interface{})
+	require.True(t, ok)
+	require.NotEmpty(t, tripRefs, "expected at least one trip reference — mock vehicle was not returned by VehiclesForAgencyID")
+
+	tripRef := tripRefs[0].(map[string]interface{})
+	routeID, ok := tripRef["routeId"].(string)
+	require.True(t, ok, "routeId must be a string")
+
+	expectedRouteID := agencyID + "_" + rawRouteID
+	assert.Equal(t, expectedRouteID, routeID, "routeId in trip reference must be in combined agencyID_routeID format")
 }


### PR DESCRIPTION
## 1. SUMMARY

This PR fixes inconsistent route ID formatting in the `vehicles-for-agency` API response by ensuring route references use the combined `agencyID_routeID` format. The change primarily affects `internal/restapi/vehicles_for_agency_handler.go` within the `vehiclesForAgencyHandler`.

---

## 2. FIX

```go
// BEFORE
routeRefs[route.ID] = models.NewRoute(
    route.ID,
    route.AgencyID, shortName, longName,
    desc, models.RouteType(route.Type),
    url, color, textColor)

// AFTER
combinedRouteID := utils.FormCombinedID(route.AgencyID, route.ID)
routeRefs[combinedRouteID] = models.NewRoute(
    combinedRouteID,
    route.AgencyID, shortName, longName,
    desc, models.RouteType(route.Type),
    url, color, textColor)
```

---

## 3. VERIFICATION

Run the `/api/where/vehicles-for-agency/{id}.json` endpoint with GTFS-RT data and inspect route + trip references. Previously, `trip.routeId` would not match any `references.routes[].id`. After the fix, both use the same combined ID format, and cross-referencing works correctly.
