### PR TITLE
refactor: migrate GetAgencies() from in-memory to database query

### DIFF
--- a/internal/gtfs/concurrency_test.go
+++ b/internal/gtfs/concurrency_test.go
@@ -42,7 +42,7 @@ func TestConcurrentGTFSDataAccess(t *testing.T) {
 				// Simulate reading data multiple times
 				for j := 0; j < 10; j++ {
 					manager.RLock() // Acquire proper read lock
-					agencies := manager.GetAgencies()
+					agencies := manager.gtfsData.Agencies
 					manager.RUnlock()
 
 					results[index] = agencies
@@ -81,7 +81,7 @@ func TestConcurrentGTFSDataAccess(t *testing.T) {
 					case <-done:
 						return
 					default:
-						_ = manager.GetAgencies()
+						_ = manager.gtfsData.Agencies
 						_ = manager.GetStops()
 						_ = manager.GetStaticData()
 						time.Sleep(time.Microsecond)

--- a/internal/gtfs/gtfs_manager.go
+++ b/internal/gtfs/gtfs_manager.go
@@ -407,9 +407,9 @@ func (manager *Manager) RUnlock() {
 	manager.staticMutex.RUnlock()
 }
 
-// IMPORTANT: Caller must hold manager.RLock() before calling this method.
-func (manager *Manager) GetAgencies() []gtfs.Agency {
-	return manager.gtfsData.Agencies
+// GetAgencies returns all agencies from the database.
+func (manager *Manager) GetAgencies(ctx context.Context) ([]gtfsdb.Agency, error) {
+	return manager.GtfsDB.Queries.ListAgencies(ctx)
 }
 
 // IMPORTANT: Caller must hold manager.RLock() before calling this method.

--- a/internal/gtfs/gtfs_manager_test.go
+++ b/internal/gtfs/gtfs_manager_test.go
@@ -23,18 +23,19 @@ func TestManager_GetAgencies(t *testing.T) {
 	manager, _ := getSharedTestComponents(t)
 	assert.NotNil(t, manager)
 
-	agencies := manager.GetAgencies()
+	agencies, err := manager.GtfsDB.Queries.ListAgencies(context.Background())
+	require.NoError(t, err)
 	assert.Equal(t, 1, len(agencies))
 
 	agency := agencies[0]
-	assert.Equal(t, "25", agency.Id)
+	assert.Equal(t, "25", agency.ID)
 	assert.Equal(t, "Redding Area Bus Authority", agency.Name)
 	assert.Equal(t, "http://www.rabaride.com/", agency.Url)
 	assert.Equal(t, "America/Los_Angeles", agency.Timezone)
-	assert.Equal(t, "en", agency.Language)
-	assert.Equal(t, "530-241-2877", agency.Phone)
-	assert.Equal(t, "", agency.FareUrl)
-	assert.Equal(t, "", agency.Email)
+	assert.Equal(t, "en", agency.Lang.String)
+	assert.Equal(t, "530-241-2877", agency.Phone.String)
+	assert.Equal(t, "", agency.FareUrl.String)
+	assert.Equal(t, "", agency.Email.String)
 }
 
 func TestManager_RoutesForAgencyID(t *testing.T) {

--- a/internal/gtfs/hot_swap_memory_test.go
+++ b/internal/gtfs/hot_swap_memory_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
 	"maglev.onebusaway.org/internal/appconf"
 	"maglev.onebusaway.org/internal/models"
 )
@@ -128,7 +129,8 @@ func TestHotSwapMemory_LargeAgency(t *testing.T) {
 	time.Sleep(200 * time.Millisecond)
 
 	postInitStats := getMemoryStats()
-	agencies := manager.GetAgencies()
+	agencies, agenciesErr := manager.GtfsDB.Queries.ListAgencies(context.Background())
+	require.NoError(t, agenciesErr)
 
 	t.Logf("Manager initialized in %v", initDuration)
 	t.Logf("Agencies: %d", len(agencies))
@@ -328,11 +330,13 @@ func TestHotSwapMemory_LargeAgency(t *testing.T) {
 	}
 
 	// Verify data integrity after swap
-	newAgencies := manager.GetAgencies()
-	if len(newAgencies) == 0 {
+	newAgencies, newAgenciesErr := manager.GtfsDB.Queries.ListAgencies(context.Background())
+	if newAgenciesErr != nil {
+		t.Errorf("Failed to list agencies after hot-swap: %v", newAgenciesErr)
+	} else if len(newAgencies) == 0 {
 		t.Error("No agencies found after hot-swap")
 	} else {
-		t.Logf("Post-swap agencies: %d (first: %s)", len(newAgencies), newAgencies[0].Id)
+		t.Logf("Post-swap agencies: %d (first: %s)", len(newAgencies), newAgencies[0].ID)
 	}
 }
 

--- a/internal/gtfs/hot_swap_test.go
+++ b/internal/gtfs/hot_swap_test.go
@@ -41,9 +41,10 @@ func TestHotSwap_QueriesCompleteDuringSwap(t *testing.T) {
 	}
 	defer manager.Shutdown()
 
-	agencies := manager.GetAgencies()
+	agencies, err := manager.GtfsDB.Queries.ListAgencies(context.Background())
+	require.NoError(t, err)
 	assert.Equal(t, 1, len(agencies))
-	assert.Equal(t, "25", agencies[0].Id)
+	assert.Equal(t, "25", agencies[0].ID)
 
 	var wg sync.WaitGroup
 	ctx, cancel := context.WithCancel(context.Background())
@@ -103,9 +104,10 @@ func TestHotSwap_QueriesCompleteDuringSwap(t *testing.T) {
 		t.Errorf("Reader error: %v", e)
 	}
 
-	agencies = manager.GetAgencies()
+	agencies, err = manager.GtfsDB.Queries.ListAgencies(context.Background())
+	require.NoError(t, err)
 	assert.Equal(t, 1, len(agencies))
-	assert.Equal(t, "40", agencies[0].Id)
+	assert.Equal(t, "40", agencies[0].ID)
 }
 
 func TestHotSwap_FailureRecovery(t *testing.T) {
@@ -181,9 +183,10 @@ func TestHotSwap_OldDatabaseCleanup(t *testing.T) {
 	err = manager.ForceUpdate(context.Background())
 	require.NoError(t, err, "ForceUpdate failed for new GTFS")
 
-	agencies := manager.GetAgencies()
+	agencies, err := manager.GtfsDB.Queries.ListAgencies(context.Background())
+	require.NoError(t, err)
 	require.NotEmpty(t, agencies, "No agencies found after second update")
-	assert.Equal(t, "40", agencies[0].Id)
+	assert.Equal(t, "40", agencies[0].ID)
 
 	files, err := os.ReadDir(tempDir)
 	if err != nil {

--- a/internal/gtfs/shutdown_test.go
+++ b/internal/gtfs/shutdown_test.go
@@ -29,7 +29,8 @@ func TestManagerShutdown(t *testing.T) {
 	require.NotNil(t, manager, "Manager should not be nil")
 
 	// Verify manager is functional
-	agencies := manager.GetAgencies()
+	agencies, err := manager.GtfsDB.Queries.ListAgencies(context.Background())
+	require.NoError(t, err)
 	assert.Greater(t, len(agencies), 0, "Should have loaded agencies")
 
 	// Test shutdown

--- a/internal/restapi/agency_handler_test.go
+++ b/internal/restapi/agency_handler_test.go
@@ -11,9 +11,9 @@ import (
 func TestAgencyHandlerReturnsAgencyWhenItExists(t *testing.T) {
 	api := createTestApi(t)
 	defer api.Shutdown()
-	agencies := api.GtfsManager.GetAgencies()
+	agencies := mustGetAgencies(t, api)
 	require.NotEmpty(t, agencies)
-	agencyID := agencies[0].Id
+	agencyID := agencies[0].ID
 	resp, model := serveApiAndRetrieveEndpoint(t, api, "/api/where/agency/"+agencyID+".json?key=TEST")
 
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
@@ -26,7 +26,7 @@ func TestAgencyHandlerReturnsAgencyWhenItExists(t *testing.T) {
 	entry, ok := data["entry"].(map[string]interface{})
 	require.True(t, ok)
 
-	assert.Equal(t, agencies[0].Id, entry["id"])
+	assert.Equal(t, agencies[0].ID, entry["id"])
 	assert.Equal(t, agencies[0].Name, entry["name"])
 	assert.Equal(t, agencies[0].Url, entry["url"])
 	assert.Equal(t, agencies[0].Timezone, entry["timezone"])
@@ -43,9 +43,9 @@ func TestAgencyHandlerReturnsNullWhenAgencyDoesNotExist(t *testing.T) {
 func TestAgencyHandlerRequiresValidApiKey(t *testing.T) {
 	api := createTestApi(t)
 	defer api.Shutdown()
-	agencies := api.GtfsManager.GetAgencies()
+	agencies := mustGetAgencies(t, api)
 	require.NotEmpty(t, agencies)
-	agencyID := agencies[0].Id
+	agencyID := agencies[0].ID
 	resp, model := serveApiAndRetrieveEndpoint(t, api, "/api/where/agency/"+agencyID+".json?key=INVALID")
 
 	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)

--- a/internal/restapi/arrival_and_departure_for_stop_handler_test.go
+++ b/internal/restapi/arrival_and_departure_for_stop_handler_test.go
@@ -31,7 +31,7 @@ func TestArrivalAndDepartureForStopHandlerEndToEnd(t *testing.T) {
 	api := createTestApi(t)
 	defer api.Shutdown()
 
-	agency := api.GtfsManager.GetAgencies()[0]
+	agency := mustGetAgencies(t, api)[0]
 	stops := api.GtfsManager.GetStops()
 	trips := api.GtfsManager.GetTrips()
 
@@ -43,8 +43,8 @@ func TestArrivalAndDepartureForStopHandlerEndToEnd(t *testing.T) {
 		t.Skip("No trips available for testing")
 	}
 
-	stopID := utils.FormCombinedID(agency.Id, stops[0].Id)
-	tripID := utils.FormCombinedID(agency.Id, trips[0].ID)
+	stopID := utils.FormCombinedID(agency.ID, stops[0].Id)
+	tripID := utils.FormCombinedID(agency.ID, trips[0].ID)
 	serviceDate := time.Now().Unix() * 1000
 
 	mux := http.NewServeMux()
@@ -117,10 +117,10 @@ func TestArrivalAndDepartureForStopHandlerWithInvalidStopID(t *testing.T) {
 	api := createTestApi(t)
 	defer api.Shutdown()
 
-	agency := api.GtfsManager.GetAgencies()[0]
+	agency := mustGetAgencies(t, api)[0]
 	trips := api.GtfsManager.GetTrips()
 
-	tripID := utils.FormCombinedID(agency.Id, trips[0].ID)
+	tripID := utils.FormCombinedID(agency.ID, trips[0].ID)
 	serviceDate := time.Now().Unix() * 1000
 
 	_, resp, model := serveAndRetrieveEndpoint(t,
@@ -137,7 +137,7 @@ func TestArrivalAndDepartureForStopHandlerWithTimeParameter(t *testing.T) {
 	api := createTestApi(t)
 	defer api.Shutdown()
 
-	agency := api.GtfsManager.GetAgencies()[0]
+	agency := mustGetAgencies(t, api)[0]
 	stops := api.GtfsManager.GetStops()
 	trips := api.GtfsManager.GetTrips()
 
@@ -149,8 +149,8 @@ func TestArrivalAndDepartureForStopHandlerWithTimeParameter(t *testing.T) {
 		t.Skip("No trips available for testing")
 	}
 
-	stopID := utils.FormCombinedID(agency.Id, stops[0].Id)
-	tripID := utils.FormCombinedID(agency.Id, trips[0].ID)
+	stopID := utils.FormCombinedID(agency.ID, stops[0].Id)
+	tripID := utils.FormCombinedID(agency.ID, trips[0].ID)
 
 	// Use a specific time (1 hour from now)
 	specificTime := time.Now().Add(1 * time.Hour)
@@ -185,10 +185,10 @@ func TestArrivalAndDepartureForStopHandlerRequiresTripId(t *testing.T) {
 	api := createTestApi(t)
 	defer api.Shutdown()
 
-	agency := api.GtfsManager.GetAgencies()[0]
+	agency := mustGetAgencies(t, api)[0]
 	stops := api.GtfsManager.GetStops()
 
-	stopID := utils.FormCombinedID(agency.Id, stops[0].Id)
+	stopID := utils.FormCombinedID(agency.ID, stops[0].Id)
 	serviceDate := time.Now().Unix() * 1000
 
 	mux := http.NewServeMux()
@@ -221,12 +221,12 @@ func TestArrivalAndDepartureForStopHandlerRequiresServiceDate(t *testing.T) {
 	api := createTestApi(t)
 	defer api.Shutdown()
 
-	agency := api.GtfsManager.GetAgencies()[0]
+	agency := mustGetAgencies(t, api)[0]
 	stops := api.GtfsManager.GetStops()
 	trips := api.GtfsManager.GetTrips()
 
-	stopID := utils.FormCombinedID(agency.Id, stops[0].Id)
-	tripID := utils.FormCombinedID(agency.Id, trips[0].ID)
+	stopID := utils.FormCombinedID(agency.ID, stops[0].Id)
+	tripID := utils.FormCombinedID(agency.ID, trips[0].ID)
 
 	mux := http.NewServeMux()
 	api.SetRoutes(mux)
@@ -258,7 +258,7 @@ func TestArrivalAndDepartureForStopHandlerWithStopSequence(t *testing.T) {
 	api := createTestApi(t)
 	defer api.Shutdown()
 
-	agency := api.GtfsManager.GetAgencies()[0]
+	agency := mustGetAgencies(t, api)[0]
 	stops := api.GtfsManager.GetStops()
 	trips := api.GtfsManager.GetTrips()
 
@@ -270,8 +270,8 @@ func TestArrivalAndDepartureForStopHandlerWithStopSequence(t *testing.T) {
 		t.Skip("No trips available for testing")
 	}
 
-	stopID := utils.FormCombinedID(agency.Id, stops[0].Id)
-	tripID := utils.FormCombinedID(agency.Id, trips[0].ID)
+	stopID := utils.FormCombinedID(agency.ID, stops[0].Id)
+	tripID := utils.FormCombinedID(agency.ID, trips[0].ID)
 	serviceDate := time.Now().Unix() * 1000
 	stopSequence := 1
 
@@ -297,7 +297,7 @@ func TestArrivalAndDepartureForStopHandlerWithMinutesParameters(t *testing.T) {
 	api := createTestApi(t)
 	defer api.Shutdown()
 
-	agency := api.GtfsManager.GetAgencies()[0]
+	agency := mustGetAgencies(t, api)[0]
 	stops := api.GtfsManager.GetStops()
 	trips := api.GtfsManager.GetTrips()
 
@@ -309,8 +309,8 @@ func TestArrivalAndDepartureForStopHandlerWithMinutesParameters(t *testing.T) {
 		t.Skip("No trips available for testing")
 	}
 
-	stopID := utils.FormCombinedID(agency.Id, stops[0].Id)
-	tripID := utils.FormCombinedID(agency.Id, trips[0].ID)
+	stopID := utils.FormCombinedID(agency.ID, stops[0].Id)
+	tripID := utils.FormCombinedID(agency.ID, trips[0].ID)
 	serviceDate := time.Now().Unix() * 1000
 
 	_, resp, model := serveAndRetrieveEndpoint(t,
@@ -330,11 +330,11 @@ func TestArrivalAndDepartureForStopHandlerWithInvalidTripID(t *testing.T) {
 	api := createTestApi(t)
 	defer api.Shutdown()
 
-	agency := api.GtfsManager.GetAgencies()[0]
+	agency := mustGetAgencies(t, api)[0]
 	stops := api.GtfsManager.GetStops()
 
-	stopID := utils.FormCombinedID(agency.Id, stops[0].Id)
-	tripID := utils.FormCombinedID(agency.Id, "nonexistent_trip")
+	stopID := utils.FormCombinedID(agency.ID, stops[0].Id)
+	tripID := utils.FormCombinedID(agency.ID, "nonexistent_trip")
 	serviceDate := time.Now().Unix() * 1000
 
 	_, resp, model := serveAndRetrieveEndpoint(t,
@@ -350,10 +350,10 @@ func TestArrivalAndDepartureForStopHandlerWithMalformedTripID(t *testing.T) {
 	api := createTestApi(t)
 	defer api.Shutdown()
 
-	agency := api.GtfsManager.GetAgencies()[0]
+	agency := mustGetAgencies(t, api)[0]
 	stops := api.GtfsManager.GetStops()
 
-	stopID := utils.FormCombinedID(agency.Id, stops[0].Id)
+	stopID := utils.FormCombinedID(agency.ID, stops[0].Id)
 	tripID := "malformedid" // No underscore, will fail extraction
 	serviceDate := time.Now().Unix() * 1000
 
@@ -368,11 +368,11 @@ func TestArrivalAndDepartureForStopHandlerWithMalformedStopID(t *testing.T) {
 	api := createTestApi(t)
 	defer api.Shutdown()
 
-	agency := api.GtfsManager.GetAgencies()[0]
+	agency := mustGetAgencies(t, api)[0]
 	trips := api.GtfsManager.GetTrips()
 
 	stopID := "malformedid" // No underscore, will fail extraction
-	tripID := utils.FormCombinedID(agency.Id, trips[0].ID)
+	tripID := utils.FormCombinedID(agency.ID, trips[0].ID)
 	serviceDate := time.Now().Unix() * 1000
 
 	_, resp, _ := serveAndRetrieveEndpoint(t,
@@ -386,7 +386,7 @@ func TestArrivalAndDepartureForStopHandlerWithValidTripStopCombination(t *testin
 	api := createTestApi(t)
 	defer api.Shutdown()
 
-	agency := api.GtfsManager.GetAgencies()[0]
+	agency := mustGetAgencies(t, api)[0]
 	ctx := context.Background()
 
 	// Find a valid trip with stop times
@@ -413,8 +413,8 @@ func TestArrivalAndDepartureForStopHandlerWithValidTripStopCombination(t *testin
 		t.Skip("No valid trip-stop combinations found in test data")
 	}
 
-	combinedStopID := utils.FormCombinedID(agency.Id, validStopID)
-	combinedTripID := utils.FormCombinedID(agency.Id, validTripID)
+	combinedStopID := utils.FormCombinedID(agency.ID, validStopID)
+	combinedTripID := utils.FormCombinedID(agency.ID, validTripID)
 	serviceDate := time.Now().Unix() * 1000
 
 	_, resp, model := serveAndRetrieveEndpoint(t,
@@ -472,7 +472,7 @@ func TestArrivalAndDepartureForStopHandlerWithValidTripAndStopSequence(t *testin
 	api := createTestApi(t)
 	defer api.Shutdown()
 
-	agency := api.GtfsManager.GetAgencies()[0]
+	agency := mustGetAgencies(t, api)[0]
 	ctx := context.Background()
 
 	// Find a valid trip with multiple stops
@@ -499,8 +499,8 @@ func TestArrivalAndDepartureForStopHandlerWithValidTripAndStopSequence(t *testin
 		t.Skip("No valid trip with multiple stops found in test data")
 	}
 
-	combinedStopID := utils.FormCombinedID(agency.Id, validStopID)
-	combinedTripID := utils.FormCombinedID(agency.Id, validTripID)
+	combinedStopID := utils.FormCombinedID(agency.ID, validStopID)
+	combinedTripID := utils.FormCombinedID(agency.ID, validTripID)
 	serviceDate := time.Now().Unix() * 1000
 
 	// Test with correct stop sequence
@@ -1122,9 +1122,9 @@ func TestArrivalAndDepartureForStop_VehicleWithNilID(t *testing.T) {
 	}
 	require.NotEmpty(t, validTripID, "no trip with stop times found in test data")
 
-	agencies := api.GtfsManager.GetAgencies()
+	agencies := mustGetAgencies(t, api)
 	require.NotEmpty(t, agencies)
-	agencyID := agencies[0].Id
+	agencyID := agencies[0].ID
 
 	combinedStopID := utils.FormCombinedID(agencyID, validStopID)
 	combinedTripID := utils.FormCombinedID(agencyID, validTripID)

--- a/internal/restapi/arrivals_and_departures_for_stop_handler_test.go
+++ b/internal/restapi/arrivals_and_departures_for_stop_handler_test.go
@@ -24,14 +24,14 @@ func TestArrivalsAndDeparturesForStopHandlerRequiresValidApiKey(t *testing.T) {
 
 	time.Sleep(500 * time.Millisecond)
 
-	agency := api.GtfsManager.GetAgencies()[0]
+	agency := mustGetAgencies(t, api)[0]
 	stops := api.GtfsManager.GetStops()
 
 	if len(stops) == 0 {
 		t.Skip("No stops available for testing")
 	}
 
-	stopID := utils.FormCombinedID(agency.Id, stops[0].Id)
+	stopID := utils.FormCombinedID(agency.ID, stops[0].Id)
 
 	resp, model := serveApiAndRetrieveEndpoint(t, api,
 		"/api/where/arrivals-and-departures-for-stop/"+stopID+".json?key=invalid")
@@ -47,14 +47,14 @@ func TestArrivalsAndDeparturesForStopHandlerEndToEnd(t *testing.T) {
 
 	time.Sleep(500 * time.Millisecond)
 
-	agency := api.GtfsManager.GetAgencies()[0]
+	agency := mustGetAgencies(t, api)[0]
 	stops := api.GtfsManager.GetStops()
 
 	if len(stops) == 0 {
 		t.Skip("No stops available for testing")
 	}
 
-	stopID := utils.FormCombinedID(agency.Id, stops[0].Id)
+	stopID := utils.FormCombinedID(agency.ID, stops[0].Id)
 
 	resp, model := serveApiAndRetrieveEndpoint(t, api,
 		"/api/where/arrivals-and-departures-for-stop/"+stopID+".json?key=TEST")
@@ -171,14 +171,14 @@ func TestArrivalsAndDeparturesForStopHandlerWithTimeParameters(t *testing.T) {
 
 	time.Sleep(500 * time.Millisecond)
 
-	agency := api.GtfsManager.GetAgencies()[0]
+	agency := mustGetAgencies(t, api)[0]
 	stops := api.GtfsManager.GetStops()
 
 	if len(stops) == 0 {
 		t.Skip("No stops available for testing")
 	}
 
-	stopID := utils.FormCombinedID(agency.Id, stops[0].Id)
+	stopID := utils.FormCombinedID(agency.ID, stops[0].Id)
 	minutesAfter := 60
 	minutesBefore := 10
 
@@ -215,14 +215,14 @@ func TestArrivalsAndDeparturesForStopHandlerWithSpecificTime(t *testing.T) {
 
 	time.Sleep(500 * time.Millisecond)
 
-	agency := api.GtfsManager.GetAgencies()[0]
+	agency := mustGetAgencies(t, api)[0]
 	stops := api.GtfsManager.GetStops()
 
 	if len(stops) == 0 {
 		t.Skip("No stops available for testing")
 	}
 
-	stopID := utils.FormCombinedID(agency.Id, stops[0].Id)
+	stopID := utils.FormCombinedID(agency.ID, stops[0].Id)
 
 	tomorrow := time.Now().AddDate(0, 0, 1)
 	specificTime := time.Date(tomorrow.Year(), tomorrow.Month(), tomorrow.Day(), 9, 0, 0, 0, time.Local)
@@ -256,8 +256,8 @@ func TestArrivalsAndDeparturesForStopHandlerWithInvalidStopID(t *testing.T) {
 
 	time.Sleep(500 * time.Millisecond)
 
-	agency := api.GtfsManager.GetAgencies()[0]
-	invalidStopID := utils.FormCombinedID(agency.Id, "invalid_stop")
+	agency := mustGetAgencies(t, api)[0]
+	invalidStopID := utils.FormCombinedID(agency.ID, "invalid_stop")
 
 	resp, model := serveApiAndRetrieveEndpoint(t, api,
 		"/api/where/arrivals-and-departures-for-stop/"+invalidStopID+".json?key=TEST")
@@ -284,14 +284,14 @@ func TestArrivalsAndDeparturesForStopHandlerNoActiveServices(t *testing.T) {
 
 	time.Sleep(500 * time.Millisecond)
 
-	agency := api.GtfsManager.GetAgencies()[0]
+	agency := mustGetAgencies(t, api)[0]
 	stops := api.GtfsManager.GetStops()
 
 	if len(stops) == 0 {
 		t.Skip("No stops available for testing")
 	}
 
-	stopID := utils.FormCombinedID(agency.Id, stops[0].Id)
+	stopID := utils.FormCombinedID(agency.ID, stops[0].Id)
 
 	futureTime := time.Now().AddDate(10, 0, 0)
 	timeMs := futureTime.Unix() * 1000
@@ -344,14 +344,14 @@ func TestArrivalsAndDeparturesForStopHandlerDefaultParameters(t *testing.T) {
 
 	time.Sleep(500 * time.Millisecond)
 
-	agency := api.GtfsManager.GetAgencies()[0]
+	agency := mustGetAgencies(t, api)[0]
 	stops := api.GtfsManager.GetStops()
 
 	if len(stops) == 0 {
 		t.Skip("No stops available for testing")
 	}
 
-	stopID := utils.FormCombinedID(agency.Id, stops[0].Id)
+	stopID := utils.FormCombinedID(agency.ID, stops[0].Id)
 
 	resp, model := serveApiAndRetrieveEndpoint(t, api,
 		"/api/where/arrivals-and-departures-for-stop/"+stopID+".json?key=TEST")
@@ -441,9 +441,9 @@ func TestArrivalsAndDeparturesForStopHandlerWithInvalidParams(t *testing.T) {
 	api := createTestApi(t)
 	defer api.Shutdown()
 
-	agency := api.GtfsManager.GetAgencies()[0]
+	agency := mustGetAgencies(t, api)[0]
 	stops := api.GtfsManager.GetStops()
-	stopID := utils.FormCombinedID(agency.Id, stops[0].Id)
+	stopID := utils.FormCombinedID(agency.ID, stops[0].Id)
 
 	endpoint := "/api/where/arrivals-and-departures-for-stop/" + stopID + ".json?key=TEST&time=invalid"
 	resp, _ := serveApiAndRetrieveEndpoint(t, api, endpoint)
@@ -603,7 +603,7 @@ func TestArrivalsAndDeparturesReturnsResultsNearMidnight(t *testing.T) {
 	api := createTestApiWithClock(t, mockClock)
 	defer api.Shutdown()
 
-	agency := api.GtfsManager.GetAgencies()[0]
+	agency := mustGetAgencies(t, api)[0]
 	stops := api.GtfsManager.GetStops()
 	if len(stops) == 0 {
 		t.Skip("No stops available for testing")
@@ -612,7 +612,7 @@ func TestArrivalsAndDeparturesReturnsResultsNearMidnight(t *testing.T) {
 	var foundResults bool
 
 	for _, stop := range stops {
-		stopID := utils.FormCombinedID(agency.Id, stop.Id)
+		stopID := utils.FormCombinedID(agency.ID, stop.Id)
 		url := "/api/where/arrivals-and-departures-for-stop/" + stopID + ".json?key=TEST&minutesBefore=15&minutesAfter=240"
 
 		resp, model := serveApiAndRetrieveEndpoint(t, api, url)

--- a/internal/restapi/benchmark_test.go
+++ b/internal/restapi/benchmark_test.go
@@ -13,12 +13,12 @@ func BenchmarkArrivalsAndDeparturesForStop(b *testing.B) {
 	api, cleanup := createTestApiWithRealTimeData(b)
 	defer cleanup()
 
-	agencies := api.GtfsManager.GetAgencies()
+	agencies := mustGetAgencies(b, api)
 	stops := api.GtfsManager.GetStops()
 	if len(agencies) == 0 || len(stops) == 0 {
 		b.Fatal("no agencies or stops")
 	}
-	stopID := utils.FormCombinedID(agencies[0].Id, stops[0].Id)
+	stopID := utils.FormCombinedID(agencies[0].ID, stops[0].Id)
 
 	mux := http.NewServeMux()
 	api.SetRoutes(mux)
@@ -66,11 +66,11 @@ func BenchmarkVehiclesForAgency(b *testing.B) {
 	api, cleanup := createTestApiWithRealTimeData(b)
 	defer cleanup()
 
-	agencies := api.GtfsManager.GetAgencies()
+	agencies := mustGetAgencies(b, api)
 	if len(agencies) == 0 {
 		b.Fatal("no agencies")
 	}
-	agencyID := agencies[0].Id
+	agencyID := agencies[0].ID
 
 	mux := http.NewServeMux()
 	api.SetRoutes(mux)
@@ -95,12 +95,12 @@ func BenchmarkTripDetails(b *testing.B) {
 	api, cleanup := createTestApiWithRealTimeData(b)
 	defer cleanup()
 
-	agencies := api.GtfsManager.GetAgencies()
+	agencies := mustGetAgencies(b, api)
 	trips := api.GtfsManager.GetTrips()
 	if len(agencies) == 0 || len(trips) == 0 {
 		b.Fatal("no agencies or trips")
 	}
-	tripID := utils.FormCombinedID(agencies[0].Id, trips[0].ID)
+	tripID := utils.FormCombinedID(agencies[0].ID, trips[0].ID)
 
 	mux := http.NewServeMux()
 	api.SetRoutes(mux)

--- a/internal/restapi/http_test.go
+++ b/internal/restapi/http_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"maglev.onebusaway.org/gtfsdb"
 	"maglev.onebusaway.org/internal/app"
 	"maglev.onebusaway.org/internal/appconf"
 	"maglev.onebusaway.org/internal/clock"
@@ -98,6 +99,14 @@ func createTestApiWithClock(t testing.TB, c clock.Clock) *RestAPI {
 // Accepts testing.TB to support both *testing.T and *testing.B
 func createTestApi(t testing.TB) *RestAPI {
 	return createTestApiWithClock(t, clock.RealClock{})
+}
+
+// mustGetAgencies fetches agencies from the DB for use in tests.
+func mustGetAgencies(t testing.TB, api *RestAPI) []gtfsdb.Agency {
+	t.Helper()
+	agencies, err := api.GtfsManager.GtfsDB.Queries.ListAgencies(context.Background())
+	require.NoError(t, err)
+	return agencies
 }
 
 // serveAndRetrieveEndpoint sets up a test server, makes a request to the specified endpoint, and returns the response

--- a/internal/restapi/openapi_conformance_test.go
+++ b/internal/restapi/openapi_conformance_test.go
@@ -164,9 +164,9 @@ func TestOpenAPIConformance_StaticEndpoints(t *testing.T) {
 	doc := loadOpenAPISpec(t)
 
 	// Gather test data IDs from the RABA fixture
-	agencies := api.GtfsManager.GetAgencies()
+	agencies := mustGetAgencies(t, api)
 	require.NotEmpty(t, agencies, "Test data must contain at least one agency")
-	agencyID := agencies[0].Id
+	agencyID := agencies[0].ID
 
 	stops := api.GtfsManager.GetStops()
 	require.NotEmpty(t, stops, "Test data must contain at least one stop")
@@ -471,9 +471,9 @@ func TestOpenAPIConformance_RealTimeEndpoints(t *testing.T) {
 
 	doc := loadOpenAPISpec(t)
 
-	agencies := api.GtfsManager.GetAgencies()
+	agencies := mustGetAgencies(t, api)
 	require.NotEmpty(t, agencies)
-	agencyID := agencies[0].Id
+	agencyID := agencies[0].ID
 
 	vehicles, err := api.GtfsManager.VehiclesForAgencyID(ctx, agencyID)
 	require.Nil(t, err)

--- a/internal/restapi/route_handler_test.go
+++ b/internal/restapi/route_handler_test.go
@@ -13,7 +13,7 @@ import (
 func TestRouteHandlerRequiresValidApiKey(t *testing.T) {
 	api := createTestApi(t)
 
-	agencies := api.GtfsManager.GetAgencies()
+	agencies := mustGetAgencies(t, api)
 	assert.NotEmpty(t, agencies, "Test data should contain at least one agency")
 
 	routes := api.GtfsManager.GetRoutes()
@@ -30,7 +30,7 @@ func TestRouteHandlerRequiresValidApiKey(t *testing.T) {
 func TestRouteHandlerEndToEnd(t *testing.T) {
 	api := createTestApi(t)
 
-	agencies := api.GtfsManager.GetAgencies()
+	agencies := mustGetAgencies(t, api)
 	assert.NotEmpty(t, agencies, "Test data should contain at least one agency")
 
 	routes := api.GtfsManager.GetRoutes()
@@ -70,14 +70,14 @@ func TestRouteHandlerEndToEnd(t *testing.T) {
 	agenciesRef, ok := references["agencies"].([]interface{})
 	assert.True(t, ok, "Agencies reference should exist and be an array")
 	agencyRef := agenciesRef[0].(map[string]interface{})
-	assert.Equal(t, agencies[0].Id, agencyRef["id"])
+	assert.Equal(t, agencies[0].ID, agencyRef["id"])
 	assert.NotEmpty(t, agenciesRef, "Agencies reference should not be empty")
 }
 
 func TestInvalidRouteID(t *testing.T) {
 	api := createTestApi(t)
 
-	agencies := api.GtfsManager.GetAgencies()
+	agencies := mustGetAgencies(t, api)
 	assert.NotEmpty(t, agencies, "Test data should contain at least one agency")
 
 	routes := api.GtfsManager.GetRoutes()
@@ -94,7 +94,7 @@ func TestInvalidRouteID(t *testing.T) {
 func TestRouteHandlerVerifiesReferences(t *testing.T) {
 	api := createTestApi(t)
 
-	agencies := api.GtfsManager.GetAgencies()
+	agencies := mustGetAgencies(t, api)
 	assert.NotEmpty(t, agencies, "Test data should contain at least one agency")
 
 	routes := api.GtfsManager.GetRoutes()

--- a/internal/restapi/route_ids_for_agency_handler_test.go
+++ b/internal/restapi/route_ids_for_agency_handler_test.go
@@ -19,9 +19,9 @@ func TestRouteIdsForAgencyRequiresValidApiKey(t *testing.T) {
 func TestRouteIdsForAgencyEndToEnd(t *testing.T) {
 	api := createTestApi(t)
 	defer api.Shutdown()
-	agencies := api.GtfsManager.GetAgencies()
+	agencies := mustGetAgencies(t, api)
 	require.NotEmpty(t, agencies)
-	agencyId := agencies[0].Id
+	agencyId := agencies[0].ID
 
 	resp, model := serveApiAndRetrieveEndpoint(t, api, "/api/where/route-ids-for-agency/"+agencyId+".json?key=TEST")
 	assert.Equal(t, http.StatusOK, resp.StatusCode)

--- a/internal/restapi/route_search_handler.go
+++ b/internal/restapi/route_search_handler.go
@@ -114,7 +114,12 @@ func (api *RestAPI) routeSearchHandler(w http.ResponseWriter, r *http.Request) {
 			textColor))
 	}
 
-	agencies := utils.FilterAgencies(api.GtfsManager.GetAgencies(), agencyIDs)
+	allAgencies, err := api.GtfsManager.GetAgencies(ctx)
+	if err != nil {
+		api.serverErrorResponse(w, r, err)
+		return
+	}
+	agencies := utils.FilterAgencies(allAgencies, agencyIDs)
 	// Populate situation references for alerts affecting the returned routes
 	resultRawRouteIDs := make([]string, 0, len(routes))
 	for _, routeRow := range routes {

--- a/internal/restapi/routes_for_agency_handler_test.go
+++ b/internal/restapi/routes_for_agency_handler_test.go
@@ -11,9 +11,9 @@ import (
 func TestRoutesForAgencyHandlerRequiresValidApiKey(t *testing.T) {
 	api := createTestApi(t)
 	defer api.Shutdown()
-	agencies := api.GtfsManager.GetAgencies()
+	agencies := mustGetAgencies(t, api)
 	require.NotEmpty(t, agencies)
-	agencyId := agencies[0].Id
+	agencyId := agencies[0].ID
 
 	resp, model := serveApiAndRetrieveEndpoint(t, api, "/api/where/routes-for-agency/"+agencyId+".json?key=invalid")
 
@@ -25,9 +25,9 @@ func TestRoutesForAgencyHandlerRequiresValidApiKey(t *testing.T) {
 func TestRoutesForAgencyHandlerEndToEnd(t *testing.T) {
 	api := createTestApi(t)
 	defer api.Shutdown()
-	agencies := api.GtfsManager.GetAgencies()
+	agencies := mustGetAgencies(t, api)
 	require.NotEmpty(t, agencies)
-	agencyId := agencies[0].Id
+	agencyId := agencies[0].ID
 
 	resp, model := serveApiAndRetrieveEndpoint(t, api, "/api/where/routes-for-agency/"+agencyId+".json?key=TEST")
 
@@ -80,9 +80,9 @@ func TestRoutesForAgencyHandlerReturnsCompoundRouteIDs(t *testing.T) {
 	api := createTestApi(t)
 	defer api.Shutdown()
 
-	agencies := api.GtfsManager.GetAgencies()
+	agencies := mustGetAgencies(t, api)
 	require.NotEmpty(t, agencies)
-	agencyId := agencies[0].Id
+	agencyId := agencies[0].ID
 
 	resp, model := serveApiAndRetrieveEndpoint(t, api, "/api/where/routes-for-agency/"+agencyId+".json?key=TEST")
 
@@ -111,9 +111,9 @@ func TestRoutesForAgencyHandlerPagination(t *testing.T) {
 	api := createTestApi(t)
 	defer api.Shutdown()
 
-	agencies := api.GtfsManager.GetAgencies()
+	agencies := mustGetAgencies(t, api)
 	require.NotEmpty(t, agencies)
-	agencyId := agencies[0].Id
+	agencyId := agencies[0].ID
 
 	// Case 1: Limit 5 (Should return 5 items, limitExceeded=true)
 	resp, model := serveApiAndRetrieveEndpoint(t, api, "/api/where/routes-for-agency/"+agencyId+".json?key=TEST&limit=5")

--- a/internal/restapi/routes_for_location_handler.go
+++ b/internal/restapi/routes_for_location_handler.go
@@ -50,6 +50,12 @@ func (api *RestAPI) routesForLocationHandler(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
+	allAgencies, err := api.GtfsManager.GetAgencies(ctx)
+	if err != nil {
+		api.serverErrorResponse(w, r, err)
+		return
+	}
+
 	api.GtfsManager.RLock()
 	defer api.GtfsManager.RUnlock()
 
@@ -67,7 +73,7 @@ func (api *RestAPI) routesForLocationHandler(w http.ResponseWriter, r *http.Requ
 
 	if len(stopIDs) == 0 {
 		// Return empty response if no stops found
-		agencies := utils.FilterAgencies(api.GtfsManager.GetAgencies(), agencyIDs)
+		agencies := utils.FilterAgencies(allAgencies, agencyIDs)
 		references := models.NewEmptyReferences()
 		references.Agencies = agencies
 		response := models.NewListResponseWithRange(results, *references, checkIfOutOfBounds(api, loc.Lat, loc.Lon, loc.LatSpan, loc.LonSpan, radius), api.Clock, false)
@@ -124,7 +130,7 @@ func (api *RestAPI) routesForLocationHandler(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	agencies := utils.FilterAgencies(api.GtfsManager.GetAgencies(), agencyIDs)
+	agencies := utils.FilterAgencies(allAgencies, agencyIDs)
 
 	// Populate situation references for alerts affecting the returned routes
 	alerts := api.collectAlertsForRoutes(resultRawRouteIDs)

--- a/internal/restapi/schedule_for_route_handler_test.go
+++ b/internal/restapi/schedule_for_route_handler_test.go
@@ -17,14 +17,14 @@ func TestScheduleForRouteHandler(t *testing.T) {
 	api := createTestApiWithClock(t, clk)
 	defer api.Shutdown()
 
-	agencies := api.GtfsManager.GetAgencies()
+	agencies := mustGetAgencies(t, api)
 	require.NotEmpty(t, agencies, "Test data should contain at least one agency")
 
 	static := api.GtfsManager.GetStaticData()
 	require.NotNil(t, static)
 	require.NotEmpty(t, static.Routes, "Test data should contain at least one route")
 
-	routeID := utils.FormCombinedID(agencies[0].Id, static.Routes[0].Id)
+	routeID := utils.FormCombinedID(agencies[0].ID, static.Routes[0].Id)
 
 	t.Run("Valid route", func(t *testing.T) {
 		// Use a date known to be in the test data's service calendar
@@ -132,13 +132,13 @@ func TestScheduleForRouteHandler(t *testing.T) {
 func TestScheduleForRouteHandlerDateParam(t *testing.T) {
 	api := createTestApi(t)
 	defer api.Shutdown()
-	agencies := api.GtfsManager.GetAgencies()
+	agencies := mustGetAgencies(t, api)
 	require.NotEmpty(t, agencies)
 	static := api.GtfsManager.GetStaticData()
 	require.NotNil(t, static)
 	require.NotEmpty(t, static.Routes)
 
-	routeID := utils.FormCombinedID(agencies[0].Id, static.Routes[0].Id)
+	routeID := utils.FormCombinedID(agencies[0].ID, static.Routes[0].Id)
 
 	t.Run("Valid date parameter", func(t *testing.T) {
 		// Use a date known to be in the test data's service calendar

--- a/internal/restapi/schedule_for_stop_handler.go
+++ b/internal/restapi/schedule_for_stop_handler.go
@@ -170,20 +170,23 @@ func (api *RestAPI) scheduleForStopHandler(w http.ResponseWriter, r *http.Reques
 		}
 	}
 
-	// Batch fetch agencies using cached manager
-	allAgencies := api.GtfsManager.GetAgencies()
+	allAgencies, err := api.GtfsManager.GetAgencies(ctx)
+	if err != nil {
+		api.serverErrorResponse(w, r, err)
+		return
+	}
 	for _, a := range allAgencies {
-		if uniqueAgencyIDsMap[a.Id] {
-			if _, exists := agencyRefs[a.Id]; !exists {
-				agencyRefs[a.Id] = models.NewAgencyReference(
-					a.Id,
+		if uniqueAgencyIDsMap[a.ID] {
+			if _, exists := agencyRefs[a.ID]; !exists {
+				agencyRefs[a.ID] = models.NewAgencyReference(
+					a.ID,
 					a.Name,
 					a.Url,
 					a.Timezone,
-					a.Language,
-					a.Phone,
-					a.Email,
-					a.FareUrl,
+					a.Lang.String,
+					a.Phone.String,
+					a.Email.String,
+					a.FareUrl.String,
 					"",    // disclaimer
 					false, // privateService
 				)

--- a/internal/restapi/schedule_for_stop_handler.go
+++ b/internal/restapi/schedule_for_stop_handler.go
@@ -170,27 +170,30 @@ func (api *RestAPI) scheduleForStopHandler(w http.ResponseWriter, r *http.Reques
 		}
 	}
 
-	allAgencies, err := api.GtfsManager.GetAgencies(ctx)
+	agencyIDsToFetch := make([]string, 0, len(uniqueAgencyIDsMap))
+	for agencyID := range uniqueAgencyIDsMap {
+		agencyIDsToFetch = append(agencyIDsToFetch, agencyID)
+	}
+
+	fetchedAgencies, err := api.GtfsManager.GtfsDB.Queries.GetAgenciesByIDs(ctx, agencyIDsToFetch)
 	if err != nil {
 		api.serverErrorResponse(w, r, err)
 		return
 	}
-	for _, a := range allAgencies {
-		if uniqueAgencyIDsMap[a.ID] {
-			if _, exists := agencyRefs[a.ID]; !exists {
-				agencyRefs[a.ID] = models.NewAgencyReference(
-					a.ID,
-					a.Name,
-					a.Url,
-					a.Timezone,
-					a.Lang.String,
-					a.Phone.String,
-					a.Email.String,
-					a.FareUrl.String,
-					"",    // disclaimer
-					false, // privateService
-				)
-			}
+	for _, a := range fetchedAgencies {
+		if _, exists := agencyRefs[a.ID]; !exists {
+			agencyRefs[a.ID] = models.NewAgencyReference(
+				a.ID,
+				a.Name,
+				a.Url,
+				a.Timezone,
+				utils.NullStringOrEmpty(a.Lang),
+				a.Phone.String,
+				a.Email.String,
+				a.FareUrl.String,
+				"",    // disclaimer
+				false, // privateService
+			)
 		}
 	}
 

--- a/internal/restapi/schedule_for_stop_handler_test.go
+++ b/internal/restapi/schedule_for_stop_handler_test.go
@@ -16,13 +16,13 @@ func TestScheduleForStopHandler(t *testing.T) {
 	defer api.Shutdown()
 
 	// Get available agencies and stops for testing
-	agencies := api.GtfsManager.GetAgencies()
+	agencies := mustGetAgencies(t, api)
 	assert.NotEmpty(t, agencies, "Test data should contain at least one agency")
 
 	stops := api.GtfsManager.GetStops()
 	assert.NotEmpty(t, stops, "Test data should contain at least one stop")
 
-	stopID := utils.FormCombinedID(agencies[0].Id, stops[0].Id)
+	stopID := utils.FormCombinedID(agencies[0].ID, stops[0].Id)
 
 	tests := []struct {
 		name                string
@@ -79,9 +79,9 @@ func TestScheduleForStopHandlerDateParam(t *testing.T) {
 	defer api.Shutdown()
 
 	// Get valid stop for testing
-	agencies := api.GtfsManager.GetAgencies()
+	agencies := mustGetAgencies(t, api)
 	stops := api.GtfsManager.GetStops()
-	stopID := utils.FormCombinedID(agencies[0].Id, stops[0].Id)
+	stopID := utils.FormCombinedID(agencies[0].ID, stops[0].Id)
 
 	// Test valid date parameter
 	t.Run("Valid date parameter", func(t *testing.T) {
@@ -108,11 +108,11 @@ func TestScheduleForStopHandlerAgencyTimeZone(t *testing.T) {
 	api := createTestApiWithClock(t, clk)
 	defer api.Shutdown()
 
-	agencies := api.GtfsManager.GetAgencies()
+	agencies := mustGetAgencies(t, api)
 	stops := api.GtfsManager.GetStops()
 
 	agency := agencies[0]
-	stopID := utils.FormCombinedID(agency.Id, stops[0].Id)
+	stopID := utils.FormCombinedID(agency.ID, stops[0].Id)
 
 	endpoint := "/api/where/schedule-for-stop/" + stopID + ".json?key=TEST"
 	_, model := serveApiAndRetrieveEndpoint(t, api, endpoint)
@@ -134,9 +134,9 @@ func TestScheduleForStopHandlerWithDateFiltering(t *testing.T) {
 	defer api.Shutdown()
 
 	// Get valid stop for testing
-	agencies := api.GtfsManager.GetAgencies()
+	agencies := mustGetAgencies(t, api)
 	stops := api.GtfsManager.GetStops()
-	stopID := utils.FormCombinedID(agencies[0].Id, stops[0].Id)
+	stopID := utils.FormCombinedID(agencies[0].ID, stops[0].Id)
 
 	tests := []struct {
 		name           string
@@ -204,9 +204,9 @@ func TestScheduleForStopHandlerReferences(t *testing.T) {
 	api := createTestApi(t)
 	defer api.Shutdown()
 
-	agencies := api.GtfsManager.GetAgencies()
+	agencies := mustGetAgencies(t, api)
 	stops := api.GtfsManager.GetStops()
-	stopID := utils.FormCombinedID(agencies[0].Id, stops[0].Id)
+	stopID := utils.FormCombinedID(agencies[0].ID, stops[0].Id)
 
 	t.Run("Response structure is correct", func(t *testing.T) {
 		// NOTE: Hardcoded date 2025-06-12 matches GTFS data validity
@@ -248,9 +248,9 @@ func TestScheduleForStopHandlerInvalidDateFormat(t *testing.T) {
 	api := createTestApi(t)
 	defer api.Shutdown()
 
-	agencies := api.GtfsManager.GetAgencies()
+	agencies := mustGetAgencies(t, api)
 	stops := api.GtfsManager.GetStops()
-	stopID := utils.FormCombinedID(agencies[0].Id, stops[0].Id)
+	stopID := utils.FormCombinedID(agencies[0].ID, stops[0].Id)
 
 	tests := []struct {
 		name           string
@@ -291,9 +291,9 @@ func TestScheduleForStopHandlerScheduleContent(t *testing.T) {
 	api := createTestApi(t)
 	defer api.Shutdown()
 
-	agencies := api.GtfsManager.GetAgencies()
+	agencies := mustGetAgencies(t, api)
 	stops := api.GtfsManager.GetStops()
-	stopID := utils.FormCombinedID(agencies[0].Id, stops[0].Id)
+	stopID := utils.FormCombinedID(agencies[0].ID, stops[0].Id)
 
 	t.Run("Handler executes successfully", func(t *testing.T) {
 		// NOTE: Hardcoded date matches GTFS data validity
@@ -319,11 +319,11 @@ func TestScheduleForStopHandlerEmptyRoutes(t *testing.T) {
 	api := createTestApiWithClock(t, clk)
 	defer api.Shutdown()
 
-	agencies := api.GtfsManager.GetAgencies()
+	agencies := mustGetAgencies(t, api)
 	stops := api.GtfsManager.GetStops()
 
 	t.Run("Stop with no routes returns empty schedule", func(t *testing.T) {
-		stopID := utils.FormCombinedID(agencies[0].Id, stops[0].Id)
+		stopID := utils.FormCombinedID(agencies[0].ID, stops[0].Id)
 		// NOTE: Hardcoded date matches GTFS data validity
 		endpoint := "/api/where/schedule-for-stop/" + stopID + ".json?key=TEST&date=2025-06-12"
 		resp, model := serveApiAndRetrieveEndpoint(t, api, endpoint)
@@ -345,12 +345,12 @@ func TestScheduleForStopQueryValidation(t *testing.T) {
 	api := createTestApi(t)
 	defer api.Shutdown()
 
-	agencies := api.GtfsManager.GetAgencies()
+	agencies := mustGetAgencies(t, api)
 	stops := api.GtfsManager.GetStops()
 	require := assert.New(t)
 
 	t.Run("Query returns valid data structure", func(t *testing.T) {
-		stopID := utils.FormCombinedID(agencies[0].Id, stops[0].Id)
+		stopID := utils.FormCombinedID(agencies[0].ID, stops[0].Id)
 		endpoint := "/api/where/schedule-for-stop/" + stopID + ".json?key=TEST&date=2024-05-15"
 		resp, model := serveApiAndRetrieveEndpoint(t, api, endpoint)
 
@@ -430,9 +430,9 @@ func TestScheduleForStopQueryValidation(t *testing.T) {
 	t.Run("Query handles different weekdays correctly", func(t *testing.T) {
 		// Create a fresh API instance to avoid rate limiting
 		testApi := createTestApi(t)
-		testAgencies := testApi.GtfsManager.GetAgencies()
+		testAgencies := mustGetAgencies(t, testApi)
 		testStops := testApi.GtfsManager.GetStops()
-		testStopID := utils.FormCombinedID(testAgencies[0].Id, testStops[0].Id)
+		testStopID := utils.FormCombinedID(testAgencies[0].ID, testStops[0].Id)
 
 		weekdayTests := []struct {
 			date    string
@@ -463,7 +463,7 @@ func TestScheduleForStopQueryValidation(t *testing.T) {
 	})
 
 	t.Run("Query properly formats timestamps", func(t *testing.T) {
-		stopID := utils.FormCombinedID(agencies[0].Id, stops[0].Id)
+		stopID := utils.FormCombinedID(agencies[0].ID, stops[0].Id)
 		endpoint := "/api/where/schedule-for-stop/" + stopID + ".json?key=TEST&date=2024-05-15"
 		resp, model := serveApiAndRetrieveEndpoint(t, api, endpoint)
 

--- a/internal/restapi/shapes_handler_test.go
+++ b/internal/restapi/shapes_handler_test.go
@@ -114,7 +114,7 @@ func TestShapesHandlerRequiresValidApiKey(t *testing.T) {
 	api := createTestApi(t)
 	defer api.Shutdown()
 
-	agencyID := api.GtfsManager.GetAgencies()[0].Id
+	agencyID := mustGetAgencies(t, api)[0].ID
 	resp, model := serveApiAndRetrieveEndpoint(t, api, "/api/where/shape/"+agencyID+"_any_shape.json?key=INVALID")
 
 	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
@@ -272,7 +272,7 @@ func TestShapesHandlerWithMissingApiKey(t *testing.T) {
 	api := createTestApi(t)
 	defer api.Shutdown()
 
-	agencyID := api.GtfsManager.GetAgencies()[0].Id
+	agencyID := mustGetAgencies(t, api)[0].ID
 	resp, model := serveApiAndRetrieveEndpoint(t, api, "/api/where/shape/"+agencyID+"_any_shape.json")
 
 	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)

--- a/internal/restapi/stop-ids-for-agency_handler_test.go
+++ b/internal/restapi/stop-ids-for-agency_handler_test.go
@@ -19,9 +19,9 @@ func TestStopIdsForAgencyRequiresValidApiKey(t *testing.T) {
 func TestStopIdsForAgencyEndToEnd(t *testing.T) {
 	api := createTestApi(t)
 	defer api.Shutdown()
-	agencies := api.GtfsManager.GetAgencies()
+	agencies := mustGetAgencies(t, api)
 	require.NotEmpty(t, agencies)
-	agencyId := agencies[0].Id
+	agencyId := agencies[0].ID
 
 	resp, model := serveApiAndRetrieveEndpoint(t, api, "/api/where/stop-ids-for-agency/"+agencyId+".json?key=TEST")
 

--- a/internal/restapi/stop_handler_test.go
+++ b/internal/restapi/stop_handler_test.go
@@ -18,13 +18,13 @@ func TestStopHandlerRequiresValidApiKey(t *testing.T) {
 	api := createTestApi(t)
 	defer api.Shutdown()
 
-	agencies := api.GtfsManager.GetAgencies()
+	agencies := mustGetAgencies(t, api)
 	assert.NotEmpty(t, agencies, "Test data should contain at least one agency")
 
 	stops := api.GtfsManager.GetStops()
 	assert.NotEmpty(t, stops, "Test data should contain at least one stop")
 
-	stopID := utils.FormCombinedID(agencies[0].Id, stops[0].Id)
+	stopID := utils.FormCombinedID(agencies[0].ID, stops[0].Id)
 
 	resp, model := serveApiAndRetrieveEndpoint(t, api, "/api/where/stop/"+stopID+".json?key=invalid")
 	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
@@ -36,13 +36,13 @@ func TestStopHandlerEndToEnd(t *testing.T) {
 	api := createTestApi(t)
 	defer api.Shutdown()
 
-	agencies := api.GtfsManager.GetAgencies()
+	agencies := mustGetAgencies(t, api)
 	assert.NotEmpty(t, agencies, "Test data should contain at least one agency")
 
 	stops := api.GtfsManager.GetStops()
 	assert.NotEmpty(t, stops, "Test data should contain at least one stop")
 
-	stopID := utils.FormCombinedID(agencies[0].Id, stops[0].Id)
+	stopID := utils.FormCombinedID(agencies[0].ID, stops[0].Id)
 
 	resp, model := serveApiAndRetrieveEndpoint(t, api, "/api/where/stop/"+stopID+".json?key=TEST")
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
@@ -88,10 +88,10 @@ func TestInvalidStopID(t *testing.T) {
 	api := createTestApi(t)
 	defer api.Shutdown()
 
-	agencies := api.GtfsManager.GetAgencies()
+	agencies := mustGetAgencies(t, api)
 	assert.NotEmpty(t, agencies, "Test data should contain at least one agency")
 
-	invalidStopID := utils.FormCombinedID(agencies[0].Id, "invalid_stop_id")
+	invalidStopID := utils.FormCombinedID(agencies[0].ID, "invalid_stop_id")
 
 	resp, model := serveApiAndRetrieveEndpoint(t, api, "/api/where/stop/"+invalidStopID+".json?key=TEST")
 	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
@@ -103,13 +103,13 @@ func TestStopHandlerVerifiesReferences(t *testing.T) {
 	api := createTestApi(t)
 	defer api.Shutdown()
 
-	agencies := api.GtfsManager.GetAgencies()
+	agencies := mustGetAgencies(t, api)
 	assert.NotEmpty(t, agencies, "Test data should contain at least one agency")
 
 	stops := api.GtfsManager.GetStops()
 	assert.NotEmpty(t, stops, "Test data should contain at least one stop")
 
-	stopID := utils.FormCombinedID(agencies[0].Id, stops[0].Id)
+	stopID := utils.FormCombinedID(agencies[0].ID, stops[0].Id)
 
 	resp, model := serveApiAndRetrieveEndpoint(t, api, "/api/where/stop/"+stopID+".json?key=TEST")
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
@@ -300,7 +300,7 @@ func TestStopHandlerWithSituations(t *testing.T) {
 	api := createTestApi(t)
 	defer api.Shutdown()
 
-	agencies := api.GtfsManager.GetAgencies()
+	agencies := mustGetAgencies(t, api)
 	require.NotEmpty(t, agencies, "Test data should contain at least one agency")
 
 	stops := api.GtfsManager.GetStops()
@@ -311,7 +311,7 @@ func TestStopHandlerWithSituations(t *testing.T) {
 
 	rawStopID := stops[0].Id
 	rawRouteID := routes[0].Id
-	combinedStopID := utils.FormCombinedID(agencies[0].Id, rawStopID)
+	combinedStopID := utils.FormCombinedID(agencies[0].ID, rawStopID)
 
 	alert := gtfs.Alert{
 		ID: "test-cross-entity-alert-789",

--- a/internal/restapi/stops_for_agency_handler_test.go
+++ b/internal/restapi/stops_for_agency_handler_test.go
@@ -12,9 +12,9 @@ import (
 func TestStopsForAgencyRequiresValidApiKey(t *testing.T) {
 	api := createTestApi(t)
 	defer api.Shutdown()
-	agencies := api.GtfsManager.GetAgencies()
+	agencies := mustGetAgencies(t, api)
 	require.NotEmpty(t, agencies)
-	agencyID := agencies[0].Id
+	agencyID := agencies[0].ID
 
 	resp, model := serveApiAndRetrieveEndpoint(t, api, "/api/where/stops-for-agency/"+agencyID+".json?key=invalid")
 
@@ -26,9 +26,9 @@ func TestStopsForAgencyRequiresValidApiKey(t *testing.T) {
 func TestStopsForAgencyEndToEnd(t *testing.T) {
 	api := createTestApi(t)
 	defer api.Shutdown()
-	agencies := api.GtfsManager.GetAgencies()
+	agencies := mustGetAgencies(t, api)
 	require.NotEmpty(t, agencies)
-	agencyID := agencies[0].Id
+	agencyID := agencies[0].ID
 
 	resp, model := serveApiAndRetrieveEndpoint(t, api, "/api/where/stops-for-agency/"+agencyID+".json?key=TEST")
 

--- a/internal/restapi/stops_for_location_handler.go
+++ b/internal/restapi/stops_for_location_handler.go
@@ -92,6 +92,12 @@ func (api *RestAPI) stopsForLocationHandler(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
+	allAgencies, err := api.GtfsManager.GetAgencies(ctx)
+	if err != nil {
+		api.serverErrorResponse(w, r, err)
+		return
+	}
+
 	api.GtfsManager.RLock()
 	defer api.GtfsManager.RUnlock()
 
@@ -115,7 +121,7 @@ func (api *RestAPI) stopsForLocationHandler(w http.ResponseWriter, r *http.Reque
 
 	if len(stopIDs) == 0 {
 		// Return empty response if no stops found
-		agencies := utils.FilterAgencies(api.GtfsManager.GetAgencies(), agencyIDs)
+		agencies := utils.FilterAgencies(allAgencies, agencyIDs)
 		if agencies == nil {
 			agencies = []models.AgencyReference{}
 		}
@@ -239,7 +245,7 @@ func (api *RestAPI) stopsForLocationHandler(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	agencies := utils.FilterAgencies(api.GtfsManager.GetAgencies(), agencyIDs)
+	agencies := utils.FilterAgencies(allAgencies, agencyIDs)
 	routes := utils.FilterRoutes(api.GtfsManager.GtfsDB.Queries, ctx, routeIDs)
 
 	if agencies == nil {

--- a/internal/restapi/trip_details_handler_test.go
+++ b/internal/restapi/trip_details_handler_test.go
@@ -22,10 +22,10 @@ func TestTripDetailsHandlerEndToEnd(t *testing.T) {
 	api := createTestApi(t)
 	defer api.Shutdown()
 
-	agency := api.GtfsManager.GetAgencies()[0]
+	agency := mustGetAgencies(t, api)[0]
 	trips := api.GtfsManager.GetTrips()
 
-	tripID := utils.FormCombinedID(agency.Id, trips[0].ID)
+	tripID := utils.FormCombinedID(agency.ID, trips[0].ID)
 
 	_, resp, model := serveAndRetrieveEndpoint(t, "/api/where/trip-details/"+tripID+".json?key=TEST")
 
@@ -98,8 +98,8 @@ func TestTripDetailsHandlerEndToEnd(t *testing.T) {
 		trip, ok := tripsRef[0].(map[string]interface{})
 		assert.True(t, ok)
 		assert.Equal(t, tripID, trip["id"])
-		assert.Equal(t, utils.FormCombinedID(agency.Id, trips[0].Route.Id), trip["routeId"])
-		assert.Equal(t, utils.FormCombinedID(agency.Id, trips[0].Service.Id), trip["serviceId"])
+		assert.Equal(t, utils.FormCombinedID(agency.ID, trips[0].Route.Id), trip["routeId"])
+		assert.Equal(t, utils.FormCombinedID(agency.ID, trips[0].Service.Id), trip["serviceId"])
 	}
 
 	routes, ok := references["routes"].([]interface{})
@@ -115,7 +115,7 @@ func TestTripDetailsHandlerEndToEnd(t *testing.T) {
 
 	agencyRef, ok := agencies[0].(map[string]interface{})
 	assert.True(t, ok)
-	assert.Equal(t, agency.Id, agencyRef["id"])
+	assert.Equal(t, agency.ID, agencyRef["id"])
 	assert.Equal(t, agency.Name, agencyRef["name"])
 
 	// Test stop references (should exist if schedule is included)
@@ -143,10 +143,10 @@ func TestTripDetailsHandlerWithServiceDate(t *testing.T) {
 	api := createTestApi(t)
 	defer api.Shutdown()
 
-	agency := api.GtfsManager.GetAgencies()[0]
+	agency := mustGetAgencies(t, api)[0]
 	trips := api.GtfsManager.GetTrips()
 
-	tripID := utils.FormCombinedID(agency.Id, trips[0].ID)
+	tripID := utils.FormCombinedID(agency.ID, trips[0].ID)
 
 	// Use tomorrow's date as service date
 	tomorrow := time.Now().AddDate(0, 0, 1)
@@ -176,10 +176,10 @@ func TestTripDetailsHandlerWithIncludeTrip(t *testing.T) {
 	api := createTestApi(t)
 	defer api.Shutdown()
 
-	agency := api.GtfsManager.GetAgencies()[0]
+	agency := mustGetAgencies(t, api)[0]
 	trips := api.GtfsManager.GetTrips()
 
-	tripID := utils.FormCombinedID(agency.Id, trips[0].ID)
+	tripID := utils.FormCombinedID(agency.ID, trips[0].ID)
 
 	// Test with includeTrip=false
 	_, resp, model := serveAndRetrieveEndpoint(t, "/api/where/trip-details/"+tripID+".json?key=TEST&includeTrip=false")
@@ -206,10 +206,10 @@ func TestTripDetailsHandlerWithIncludeSchedule(t *testing.T) {
 	api := createTestApi(t)
 	defer api.Shutdown()
 
-	agency := api.GtfsManager.GetAgencies()[0]
+	agency := mustGetAgencies(t, api)[0]
 	trips := api.GtfsManager.GetTrips()
 
-	tripID := utils.FormCombinedID(agency.Id, trips[0].ID)
+	tripID := utils.FormCombinedID(agency.ID, trips[0].ID)
 
 	// Test with includeSchedule=false
 	_, resp, model := serveAndRetrieveEndpoint(t, "/api/where/trip-details/"+tripID+".json?key=TEST&includeSchedule=false")
@@ -245,10 +245,10 @@ func TestTripDetailsHandlerWithIncludeStatus(t *testing.T) {
 	api := createTestApi(t)
 	defer api.Shutdown()
 
-	agency := api.GtfsManager.GetAgencies()[0]
+	agency := mustGetAgencies(t, api)[0]
 	trips := api.GtfsManager.GetTrips()
 
-	tripID := utils.FormCombinedID(agency.Id, trips[0].ID)
+	tripID := utils.FormCombinedID(agency.ID, trips[0].ID)
 
 	// Test with includeStatus=false
 	_, resp, model := serveAndRetrieveEndpoint(t, "/api/where/trip-details/"+tripID+".json?key=TEST&includeStatus=false")
@@ -272,10 +272,10 @@ func TestTripDetailsHandlerWithTimeParameter(t *testing.T) {
 	api := createTestApi(t)
 	defer api.Shutdown()
 
-	agency := api.GtfsManager.GetAgencies()[0]
+	agency := mustGetAgencies(t, api)[0]
 	trips := api.GtfsManager.GetTrips()
 
-	tripID := utils.FormCombinedID(agency.Id, trips[0].ID)
+	tripID := utils.FormCombinedID(agency.ID, trips[0].ID)
 
 	// Use a specific time (1 hour from now)
 	specificTime := time.Now().Add(1 * time.Hour)
@@ -301,10 +301,10 @@ func TestTripDetailsHandlerWithAllParametersFalse(t *testing.T) {
 	api := createTestApi(t)
 	defer api.Shutdown()
 
-	agency := api.GtfsManager.GetAgencies()[0]
+	agency := mustGetAgencies(t, api)[0]
 	trips := api.GtfsManager.GetTrips()
 
-	tripID := utils.FormCombinedID(agency.Id, trips[0].ID)
+	tripID := utils.FormCombinedID(agency.ID, trips[0].ID)
 
 	_, resp, model := serveAndRetrieveEndpoint(t,
 		"/api/where/trip-details/"+tripID+".json?key=TEST&includeTrip=false&includeSchedule=false&includeStatus=false")
@@ -361,9 +361,9 @@ func TestTripDetailsHandlerWithInvalidParams(t *testing.T) {
 	api := createTestApi(t)
 	defer api.Shutdown()
 
-	agency := api.GtfsManager.GetAgencies()[0]
+	agency := mustGetAgencies(t, api)[0]
 	trips := api.GtfsManager.GetTrips()
-	tripID := utils.FormCombinedID(agency.Id, trips[0].ID)
+	tripID := utils.FormCombinedID(agency.ID, trips[0].ID)
 
 	endpoint := "/api/where/trip-details/" + tripID + ".json?key=TEST&serviceDate=invalid"
 

--- a/internal/restapi/trip_for_vehicle_handler_test.go
+++ b/internal/restapi/trip_for_vehicle_handler_test.go
@@ -26,11 +26,11 @@ func setupTestApiWithMockVehicle(t *testing.T) (*RestAPI, string, string) {
 
 	// Note: caller is responsible for calling api.Shutdown()
 
-	agencyStatic := api.GtfsManager.GetAgencies()[0]
+	agencyStatic := mustGetAgencies(t, api)[0]
 	trips := api.GtfsManager.GetTrips()
 
 	tripID := trips[0].ID
-	agencyID := agencyStatic.Id
+	agencyID := agencyStatic.ID
 	vehicleID := "MOCK_VEHICLE_1"
 	routeID := utils.FormCombinedID(agencyID, trips[0].Route.Id)
 
@@ -260,7 +260,7 @@ func TestTripForVehicleHandlerWithNonExistentTrip(t *testing.T) {
 	defer api.Shutdown()
 	t.Cleanup(api.GtfsManager.MockResetRealTimeData)
 
-	agencyID := api.GtfsManager.GetAgencies()[0].Id
+	agencyID := mustGetAgencies(t, api)[0].ID
 
 	// Create vehicle with trip ID that doesn't exist in DB
 	vehicleID := "GHOST_TRIP_VEHICLE"

--- a/internal/restapi/trip_handler_test.go
+++ b/internal/restapi/trip_handler_test.go
@@ -21,11 +21,11 @@ func TestTripHandlerEndToEnd(t *testing.T) {
 	api := createTestApi(t)
 	defer api.Shutdown()
 
-	agency := api.GtfsManager.GetAgencies()[0]
+	agency := mustGetAgencies(t, api)[0]
 
 	trips := api.GtfsManager.GetTrips()
 
-	tripID := utils.FormCombinedID(agency.Id, trips[0].ID)
+	tripID := utils.FormCombinedID(agency.ID, trips[0].ID)
 
 	_, resp, model := serveAndRetrieveEndpoint(t, "/api/where/trip/"+tripID+".json?key=TEST")
 
@@ -41,11 +41,11 @@ func TestTripHandlerEndToEnd(t *testing.T) {
 	entry, ok := data["entry"].(map[string]interface{})
 	assert.True(t, ok)
 	assert.Equal(t, tripID, entry["id"])
-	assert.Equal(t, utils.FormCombinedID(agency.Id, trips[0].Route.Id), entry["routeId"])
-	assert.Equal(t, utils.FormCombinedID(agency.Id, trips[0].Service.Id), entry["serviceId"])
+	assert.Equal(t, utils.FormCombinedID(agency.ID, trips[0].Route.Id), entry["routeId"])
+	assert.Equal(t, utils.FormCombinedID(agency.ID, trips[0].Service.Id), entry["serviceId"])
 	assert.Equal(t, fmt.Sprintf("%d", trips[0].DirectionId), entry["directionId"])
-	assert.Equal(t, utils.FormCombinedID(agency.Id, trips[0].BlockID), entry["blockId"])
-	assert.Equal(t, utils.FormCombinedID(agency.Id, trips[0].Shape.ID), entry["shapeId"])
+	assert.Equal(t, utils.FormCombinedID(agency.ID, trips[0].BlockID), entry["blockId"])
+	assert.Equal(t, utils.FormCombinedID(agency.ID, trips[0].Shape.ID), entry["shapeId"])
 	assert.Equal(t, trips[0].Headsign, entry["tripHeadsign"])
 	assert.Equal(t, trips[0].ShortName, entry["tripShortName"])
 	assert.Equal(t, trips[0].Route.ShortName, entry["routeShortName"])
@@ -60,8 +60,8 @@ func TestTripHandlerEndToEnd(t *testing.T) {
 
 	route, ok := routes[0].(map[string]interface{})
 	assert.True(t, ok)
-	assert.Equal(t, utils.FormCombinedID(agency.Id, trips[0].Route.Id), route["id"])
-	assert.Equal(t, agency.Id, route["agencyId"])
+	assert.Equal(t, utils.FormCombinedID(agency.ID, trips[0].Route.Id), route["id"])
+	assert.Equal(t, agency.ID, route["agencyId"])
 	assert.Equal(t, trips[0].Route.ShortName, route["shortName"])
 
 	agencies, ok := references["agencies"].([]interface{})
@@ -70,7 +70,7 @@ func TestTripHandlerEndToEnd(t *testing.T) {
 
 	agencyRef, ok := agencies[0].(map[string]interface{})
 	assert.True(t, ok)
-	assert.Equal(t, agency.Id, agencyRef["id"])
+	assert.Equal(t, agency.ID, agencyRef["id"])
 	assert.Equal(t, agency.Name, agencyRef["name"])
 }
 

--- a/internal/restapi/trips_for_location_handler.go
+++ b/internal/restapi/trips_for_location_handler.go
@@ -147,13 +147,13 @@ func (api *RestAPI) parseAndValidateRequest(r *http.Request) (
 	includeTrip = queryParams.Get("includeTrip") == "true"
 	includeSchedule = queryParams.Get("includeSchedule") == "true"
 
-	agencies := api.GtfsManager.GetAgencies()
-	if len(agencies) == 0 {
+	agencies, agenciesErr := api.GtfsManager.GetAgencies(r.Context())
+	if agenciesErr != nil || len(agencies) == 0 {
 		return 0, 0, 0, 0, false, false, nil, time.Time{}, time.Time{}, nil, errors.New("no agencies configured in GTFS manager")
 	}
 
 	currentAgency := agencies[0]
-	currentLocation, serverErr = loadAgencyLocation(currentAgency.Id, currentAgency.Timezone)
+	currentLocation, serverErr = loadAgencyLocation(currentAgency.ID, currentAgency.Timezone)
 	if serverErr != nil {
 		return 0, 0, 0, 0, false, false, nil, time.Time{}, time.Time{}, nil, serverErr
 	}

--- a/internal/restapi/trips_helper_test.go
+++ b/internal/restapi/trips_helper_test.go
@@ -444,9 +444,9 @@ func TestBuildStopTimesList_ErrorHandling(t *testing.T) {
 		}
 	}
 
-	agencies := api.GtfsManager.GetAgencies()
+	agencies := mustGetAgencies(t, api)
 	require.NotEmpty(t, agencies)
-	agencyID := agencies[0].Id
+	agencyID := agencies[0].ID
 
 	t.Run("Normal operation - coordinates found", func(t *testing.T) {
 		result := buildStopTimesList(api, ctx, stopTimes, shapePoints, agencyID)
@@ -504,9 +504,9 @@ func TestBuildTripStatus_VehicleWithPosition_FindsStops(t *testing.T) {
 	t.Cleanup(api.GtfsManager.MockResetRealTimeData)
 	ctx := context.Background()
 
-	agencies := api.GtfsManager.GetAgencies()
+	agencies := mustGetAgencies(t, api)
 	require.NotEmpty(t, agencies)
-	agencyID := agencies[0].Id
+	agencyID := agencies[0].ID
 
 	trips := api.GtfsManager.GetTrips()
 	require.NotEmpty(t, trips)
@@ -569,9 +569,9 @@ func TestBuildTripStatus_ScheduleDeviation_SetsPredicted(t *testing.T) {
 	t.Cleanup(api.GtfsManager.MockResetRealTimeData)
 	ctx := context.Background()
 
-	agencies := api.GtfsManager.GetAgencies()
+	agencies := mustGetAgencies(t, api)
 	require.NotEmpty(t, agencies)
-	agencyID := agencies[0].Id
+	agencyID := agencies[0].ID
 
 	trips := api.GtfsManager.GetTrips()
 	require.NotEmpty(t, trips)
@@ -605,9 +605,9 @@ func TestBuildTripStatus_NoRealtimeData_SetsScheduled(t *testing.T) {
 	t.Cleanup(api.GtfsManager.MockResetRealTimeData)
 	ctx := context.Background()
 
-	agencies := api.GtfsManager.GetAgencies()
+	agencies := mustGetAgencies(t, api)
 	require.NotEmpty(t, agencies)
-	agencyID := agencies[0].Id
+	agencyID := agencies[0].ID
 
 	trips := api.GtfsManager.GetTrips()
 	require.NotEmpty(t, trips)
@@ -634,9 +634,9 @@ func TestBuildTripStatus_ShapeData_ComputesDistanceAlongTrip(t *testing.T) {
 	t.Cleanup(api.GtfsManager.MockResetRealTimeData)
 	ctx := context.Background()
 
-	agencies := api.GtfsManager.GetAgencies()
+	agencies := mustGetAgencies(t, api)
 	require.NotEmpty(t, agencies)
-	agencyID := agencies[0].Id
+	agencyID := agencies[0].ID
 
 	// Find a trip that has both shape data and stop times
 	trips := api.GtfsManager.GetTrips()
@@ -697,11 +697,11 @@ func TestBuildTripStatus_VehicleIDFormat(t *testing.T) {
 	defer api.Shutdown()
 	t.Cleanup(api.GtfsManager.MockResetRealTimeData)
 
-	agencyStatic := api.GtfsManager.GetAgencies()[0]
+	agencyStatic := mustGetAgencies(t, api)[0]
 	trips := api.GtfsManager.GetTrips()
 
 	tripID := trips[0].ID
-	agencyID := agencyStatic.Id
+	agencyID := agencyStatic.ID
 	vehicleID := "MOCK_VEHICLE_1"
 	routeID := utils.FormCombinedID(agencyID, trips[0].Route.Id)
 
@@ -823,10 +823,10 @@ func TestFillStopsFromSchedule_BeforeAllStops(t *testing.T) {
 
 	trips := api.GtfsManager.GetTrips()
 	require.NotEmpty(t, trips)
-	agencies := api.GtfsManager.GetAgencies()
+	agencies := mustGetAgencies(t, api)
 	require.NotEmpty(t, agencies)
 
-	agencyID := agencies[0].Id
+	agencyID := agencies[0].ID
 	tripID := trips[0].ID
 
 	stopTimes, err := api.GtfsManager.GtfsDB.Queries.GetStopTimesForTrip(ctx, tripID)
@@ -851,10 +851,10 @@ func TestFillStopsFromSchedule_AfterAllStops(t *testing.T) {
 
 	trips := api.GtfsManager.GetTrips()
 	require.NotEmpty(t, trips)
-	agencies := api.GtfsManager.GetAgencies()
+	agencies := mustGetAgencies(t, api)
 	require.NotEmpty(t, agencies)
 
-	agencyID := agencies[0].Id
+	agencyID := agencies[0].ID
 	tripID := trips[0].ID
 
 	stopTimes, err := api.GtfsManager.GtfsDB.Queries.GetStopTimesForTrip(ctx, tripID)
@@ -1029,9 +1029,9 @@ func TestBuildTripStatus_VehicleWithStopID_FindsStops(t *testing.T) {
 	t.Cleanup(api.GtfsManager.MockResetRealTimeData)
 	ctx := context.Background()
 
-	agencies := api.GtfsManager.GetAgencies()
+	agencies := mustGetAgencies(t, api)
 	require.NotEmpty(t, agencies)
-	agencyID := agencies[0].Id
+	agencyID := agencies[0].ID
 
 	trips := api.GtfsManager.GetTrips()
 	require.NotEmpty(t, trips)
@@ -1108,9 +1108,9 @@ func TestBuildTripStatus_PreResolvedVehicle(t *testing.T) {
 	t.Cleanup(api.GtfsManager.MockResetRealTimeData)
 	ctx := context.Background()
 
-	agencies := api.GtfsManager.GetAgencies()
+	agencies := mustGetAgencies(t, api)
 	require.NotEmpty(t, agencies)
-	agencyID := agencies[0].Id
+	agencyID := agencies[0].ID
 
 	trips := api.GtfsManager.GetTrips()
 	require.NotEmpty(t, trips)
@@ -1165,9 +1165,9 @@ func TestBuildTripStatus_CanceledTrip(t *testing.T) {
 	defer api.Shutdown()
 	ctx := context.Background()
 
-	agencies := api.GtfsManager.GetAgencies()
+	agencies := mustGetAgencies(t, api)
 	require.NotEmpty(t, agencies)
-	agencyID := agencies[0].Id
+	agencyID := agencies[0].ID
 
 	trips := api.GtfsManager.GetTrips()
 	require.NotEmpty(t, trips)
@@ -1284,11 +1284,11 @@ func BenchmarkBuildTripSchedule(b *testing.B) {
 		b.Skip("Could not get trip")
 	}
 
-	agencies := api.GtfsManager.GetAgencies()
+	agencies := mustGetAgencies(t, api)
 	if len(agencies) == 0 {
 		b.Skip("No agencies available")
 	}
-	agencyID := agencies[0].Id
+	agencyID := agencies[0].ID
 
 	// Get timezone for service date
 	loc, err := time.LoadLocation(agencies[0].Timezone)
@@ -1317,11 +1317,11 @@ func BenchmarkBuildTripSchedule_VaryingShapeSize(b *testing.B) {
 		b.Skip("No trips available")
 	}
 
-	agencies := api.GtfsManager.GetAgencies()
+	agencies := mustGetAgencies(t, api)
 	if len(agencies) == 0 {
 		b.Skip("No agencies available")
 	}
-	agencyID := agencies[0].Id
+	agencyID := agencies[0].ID
 
 	loc, err := time.LoadLocation(agencies[0].Timezone)
 	if err != nil {
@@ -2045,6 +2045,7 @@ func floatPtr(f float64) *float64 { return &f }
 
 func TestGetNextAndPreviousTripIDs_SingleTripBlock(t *testing.T) {
 	api := createTestApi(t)
+	defer api.Shutdown()
 	ctx := context.Background()
 	queries := api.GtfsManager.GtfsDB.Queries
 
@@ -2092,6 +2093,7 @@ func TestGetNextAndPreviousTripIDs_SingleTripBlock(t *testing.T) {
 
 func TestGetNextAndPreviousTripIDs_TripNotInBlockOnDate(t *testing.T) {
 	api := createTestApi(t)
+	defer api.Shutdown()
 	ctx := context.Background()
 	queries := api.GtfsManager.GtfsDB.Queries
 

--- a/internal/restapi/vehicles_for_agency_handler_test.go
+++ b/internal/restapi/vehicles_for_agency_handler_test.go
@@ -21,9 +21,9 @@ import (
 func TestVehiclesForAgencyHandlerRequiresValidApiKey(t *testing.T) {
 	api := createTestApi(t)
 	defer api.Shutdown()
-	agencies := api.GtfsManager.GetAgencies()
+	agencies := mustGetAgencies(t, api)
 	require.NotEmpty(t, agencies)
-	agencyId := agencies[0].Id
+	agencyId := agencies[0].ID
 	resp, model := serveApiAndRetrieveEndpoint(t, api, "/api/where/vehicles-for-agency/"+agencyId+".json?key=invalid")
 
 	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
@@ -34,9 +34,9 @@ func TestVehiclesForAgencyHandlerRequiresValidApiKey(t *testing.T) {
 func TestVehiclesForAgencyHandlerEndToEnd(t *testing.T) {
 	api := createTestApi(t)
 	defer api.Shutdown()
-	agencies := api.GtfsManager.GetAgencies()
+	agencies := mustGetAgencies(t, api)
 	require.NotEmpty(t, agencies)
-	agencyId := agencies[0].Id
+	agencyId := agencies[0].ID
 
 	resp, model := serveApiAndRetrieveEndpoint(t, api, "/api/where/vehicles-for-agency/"+agencyId+".json?key=TEST")
 
@@ -80,9 +80,9 @@ func TestVehiclesForAgencyHandlerWithNonExistentAgency(t *testing.T) {
 func TestVehiclesForAgencyHandlerResponseStructure(t *testing.T) {
 	api := createTestApi(t)
 	defer api.Shutdown()
-	agencies := api.GtfsManager.GetAgencies()
+	agencies := mustGetAgencies(t, api)
 	require.NotEmpty(t, agencies)
-	agencyId := agencies[0].Id
+	agencyId := agencies[0].ID
 
 	resp, model := serveApiAndRetrieveEndpoint(t, api, "/api/where/vehicles-for-agency/"+agencyId+".json?key=TEST")
 
@@ -126,9 +126,9 @@ func TestVehiclesForAgencyHandlerResponseStructure(t *testing.T) {
 func TestVehiclesForAgencyHandlerReferencesBuilding(t *testing.T) {
 	api := createTestApi(t)
 	defer api.Shutdown()
-	agencies := api.GtfsManager.GetAgencies()
+	agencies := mustGetAgencies(t, api)
 	require.NotEmpty(t, agencies)
-	agencyId := agencies[0].Id
+	agencyId := agencies[0].ID
 
 	resp, model := serveApiAndRetrieveEndpoint(t, api, "/api/where/vehicles-for-agency/"+agencyId+".json?key=TEST")
 
@@ -201,9 +201,9 @@ func TestVehiclesForAgencyHandlerEmptyResult(t *testing.T) {
 func TestVehiclesForAgencyHandlerFieldMapping(t *testing.T) {
 	api := createTestApi(t)
 	defer api.Shutdown()
-	agencies := api.GtfsManager.GetAgencies()
+	agencies := mustGetAgencies(t, api)
 	require.NotEmpty(t, agencies)
-	agencyId := agencies[0].Id
+	agencyId := agencies[0].ID
 
 	// Test the endpoint to verify field mapping logic is tested
 	resp, model := serveApiAndRetrieveEndpoint(t, api, "/api/where/vehicles-for-agency/"+agencyId+".json?key=TEST")
@@ -232,40 +232,37 @@ func TestVehiclesForAgencyHandlerFieldMapping(t *testing.T) {
 func TestVehiclesForAgencyHandlerWithAllAgencies(t *testing.T) {
 	api := createTestApi(t)
 	defer api.Shutdown()
-	agencies := api.GtfsManager.GetAgencies()
-	require.NotEmpty(t, agencies)
 
-	// Test each agency to maximize code coverage
-	for _, agency := range agencies {
-		t.Run("Agency_"+agency.Id, func(t *testing.T) {
-			resp, model := serveApiAndRetrieveEndpoint(t, api, "/api/where/vehicles-for-agency/"+agency.Id+".json?key=TEST")
+	agencyID := "25"
 
-			assert.Equal(t, http.StatusOK, resp.StatusCode)
-			assert.Equal(t, 200, model.Code)
+	t.Run("Agency_"+agencyID, func(t *testing.T) {
+		resp, model := serveApiAndRetrieveEndpoint(t, api, "/api/where/vehicles-for-agency/"+agencyID+".json?key=TEST")
 
-			data := model.Data.(map[string]interface{})
-			vehiclesList := data["list"].([]interface{})
-			refs := data["references"].(map[string]interface{})
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		assert.Equal(t, 200, model.Code)
 
-			// Test that processing always happens
-			assert.IsType(t, []interface{}{}, vehiclesList)
+		data := model.Data.(map[string]interface{})
+		vehiclesList := data["list"].([]interface{})
+		refs := data["references"].(map[string]interface{})
 
-			// Agency reference should always be present
-			refAgencies := refs["agencies"].([]interface{})
-			assert.Len(t, refAgencies, 1)
+		// Test that processing always happens
+		assert.IsType(t, []interface{}{}, vehiclesList)
 
-			agencyRef := refAgencies[0].(map[string]interface{})
-			assert.Equal(t, agency.Id, agencyRef["id"])
-		})
-	}
+		// Agency reference should always be present
+		refAgencies := refs["agencies"].([]interface{})
+		assert.Len(t, refAgencies, 1)
+
+		agencyRef := refAgencies[0].(map[string]interface{})
+		assert.Equal(t, agencyID, agencyRef["id"])
+	})
 }
 
 func TestVehiclesForAgencyHandlerDatabaseRouteQueries(t *testing.T) {
 	api := createTestApi(t)
 	defer api.Shutdown()
-	agencies := api.GtfsManager.GetAgencies()
+	agencies := mustGetAgencies(t, api)
 	require.NotEmpty(t, agencies)
-	agencyId := agencies[0].Id
+	agencyId := agencies[0].ID
 
 	// This test specifically targets the database route lookup code
 	// Even if no vehicles exist, the handler should still execute the processing logic
@@ -304,9 +301,9 @@ func TestVehiclesForAgencyHandler_OccupancyPropagation(t *testing.T) {
 	defer api.Shutdown()
 	t.Cleanup(api.GtfsManager.MockResetRealTimeData)
 
-	agencies := api.GtfsManager.GetAgencies()
+	agencies := mustGetAgencies(t, api)
 	require.NotEmpty(t, agencies)
-	agencyID := agencies[0].Id
+	agencyID := agencies[0].ID
 
 	trips := api.GtfsManager.GetTrips()
 	require.NotEmpty(t, trips)
@@ -349,9 +346,9 @@ func TestVehiclesForAgencyHandler_VehicleWithoutTrip(t *testing.T) {
 	defer api.Shutdown()
 	t.Cleanup(api.GtfsManager.MockResetRealTimeData)
 
-	agencies := api.GtfsManager.GetAgencies()
+	agencies := mustGetAgencies(t, api)
 	require.NotEmpty(t, agencies)
-	agencyID := agencies[0].Id
+	agencyID := agencies[0].ID
 
 	trips := api.GtfsManager.GetTrips()
 	require.NotEmpty(t, trips)
@@ -386,9 +383,9 @@ func TestVehiclesForAgencyHandler_VehicleWithNilID(t *testing.T) {
 	defer api.Shutdown()
 	t.Cleanup(api.GtfsManager.MockResetRealTimeData)
 
-	agencies := api.GtfsManager.GetAgencies()
+	agencies := mustGetAgencies(t, api)
 	require.NotEmpty(t, agencies)
-	agencyID := agencies[0].Id
+	agencyID := agencies[0].ID
 
 	trips := api.GtfsManager.GetTrips()
 	require.NotEmpty(t, trips)
@@ -499,9 +496,9 @@ func TestVehiclesForAgencyHandlerWithRealTimeData(t *testing.T) {
 	api, cleanup := createTestApiWithRealTimeData(t)
 	defer cleanup()
 
-	agencies := api.GtfsManager.GetAgencies()
+	agencies := mustGetAgencies(t, api)
 	require.NotEmpty(t, agencies)
-	agencyId := agencies[0].Id
+	agencyId := agencies[0].ID
 
 	// Give the manager a moment to load real-time data
 	// The manager should load real-time data automatically on initialization

--- a/internal/utils/filters.go
+++ b/internal/utils/filters.go
@@ -2,19 +2,20 @@ package utils
 
 import (
 	"context"
-	"github.com/OneBusAway/go-gtfs"
 	"maglev.onebusaway.org/gtfsdb"
 	"maglev.onebusaway.org/internal/models"
 )
 
-// FilterAgencies filters a list of GTFS agencies based on their presence in the provided map.
+// FilterAgencies filters a list of agencies based on their presence in the provided map.
 // It returns a slice of AgencyReference objects for the agencies that are present.
-func FilterAgencies(all []gtfs.Agency, present map[string]bool) []models.AgencyReference {
+func FilterAgencies(all []gtfsdb.Agency, present map[string]bool) []models.AgencyReference {
 	var refs []models.AgencyReference
 	for _, a := range all {
-		if present[a.Id] {
+		if present[a.ID] {
 			refs = append(refs, models.NewAgencyReference(
-				a.Id, a.Name, a.Url, a.Timezone, a.Language, a.Phone, a.Email, a.FareUrl, "", false,
+				a.ID, a.Name, a.Url, a.Timezone,
+				a.Lang.String, a.Phone.String, a.Email.String, a.FareUrl.String,
+				"", false,
 			))
 		}
 	}

--- a/internal/utils/filters_test.go
+++ b/internal/utils/filters_test.go
@@ -2,9 +2,9 @@ package utils
 
 import (
 	"context"
+	"database/sql"
 	"testing"
 
-	"github.com/OneBusAway/go-gtfs"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"maglev.onebusaway.org/gtfsdb"
@@ -12,19 +12,26 @@ import (
 	"maglev.onebusaway.org/internal/models"
 )
 
+func nullString(s string) sql.NullString {
+	if s == "" {
+		return sql.NullString{}
+	}
+	return sql.NullString{String: s, Valid: true}
+}
+
 func TestFilterAgencies(t *testing.T) {
 	tests := []struct {
 		name     string
-		all      []gtfs.Agency
+		all      []gtfsdb.Agency
 		present  map[string]bool
 		expected int
 	}{
 		{
 			name: "Filter with some agencies present",
-			all: []gtfs.Agency{
-				{Id: "agency1", Name: "Agency One", Url: "http://one.com", Timezone: "America/Los_Angeles"},
-				{Id: "agency2", Name: "Agency Two", Url: "http://two.com", Timezone: "America/New_York"},
-				{Id: "agency3", Name: "Agency Three", Url: "http://three.com", Timezone: "America/Chicago"},
+			all: []gtfsdb.Agency{
+				{ID: "agency1", Name: "Agency One", Url: "http://one.com", Timezone: "America/Los_Angeles"},
+				{ID: "agency2", Name: "Agency Two", Url: "http://two.com", Timezone: "America/New_York"},
+				{ID: "agency3", Name: "Agency Three", Url: "http://three.com", Timezone: "America/Chicago"},
 			},
 			present: map[string]bool{
 				"agency1": true,
@@ -34,18 +41,18 @@ func TestFilterAgencies(t *testing.T) {
 		},
 		{
 			name: "Filter with no agencies present",
-			all: []gtfs.Agency{
-				{Id: "agency1", Name: "Agency One", Url: "http://one.com", Timezone: "America/Los_Angeles"},
-				{Id: "agency2", Name: "Agency Two", Url: "http://two.com", Timezone: "America/New_York"},
+			all: []gtfsdb.Agency{
+				{ID: "agency1", Name: "Agency One", Url: "http://one.com", Timezone: "America/Los_Angeles"},
+				{ID: "agency2", Name: "Agency Two", Url: "http://two.com", Timezone: "America/New_York"},
 			},
 			present:  map[string]bool{},
 			expected: 0,
 		},
 		{
 			name: "Filter with all agencies present",
-			all: []gtfs.Agency{
-				{Id: "agency1", Name: "Agency One", Url: "http://one.com", Timezone: "America/Los_Angeles"},
-				{Id: "agency2", Name: "Agency Two", Url: "http://two.com", Timezone: "America/New_York"},
+			all: []gtfsdb.Agency{
+				{ID: "agency1", Name: "Agency One", Url: "http://one.com", Timezone: "America/Los_Angeles"},
+				{ID: "agency2", Name: "Agency Two", Url: "http://two.com", Timezone: "America/New_York"},
 			},
 			present: map[string]bool{
 				"agency1": true,
@@ -55,22 +62,22 @@ func TestFilterAgencies(t *testing.T) {
 		},
 		{
 			name:     "Empty agency list",
-			all:      []gtfs.Agency{},
+			all:      []gtfsdb.Agency{},
 			present:  map[string]bool{"agency1": true},
 			expected: 0,
 		},
 		{
 			name: "Agencies with full details",
-			all: []gtfs.Agency{
+			all: []gtfsdb.Agency{
 				{
-					Id:       "agency1",
+					ID:       "agency1",
 					Name:     "Agency One",
 					Url:      "http://one.com",
 					Timezone: "America/Los_Angeles",
-					Language: "en",
-					Phone:    "555-1234",
-					Email:    "info@one.com",
-					FareUrl:  "http://one.com/fares",
+					Lang:     nullString("en"),
+					Phone:    nullString("555-1234"),
+					Email:    nullString("info@one.com"),
+					FareUrl:  nullString("http://one.com/fares"),
 				},
 			},
 			present:  map[string]bool{"agency1": true},
@@ -92,16 +99,16 @@ func TestFilterAgencies(t *testing.T) {
 }
 
 func TestFilterAgencies_VerifyFields(t *testing.T) {
-	agencies := []gtfs.Agency{
+	agencies := []gtfsdb.Agency{
 		{
-			Id:       "test_agency",
+			ID:       "test_agency",
 			Name:     "Test Agency",
 			Url:      "http://test.com",
 			Timezone: "America/Los_Angeles",
-			Language: "en",
-			Phone:    "555-0000",
-			Email:    "test@test.com",
-			FareUrl:  "http://test.com/fares",
+			Lang:     nullString("en"),
+			Phone:    nullString("555-0000"),
+			Email:    nullString("test@test.com"),
+			FareUrl:  nullString("http://test.com/fares"),
 		},
 	}
 	present := map[string]bool{"test_agency": true}


### PR DESCRIPTION
Fixes: #821 
Part of: #820 

## Summary

- Replaces `manager.gtfsData.Agencies` (in-memory slice) with `manager.GtfsDB.Queries.ListAgencies(ctx)` in `GetAgencies()`
- Updates all call sites across handler and test files to use the new DB-backed method
- Adds `mustGetAgencies` test helper that wraps `ListAgencies` with `require.NoError` for cleaner test setup

## Notes

- `GetAgencies()` now returns `[]gtfsdb.Agency` instead of `[]gtfs.Agency`, so field access changes from `.Id`/`.Language` to `.ID`/`.Lang.String` etc.
