### PR TITLE
fix: populate situations in vehicles-for-agency references

### DIFF
--- a/internal/gtfs/gtfs_manager_mock.go
+++ b/internal/gtfs/gtfs_manager_mock.go
@@ -154,7 +154,7 @@ func (m *Manager) MockAddAlert(feedID string, alert gtfs.Alert) {
 	m.rebuildMergedRealtimeLocked()
 }
 
-// MockResetRealTimeData clears all mock real-time vehicles and trip updates.
+// MockResetRealTimeData clears all mock real-time vehicles, trip updates, and alerts.
 func (m *Manager) MockResetRealTimeData() {
 	m.realTimeMutex.Lock()
 	defer m.realTimeMutex.Unlock()
@@ -165,6 +165,8 @@ func (m *Manager) MockResetRealTimeData() {
 	m.duplicatedVehicleByRoute = make(map[string][]gtfs.Vehicle)
 	m.realTimeTrips = nil
 	m.realTimeTripLookup = make(map[string]int)
+	m.feedAlerts = make(map[string][]gtfs.Alert)
+	m.rebuildMergedRealtimeLocked()
 }
 
 // MockClearServiceIDsCache evicts all entries from the active-service-IDs cache.

--- a/internal/restapi/vehicles_for_agency_handler.go
+++ b/internal/restapi/vehicles_for_agency_handler.go
@@ -236,6 +236,12 @@ func (api *RestAPI) vehiclesForAgencyHandler(w http.ResponseWriter, r *http.Requ
 	references.Routes = routeRefList
 	references.Trips = tripRefList
 
+	alerts := deduplicateAlerts(
+		api.collectAlertsForRoutes(routeIDs),
+		api.GtfsManager.GetAlertsByIDs("", "", id),
+	)
+	references.Situations = append(references.Situations, api.BuildSituationReferences(alerts)...)
+
 	response := models.NewListResponse(vehiclesList, *references, limitExceeded, api.Clock)
 	api.sendResponse(w, r, response)
 }

--- a/internal/restapi/vehicles_for_agency_handler_test.go
+++ b/internal/restapi/vehicles_for_agency_handler_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	gogtfs "github.com/OneBusAway/go-gtfs"
 	gtfsrt "github.com/OneBusAway/go-gtfs/proto"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -412,6 +413,113 @@ func TestVehiclesForAgencyHandler_VehicleWithNilID(t *testing.T) {
 		v := item.(map[string]interface{})
 		assert.NotEqual(t, "", v["vehicleId"], "vehicle with nil ID must be skipped, not returned with empty vehicleId")
 	}
+}
+
+// TestVehiclesForAgencyHandler_SituationsPopulatedInReferences verifies that route-level
+// alerts are reflected in references.situations for vehicles serving that route.
+func TestVehiclesForAgencyHandler_SituationsPopulatedInReferences(t *testing.T) {
+	api := createTestApi(t)
+	defer api.Shutdown()
+	t.Cleanup(api.GtfsManager.MockResetRealTimeData)
+
+	agencies := api.GtfsManager.GetAgencies()
+	require.NotEmpty(t, agencies)
+	agencyID := agencies[0].Id
+
+	trips := api.GtfsManager.GetTrips()
+	require.NotEmpty(t, trips)
+
+	rawTripID := trips[0].ID
+	rawRouteID := trips[0].Route.Id
+
+	const alertID = "alert-vehicles-test"
+	// MockAddAlert must precede MockAddVehicleWithOptions: it triggers rebuildMergedRealtimeLocked,
+	// which rebuilds realTimeVehicles from feedVehicles (empty), wiping any vehicle added first.
+	api.GtfsManager.MockAddAlert("feed-0", gogtfs.Alert{
+		ID: alertID,
+		InformedEntities: []gogtfs.AlertInformedEntity{
+			{RouteID: &rawRouteID},
+		},
+	})
+
+	api.GtfsManager.MockAddVehicleWithOptions("v_situation_test", rawTripID, rawRouteID, gtfs.MockVehicleOptions{})
+
+	_, model := serveApiAndRetrieveEndpoint(t, api, "/api/where/vehicles-for-agency/"+agencyID+".json?key=TEST")
+
+	data, ok := model.Data.(map[string]interface{})
+	require.True(t, ok)
+
+	vehiclesList, ok := data["list"].([]interface{})
+	require.True(t, ok)
+	require.NotEmpty(t, vehiclesList, "mock vehicle not returned by VehiclesForAgencyID")
+
+	refs, ok := data["references"].(map[string]interface{})
+	require.True(t, ok)
+
+	situations, ok := refs["situations"].([]interface{})
+	require.True(t, ok)
+	require.NotEmpty(t, situations, "expected at least one situation in references")
+
+	found := false
+	for _, s := range situations {
+		sit := s.(map[string]interface{})
+		if sit["id"] == alertID {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "expected situation with id %q in references.situations", alertID)
+}
+
+// TestVehiclesForAgencyHandler_AgencySituationsPopulatedInReferences verifies that
+// agency-wide alerts are reflected in references.situations.
+func TestVehiclesForAgencyHandler_AgencySituationsPopulatedInReferences(t *testing.T) {
+	api := createTestApi(t)
+	defer api.Shutdown()
+	t.Cleanup(api.GtfsManager.MockResetRealTimeData)
+
+	agencies := api.GtfsManager.GetAgencies()
+	require.NotEmpty(t, agencies)
+	agencyID := agencies[0].Id
+
+	trips := api.GtfsManager.GetTrips()
+	require.NotEmpty(t, trips)
+
+	const alertID = "alert-agency-wide-test"
+	api.GtfsManager.MockAddAlert("feed-0", gogtfs.Alert{
+		ID: alertID,
+		InformedEntities: []gogtfs.AlertInformedEntity{
+			{AgencyID: &agencyID},
+		},
+	})
+
+	api.GtfsManager.MockAddVehicleWithOptions("v_agency_alert_test", trips[0].ID, trips[0].Route.Id, gtfs.MockVehicleOptions{})
+
+	_, model := serveApiAndRetrieveEndpoint(t, api, "/api/where/vehicles-for-agency/"+agencyID+".json?key=TEST")
+
+	data, ok := model.Data.(map[string]interface{})
+	require.True(t, ok)
+
+	vehiclesList, ok := data["list"].([]interface{})
+	require.True(t, ok)
+	require.NotEmpty(t, vehiclesList, "mock vehicle not returned by VehiclesForAgencyID")
+
+	refs, ok := data["references"].(map[string]interface{})
+	require.True(t, ok)
+
+	situations, ok := refs["situations"].([]interface{})
+	require.True(t, ok)
+	require.NotEmpty(t, situations, "expected agency-wide alert in references.situations")
+
+	found := false
+	for _, s := range situations {
+		sit := s.(map[string]interface{})
+		if sit["id"] == alertID {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "expected situation with id %q in references.situations", alertID)
 }
 
 // createTestApiWithRealTimeData creates a test API with real-time GTFS-RT data served from local files


### PR DESCRIPTION
closes #818 

fixes the `vehicles-for-agency` endpoint always returning an empty
`references.situations` array. Checked the Java OBA server (MTA NYCT
production) and it does return situations in the references block for this
endpoint.

The handler was simply never wired up to collect alerts. Every other endpoint
that returns a `references` block already does this.

## Changes

**`internal/restapi/vehicles_for_agency_handler.go`**

After building the vehicle list, collect route-level and agency-wide alerts
and populate `references.situations`. Route IDs are already gathered before
the loop for the existing batch route fetch, so nothing new hits the DB.

```go
alerts := deduplicateAlerts(
    api.collectAlertsForRoutes(routeIDs),
    api.GtfsManager.GetAlertsByIDs("", "", id),
)
references.Situations = append(references.Situations, api.BuildSituationReferences(alerts)...)
```



**`internal/gtfs/gtfs_manager_mock.go`**

`MockResetRealTimeData` wasn't clearing `feedAlerts`, so any test that
injected an alert into the shared manager would leak it into later tests.
Added the missing reset and a `rebuildMergedRealtimeLocked` call.

## Testing

Added two tests:
- route-scoped alert shows up in `references.situations`
- agency-wide alert shows up in `references.situations`

Trip-scoped alerts are intentionally not collected here doing so would
require a DB query per vehicle which doesn't scale over a full fleet. Route
and agency scoping covers what real feeds publish in practice, and matches
how other endpoints handle the same trade-off.