### PR TITLE
refactor: use sql database for FindAgency

### DIFF
--- a/gtfsdb/db.go
+++ b/gtfsdb/db.go
@@ -339,6 +339,9 @@ func Prepare(ctx context.Context, db DBTX) (*Queries, error) {
 	if q.listAgenciesStmt, err = db.PrepareContext(ctx, listAgencies); err != nil {
 		return nil, fmt.Errorf("error preparing query ListAgencies: %w", err)
 	}
+	if q.listAgencyIdsStmt, err = db.PrepareContext(ctx, listAgencyIds); err != nil {
+		return nil, fmt.Errorf("error preparing query ListAgencyIds: %w", err)
+	}
 	if q.listRoutesStmt, err = db.PrepareContext(ctx, listRoutes); err != nil {
 		return nil, fmt.Errorf("error preparing query ListRoutes: %w", err)
 	}
@@ -884,6 +887,11 @@ func (q *Queries) Close() error {
 			err = fmt.Errorf("error closing listAgenciesStmt: %w", cerr)
 		}
 	}
+	if q.listAgencyIdsStmt != nil {
+		if cerr := q.listAgencyIdsStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing listAgencyIdsStmt: %w", cerr)
+		}
+	}
 	if q.listRoutesStmt != nil {
 		if cerr := q.listRoutesStmt.Close(); cerr != nil {
 			err = fmt.Errorf("error closing listRoutesStmt: %w", cerr)
@@ -1053,6 +1061,7 @@ type Queries struct {
 	getTripsInBlockStmt                           *sql.Stmt
 	getTripsInBlockWithTimeBoundsStmt             *sql.Stmt
 	listAgenciesStmt                              *sql.Stmt
+	listAgencyIdsStmt                             *sql.Stmt
 	listRoutesStmt                                *sql.Stmt
 	listStopsStmt                                 *sql.Stmt
 	listTripsStmt                                 *sql.Stmt
@@ -1169,6 +1178,7 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		getTripsInBlockStmt:                           q.getTripsInBlockStmt,
 		getTripsInBlockWithTimeBoundsStmt:             q.getTripsInBlockWithTimeBoundsStmt,
 		listAgenciesStmt:                              q.listAgenciesStmt,
+		listAgencyIdsStmt:                             q.listAgencyIdsStmt,
 		listRoutesStmt:                                q.listRoutesStmt,
 		listStopsStmt:                                 q.listStopsStmt,
 		listTripsStmt:                                 q.listTripsStmt,

--- a/gtfsdb/query.sql
+++ b/gtfsdb/query.sql
@@ -24,6 +24,14 @@ FROM
 ORDER BY
     id;
 
+-- name: ListAgencyIds :many
+SELECT
+    id
+FROM
+    agencies
+ORDER BY
+    id;
+
 -- name: CreateAgency :one
 INSERT
 OR REPLACE INTO agencies (

--- a/gtfsdb/query.sql.go
+++ b/gtfsdb/query.sql.go
@@ -4789,6 +4789,38 @@ func (q *Queries) ListAgencies(ctx context.Context) ([]Agency, error) {
 	return items, nil
 }
 
+const listAgencyIds = `-- name: ListAgencyIds :many
+SELECT
+    id
+FROM
+    agencies
+ORDER BY
+    id
+`
+
+func (q *Queries) ListAgencyIds(ctx context.Context) ([]string, error) {
+	rows, err := q.query(ctx, q.listAgencyIdsStmt, listAgencyIds)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		items = append(items, id)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listRoutes = `-- name: ListRoutes :many
 SELECT
     id,

--- a/gtfsdb/utils.go
+++ b/gtfsdb/utils.go
@@ -1,0 +1,15 @@
+package gtfsdb
+
+import (
+	"database/sql"
+)
+
+// NullStringOrEmpty returns the string value if valid, otherwise returns an empty string
+// This duplicates utils.NullStringOrEmpty to avoid cyclic dependencies.
+// TODO: move utils.NullStringOrEmpty into another package (maybe this one) so it can share its implementation.
+func NullStringOrEmpty(ns sql.NullString) string {
+	if ns.Valid {
+		return ns.String
+	}
+	return ""
+}

--- a/gtfsdb/utils_test.go
+++ b/gtfsdb/utils_test.go
@@ -1,0 +1,13 @@
+package gtfsdb
+
+import (
+	"database/sql"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNullStringOrEmpty(t *testing.T) {
+	assert.Equal(t, "test", NullStringOrEmpty(sql.NullString{String: "test", Valid: true}))
+	assert.Equal(t, "", NullStringOrEmpty(sql.NullString{String: "test", Valid: false}))
+}

--- a/internal/gtfs/gtfs_manager.go
+++ b/internal/gtfs/gtfs_manager.go
@@ -2,9 +2,12 @@ package gtfs
 
 import (
 	"context"
+	"database/sql"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -55,7 +58,6 @@ type Manager struct {
 	realTimeVehicleLookupByVehicle map[string]int
 	duplicatedVehicleByRoute       map[string][]gtfs.Vehicle
 	alertIdx                       alertIndex
-	agenciesMap                    map[string]*gtfs.Agency
 	routesMap                      map[string]*gtfs.Route
 	frequencyTripIDs               map[string]struct{}
 	staticUpdateMutex              sync.Mutex   // Protects against concurrent ForceUpdate calls
@@ -287,6 +289,13 @@ func InitGTFSManager(ctx context.Context, config Config) (*Manager, error) {
 	manager.GtfsDB = gtfsDB
 
 	// Startup validation and logging for agency filtering
+	manager.staticMutex.RLock()
+	validAgencies, err := manager.GtfsDB.Queries.ListAgencyIds(ctx)
+	manager.staticMutex.RUnlock()
+	if err != nil {
+		return nil, err
+	}
+
 	enabledFeeds := config.enabledFeeds()
 	for _, feedCfg := range enabledFeeds {
 		if len(feedCfg.AgencyIDs) > 0 {
@@ -295,17 +304,9 @@ func InitGTFSManager(ctx context.Context, config Config) (*Manager, error) {
 				slog.Any("agency_ids", feedCfg.AgencyIDs),
 			)
 
-			manager.staticMutex.RLock()
-			var validAgencies []string
 			for _, configuredAgencyID := range feedCfg.AgencyIDs {
-				if _, exists := manager.agenciesMap[configuredAgencyID]; !exists {
-					if validAgencies == nil {
-						for validID := range manager.agenciesMap {
-							validAgencies = append(validAgencies, validID)
-						}
-						sort.Strings(validAgencies)
-					}
-
+				found := slices.Index(validAgencies, configuredAgencyID) != -1
+				if !found {
 					logger.Warn("configured agency-id not found in static GTFS data",
 						slog.String("feed", feedCfg.ID),
 						slog.String("invalid_agency_id", configuredAgencyID),
@@ -313,7 +314,6 @@ func InitGTFSManager(ctx context.Context, config Config) (*Manager, error) {
 					)
 				}
 			}
-			manager.staticMutex.RUnlock()
 		}
 	}
 	manager.parseAndLogFeedExpiryLocked(ctx, logger)
@@ -433,11 +433,15 @@ func (manager *Manager) GetBlockLayoverIndicesForRoute(routeID string) []*BlockL
 }
 
 // IMPORTANT: Caller must hold manager.RLock() before calling this method.
-func (manager *Manager) FindAgency(id string) *gtfs.Agency {
-	if agency, ok := manager.agenciesMap[id]; ok {
-		return agency
+func (manager *Manager) FindAgency(ctx context.Context, id string) (*gtfsdb.Agency, error) {
+	agency, err := manager.GtfsDB.Queries.GetAgency(ctx, id)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	} else if err != nil {
+		return nil, err
 	}
-	return nil
+
+	return &agency, nil
 }
 
 // IMPORTANT: Caller must hold manager.RLock() before calling this method.

--- a/internal/gtfs/gtfs_manager_test.go
+++ b/internal/gtfs/gtfs_manager_test.go
@@ -111,13 +111,15 @@ func TestManager_GetTrips(t *testing.T) {
 func TestManager_FindAgency(t *testing.T) {
 	manager, _ := getSharedTestComponents(t)
 
-	agency := manager.FindAgency("25")
+	agency, err := manager.FindAgency(context.Background(), "25")
+	assert.Nil(t, err)
 	assert.NotNil(t, agency)
-	assert.Equal(t, "25", agency.Id)
+	assert.Equal(t, "25", agency.ID)
 	assert.Equal(t, "Redding Area Bus Authority", agency.Name)
 
-	agencyNotFound := manager.FindAgency("nonexistent")
-	assert.Nil(t, agencyNotFound)
+	agency, err = manager.FindAgency(context.Background(), "nonexistent")
+	assert.Nil(t, err)
+	assert.Nil(t, agency)
 }
 
 func TestManager_GetVehicleByID(t *testing.T) {
@@ -334,49 +336,18 @@ func TestManager_GetVehicleForTrip(t *testing.T) {
 
 func TestBuildLookupMaps(t *testing.T) {
 	staticData := &gtfs.Static{
-		Agencies: []gtfs.Agency{
-			{Id: "agency_1", Name: "Metro"},
-			{Id: "agency_2", Name: "Bus"},
-		},
 		Routes: []gtfs.Route{
 			{Id: "route_101", ShortName: "101"},
 			{Id: "route_102", ShortName: "102"},
 		},
 	}
 
-	agencyMap, routeMap := buildLookupMaps(staticData)
-
-	assert.Equal(t, 2, len(agencyMap))
-	assert.NotNil(t, agencyMap["agency_1"])
-	assert.Equal(t, "Metro", agencyMap["agency_1"].Name)
-	assert.Nil(t, agencyMap["agency_999"], "Should return nil for non-existent agency")
+	routeMap := buildRoutesMaps(staticData)
 
 	assert.Equal(t, 2, len(routeMap))
 	assert.NotNil(t, routeMap["route_101"])
 	assert.Equal(t, "101", routeMap["route_101"].ShortName)
 	assert.Nil(t, routeMap["route_999"], "Should return nil for non-existent route")
-}
-
-func TestManager_FindAgency_UsesMap(t *testing.T) {
-	// This test proves we are using the Map, not the Slice.
-	// We populate the Map, but leave the Slice empty.
-	// If the code was still looping over the slice, this would fail.
-	manager := &Manager{
-		agenciesMap: map[string]*gtfs.Agency{
-			"A1": {Id: "A1", Name: "Fast Agency"},
-		},
-		// Empty Slice to ensure we aren't using the old linear search
-		gtfsData: &gtfs.Static{
-			Agencies: []gtfs.Agency{},
-		},
-	}
-
-	result := manager.FindAgency("A1")
-	assert.NotNil(t, result)
-	assert.Equal(t, "Fast Agency", result.Name)
-
-	result = manager.FindAgency("B2")
-	assert.Nil(t, result)
 }
 
 func TestManager_FindRoute_UsesMap(t *testing.T) {

--- a/internal/gtfs/static.go
+++ b/internal/gtfs/static.go
@@ -362,7 +362,7 @@ func (manager *Manager) ForceUpdate(ctx context.Context) error {
 
 	manager.gtfsData = newStaticData
 	manager.GtfsDB = client
-	manager.agenciesMap, manager.routesMap = buildLookupMaps(newStaticData)
+	manager.routesMap = buildRoutesMaps(newStaticData)
 	manager.blockLayoverIndices = newBlockLayoverIndices
 	manager.stopSpatialIndex = newStopSpatialIndex
 	manager.regionBounds = newRegionBounds
@@ -431,7 +431,7 @@ func (manager *Manager) setStaticGTFS(staticData *gtfs.Static) {
 
 	manager.isHealthy = true
 
-	manager.agenciesMap, manager.routesMap = buildLookupMaps(staticData)
+	manager.routesMap = buildRoutesMaps(staticData)
 
 	manager.blockLayoverIndices = buildBlockLayoverIndices(staticData)
 	manager.regionBounds = ComputeRegionBounds(staticData.Shapes, staticData.Stops)
@@ -477,18 +477,13 @@ func (manager *Manager) setStaticGTFS(staticData *gtfs.Static) {
 	}
 }
 
-// buildLookupMaps is used to create O(1) lookup maps for agencies and routes
-func buildLookupMaps(data *gtfs.Static) (map[string]*gtfs.Agency, map[string]*gtfs.Route) {
-	agencies := make(map[string]*gtfs.Agency, len(data.Agencies))
-	for i := range data.Agencies {
-		agencies[data.Agencies[i].Id] = &data.Agencies[i]
-	}
-
+// buildRoutesMaps is used to create an index for routes by ID.
+func buildRoutesMaps(data *gtfs.Static) map[string]*gtfs.Route {
 	routes := make(map[string]*gtfs.Route, len(data.Routes))
 	for i := range data.Routes {
 		routes[data.Routes[i].Id] = &data.Routes[i]
 	}
-	return agencies, routes
+	return routes
 }
 
 // buildFrequencyCache queries the DB for frequency trip IDs and returns a set.

--- a/internal/models/agency.go
+++ b/internal/models/agency.go
@@ -1,5 +1,7 @@
 package models
 
+import "maglev.onebusaway.org/gtfsdb"
+
 // AgencyCoverage represents the geographical coverage area of a transit agency
 type AgencyCoverage struct {
 	AgencyID string  `json:"agencyId"`
@@ -46,5 +48,20 @@ func NewAgencyReference(id, name, url, timezone, lang, phone, email, fareUrl, di
 		FareUrl:        fareUrl,
 		Disclaimer:     disclaimer,
 		PrivateService: privateService,
+	}
+}
+
+func AgencyReferenceFromDatabase(agency *gtfsdb.Agency) AgencyReference {
+	return AgencyReference{
+		ID:             agency.ID,
+		Name:           agency.Name,
+		URL:            agency.Url,
+		Timezone:       agency.Timezone,
+		Lang:           gtfsdb.NullStringOrEmpty(agency.Lang),
+		Phone:          gtfsdb.NullStringOrEmpty(agency.Phone),
+		Email:          gtfsdb.NullStringOrEmpty(agency.Email),
+		FareUrl:        gtfsdb.NullStringOrEmpty(agency.FareUrl),
+		Disclaimer:     "",
+		PrivateService: false,
 	}
 }

--- a/internal/restapi/agency_handler.go
+++ b/internal/restapi/agency_handler.go
@@ -16,26 +16,17 @@ func (api *RestAPI) agencyHandler(w http.ResponseWriter, r *http.Request) {
 	api.GtfsManager.RLock()
 	defer api.GtfsManager.RUnlock()
 
-	agency := api.GtfsManager.FindAgency(id)
-
+	agency, err := api.GtfsManager.FindAgency(r.Context(), id)
+	if err != nil {
+		api.serverErrorResponse(w, r, err)
+		return
+	}
 	if agency == nil {
 		api.sendNotFound(w, r)
 		return
 	}
 
-	agencyData := models.NewAgencyReference(
-		agency.Id,
-		agency.Name,
-		agency.Url,
-		agency.Timezone,
-		agency.Language,
-		agency.Phone,
-		agency.Email,
-		agency.FareUrl,
-		"",
-		false,
-	)
-
+	agencyData := models.AgencyReferenceFromDatabase(agency)
 	response := models.NewEntryResponse(agencyData, *models.NewEmptyReferences(), api.Clock)
 	api.sendResponse(w, r, response)
 }

--- a/internal/restapi/route_ids_for_agency_handler.go
+++ b/internal/restapi/route_ids_for_agency_handler.go
@@ -17,14 +17,16 @@ func (api *RestAPI) routeIDsForAgencyHandler(w http.ResponseWriter, r *http.Requ
 	api.GtfsManager.RLock()
 	defer api.GtfsManager.RUnlock()
 
-	agency := api.GtfsManager.FindAgency(id)
-
+	ctx := r.Context()
+	agency, err := api.GtfsManager.FindAgency(ctx, id)
+	if err != nil {
+		api.serverErrorResponse(w, r, err)
+		return
+	}
 	if agency == nil {
 		api.sendNull(w, r)
 		return
 	}
-
-	ctx := r.Context()
 
 	routeIDs, err := api.GtfsManager.GtfsDB.Queries.GetRouteIDsForAgency(ctx, id)
 

--- a/internal/restapi/routes_for_agency_handler.go
+++ b/internal/restapi/routes_for_agency_handler.go
@@ -17,14 +17,18 @@ func (api *RestAPI) routesForAgencyHandler(w http.ResponseWriter, r *http.Reques
 	api.GtfsManager.RLock()
 	defer api.GtfsManager.RUnlock()
 
-	agency := api.GtfsManager.FindAgency(id)
-
+	ctx := r.Context()
+	agency, err := api.GtfsManager.FindAgency(ctx, id)
+	if err != nil {
+		api.serverErrorResponse(w, r, err)
+		return
+	}
 	if agency == nil {
 		api.sendNull(w, r)
 		return
 	}
 
-	routesForAgency, err := api.GtfsManager.RoutesForAgencyID(r.Context(), id)
+	routesForAgency, err := api.GtfsManager.RoutesForAgencyID(ctx, id)
 	if err != nil {
 		api.serverErrorResponse(w, r, err)
 		return
@@ -37,8 +41,8 @@ func (api *RestAPI) routesForAgencyHandler(w http.ResponseWriter, r *http.Reques
 
 	for _, route := range routesForAgency {
 		routesList = append(routesList, models.NewRoute(
-			utils.FormCombinedID(agency.Id, route.ID),
-			agency.Id,
+			utils.FormCombinedID(agency.ID, route.ID),
+			agency.ID,
 			utils.NullStringOrEmpty(route.ShortName),
 			utils.NullStringOrEmpty(route.LongName),
 			utils.NullStringOrEmpty(route.Desc),
@@ -50,11 +54,7 @@ func (api *RestAPI) routesForAgencyHandler(w http.ResponseWriter, r *http.Reques
 
 	references := models.NewEmptyReferences()
 	references.Agencies = []models.AgencyReference{
-		models.NewAgencyReference(
-			agency.Id, agency.Name, agency.Url, agency.Timezone,
-			agency.Language, agency.Phone, agency.Email,
-			agency.FareUrl, "", false,
-		),
+		models.AgencyReferenceFromDatabase(agency),
 	}
 
 	response := models.NewListResponse(routesList, *references, limitExceeded, api.Clock)

--- a/internal/restapi/stop-ids-for-agency_handler.go
+++ b/internal/restapi/stop-ids-for-agency_handler.go
@@ -18,14 +18,16 @@ func (api *RestAPI) stopIDsForAgencyHandler(w http.ResponseWriter, r *http.Reque
 	api.GtfsManager.RLock()
 	defer api.GtfsManager.RUnlock()
 
-	agency := api.GtfsManager.FindAgency(id)
-
+	ctx := r.Context()
+	agency, err := api.GtfsManager.FindAgency(ctx, id)
+	if err != nil {
+		api.serverErrorResponse(w, r, err)
+		return
+	}
 	if agency == nil {
 		api.sendNull(w, r)
 		return
 	}
-
-	ctx := r.Context()
 
 	// Check if context is already cancelled
 	if ctx.Err() != nil {

--- a/internal/restapi/stops_for_agency_handler.go
+++ b/internal/restapi/stops_for_agency_handler.go
@@ -27,7 +27,11 @@ func (api *RestAPI) stopsForAgencyHandler(w http.ResponseWriter, r *http.Request
 	}
 
 	// Validate agency exists
-	agency := api.GtfsManager.FindAgency(id)
+	agency, err := api.GtfsManager.FindAgency(ctx, id)
+	if err != nil {
+		api.serverErrorResponse(w, r, err)
+		return
+	}
 	if agency == nil {
 		api.sendNull(w, r)
 		return
@@ -47,20 +51,6 @@ func (api *RestAPI) stopsForAgencyHandler(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	// Build agency reference
-	agencyRef := models.NewAgencyReference(
-		agency.Id,
-		agency.Name,
-		agency.Url,
-		agency.Timezone,
-		agency.Language,
-		agency.Phone,
-		agency.Email,
-		agency.FareUrl,
-		"",
-		false,
-	)
-
 	// Build route references from stops
 	routeRefs, err := api.BuildRouteReferences(ctx, id, stopsList)
 	if err != nil {
@@ -70,7 +60,7 @@ func (api *RestAPI) stopsForAgencyHandler(w http.ResponseWriter, r *http.Request
 
 	// Build references
 	references := models.NewEmptyReferences()
-	references.Agencies = []models.AgencyReference{agencyRef}
+	references.Agencies = []models.AgencyReference{models.AgencyReferenceFromDatabase(agency)}
 	references.Routes = routeRefs
 
 	response := models.NewListResponse(stopsList, *references, false, api.Clock)

--- a/internal/restapi/trips_for_route_handler.go
+++ b/internal/restapi/trips_for_route_handler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"log/slog"
 	"net/http"
 	"strconv"
 	"strings"
@@ -562,19 +563,13 @@ func buildTripReferences(
 				route.TextColor.String)
 
 			if _, exists := presentAgencies[route.AgencyID]; !exists {
-				if agency := api.GtfsManager.FindAgency(route.AgencyID); agency != nil {
-					presentAgencies[agency.Id] = models.NewAgencyReference(
-						agency.Id,
-						agency.Name,
-						agency.Url,
-						agency.Timezone,
-						agency.Language,
-						agency.Phone,
-						agency.Email,
-						agency.FareUrl,
-						"",
-						false,
-					)
+				agency, err := api.GtfsManager.FindAgency(ctx, route.AgencyID)
+				if err != nil {
+					logging.LogError(api.Logger, "failed to fetch agency for references", err, slog.String("agency", route.AgencyID))
+				}
+
+				if agency != nil {
+					presentAgencies[agency.ID] = models.AgencyReferenceFromDatabase(agency)
 				}
 			}
 		}

--- a/internal/restapi/vehicles_for_agency_handler.go
+++ b/internal/restapi/vehicles_for_agency_handler.go
@@ -21,8 +21,12 @@ func (api *RestAPI) vehiclesForAgencyHandler(w http.ResponseWriter, r *http.Requ
 	// Acquire static lock only for the agency lookup; release immediately.
 	// VehiclesForAgencyID manages its own locking internally.
 	api.GtfsManager.RLock()
-	agency := api.GtfsManager.FindAgency(id)
+	agency, err := api.GtfsManager.FindAgency(ctx, id)
 	api.GtfsManager.RUnlock()
+	if err != nil {
+		api.serverErrorResponse(w, r, err)
+		return
+	}
 
 	if agency == nil {
 		// return an empty list response.
@@ -63,7 +67,6 @@ func (api *RestAPI) vehiclesForAgencyHandler(w http.ResponseWriter, r *http.Requ
 	}
 
 	// Maps to build references
-	agencyRefs := make(map[string]models.AgencyReference)
 	routeRefs := make(map[string]models.Route)
 	tripRefs := make(map[string]models.Trip)
 
@@ -208,19 +211,7 @@ func (api *RestAPI) vehiclesForAgencyHandler(w http.ResponseWriter, r *http.Requ
 		vehiclesList = append(vehiclesList, vehicleStatus)
 	}
 
-	// Add agency to references
-	agencyRefs[agency.Id] = models.NewAgencyReference(
-		agency.Id, agency.Name, agency.Url, agency.Timezone,
-		agency.Language, agency.Phone, agency.Email,
-		agency.FareUrl, "", false,
-	)
-
 	// Convert maps to slices for references
-	agencyRefList := make([]models.AgencyReference, 0, len(agencyRefs))
-	for _, agencyRef := range agencyRefs {
-		agencyRefList = append(agencyRefList, agencyRef)
-	}
-
 	routeRefList := make([]models.Route, 0, len(routeRefs))
 	for _, routeRef := range routeRefs {
 		routeRefList = append(routeRefList, routeRef)
@@ -232,7 +223,7 @@ func (api *RestAPI) vehiclesForAgencyHandler(w http.ResponseWriter, r *http.Requ
 	}
 
 	references := models.NewEmptyReferences()
-	references.Agencies = agencyRefList
+	references.Agencies = []models.AgencyReference{models.AgencyReferenceFromDatabase(agency)}
 	references.Routes = routeRefList
 	references.Trips = tripRefList
 


### PR DESCRIPTION
Replace use of in-memory index with queries to the sql database.