### PR TITLE
refactor: migrate GetStops() from in-memory to database query

### DIFF
--- a/gtfsdb/db.go
+++ b/gtfsdb/db.go
@@ -105,6 +105,9 @@ func Prepare(ctx context.Context, db DBTX) (*Queries, error) {
 	if q.getActiveServiceIDsForDateStmt, err = db.PrepareContext(ctx, getActiveServiceIDsForDate); err != nil {
 		return nil, fmt.Errorf("error preparing query GetActiveServiceIDsForDate: %w", err)
 	}
+	if q.getActiveStopsStmt, err = db.PrepareContext(ctx, getActiveStops); err != nil {
+		return nil, fmt.Errorf("error preparing query GetActiveStops: %w", err)
+	}
 	if q.getActiveTripForRouteAtTimeStmt, err = db.PrepareContext(ctx, getActiveTripForRouteAtTime); err != nil {
 		return nil, fmt.Errorf("error preparing query GetActiveTripForRouteAtTime: %w", err)
 	}
@@ -492,6 +495,11 @@ func (q *Queries) Close() error {
 	if q.getActiveServiceIDsForDateStmt != nil {
 		if cerr := q.getActiveServiceIDsForDateStmt.Close(); cerr != nil {
 			err = fmt.Errorf("error closing getActiveServiceIDsForDateStmt: %w", cerr)
+		}
+	}
+	if q.getActiveStopsStmt != nil {
+		if cerr := q.getActiveStopsStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing getActiveStopsStmt: %w", cerr)
 		}
 	}
 	if q.getActiveTripForRouteAtTimeStmt != nil {
@@ -975,6 +983,7 @@ type Queries struct {
 	createTripStmt                                *sql.Stmt
 	getActiveRouteIDsForStopsOnDateStmt           *sql.Stmt
 	getActiveServiceIDsForDateStmt                *sql.Stmt
+	getActiveStopsStmt                            *sql.Stmt
 	getActiveTripForRouteAtTimeStmt               *sql.Stmt
 	getActiveTripInBlockAtTimeStmt                *sql.Stmt
 	getActiveTripsWithNullBlockForRouteStmt       *sql.Stmt
@@ -1091,6 +1100,7 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		createTripStmt:                                q.createTripStmt,
 		getActiveRouteIDsForStopsOnDateStmt:           q.getActiveRouteIDsForStopsOnDateStmt,
 		getActiveServiceIDsForDateStmt:                q.getActiveServiceIDsForDateStmt,
+		getActiveStopsStmt:                            q.getActiveStopsStmt,
 		getActiveTripForRouteAtTimeStmt:               q.getActiveTripForRouteAtTimeStmt,
 		getActiveTripInBlockAtTimeStmt:                q.getActiveTripInBlockAtTimeStmt,
 		getActiveTripsWithNullBlockForRouteStmt:       q.getActiveTripsWithNullBlockForRouteStmt,

--- a/gtfsdb/helpers.go
+++ b/gtfsdb/helpers.go
@@ -368,6 +368,10 @@ func (c *Client) processAndStoreGTFSDataWithSource(b []byte, source string) erro
 		if s.Latitude == nil || s.Longitude == nil {
 			continue
 		}
+		parentStation := ""
+		if s.Parent != nil {
+			parentStation = s.Parent.Id
+		}
 		params := CreateStopParams{
 			ID:                 s.Id,
 			Code:               toNullString(s.Code),
@@ -382,6 +386,7 @@ func (c *Client) processAndStoreGTFSDataWithSource(b []byte, source string) erro
 			WheelchairBoarding: toNullInt64(int64(s.WheelchairBoarding)),
 			PlatformCode:       toNullString(s.PlatformCode),
 			Direction:          sql.NullString{}, // Will be computed later
+			ParentStation:      toNullString(parentStation),
 		}
 
 		allStopParams = append(allStopParams, params)

--- a/gtfsdb/query.sql
+++ b/gtfsdb/query.sql
@@ -80,10 +80,11 @@ OR REPLACE INTO stops (
     timezone,
     wheelchair_boarding,
     platform_code,
-    direction
+    direction,
+    parent_station
 )
 VALUES
-    (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) RETURNING *;
+    (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) RETURNING *;
 
 -- name: CreateCalendar :one
 INSERT
@@ -302,7 +303,8 @@ SELECT
     timezone,
     wheelchair_boarding,
     platform_code,
-    direction
+    direction,
+    parent_station
 FROM
     stops
 WHERE

--- a/gtfsdb/query.sql
+++ b/gtfsdb/query.sql
@@ -346,6 +346,13 @@ FROM
 ORDER BY
     id;
 
+-- name: GetActiveStops :many
+SELECT DISTINCT
+    s.*
+FROM
+    stops s
+    INNER JOIN stop_times st ON s.id = st.stop_id;
+
 -- name: GetRoutesForStop :many
 SELECT DISTINCT
     routes.id,

--- a/gtfsdb/query.sql.go
+++ b/gtfsdb/query.sql.go
@@ -555,10 +555,11 @@ OR REPLACE INTO stops (
     timezone,
     wheelchair_boarding,
     platform_code,
-    direction
+    direction,
+    parent_station
 )
 VALUES
-    (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) RETURNING id, code, name, "desc", lat, lon, zone_id, url, location_type, timezone, wheelchair_boarding, platform_code, direction, parent_station
+    (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) RETURNING id, code, name, "desc", lat, lon, zone_id, url, location_type, timezone, wheelchair_boarding, platform_code, direction, parent_station
 `
 
 type CreateStopParams struct {
@@ -575,6 +576,7 @@ type CreateStopParams struct {
 	WheelchairBoarding sql.NullInt64
 	PlatformCode       sql.NullString
 	Direction          sql.NullString
+	ParentStation      sql.NullString
 }
 
 func (q *Queries) CreateStop(ctx context.Context, arg CreateStopParams) (Stop, error) {
@@ -592,6 +594,7 @@ func (q *Queries) CreateStop(ctx context.Context, arg CreateStopParams) (Stop, e
 		arg.WheelchairBoarding,
 		arg.PlatformCode,
 		arg.Direction,
+		arg.ParentStation,
 	)
 	var i Stop
 	err := row.Scan(
@@ -3167,7 +3170,8 @@ SELECT
     timezone,
     wheelchair_boarding,
     platform_code,
-    direction
+    direction,
+    parent_station
 FROM
     stops
 WHERE
@@ -3176,25 +3180,9 @@ LIMIT
     1
 `
 
-type GetStopRow struct {
-	ID                 string
-	Code               sql.NullString
-	Name               sql.NullString
-	Desc               sql.NullString
-	Lat                float64
-	Lon                float64
-	ZoneID             sql.NullString
-	Url                sql.NullString
-	LocationType       sql.NullInt64
-	Timezone           sql.NullString
-	WheelchairBoarding sql.NullInt64
-	PlatformCode       sql.NullString
-	Direction          sql.NullString
-}
-
-func (q *Queries) GetStop(ctx context.Context, id string) (GetStopRow, error) {
+func (q *Queries) GetStop(ctx context.Context, id string) (Stop, error) {
 	row := q.queryRow(ctx, q.getStopStmt, getStop, id)
-	var i GetStopRow
+	var i Stop
 	err := row.Scan(
 		&i.ID,
 		&i.Code,
@@ -3209,6 +3197,7 @@ func (q *Queries) GetStop(ctx context.Context, id string) (GetStopRow, error) {
 		&i.WheelchairBoarding,
 		&i.PlatformCode,
 		&i.Direction,
+		&i.ParentStation,
 	)
 	return i, err
 }

--- a/gtfsdb/query.sql.go
+++ b/gtfsdb/query.sql.go
@@ -869,6 +869,52 @@ func (q *Queries) GetActiveServiceIDsForDate(ctx context.Context, substr interfa
 	return items, nil
 }
 
+const getActiveStops = `-- name: GetActiveStops :many
+SELECT DISTINCT
+    s.id, s.code, s.name, s."desc", s.lat, s.lon, s.zone_id, s.url, s.location_type, s.timezone, s.wheelchair_boarding, s.platform_code, s.direction, s.parent_station
+FROM
+    stops s
+    INNER JOIN stop_times st ON s.id = st.stop_id
+`
+
+func (q *Queries) GetActiveStops(ctx context.Context) ([]Stop, error) {
+	rows, err := q.query(ctx, q.getActiveStopsStmt, getActiveStops)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []Stop
+	for rows.Next() {
+		var i Stop
+		if err := rows.Scan(
+			&i.ID,
+			&i.Code,
+			&i.Name,
+			&i.Desc,
+			&i.Lat,
+			&i.Lon,
+			&i.ZoneID,
+			&i.Url,
+			&i.LocationType,
+			&i.Timezone,
+			&i.WheelchairBoarding,
+			&i.PlatformCode,
+			&i.Direction,
+			&i.ParentStation,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const getActiveTripForRouteAtTime = `-- name: GetActiveTripForRouteAtTime :one
 SELECT
     t.id, t.route_id, t.service_id, t.trip_headsign, t.trip_short_name,

--- a/internal/gtfs/concurrency_test.go
+++ b/internal/gtfs/concurrency_test.go
@@ -1,6 +1,7 @@
 package gtfs
 
 import (
+	"context"
 	"os"
 	"sync"
 	"testing"
@@ -82,7 +83,7 @@ func TestConcurrentGTFSDataAccess(t *testing.T) {
 						return
 					default:
 						_ = manager.gtfsData.Agencies
-						_ = manager.GetStops()
+						_, _ = manager.GetStops(context.Background())
 						_ = manager.GetStaticData()
 						time.Sleep(time.Microsecond)
 					}

--- a/internal/gtfs/gtfs_manager.go
+++ b/internal/gtfs/gtfs_manager.go
@@ -413,8 +413,11 @@ func (manager *Manager) GetStaticData() *gtfs.Static {
 }
 
 // IMPORTANT: Caller must hold manager.RLock() before calling this method.
-func (manager *Manager) GetStops() []gtfs.Stop {
-	return manager.gtfsData.Stops
+func (manager *Manager) GetStops(ctx context.Context) ([]gtfsdb.Stop, error) {
+	if manager.GtfsDB == nil {
+		return nil, nil
+	}
+	return manager.GtfsDB.Queries.ListStops(ctx)
 }
 
 // IMPORTANT: Caller must hold manager.RLock() before calling this method.

--- a/internal/gtfs/gtfs_manager.go
+++ b/internal/gtfs/gtfs_manager.go
@@ -414,9 +414,6 @@ func (manager *Manager) GetStaticData() *gtfs.Static {
 
 // IMPORTANT: Caller must hold manager.RLock() before calling this method.
 func (manager *Manager) GetStops(ctx context.Context) ([]gtfsdb.Stop, error) {
-	if manager.GtfsDB == nil {
-		return nil, nil
-	}
 	return manager.GtfsDB.Queries.ListStops(ctx)
 }
 

--- a/internal/restapi/arrival_and_departure_for_stop_handler_test.go
+++ b/internal/restapi/arrival_and_departure_for_stop_handler_test.go
@@ -32,7 +32,7 @@ func TestArrivalAndDepartureForStopHandlerEndToEnd(t *testing.T) {
 	defer api.Shutdown()
 
 	agency := mustGetAgencies(t, api)[0]
-	stops := api.GtfsManager.GetStops()
+	stops := mustGetStops(t, api)
 	trips := api.GtfsManager.GetTrips()
 
 	if len(stops) == 0 {
@@ -43,7 +43,7 @@ func TestArrivalAndDepartureForStopHandlerEndToEnd(t *testing.T) {
 		t.Skip("No trips available for testing")
 	}
 
-	stopID := utils.FormCombinedID(agency.ID, stops[0].Id)
+	stopID := utils.FormCombinedID(agency.ID, stops[0].ID)
 	tripID := utils.FormCombinedID(agency.ID, trips[0].ID)
 	serviceDate := time.Now().Unix() * 1000
 
@@ -138,7 +138,7 @@ func TestArrivalAndDepartureForStopHandlerWithTimeParameter(t *testing.T) {
 	defer api.Shutdown()
 
 	agency := mustGetAgencies(t, api)[0]
-	stops := api.GtfsManager.GetStops()
+	stops := mustGetStops(t, api)
 	trips := api.GtfsManager.GetTrips()
 
 	if len(stops) == 0 {
@@ -149,7 +149,7 @@ func TestArrivalAndDepartureForStopHandlerWithTimeParameter(t *testing.T) {
 		t.Skip("No trips available for testing")
 	}
 
-	stopID := utils.FormCombinedID(agency.ID, stops[0].Id)
+	stopID := utils.FormCombinedID(agency.ID, stops[0].ID)
 	tripID := utils.FormCombinedID(agency.ID, trips[0].ID)
 
 	// Use a specific time (1 hour from now)
@@ -186,9 +186,9 @@ func TestArrivalAndDepartureForStopHandlerRequiresTripId(t *testing.T) {
 	defer api.Shutdown()
 
 	agency := mustGetAgencies(t, api)[0]
-	stops := api.GtfsManager.GetStops()
+	stops := mustGetStops(t, api)
 
-	stopID := utils.FormCombinedID(agency.ID, stops[0].Id)
+	stopID := utils.FormCombinedID(agency.ID, stops[0].ID)
 	serviceDate := time.Now().Unix() * 1000
 
 	mux := http.NewServeMux()
@@ -222,10 +222,10 @@ func TestArrivalAndDepartureForStopHandlerRequiresServiceDate(t *testing.T) {
 	defer api.Shutdown()
 
 	agency := mustGetAgencies(t, api)[0]
-	stops := api.GtfsManager.GetStops()
+	stops := mustGetStops(t, api)
 	trips := api.GtfsManager.GetTrips()
 
-	stopID := utils.FormCombinedID(agency.ID, stops[0].Id)
+	stopID := utils.FormCombinedID(agency.ID, stops[0].ID)
 	tripID := utils.FormCombinedID(agency.ID, trips[0].ID)
 
 	mux := http.NewServeMux()
@@ -259,7 +259,7 @@ func TestArrivalAndDepartureForStopHandlerWithStopSequence(t *testing.T) {
 	defer api.Shutdown()
 
 	agency := mustGetAgencies(t, api)[0]
-	stops := api.GtfsManager.GetStops()
+	stops := mustGetStops(t, api)
 	trips := api.GtfsManager.GetTrips()
 
 	if len(stops) == 0 {
@@ -270,7 +270,7 @@ func TestArrivalAndDepartureForStopHandlerWithStopSequence(t *testing.T) {
 		t.Skip("No trips available for testing")
 	}
 
-	stopID := utils.FormCombinedID(agency.ID, stops[0].Id)
+	stopID := utils.FormCombinedID(agency.ID, stops[0].ID)
 	tripID := utils.FormCombinedID(agency.ID, trips[0].ID)
 	serviceDate := time.Now().Unix() * 1000
 	stopSequence := 1
@@ -298,7 +298,7 @@ func TestArrivalAndDepartureForStopHandlerWithMinutesParameters(t *testing.T) {
 	defer api.Shutdown()
 
 	agency := mustGetAgencies(t, api)[0]
-	stops := api.GtfsManager.GetStops()
+	stops := mustGetStops(t, api)
 	trips := api.GtfsManager.GetTrips()
 
 	if len(stops) == 0 {
@@ -309,7 +309,7 @@ func TestArrivalAndDepartureForStopHandlerWithMinutesParameters(t *testing.T) {
 		t.Skip("No trips available for testing")
 	}
 
-	stopID := utils.FormCombinedID(agency.ID, stops[0].Id)
+	stopID := utils.FormCombinedID(agency.ID, stops[0].ID)
 	tripID := utils.FormCombinedID(agency.ID, trips[0].ID)
 	serviceDate := time.Now().Unix() * 1000
 
@@ -331,9 +331,9 @@ func TestArrivalAndDepartureForStopHandlerWithInvalidTripID(t *testing.T) {
 	defer api.Shutdown()
 
 	agency := mustGetAgencies(t, api)[0]
-	stops := api.GtfsManager.GetStops()
+	stops := mustGetStops(t, api)
 
-	stopID := utils.FormCombinedID(agency.ID, stops[0].Id)
+	stopID := utils.FormCombinedID(agency.ID, stops[0].ID)
 	tripID := utils.FormCombinedID(agency.ID, "nonexistent_trip")
 	serviceDate := time.Now().Unix() * 1000
 
@@ -351,9 +351,9 @@ func TestArrivalAndDepartureForStopHandlerWithMalformedTripID(t *testing.T) {
 	defer api.Shutdown()
 
 	agency := mustGetAgencies(t, api)[0]
-	stops := api.GtfsManager.GetStops()
+	stops := mustGetStops(t, api)
 
-	stopID := utils.FormCombinedID(agency.ID, stops[0].Id)
+	stopID := utils.FormCombinedID(agency.ID, stops[0].ID)
 	tripID := "malformedid" // No underscore, will fail extraction
 	serviceDate := time.Now().Unix() * 1000
 

--- a/internal/restapi/arrivals_and_departures_for_stop_handler_test.go
+++ b/internal/restapi/arrivals_and_departures_for_stop_handler_test.go
@@ -25,13 +25,13 @@ func TestArrivalsAndDeparturesForStopHandlerRequiresValidApiKey(t *testing.T) {
 	time.Sleep(500 * time.Millisecond)
 
 	agency := mustGetAgencies(t, api)[0]
-	stops := api.GtfsManager.GetStops()
+	stops := mustGetStops(t, api)
 
 	if len(stops) == 0 {
 		t.Skip("No stops available for testing")
 	}
 
-	stopID := utils.FormCombinedID(agency.ID, stops[0].Id)
+	stopID := utils.FormCombinedID(agency.ID, stops[0].ID)
 
 	resp, model := serveApiAndRetrieveEndpoint(t, api,
 		"/api/where/arrivals-and-departures-for-stop/"+stopID+".json?key=invalid")
@@ -48,13 +48,13 @@ func TestArrivalsAndDeparturesForStopHandlerEndToEnd(t *testing.T) {
 	time.Sleep(500 * time.Millisecond)
 
 	agency := mustGetAgencies(t, api)[0]
-	stops := api.GtfsManager.GetStops()
+	stops := mustGetStops(t, api)
 
 	if len(stops) == 0 {
 		t.Skip("No stops available for testing")
 	}
 
-	stopID := utils.FormCombinedID(agency.ID, stops[0].Id)
+	stopID := utils.FormCombinedID(agency.ID, stops[0].ID)
 
 	resp, model := serveApiAndRetrieveEndpoint(t, api,
 		"/api/where/arrivals-and-departures-for-stop/"+stopID+".json?key=TEST")
@@ -172,13 +172,13 @@ func TestArrivalsAndDeparturesForStopHandlerWithTimeParameters(t *testing.T) {
 	time.Sleep(500 * time.Millisecond)
 
 	agency := mustGetAgencies(t, api)[0]
-	stops := api.GtfsManager.GetStops()
+	stops := mustGetStops(t, api)
 
 	if len(stops) == 0 {
 		t.Skip("No stops available for testing")
 	}
 
-	stopID := utils.FormCombinedID(agency.ID, stops[0].Id)
+	stopID := utils.FormCombinedID(agency.ID, stops[0].ID)
 	minutesAfter := 60
 	minutesBefore := 10
 
@@ -216,13 +216,13 @@ func TestArrivalsAndDeparturesForStopHandlerWithSpecificTime(t *testing.T) {
 	time.Sleep(500 * time.Millisecond)
 
 	agency := mustGetAgencies(t, api)[0]
-	stops := api.GtfsManager.GetStops()
+	stops := mustGetStops(t, api)
 
 	if len(stops) == 0 {
 		t.Skip("No stops available for testing")
 	}
 
-	stopID := utils.FormCombinedID(agency.ID, stops[0].Id)
+	stopID := utils.FormCombinedID(agency.ID, stops[0].ID)
 
 	tomorrow := time.Now().AddDate(0, 0, 1)
 	specificTime := time.Date(tomorrow.Year(), tomorrow.Month(), tomorrow.Day(), 9, 0, 0, 0, time.Local)
@@ -285,13 +285,13 @@ func TestArrivalsAndDeparturesForStopHandlerNoActiveServices(t *testing.T) {
 	time.Sleep(500 * time.Millisecond)
 
 	agency := mustGetAgencies(t, api)[0]
-	stops := api.GtfsManager.GetStops()
+	stops := mustGetStops(t, api)
 
 	if len(stops) == 0 {
 		t.Skip("No stops available for testing")
 	}
 
-	stopID := utils.FormCombinedID(agency.ID, stops[0].Id)
+	stopID := utils.FormCombinedID(agency.ID, stops[0].ID)
 
 	futureTime := time.Now().AddDate(10, 0, 0)
 	timeMs := futureTime.Unix() * 1000
@@ -345,13 +345,13 @@ func TestArrivalsAndDeparturesForStopHandlerDefaultParameters(t *testing.T) {
 	time.Sleep(500 * time.Millisecond)
 
 	agency := mustGetAgencies(t, api)[0]
-	stops := api.GtfsManager.GetStops()
+	stops := mustGetStops(t, api)
 
 	if len(stops) == 0 {
 		t.Skip("No stops available for testing")
 	}
 
-	stopID := utils.FormCombinedID(agency.ID, stops[0].Id)
+	stopID := utils.FormCombinedID(agency.ID, stops[0].ID)
 
 	resp, model := serveApiAndRetrieveEndpoint(t, api,
 		"/api/where/arrivals-and-departures-for-stop/"+stopID+".json?key=TEST")
@@ -442,8 +442,8 @@ func TestArrivalsAndDeparturesForStopHandlerWithInvalidParams(t *testing.T) {
 	defer api.Shutdown()
 
 	agency := mustGetAgencies(t, api)[0]
-	stops := api.GtfsManager.GetStops()
-	stopID := utils.FormCombinedID(agency.ID, stops[0].Id)
+	stops := mustGetStops(t, api)
+	stopID := utils.FormCombinedID(agency.ID, stops[0].ID)
 
 	endpoint := "/api/where/arrivals-and-departures-for-stop/" + stopID + ".json?key=TEST&time=invalid"
 	resp, _ := serveApiAndRetrieveEndpoint(t, api, endpoint)
@@ -604,7 +604,7 @@ func TestArrivalsAndDeparturesReturnsResultsNearMidnight(t *testing.T) {
 	defer api.Shutdown()
 
 	agency := mustGetAgencies(t, api)[0]
-	stops := api.GtfsManager.GetStops()
+	stops := mustGetStops(t, api)
 	if len(stops) == 0 {
 		t.Skip("No stops available for testing")
 	}
@@ -612,7 +612,7 @@ func TestArrivalsAndDeparturesReturnsResultsNearMidnight(t *testing.T) {
 	var foundResults bool
 
 	for _, stop := range stops {
-		stopID := utils.FormCombinedID(agency.ID, stop.Id)
+		stopID := utils.FormCombinedID(agency.ID, stop.ID)
 		url := "/api/where/arrivals-and-departures-for-stop/" + stopID + ".json?key=TEST&minutesBefore=15&minutesAfter=240"
 
 		resp, model := serveApiAndRetrieveEndpoint(t, api, url)

--- a/internal/restapi/benchmark_test.go
+++ b/internal/restapi/benchmark_test.go
@@ -14,11 +14,11 @@ func BenchmarkArrivalsAndDeparturesForStop(b *testing.B) {
 	defer cleanup()
 
 	agencies := mustGetAgencies(b, api)
-	stops := api.GtfsManager.GetStops()
+	stops := mustGetStops(b, api)
 	if len(agencies) == 0 || len(stops) == 0 {
 		b.Fatal("no agencies or stops")
 	}
-	stopID := utils.FormCombinedID(agencies[0].ID, stops[0].Id)
+	stopID := utils.FormCombinedID(agencies[0].ID, stops[0].ID)
 
 	mux := http.NewServeMux()
 	api.SetRoutes(mux)

--- a/internal/restapi/http_test.go
+++ b/internal/restapi/http_test.go
@@ -146,6 +146,14 @@ func mustGetRoutes(t testing.TB, api *RestAPI) []gtfsdb.Route {
 	return routes
 }
 
+// mustGetStops returns all active stops from the DB (stops with stop times)
+func mustGetStops(t testing.TB, api *RestAPI) []gtfsdb.Stop {
+	t.Helper()
+	stops, err := api.GtfsManager.GtfsDB.Queries.GetActiveStops(context.Background())
+	require.NoError(t, err)
+	return stops
+}
+
 func TestCompressionMiddleware(t *testing.T) {
 	// Create a test handler that returns a large response
 	testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/restapi/openapi_conformance_test.go
+++ b/internal/restapi/openapi_conformance_test.go
@@ -168,9 +168,9 @@ func TestOpenAPIConformance_StaticEndpoints(t *testing.T) {
 	require.NotEmpty(t, agencies, "Test data must contain at least one agency")
 	agencyID := agencies[0].ID
 
-	stops := api.GtfsManager.GetStops()
+	stops := mustGetStops(t, api)
 	require.NotEmpty(t, stops, "Test data must contain at least one stop")
-	stopID := utils.FormCombinedID(agencyID, stops[0].Id)
+	stopID := utils.FormCombinedID(agencyID, stops[0].ID)
 
 	routes := api.GtfsManager.GetStaticData().Routes
 	require.NotEmpty(t, routes, "Test data must contain at least one route")

--- a/internal/restapi/schedule_for_stop_handler_test.go
+++ b/internal/restapi/schedule_for_stop_handler_test.go
@@ -19,10 +19,10 @@ func TestScheduleForStopHandler(t *testing.T) {
 	agencies := mustGetAgencies(t, api)
 	assert.NotEmpty(t, agencies, "Test data should contain at least one agency")
 
-	stops := api.GtfsManager.GetStops()
+	stops := mustGetStops(t, api)
 	assert.NotEmpty(t, stops, "Test data should contain at least one stop")
 
-	stopID := utils.FormCombinedID(agencies[0].ID, stops[0].Id)
+	stopID := utils.FormCombinedID(agencies[0].ID, stops[0].ID)
 
 	tests := []struct {
 		name                string
@@ -80,8 +80,8 @@ func TestScheduleForStopHandlerDateParam(t *testing.T) {
 
 	// Get valid stop for testing
 	agencies := mustGetAgencies(t, api)
-	stops := api.GtfsManager.GetStops()
-	stopID := utils.FormCombinedID(agencies[0].ID, stops[0].Id)
+	stops := mustGetStops(t, api)
+	stopID := utils.FormCombinedID(agencies[0].ID, stops[0].ID)
 
 	// Test valid date parameter
 	t.Run("Valid date parameter", func(t *testing.T) {
@@ -109,10 +109,10 @@ func TestScheduleForStopHandlerAgencyTimeZone(t *testing.T) {
 	defer api.Shutdown()
 
 	agencies := mustGetAgencies(t, api)
-	stops := api.GtfsManager.GetStops()
+	stops := mustGetStops(t, api)
 
 	agency := agencies[0]
-	stopID := utils.FormCombinedID(agency.ID, stops[0].Id)
+	stopID := utils.FormCombinedID(agency.ID, stops[0].ID)
 
 	endpoint := "/api/where/schedule-for-stop/" + stopID + ".json?key=TEST"
 	_, model := serveApiAndRetrieveEndpoint(t, api, endpoint)
@@ -135,8 +135,8 @@ func TestScheduleForStopHandlerWithDateFiltering(t *testing.T) {
 
 	// Get valid stop for testing
 	agencies := mustGetAgencies(t, api)
-	stops := api.GtfsManager.GetStops()
-	stopID := utils.FormCombinedID(agencies[0].ID, stops[0].Id)
+	stops := mustGetStops(t, api)
+	stopID := utils.FormCombinedID(agencies[0].ID, stops[0].ID)
 
 	tests := []struct {
 		name           string
@@ -205,8 +205,8 @@ func TestScheduleForStopHandlerReferences(t *testing.T) {
 	defer api.Shutdown()
 
 	agencies := mustGetAgencies(t, api)
-	stops := api.GtfsManager.GetStops()
-	stopID := utils.FormCombinedID(agencies[0].ID, stops[0].Id)
+	stops := mustGetStops(t, api)
+	stopID := utils.FormCombinedID(agencies[0].ID, stops[0].ID)
 
 	t.Run("Response structure is correct", func(t *testing.T) {
 		// NOTE: Hardcoded date 2025-06-12 matches GTFS data validity
@@ -249,8 +249,8 @@ func TestScheduleForStopHandlerInvalidDateFormat(t *testing.T) {
 	defer api.Shutdown()
 
 	agencies := mustGetAgencies(t, api)
-	stops := api.GtfsManager.GetStops()
-	stopID := utils.FormCombinedID(agencies[0].ID, stops[0].Id)
+	stops := mustGetStops(t, api)
+	stopID := utils.FormCombinedID(agencies[0].ID, stops[0].ID)
 
 	tests := []struct {
 		name           string
@@ -292,8 +292,8 @@ func TestScheduleForStopHandlerScheduleContent(t *testing.T) {
 	defer api.Shutdown()
 
 	agencies := mustGetAgencies(t, api)
-	stops := api.GtfsManager.GetStops()
-	stopID := utils.FormCombinedID(agencies[0].ID, stops[0].Id)
+	stops := mustGetStops(t, api)
+	stopID := utils.FormCombinedID(agencies[0].ID, stops[0].ID)
 
 	t.Run("Handler executes successfully", func(t *testing.T) {
 		// NOTE: Hardcoded date matches GTFS data validity
@@ -320,10 +320,10 @@ func TestScheduleForStopHandlerEmptyRoutes(t *testing.T) {
 	defer api.Shutdown()
 
 	agencies := mustGetAgencies(t, api)
-	stops := api.GtfsManager.GetStops()
+	stops := mustGetStops(t, api)
 
 	t.Run("Stop with no routes returns empty schedule", func(t *testing.T) {
-		stopID := utils.FormCombinedID(agencies[0].ID, stops[0].Id)
+		stopID := utils.FormCombinedID(agencies[0].ID, stops[0].ID)
 		// NOTE: Hardcoded date matches GTFS data validity
 		endpoint := "/api/where/schedule-for-stop/" + stopID + ".json?key=TEST&date=2025-06-12"
 		resp, model := serveApiAndRetrieveEndpoint(t, api, endpoint)
@@ -346,11 +346,11 @@ func TestScheduleForStopQueryValidation(t *testing.T) {
 	defer api.Shutdown()
 
 	agencies := mustGetAgencies(t, api)
-	stops := api.GtfsManager.GetStops()
+	stops := mustGetStops(t, api)
 	require := assert.New(t)
 
 	t.Run("Query returns valid data structure", func(t *testing.T) {
-		stopID := utils.FormCombinedID(agencies[0].ID, stops[0].Id)
+		stopID := utils.FormCombinedID(agencies[0].ID, stops[0].ID)
 		endpoint := "/api/where/schedule-for-stop/" + stopID + ".json?key=TEST&date=2024-05-15"
 		resp, model := serveApiAndRetrieveEndpoint(t, api, endpoint)
 
@@ -431,8 +431,8 @@ func TestScheduleForStopQueryValidation(t *testing.T) {
 		// Create a fresh API instance to avoid rate limiting
 		testApi := createTestApi(t)
 		testAgencies := mustGetAgencies(t, testApi)
-		testStops := testApi.GtfsManager.GetStops()
-		testStopID := utils.FormCombinedID(testAgencies[0].ID, testStops[0].Id)
+		testStops := mustGetStops(t, testApi)
+		testStopID := utils.FormCombinedID(testAgencies[0].ID, testStops[0].ID)
 
 		weekdayTests := []struct {
 			date    string
@@ -463,7 +463,7 @@ func TestScheduleForStopQueryValidation(t *testing.T) {
 	})
 
 	t.Run("Query properly formats timestamps", func(t *testing.T) {
-		stopID := utils.FormCombinedID(agencies[0].ID, stops[0].Id)
+		stopID := utils.FormCombinedID(agencies[0].ID, stops[0].ID)
 		endpoint := "/api/where/schedule-for-stop/" + stopID + ".json?key=TEST&date=2024-05-15"
 		resp, model := serveApiAndRetrieveEndpoint(t, api, endpoint)
 

--- a/internal/restapi/search_stops_handler_test.go
+++ b/internal/restapi/search_stops_handler_test.go
@@ -57,11 +57,11 @@ func TestSearchStopsHandlerMissingInput(t *testing.T) {
 func TestSearchStopsHandlerEndToEnd(t *testing.T) {
 	api := createTestApi(t)
 
-	stops := api.GtfsManager.GetStops()
+	stops := mustGetStops(t, api)
 	require.NotEmpty(t, stops)
 	targetStop := stops[0]
 
-	query := url.QueryEscape(targetStop.Name)
+	query := url.QueryEscape(targetStop.Name.String)
 	reqUrl := fmt.Sprintf("/api/where/search/stop.json?key=TEST&input=%s", query)
 
 	mux := http.NewServeMux()
@@ -131,13 +131,13 @@ func TestSearchStopsHandlerNoResults(t *testing.T) {
 func TestSearchStopsHandlerMaxCount(t *testing.T) {
 	api := createTestApi(t)
 
-	stops := api.GtfsManager.GetStops()
+	stops := mustGetStops(t, api)
 	if len(stops) < 2 {
 		t.Skip("Not enough stops")
 	}
 
 	targetStop := stops[0]
-	query := url.QueryEscape(targetStop.Name)
+	query := url.QueryEscape(targetStop.Name.String)
 
 	reqUrl := fmt.Sprintf(
 		"/api/where/search/stop.json?key=TEST&input=%s&maxCount=1",
@@ -213,11 +213,11 @@ func TestSearchStopsHandlerSpecialCharactersOnly(t *testing.T) {
 func TestSearchStopsHandlerMaxCountBoundaries(t *testing.T) {
 	api := createTestApi(t)
 
-	stops := api.GtfsManager.GetStops()
+	stops := mustGetStops(t, api)
 	require.NotEmpty(t, stops)
 
 	targetStop := stops[0]
-	query := url.QueryEscape(targetStop.Name)
+	query := url.QueryEscape(targetStop.Name.String)
 
 	tests := []struct {
 		name     string

--- a/internal/restapi/stop_handler.go
+++ b/internal/restapi/stop_handler.go
@@ -38,17 +38,23 @@ func (api *RestAPI) stopHandler(w http.ResponseWriter, r *http.Request) {
 		combinedRouteIDs[i] = utils.FormCombinedID(route.AgencyID, route.ID)
 	}
 
+	parentID := ""
+	if stop.ParentStation.Valid && stop.ParentStation.String != "" {
+		parentID = utils.FormCombinedID(agencyID, stop.ParentStation.String)
+	}
+
 	stopData := &models.Stop{
 		ID:                 utils.FormCombinedID(agencyID, stop.ID),
 		Name:               utils.NullStringOrEmpty(stop.Name),
 		Lat:                stop.Lat,
 		Lon:                stop.Lon,
-		Code:               utils.NullStringOrEmpty(stop.Code),
+		Code:               utils.NullStringOrDefault(stop.Code, stop.ID),
 		Direction:          utils.NullStringOrEmpty(stop.Direction),
 		LocationType:       int(stop.LocationType.Int64),
 		WheelchairBoarding: utils.MapWheelchairBoarding(utils.NullWheelchairBoardingOrUnknown(stop.WheelchairBoarding)),
 		RouteIDs:           combinedRouteIDs,
 		StaticRouteIDs:     combinedRouteIDs,
+		Parent:             parentID,
 	}
 
 	references := models.NewEmptyReferences()
@@ -88,6 +94,29 @@ func (api *RestAPI) stopHandler(w http.ResponseWriter, r *http.Request) {
 				false,
 			)
 			references.Agencies = append(references.Agencies, agencyModel)
+		}
+	}
+
+	if stop.ParentStation.Valid && stop.ParentStation.String != "" {
+		parentStop, err := api.GtfsManager.GtfsDB.Queries.GetStop(ctx, stop.ParentStation.String)
+		if err == nil {
+			parentRoutes, _ := api.GtfsManager.GtfsDB.Queries.GetRoutesForStop(ctx, parentStop.ID)
+			parentRouteIDs := make([]string, len(parentRoutes))
+			for i, r := range parentRoutes {
+				parentRouteIDs[i] = utils.FormCombinedID(r.AgencyID, r.ID)
+			}
+			references.Stops = append(references.Stops, models.Stop{
+				ID:                 utils.FormCombinedID(agencyID, parentStop.ID),
+				Name:               utils.NullStringOrEmpty(parentStop.Name),
+				Lat:                parentStop.Lat,
+				Lon:                parentStop.Lon,
+				Code:               utils.NullStringOrDefault(parentStop.Code, parentStop.ID),
+				Direction:          utils.NullStringOrEmpty(parentStop.Direction),
+				LocationType:       int(parentStop.LocationType.Int64),
+				WheelchairBoarding: utils.MapWheelchairBoarding(utils.NullWheelchairBoardingOrUnknown(parentStop.WheelchairBoarding)),
+				RouteIDs:           parentRouteIDs,
+				StaticRouteIDs:     parentRouteIDs,
+			})
 		}
 	}
 

--- a/internal/restapi/stop_handler.go
+++ b/internal/restapi/stop_handler.go
@@ -39,7 +39,7 @@ func (api *RestAPI) stopHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	parentID := ""
-	if stop.ParentStation.Valid && stop.ParentStation.String != "" {
+	if utils.NullStringOrEmpty(stop.ParentStation) != "" {
 		parentID = utils.FormCombinedID(agencyID, stop.ParentStation.String)
 	}
 
@@ -97,7 +97,7 @@ func (api *RestAPI) stopHandler(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	if stop.ParentStation.Valid && stop.ParentStation.String != "" {
+	if utils.NullStringOrEmpty(stop.ParentStation) != "" {
 		parentStop, err := api.GtfsManager.GtfsDB.Queries.GetStop(ctx, stop.ParentStation.String)
 		if err == nil {
 			parentRoutes, _ := api.GtfsManager.GtfsDB.Queries.GetRoutesForStop(ctx, parentStop.ID)
@@ -112,7 +112,7 @@ func (api *RestAPI) stopHandler(w http.ResponseWriter, r *http.Request) {
 				Lon:                parentStop.Lon,
 				Code:               utils.NullStringOrDefault(parentStop.Code, parentStop.ID),
 				Direction:          utils.NullStringOrEmpty(parentStop.Direction),
-				LocationType:       int(parentStop.LocationType.Int64),
+				LocationType:       int(utils.NullInt64OrDefault(parentStop.LocationType, 0)),
 				WheelchairBoarding: utils.MapWheelchairBoarding(utils.NullWheelchairBoardingOrUnknown(parentStop.WheelchairBoarding)),
 				RouteIDs:           parentRouteIDs,
 				StaticRouteIDs:     parentRouteIDs,

--- a/internal/restapi/stop_handler_test.go
+++ b/internal/restapi/stop_handler_test.go
@@ -21,10 +21,10 @@ func TestStopHandlerRequiresValidApiKey(t *testing.T) {
 	agencies := mustGetAgencies(t, api)
 	assert.NotEmpty(t, agencies, "Test data should contain at least one agency")
 
-	stops := api.GtfsManager.GetStops()
+	stops := mustGetStops(t, api)
 	assert.NotEmpty(t, stops, "Test data should contain at least one stop")
 
-	stopID := utils.FormCombinedID(agencies[0].ID, stops[0].Id)
+	stopID := utils.FormCombinedID(agencies[0].ID, stops[0].ID)
 
 	resp, model := serveApiAndRetrieveEndpoint(t, api, "/api/where/stop/"+stopID+".json?key=invalid")
 	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
@@ -39,10 +39,10 @@ func TestStopHandlerEndToEnd(t *testing.T) {
 	agencies := mustGetAgencies(t, api)
 	assert.NotEmpty(t, agencies, "Test data should contain at least one agency")
 
-	stops := api.GtfsManager.GetStops()
+	stops := mustGetStops(t, api)
 	assert.NotEmpty(t, stops, "Test data should contain at least one stop")
 
-	stopID := utils.FormCombinedID(agencies[0].ID, stops[0].Id)
+	stopID := utils.FormCombinedID(agencies[0].ID, stops[0].ID)
 
 	resp, model := serveApiAndRetrieveEndpoint(t, api, "/api/where/stop/"+stopID+".json?key=TEST")
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
@@ -56,11 +56,11 @@ func TestStopHandlerEndToEnd(t *testing.T) {
 	entry, ok := data["entry"].(map[string]interface{})
 	assert.True(t, ok)
 	assert.Equal(t, stopID, entry["id"])
-	assert.Equal(t, stops[0].Name, entry["name"])
-	assert.Equal(t, stops[0].Code, entry["code"])
+	assert.Equal(t, stops[0].Name.String, entry["name"])
+	assert.Equal(t, stops[0].Code.String, entry["code"])
 	assert.Equal(t, models.UnknownValue, entry["wheelchairBoarding"])
-	assert.Equal(t, *stops[0].Latitude, entry["lat"])
-	assert.Equal(t, *stops[0].Longitude, entry["lon"])
+	assert.Equal(t, stops[0].Lat, entry["lat"])
+	assert.Equal(t, stops[0].Lon, entry["lon"])
 
 	assert.Contains(t, entry, "direction", "direction field should exist")
 
@@ -106,10 +106,10 @@ func TestStopHandlerVerifiesReferences(t *testing.T) {
 	agencies := mustGetAgencies(t, api)
 	assert.NotEmpty(t, agencies, "Test data should contain at least one agency")
 
-	stops := api.GtfsManager.GetStops()
+	stops := mustGetStops(t, api)
 	assert.NotEmpty(t, stops, "Test data should contain at least one stop")
 
-	stopID := utils.FormCombinedID(agencies[0].ID, stops[0].Id)
+	stopID := utils.FormCombinedID(agencies[0].ID, stops[0].ID)
 
 	resp, model := serveApiAndRetrieveEndpoint(t, api, "/api/where/stop/"+stopID+".json?key=TEST")
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
@@ -303,13 +303,13 @@ func TestStopHandlerWithSituations(t *testing.T) {
 	agencies := mustGetAgencies(t, api)
 	require.NotEmpty(t, agencies, "Test data should contain at least one agency")
 
-	stops := api.GtfsManager.GetStops()
+	stops := mustGetStops(t, api)
 	require.NotEmpty(t, stops, "Test data should contain at least one stop")
 
 	routes := mustGetRoutes(t, api)
 	require.NotEmpty(t, routes, "Test data should contain at least one route")
 
-	rawStopID := stops[0].Id
+	rawStopID := stops[0].ID
 	rawRouteID := routes[0].ID
 	combinedStopID := utils.FormCombinedID(agencies[0].ID, rawStopID)
 

--- a/internal/utils/database.go
+++ b/internal/utils/database.go
@@ -14,6 +14,13 @@ func NullStringOrEmpty(ns sql.NullString) string {
 	return ""
 }
 
+func NullStringOrDefault(ns sql.NullString, defaultValue string) string {
+	if ns.Valid && ns.String != "" {
+		return ns.String
+	}
+	return defaultValue
+}
+
 // NullInt64OrDefault returns the int64 value if valid, otherwise returns the default value
 func NullInt64OrDefault(ni sql.NullInt64, defaultValue int64) int64 {
 	if ni.Valid {


### PR DESCRIPTION
Fixes: #825 
Part of: #820 

## Summary

- Replaces `manager.gtfsData.Stops` (in-memory slice) with `manager.GtfsDB.Queries.ListStops(ctx)` in `GetStops()`
- Updates all 35 call sites across 7 test files to use the new DB-backed method
- Adds `mustGetStops` test helper that uses `GetActiveStops` (stops with stop times) so tests always get stops that have routes and valid names

