### PR TITLE
refactor: replace GetTrips() full-table load with targeted DB query

### DIFF
--- a/gtfsdb/db.go
+++ b/gtfsdb/db.go
@@ -351,6 +351,9 @@ func Prepare(ctx context.Context, db DBTX) (*Queries, error) {
 	if q.listTripsStmt, err = db.PrepareContext(ctx, listTrips); err != nil {
 		return nil, fmt.Errorf("error preparing query ListTrips: %w", err)
 	}
+	if q.listTripsWithLimitStmt, err = db.PrepareContext(ctx, listTripsWithLimit); err != nil {
+		return nil, fmt.Errorf("error preparing query ListTripsWithLimit: %w", err)
+	}
 	if q.updateStopDirectionStmt, err = db.PrepareContext(ctx, updateStopDirection); err != nil {
 		return nil, fmt.Errorf("error preparing query UpdateStopDirection: %w", err)
 	}
@@ -907,6 +910,11 @@ func (q *Queries) Close() error {
 			err = fmt.Errorf("error closing listTripsStmt: %w", cerr)
 		}
 	}
+	if q.listTripsWithLimitStmt != nil {
+		if cerr := q.listTripsWithLimitStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing listTripsWithLimitStmt: %w", cerr)
+		}
+	}
 	if q.updateStopDirectionStmt != nil {
 		if cerr := q.updateStopDirectionStmt.Close(); cerr != nil {
 			err = fmt.Errorf("error closing updateStopDirectionStmt: %w", cerr)
@@ -1065,6 +1073,7 @@ type Queries struct {
 	listRoutesStmt                                *sql.Stmt
 	listStopsStmt                                 *sql.Stmt
 	listTripsStmt                                 *sql.Stmt
+	listTripsWithLimitStmt                        *sql.Stmt
 	updateStopDirectionStmt                       *sql.Stmt
 	upsertImportMetadataStmt                      *sql.Stmt
 }
@@ -1182,6 +1191,7 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		listRoutesStmt:                                q.listRoutesStmt,
 		listStopsStmt:                                 q.listStopsStmt,
 		listTripsStmt:                                 q.listTripsStmt,
+		listTripsWithLimitStmt:                        q.listTripsWithLimitStmt,
 		updateStopDirectionStmt:                       q.updateStopDirectionStmt,
 		upsertImportMetadataStmt:                      q.upsertImportMetadataStmt,
 	}

--- a/gtfsdb/query.sql
+++ b/gtfsdb/query.sql
@@ -853,6 +853,13 @@ SELECT
 FROM
     trips;
 
+-- name: ListTripsWithLimit :many
+SELECT
+    *
+FROM
+    trips
+LIMIT ?;
+
 -- name: GetArrivalsAndDeparturesForStop :many
 SELECT
     st.trip_id,

--- a/gtfsdb/query.sql.go
+++ b/gtfsdb/query.sql.go
@@ -4943,6 +4943,50 @@ func (q *Queries) ListTrips(ctx context.Context) ([]Trip, error) {
 	return items, nil
 }
 
+const listTripsWithLimit = `-- name: ListTripsWithLimit :many
+SELECT
+    id, route_id, service_id, trip_headsign, trip_short_name, direction_id, block_id, shape_id, wheelchair_accessible, bikes_allowed, min_arrival_time, max_departure_time
+FROM
+    trips
+LIMIT ?
+`
+
+func (q *Queries) ListTripsWithLimit(ctx context.Context, limit int64) ([]Trip, error) {
+	rows, err := q.query(ctx, q.listTripsWithLimitStmt, listTripsWithLimit, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []Trip
+	for rows.Next() {
+		var i Trip
+		if err := rows.Scan(
+			&i.ID,
+			&i.RouteID,
+			&i.ServiceID,
+			&i.TripHeadsign,
+			&i.TripShortName,
+			&i.DirectionID,
+			&i.BlockID,
+			&i.ShapeID,
+			&i.WheelchairAccessible,
+			&i.BikesAllowed,
+			&i.MinArrivalTime,
+			&i.MaxDepartureTime,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const updateStopDirection = `-- name: UpdateStopDirection :exec
 UPDATE stops
 SET direction = ?

--- a/internal/gtfs/gtfs_manager.go
+++ b/internal/gtfs/gtfs_manager.go
@@ -402,9 +402,9 @@ func (manager *Manager) GetAgencies(ctx context.Context) ([]gtfsdb.Agency, error
 	return manager.GtfsDB.Queries.ListAgencies(ctx)
 }
 
-// IMPORTANT: Caller must hold manager.RLock() before calling this method.
-func (manager *Manager) GetTrips() []gtfs.ScheduledTrip {
-	return manager.gtfsData.Trips
+// GetTrips returns up to limit trips from the database.
+func (manager *Manager) GetTrips(ctx context.Context, limit int64) ([]gtfsdb.Trip, error) {
+	return manager.GtfsDB.Queries.ListTripsWithLimit(ctx, limit)
 }
 
 // IMPORTANT: Caller must hold manager.RLock() before calling this method.

--- a/internal/gtfs/gtfs_manager_test.go
+++ b/internal/gtfs/gtfs_manager_test.go
@@ -104,7 +104,8 @@ func TestManager_GetTrips(t *testing.T) {
 	manager, _ := getSharedTestComponents(t)
 	assert.NotNil(t, manager)
 
-	trips := manager.GetTrips()
+	trips, err := manager.GetTrips(context.Background(), 100)
+	require.NoError(t, err)
 	assert.NotEmpty(t, trips)
 	assert.NotEmpty(t, trips[0].ID)
 }
@@ -238,10 +239,11 @@ func TestManager_IsServiceActiveOnDate(t *testing.T) {
 	manager, _ := getSharedTestComponents(t)
 
 	// Get a trip to find a valid service ID
-	trips := manager.GetTrips()
+	trips, err := manager.GetTrips(context.Background(), 100)
+	require.NoError(t, err)
 	assert.NotEmpty(t, trips)
 
-	serviceID := trips[0].Service.Id
+	serviceID := trips[0].ServiceID
 
 	testCases := []struct {
 		name    string

--- a/internal/restapi/arrival_and_departure_for_stop_handler_test.go
+++ b/internal/restapi/arrival_and_departure_for_stop_handler_test.go
@@ -33,7 +33,7 @@ func TestArrivalAndDepartureForStopHandlerEndToEnd(t *testing.T) {
 
 	agency := mustGetAgencies(t, api)[0]
 	stops := mustGetStops(t, api)
-	trips := api.GtfsManager.GetTrips()
+	trips := mustGetTrips(t, api)
 
 	if len(stops) == 0 {
 		t.Skip("No stops available for testing")
@@ -118,7 +118,7 @@ func TestArrivalAndDepartureForStopHandlerWithInvalidStopID(t *testing.T) {
 	defer api.Shutdown()
 
 	agency := mustGetAgencies(t, api)[0]
-	trips := api.GtfsManager.GetTrips()
+	trips := mustGetTrips(t, api)
 
 	tripID := utils.FormCombinedID(agency.ID, trips[0].ID)
 	serviceDate := time.Now().Unix() * 1000
@@ -139,7 +139,7 @@ func TestArrivalAndDepartureForStopHandlerWithTimeParameter(t *testing.T) {
 
 	agency := mustGetAgencies(t, api)[0]
 	stops := mustGetStops(t, api)
-	trips := api.GtfsManager.GetTrips()
+	trips := mustGetTrips(t, api)
 
 	if len(stops) == 0 {
 		t.Skip("No stops available for testing")
@@ -223,7 +223,7 @@ func TestArrivalAndDepartureForStopHandlerRequiresServiceDate(t *testing.T) {
 
 	agency := mustGetAgencies(t, api)[0]
 	stops := mustGetStops(t, api)
-	trips := api.GtfsManager.GetTrips()
+	trips := mustGetTrips(t, api)
 
 	stopID := utils.FormCombinedID(agency.ID, stops[0].ID)
 	tripID := utils.FormCombinedID(agency.ID, trips[0].ID)
@@ -260,7 +260,7 @@ func TestArrivalAndDepartureForStopHandlerWithStopSequence(t *testing.T) {
 
 	agency := mustGetAgencies(t, api)[0]
 	stops := mustGetStops(t, api)
-	trips := api.GtfsManager.GetTrips()
+	trips := mustGetTrips(t, api)
 
 	if len(stops) == 0 {
 		t.Skip("No stops available for testing")
@@ -299,7 +299,7 @@ func TestArrivalAndDepartureForStopHandlerWithMinutesParameters(t *testing.T) {
 
 	agency := mustGetAgencies(t, api)[0]
 	stops := mustGetStops(t, api)
-	trips := api.GtfsManager.GetTrips()
+	trips := mustGetTrips(t, api)
 
 	if len(stops) == 0 {
 		t.Skip("No stops available for testing")
@@ -369,7 +369,7 @@ func TestArrivalAndDepartureForStopHandlerWithMalformedStopID(t *testing.T) {
 	defer api.Shutdown()
 
 	agency := mustGetAgencies(t, api)[0]
-	trips := api.GtfsManager.GetTrips()
+	trips := mustGetTrips(t, api)
 
 	stopID := "malformedid" // No underscore, will fail extraction
 	tripID := utils.FormCombinedID(agency.ID, trips[0].ID)
@@ -390,7 +390,7 @@ func TestArrivalAndDepartureForStopHandlerWithValidTripStopCombination(t *testin
 	ctx := context.Background()
 
 	// Find a valid trip with stop times
-	trips := api.GtfsManager.GetTrips()
+	trips := mustGetTrips(t, api)
 	if len(trips) == 0 {
 		t.Skip("No trips available for testing")
 	}
@@ -476,7 +476,7 @@ func TestArrivalAndDepartureForStopHandlerWithValidTripAndStopSequence(t *testin
 	ctx := context.Background()
 
 	// Find a valid trip with multiple stops
-	trips := api.GtfsManager.GetTrips()
+	trips := mustGetTrips(t, api)
 	if len(trips) == 0 {
 		t.Skip("No trips available for testing")
 	}
@@ -1106,7 +1106,7 @@ func TestArrivalAndDepartureForStop_VehicleWithNilID(t *testing.T) {
 
 	ctx := context.Background()
 
-	trips := api.GtfsManager.GetTrips()
+	trips := mustGetTrips(t, api)
 	require.NotEmpty(t, trips)
 
 	var validTripID, validStopID string

--- a/internal/restapi/arrival_and_departure_for_stop_handler_test.go
+++ b/internal/restapi/arrival_and_departure_for_stop_handler_test.go
@@ -33,18 +33,15 @@ func TestArrivalAndDepartureForStopHandlerEndToEnd(t *testing.T) {
 
 	agency := mustGetAgencies(t, api)[0]
 	stops := mustGetStops(t, api)
-	trips := mustGetTrips(t, api)
+	trip := mustGetTrip(t, api)
 
 	if len(stops) == 0 {
 		t.Skip("No stops available for testing")
 	}
 
-	if len(trips) == 0 {
-		t.Skip("No trips available for testing")
-	}
 
 	stopID := utils.FormCombinedID(agency.ID, stops[0].ID)
-	tripID := utils.FormCombinedID(agency.ID, trips[0].ID)
+	tripID := utils.FormCombinedID(agency.ID, trip.ID)
 	serviceDate := time.Now().Unix() * 1000
 
 	mux := http.NewServeMux()
@@ -118,9 +115,9 @@ func TestArrivalAndDepartureForStopHandlerWithInvalidStopID(t *testing.T) {
 	defer api.Shutdown()
 
 	agency := mustGetAgencies(t, api)[0]
-	trips := mustGetTrips(t, api)
+	trip := mustGetTrip(t, api)
 
-	tripID := utils.FormCombinedID(agency.ID, trips[0].ID)
+	tripID := utils.FormCombinedID(agency.ID, trip.ID)
 	serviceDate := time.Now().Unix() * 1000
 
 	_, resp, model := serveAndRetrieveEndpoint(t,
@@ -139,18 +136,15 @@ func TestArrivalAndDepartureForStopHandlerWithTimeParameter(t *testing.T) {
 
 	agency := mustGetAgencies(t, api)[0]
 	stops := mustGetStops(t, api)
-	trips := mustGetTrips(t, api)
+	trip := mustGetTrip(t, api)
 
 	if len(stops) == 0 {
 		t.Skip("No stops available for testing")
 	}
 
-	if len(trips) == 0 {
-		t.Skip("No trips available for testing")
-	}
 
 	stopID := utils.FormCombinedID(agency.ID, stops[0].ID)
-	tripID := utils.FormCombinedID(agency.ID, trips[0].ID)
+	tripID := utils.FormCombinedID(agency.ID, trip.ID)
 
 	// Use a specific time (1 hour from now)
 	specificTime := time.Now().Add(1 * time.Hour)
@@ -223,10 +217,10 @@ func TestArrivalAndDepartureForStopHandlerRequiresServiceDate(t *testing.T) {
 
 	agency := mustGetAgencies(t, api)[0]
 	stops := mustGetStops(t, api)
-	trips := mustGetTrips(t, api)
+	trip := mustGetTrip(t, api)
 
 	stopID := utils.FormCombinedID(agency.ID, stops[0].ID)
-	tripID := utils.FormCombinedID(agency.ID, trips[0].ID)
+	tripID := utils.FormCombinedID(agency.ID, trip.ID)
 
 	mux := http.NewServeMux()
 	api.SetRoutes(mux)
@@ -260,18 +254,15 @@ func TestArrivalAndDepartureForStopHandlerWithStopSequence(t *testing.T) {
 
 	agency := mustGetAgencies(t, api)[0]
 	stops := mustGetStops(t, api)
-	trips := mustGetTrips(t, api)
+	trip := mustGetTrip(t, api)
 
 	if len(stops) == 0 {
 		t.Skip("No stops available for testing")
 	}
 
-	if len(trips) == 0 {
-		t.Skip("No trips available for testing")
-	}
 
 	stopID := utils.FormCombinedID(agency.ID, stops[0].ID)
-	tripID := utils.FormCombinedID(agency.ID, trips[0].ID)
+	tripID := utils.FormCombinedID(agency.ID, trip.ID)
 	serviceDate := time.Now().Unix() * 1000
 	stopSequence := 1
 
@@ -299,18 +290,15 @@ func TestArrivalAndDepartureForStopHandlerWithMinutesParameters(t *testing.T) {
 
 	agency := mustGetAgencies(t, api)[0]
 	stops := mustGetStops(t, api)
-	trips := mustGetTrips(t, api)
+	trip := mustGetTrip(t, api)
 
 	if len(stops) == 0 {
 		t.Skip("No stops available for testing")
 	}
 
-	if len(trips) == 0 {
-		t.Skip("No trips available for testing")
-	}
 
 	stopID := utils.FormCombinedID(agency.ID, stops[0].ID)
-	tripID := utils.FormCombinedID(agency.ID, trips[0].ID)
+	tripID := utils.FormCombinedID(agency.ID, trip.ID)
 	serviceDate := time.Now().Unix() * 1000
 
 	_, resp, model := serveAndRetrieveEndpoint(t,
@@ -369,10 +357,10 @@ func TestArrivalAndDepartureForStopHandlerWithMalformedStopID(t *testing.T) {
 	defer api.Shutdown()
 
 	agency := mustGetAgencies(t, api)[0]
-	trips := mustGetTrips(t, api)
+	trip := mustGetTrip(t, api)
 
 	stopID := "malformedid" // No underscore, will fail extraction
-	tripID := utils.FormCombinedID(agency.ID, trips[0].ID)
+	tripID := utils.FormCombinedID(agency.ID, trip.ID)
 	serviceDate := time.Now().Unix() * 1000
 
 	_, resp, _ := serveAndRetrieveEndpoint(t,
@@ -390,7 +378,10 @@ func TestArrivalAndDepartureForStopHandlerWithValidTripStopCombination(t *testin
 	ctx := context.Background()
 
 	// Find a valid trip with stop times
-	trips := mustGetTrips(t, api)
+	trips, err := api.GtfsManager.GetTrips(ctx, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if len(trips) == 0 {
 		t.Skip("No trips available for testing")
 	}
@@ -476,7 +467,10 @@ func TestArrivalAndDepartureForStopHandlerWithValidTripAndStopSequence(t *testin
 	ctx := context.Background()
 
 	// Find a valid trip with multiple stops
-	trips := mustGetTrips(t, api)
+	trips, err := api.GtfsManager.GetTrips(ctx, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if len(trips) == 0 {
 		t.Skip("No trips available for testing")
 	}
@@ -1106,7 +1100,10 @@ func TestArrivalAndDepartureForStop_VehicleWithNilID(t *testing.T) {
 
 	ctx := context.Background()
 
-	trips := mustGetTrips(t, api)
+	trips, err := api.GtfsManager.GetTrips(ctx, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
 	require.NotEmpty(t, trips)
 
 	var validTripID, validStopID string

--- a/internal/restapi/benchmark_test.go
+++ b/internal/restapi/benchmark_test.go
@@ -96,7 +96,7 @@ func BenchmarkTripDetails(b *testing.B) {
 	defer cleanup()
 
 	agencies := mustGetAgencies(b, api)
-	trips := api.GtfsManager.GetTrips()
+	trips := mustGetTrips(b, api)
 	if len(agencies) == 0 || len(trips) == 0 {
 		b.Fatal("no agencies or trips")
 	}

--- a/internal/restapi/benchmark_test.go
+++ b/internal/restapi/benchmark_test.go
@@ -96,11 +96,11 @@ func BenchmarkTripDetails(b *testing.B) {
 	defer cleanup()
 
 	agencies := mustGetAgencies(b, api)
-	trips := mustGetTrips(b, api)
-	if len(agencies) == 0 || len(trips) == 0 {
-		b.Fatal("no agencies or trips")
+	if len(agencies) == 0 {
+		b.Fatal("no agencies")
 	}
-	tripID := utils.FormCombinedID(agencies[0].ID, trips[0].ID)
+	trip := mustGetTrip(b, api)
+	tripID := utils.FormCombinedID(agencies[0].ID, trip.ID)
 
 	mux := http.NewServeMux()
 	api.SetRoutes(mux)

--- a/internal/restapi/calculate_block_trip_sequence_test.go
+++ b/internal/restapi/calculate_block_trip_sequence_test.go
@@ -19,7 +19,8 @@ func TestCalculateBlockTripSequence(t *testing.T) {
 	api.GtfsManager.RLock()
 	defer api.GtfsManager.RUnlock()
 
-	trips := mustGetTrips(t, api)
+	trips, err := api.GtfsManager.GetTrips(ctx, 100)
+	require.NoError(t, err)
 	require.NotEmpty(t, trips, "Should have test trips")
 
 	// Monday within the RABA dataset's active service period (calendar range covers this date)

--- a/internal/restapi/calculate_block_trip_sequence_test.go
+++ b/internal/restapi/calculate_block_trip_sequence_test.go
@@ -19,7 +19,7 @@ func TestCalculateBlockTripSequence(t *testing.T) {
 	api.GtfsManager.RLock()
 	defer api.GtfsManager.RUnlock()
 
-	trips := api.GtfsManager.GetTrips()
+	trips := mustGetTrips(t, api)
 	require.NotEmpty(t, trips, "Should have test trips")
 
 	// Monday within the RABA dataset's active service period (calendar range covers this date)

--- a/internal/restapi/http_test.go
+++ b/internal/restapi/http_test.go
@@ -109,6 +109,14 @@ func mustGetAgencies(t testing.TB, api *RestAPI) []gtfsdb.Agency {
 	return agencies
 }
 
+// mustGetTrips fetches up to 100 trips from the DB for use in tests.
+func mustGetTrips(t testing.TB, api *RestAPI) []gtfsdb.Trip {
+	t.Helper()
+	trips, err := api.GtfsManager.GetTrips(context.Background(), 100)
+	require.NoError(t, err)
+	return trips
+}
+
 // serveAndRetrieveEndpoint sets up a test server, makes a request to the specified endpoint, and returns the response
 // and decoded model.
 // Accepts testing.TB to support both *testing.T and *testing.B

--- a/internal/restapi/http_test.go
+++ b/internal/restapi/http_test.go
@@ -109,12 +109,13 @@ func mustGetAgencies(t testing.TB, api *RestAPI) []gtfsdb.Agency {
 	return agencies
 }
 
-// mustGetTrips fetches up to 100 trips from the DB for use in tests.
-func mustGetTrips(t testing.TB, api *RestAPI) []gtfsdb.Trip {
+// mustGetTrip fetches a single trip from the DB for use in tests.
+func mustGetTrip(t testing.TB, api *RestAPI) gtfsdb.Trip {
 	t.Helper()
-	trips, err := api.GtfsManager.GetTrips(context.Background(), 100)
+	trips, err := api.GtfsManager.GetTrips(context.Background(), 1)
 	require.NoError(t, err)
-	return trips
+	require.NotEmpty(t, trips, "test data should contain at least one trip")
+	return trips[0]
 }
 
 // serveAndRetrieveEndpoint sets up a test server, makes a request to the specified endpoint, and returns the response

--- a/internal/restapi/trip_details_handler_test.go
+++ b/internal/restapi/trip_details_handler_test.go
@@ -23,7 +23,7 @@ func TestTripDetailsHandlerEndToEnd(t *testing.T) {
 	defer api.Shutdown()
 
 	agency := mustGetAgencies(t, api)[0]
-	trips := api.GtfsManager.GetTrips()
+	trips := mustGetTrips(t, api)
 
 	tripID := utils.FormCombinedID(agency.ID, trips[0].ID)
 
@@ -98,8 +98,8 @@ func TestTripDetailsHandlerEndToEnd(t *testing.T) {
 		trip, ok := tripsRef[0].(map[string]interface{})
 		assert.True(t, ok)
 		assert.Equal(t, tripID, trip["id"])
-		assert.Equal(t, utils.FormCombinedID(agency.ID, trips[0].Route.Id), trip["routeId"])
-		assert.Equal(t, utils.FormCombinedID(agency.ID, trips[0].Service.Id), trip["serviceId"])
+		assert.Equal(t, utils.FormCombinedID(agency.ID, trips[0].RouteID), trip["routeId"])
+		assert.Equal(t, utils.FormCombinedID(agency.ID, trips[0].ServiceID), trip["serviceId"])
 	}
 
 	routes, ok := references["routes"].([]interface{})
@@ -144,7 +144,7 @@ func TestTripDetailsHandlerWithServiceDate(t *testing.T) {
 	defer api.Shutdown()
 
 	agency := mustGetAgencies(t, api)[0]
-	trips := api.GtfsManager.GetTrips()
+	trips := mustGetTrips(t, api)
 
 	tripID := utils.FormCombinedID(agency.ID, trips[0].ID)
 
@@ -177,7 +177,7 @@ func TestTripDetailsHandlerWithIncludeTrip(t *testing.T) {
 	defer api.Shutdown()
 
 	agency := mustGetAgencies(t, api)[0]
-	trips := api.GtfsManager.GetTrips()
+	trips := mustGetTrips(t, api)
 
 	tripID := utils.FormCombinedID(agency.ID, trips[0].ID)
 
@@ -207,7 +207,7 @@ func TestTripDetailsHandlerWithIncludeSchedule(t *testing.T) {
 	defer api.Shutdown()
 
 	agency := mustGetAgencies(t, api)[0]
-	trips := api.GtfsManager.GetTrips()
+	trips := mustGetTrips(t, api)
 
 	tripID := utils.FormCombinedID(agency.ID, trips[0].ID)
 
@@ -246,7 +246,7 @@ func TestTripDetailsHandlerWithIncludeStatus(t *testing.T) {
 	defer api.Shutdown()
 
 	agency := mustGetAgencies(t, api)[0]
-	trips := api.GtfsManager.GetTrips()
+	trips := mustGetTrips(t, api)
 
 	tripID := utils.FormCombinedID(agency.ID, trips[0].ID)
 
@@ -273,7 +273,7 @@ func TestTripDetailsHandlerWithTimeParameter(t *testing.T) {
 	defer api.Shutdown()
 
 	agency := mustGetAgencies(t, api)[0]
-	trips := api.GtfsManager.GetTrips()
+	trips := mustGetTrips(t, api)
 
 	tripID := utils.FormCombinedID(agency.ID, trips[0].ID)
 
@@ -302,7 +302,7 @@ func TestTripDetailsHandlerWithAllParametersFalse(t *testing.T) {
 	defer api.Shutdown()
 
 	agency := mustGetAgencies(t, api)[0]
-	trips := api.GtfsManager.GetTrips()
+	trips := mustGetTrips(t, api)
 
 	tripID := utils.FormCombinedID(agency.ID, trips[0].ID)
 
@@ -362,7 +362,7 @@ func TestTripDetailsHandlerWithInvalidParams(t *testing.T) {
 	defer api.Shutdown()
 
 	agency := mustGetAgencies(t, api)[0]
-	trips := api.GtfsManager.GetTrips()
+	trips := mustGetTrips(t, api)
 	tripID := utils.FormCombinedID(agency.ID, trips[0].ID)
 
 	endpoint := "/api/where/trip-details/" + tripID + ".json?key=TEST&serviceDate=invalid"

--- a/internal/restapi/trip_details_handler_test.go
+++ b/internal/restapi/trip_details_handler_test.go
@@ -23,9 +23,9 @@ func TestTripDetailsHandlerEndToEnd(t *testing.T) {
 	defer api.Shutdown()
 
 	agency := mustGetAgencies(t, api)[0]
-	trips := mustGetTrips(t, api)
+	trip := mustGetTrip(t, api)
 
-	tripID := utils.FormCombinedID(agency.ID, trips[0].ID)
+	tripID := utils.FormCombinedID(agency.ID, trip.ID)
 
 	_, resp, model := serveAndRetrieveEndpoint(t, "/api/where/trip-details/"+tripID+".json?key=TEST")
 
@@ -95,11 +95,11 @@ func TestTripDetailsHandlerEndToEnd(t *testing.T) {
 	if tripsOk {
 		assert.NotEmpty(t, tripsRef, "Trips should not be empty")
 
-		trip, ok := tripsRef[0].(map[string]interface{})
+		tripRef, ok := tripsRef[0].(map[string]interface{})
 		assert.True(t, ok)
-		assert.Equal(t, tripID, trip["id"])
-		assert.Equal(t, utils.FormCombinedID(agency.ID, trips[0].RouteID), trip["routeId"])
-		assert.Equal(t, utils.FormCombinedID(agency.ID, trips[0].ServiceID), trip["serviceId"])
+		assert.Equal(t, tripID, tripRef["id"])
+		assert.Equal(t, utils.FormCombinedID(agency.ID, trip.RouteID), tripRef["routeId"])
+		assert.Equal(t, utils.FormCombinedID(agency.ID, trip.ServiceID), tripRef["serviceId"])
 	}
 
 	routes, ok := references["routes"].([]interface{})
@@ -144,9 +144,9 @@ func TestTripDetailsHandlerWithServiceDate(t *testing.T) {
 	defer api.Shutdown()
 
 	agency := mustGetAgencies(t, api)[0]
-	trips := mustGetTrips(t, api)
+	trip := mustGetTrip(t, api)
 
-	tripID := utils.FormCombinedID(agency.ID, trips[0].ID)
+	tripID := utils.FormCombinedID(agency.ID, trip.ID)
 
 	// Use tomorrow's date as service date
 	tomorrow := time.Now().AddDate(0, 0, 1)
@@ -177,9 +177,9 @@ func TestTripDetailsHandlerWithIncludeTrip(t *testing.T) {
 	defer api.Shutdown()
 
 	agency := mustGetAgencies(t, api)[0]
-	trips := mustGetTrips(t, api)
+	trip := mustGetTrip(t, api)
 
-	tripID := utils.FormCombinedID(agency.ID, trips[0].ID)
+	tripID := utils.FormCombinedID(agency.ID, trip.ID)
 
 	// Test with includeTrip=false
 	_, resp, model := serveAndRetrieveEndpoint(t, "/api/where/trip-details/"+tripID+".json?key=TEST&includeTrip=false")
@@ -207,9 +207,9 @@ func TestTripDetailsHandlerWithIncludeSchedule(t *testing.T) {
 	defer api.Shutdown()
 
 	agency := mustGetAgencies(t, api)[0]
-	trips := mustGetTrips(t, api)
+	trip := mustGetTrip(t, api)
 
-	tripID := utils.FormCombinedID(agency.ID, trips[0].ID)
+	tripID := utils.FormCombinedID(agency.ID, trip.ID)
 
 	// Test with includeSchedule=false
 	_, resp, model := serveAndRetrieveEndpoint(t, "/api/where/trip-details/"+tripID+".json?key=TEST&includeSchedule=false")
@@ -246,9 +246,9 @@ func TestTripDetailsHandlerWithIncludeStatus(t *testing.T) {
 	defer api.Shutdown()
 
 	agency := mustGetAgencies(t, api)[0]
-	trips := mustGetTrips(t, api)
+	trip := mustGetTrip(t, api)
 
-	tripID := utils.FormCombinedID(agency.ID, trips[0].ID)
+	tripID := utils.FormCombinedID(agency.ID, trip.ID)
 
 	// Test with includeStatus=false
 	_, resp, model := serveAndRetrieveEndpoint(t, "/api/where/trip-details/"+tripID+".json?key=TEST&includeStatus=false")
@@ -273,9 +273,9 @@ func TestTripDetailsHandlerWithTimeParameter(t *testing.T) {
 	defer api.Shutdown()
 
 	agency := mustGetAgencies(t, api)[0]
-	trips := mustGetTrips(t, api)
+	trip := mustGetTrip(t, api)
 
-	tripID := utils.FormCombinedID(agency.ID, trips[0].ID)
+	tripID := utils.FormCombinedID(agency.ID, trip.ID)
 
 	// Use a specific time (1 hour from now)
 	specificTime := time.Now().Add(1 * time.Hour)
@@ -302,9 +302,9 @@ func TestTripDetailsHandlerWithAllParametersFalse(t *testing.T) {
 	defer api.Shutdown()
 
 	agency := mustGetAgencies(t, api)[0]
-	trips := mustGetTrips(t, api)
+	trip := mustGetTrip(t, api)
 
-	tripID := utils.FormCombinedID(agency.ID, trips[0].ID)
+	tripID := utils.FormCombinedID(agency.ID, trip.ID)
 
 	_, resp, model := serveAndRetrieveEndpoint(t,
 		"/api/where/trip-details/"+tripID+".json?key=TEST&includeTrip=false&includeSchedule=false&includeStatus=false")
@@ -362,8 +362,8 @@ func TestTripDetailsHandlerWithInvalidParams(t *testing.T) {
 	defer api.Shutdown()
 
 	agency := mustGetAgencies(t, api)[0]
-	trips := mustGetTrips(t, api)
-	tripID := utils.FormCombinedID(agency.ID, trips[0].ID)
+	trip := mustGetTrip(t, api)
+	tripID := utils.FormCombinedID(agency.ID, trip.ID)
 
 	endpoint := "/api/where/trip-details/" + tripID + ".json?key=TEST&serviceDate=invalid"
 

--- a/internal/restapi/trip_for_vehicle_handler_test.go
+++ b/internal/restapi/trip_for_vehicle_handler_test.go
@@ -27,12 +27,12 @@ func setupTestApiWithMockVehicle(t *testing.T) (*RestAPI, string, string) {
 	// Note: caller is responsible for calling api.Shutdown()
 
 	agencyStatic := mustGetAgencies(t, api)[0]
-	trips := mustGetTrips(t, api)
+	trip := mustGetTrip(t, api)
 
-	tripID := trips[0].ID
+	tripID := trip.ID
 	agencyID := agencyStatic.ID
 	vehicleID := "MOCK_VEHICLE_1"
-	routeID := utils.FormCombinedID(agencyID, trips[0].RouteID)
+	routeID := utils.FormCombinedID(agencyID, trip.RouteID)
 
 	api.GtfsManager.MockAddAgency(agencyID, "unitrans")
 	api.GtfsManager.MockAddRoute(routeID, agencyID, routeID)

--- a/internal/restapi/trip_for_vehicle_handler_test.go
+++ b/internal/restapi/trip_for_vehicle_handler_test.go
@@ -27,12 +27,12 @@ func setupTestApiWithMockVehicle(t *testing.T) (*RestAPI, string, string) {
 	// Note: caller is responsible for calling api.Shutdown()
 
 	agencyStatic := mustGetAgencies(t, api)[0]
-	trips := api.GtfsManager.GetTrips()
+	trips := mustGetTrips(t, api)
 
 	tripID := trips[0].ID
 	agencyID := agencyStatic.ID
 	vehicleID := "MOCK_VEHICLE_1"
-	routeID := utils.FormCombinedID(agencyID, trips[0].Route.Id)
+	routeID := utils.FormCombinedID(agencyID, trips[0].RouteID)
 
 	api.GtfsManager.MockAddAgency(agencyID, "unitrans")
 	api.GtfsManager.MockAddRoute(routeID, agencyID, routeID)

--- a/internal/restapi/trip_handler_test.go
+++ b/internal/restapi/trip_handler_test.go
@@ -24,9 +24,8 @@ func TestTripHandlerEndToEnd(t *testing.T) {
 	defer api.Shutdown()
 
 	agency := mustGetAgencies(t, api)[0]
-	trips := mustGetTrips(t, api)
+	trip := mustGetTrip(t, api)
 
-	trip := trips[0]
 	tripID := utils.FormCombinedID(agency.ID, trip.ID)
 
 	ctx := context.Background()

--- a/internal/restapi/trip_handler_test.go
+++ b/internal/restapi/trip_handler_test.go
@@ -1,11 +1,13 @@
 package restapi
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"maglev.onebusaway.org/internal/utils"
 )
 
@@ -22,10 +24,14 @@ func TestTripHandlerEndToEnd(t *testing.T) {
 	defer api.Shutdown()
 
 	agency := mustGetAgencies(t, api)[0]
+	trips := mustGetTrips(t, api)
 
-	trips := api.GtfsManager.GetTrips()
+	trip := trips[0]
+	tripID := utils.FormCombinedID(agency.ID, trip.ID)
 
-	tripID := utils.FormCombinedID(agency.ID, trips[0].ID)
+	ctx := context.Background()
+	route, err := api.GtfsManager.GtfsDB.Queries.GetRoute(ctx, trip.RouteID)
+	require.NoError(t, err)
 
 	_, resp, model := serveAndRetrieveEndpoint(t, "/api/where/trip/"+tripID+".json?key=TEST")
 
@@ -41,14 +47,14 @@ func TestTripHandlerEndToEnd(t *testing.T) {
 	entry, ok := data["entry"].(map[string]interface{})
 	assert.True(t, ok)
 	assert.Equal(t, tripID, entry["id"])
-	assert.Equal(t, utils.FormCombinedID(agency.ID, trips[0].Route.Id), entry["routeId"])
-	assert.Equal(t, utils.FormCombinedID(agency.ID, trips[0].Service.Id), entry["serviceId"])
-	assert.Equal(t, fmt.Sprintf("%d", trips[0].DirectionId), entry["directionId"])
-	assert.Equal(t, utils.FormCombinedID(agency.ID, trips[0].BlockID), entry["blockId"])
-	assert.Equal(t, utils.FormCombinedID(agency.ID, trips[0].Shape.ID), entry["shapeId"])
-	assert.Equal(t, trips[0].Headsign, entry["tripHeadsign"])
-	assert.Equal(t, trips[0].ShortName, entry["tripShortName"])
-	assert.Equal(t, trips[0].Route.ShortName, entry["routeShortName"])
+	assert.Equal(t, utils.FormCombinedID(agency.ID, trip.RouteID), entry["routeId"])
+	assert.Equal(t, utils.FormCombinedID(agency.ID, trip.ServiceID), entry["serviceId"])
+	assert.Equal(t, fmt.Sprintf("%d", utils.NullInt64OrDefault(trip.DirectionID, 0)), entry["directionId"])
+	assert.Equal(t, utils.FormCombinedID(agency.ID, utils.NullStringOrEmpty(trip.BlockID)), entry["blockId"])
+	assert.Equal(t, utils.FormCombinedID(agency.ID, utils.NullStringOrEmpty(trip.ShapeID)), entry["shapeId"])
+	assert.Equal(t, utils.NullStringOrEmpty(trip.TripHeadsign), entry["tripHeadsign"])
+	assert.Equal(t, utils.NullStringOrEmpty(trip.TripShortName), entry["tripShortName"])
+	assert.Equal(t, utils.NullStringOrEmpty(route.ShortName), entry["routeShortName"])
 
 	references, ok := data["references"].(map[string]interface{})
 	assert.True(t, ok, "References section should exist")
@@ -58,11 +64,11 @@ func TestTripHandlerEndToEnd(t *testing.T) {
 	assert.True(t, ok, "Routes section should exist in references")
 	assert.NotEmpty(t, routes, "Routes should not be empty")
 
-	route, ok := routes[0].(map[string]interface{})
+	routeRef, ok := routes[0].(map[string]interface{})
 	assert.True(t, ok)
-	assert.Equal(t, utils.FormCombinedID(agency.ID, trips[0].Route.Id), route["id"])
-	assert.Equal(t, agency.ID, route["agencyId"])
-	assert.Equal(t, trips[0].Route.ShortName, route["shortName"])
+	assert.Equal(t, utils.FormCombinedID(agency.ID, trip.RouteID), routeRef["id"])
+	assert.Equal(t, agency.ID, routeRef["agencyId"])
+	assert.Equal(t, utils.NullStringOrEmpty(route.ShortName), routeRef["shortName"])
 
 	agencies, ok := references["agencies"].([]interface{})
 	assert.True(t, ok, "Agencies section should exist in references")

--- a/internal/restapi/trips_helper_test.go
+++ b/internal/restapi/trips_helper_test.go
@@ -195,12 +195,12 @@ func TestCalculatePreciseDistanceAlongTrip(t *testing.T) {
 	ctx := context.Background()
 
 	// Get a test trip with shape data
-	trips := api.GtfsManager.GetTrips()
+	trips := mustGetTrips(t, api)
 	require.NotEmpty(t, trips, "Should have test trips")
 
 	var testTripID string
 	for _, trip := range trips {
-		if trip.Shape != nil && len(trip.Shape.Points) > 0 {
+		if trip.ShapeID.Valid && trip.ShapeID.String != "" {
 			testTripID = trip.ID
 			break
 		}
@@ -269,7 +269,7 @@ func TestCalculatePreciseDistanceAlongTrip_EdgeCases(t *testing.T) {
 
 	t.Run("Single shape point", func(t *testing.T) {
 		// Get a valid stop
-		trips := api.GtfsManager.GetTrips()
+		trips := mustGetTrips(t, api)
 		require.NotEmpty(t, trips)
 
 		stopTimes, err := api.GtfsManager.GtfsDB.Queries.GetStopTimesForTrip(ctx, trips[0].ID)
@@ -301,7 +301,7 @@ func TestCalculatePreciseDistanceAlongTrip_Correctness(t *testing.T) {
 	}
 
 	// Get a real stop to test with (we'll use its ID but override the coordinates conceptually)
-	trips := api.GtfsManager.GetTrips()
+	trips := mustGetTrips(t, api)
 	require.NotEmpty(t, trips)
 
 	stopTimes, err := api.GtfsManager.GtfsDB.Queries.GetStopTimesForTrip(ctx, trips[0].ID)
@@ -425,7 +425,7 @@ func TestBuildStopTimesList_ErrorHandling(t *testing.T) {
 	ctx := context.Background()
 
 	// Get real stop times to work with
-	trips := api.GtfsManager.GetTrips()
+	trips := mustGetTrips(t, api)
 	require.NotEmpty(t, trips)
 
 	stopTimes, err := api.GtfsManager.GtfsDB.Queries.GetStopTimesForTrip(ctx, trips[0].ID)
@@ -508,7 +508,7 @@ func TestBuildTripStatus_VehicleWithPosition_FindsStops(t *testing.T) {
 	require.NotEmpty(t, agencies)
 	agencyID := agencies[0].ID
 
-	trips := api.GtfsManager.GetTrips()
+	trips := mustGetTrips(t, api)
 	require.NotEmpty(t, trips)
 
 	// Find a trip with stop times so we can exercise the stop-finding branch
@@ -533,7 +533,7 @@ func TestBuildTripStatus_VehicleWithPosition_FindsStops(t *testing.T) {
 	lat := float32(stops[0].Lat)
 	lon := float32(stops[0].Lon)
 
-	routeID := trips[0].Route.Id
+	routeID := trips[0].RouteID
 	vehicleID := "VEHICLE_POS_TEST"
 
 	api.GtfsManager.MockAddVehicleWithOptions(vehicleID, tripID, routeID, internalgtfs.MockVehicleOptions{
@@ -573,10 +573,10 @@ func TestBuildTripStatus_ScheduleDeviation_SetsPredicted(t *testing.T) {
 	require.NotEmpty(t, agencies)
 	agencyID := agencies[0].ID
 
-	trips := api.GtfsManager.GetTrips()
+	trips := mustGetTrips(t, api)
 	require.NotEmpty(t, trips)
 	tripID := trips[0].ID
-	routeID := trips[0].Route.Id
+	routeID := trips[0].RouteID
 
 	// Add a trip update with a 120-second delay (no vehicle, just trip update)
 	delay := 120 * time.Second
@@ -609,7 +609,7 @@ func TestBuildTripStatus_NoRealtimeData_SetsScheduled(t *testing.T) {
 	require.NotEmpty(t, agencies)
 	agencyID := agencies[0].ID
 
-	trips := api.GtfsManager.GetTrips()
+	trips := mustGetTrips(t, api)
 	require.NotEmpty(t, trips)
 	tripID := trips[0].ID
 
@@ -639,7 +639,7 @@ func TestBuildTripStatus_ShapeData_ComputesDistanceAlongTrip(t *testing.T) {
 	agencyID := agencies[0].ID
 
 	// Find a trip that has both shape data and stop times
-	trips := api.GtfsManager.GetTrips()
+	trips := mustGetTrips(t, api)
 	require.NotEmpty(t, trips)
 
 	var tripID, routeID string
@@ -649,7 +649,7 @@ func TestBuildTripStatus_ShapeData_ComputesDistanceAlongTrip(t *testing.T) {
 			st, err := api.GtfsManager.GtfsDB.Queries.GetStopTimesForTrip(ctx, trip.ID)
 			if err == nil && len(st) >= 2 {
 				tripID = trip.ID
-				routeID = trip.Route.Id
+				routeID = trip.RouteID
 				break
 			}
 		}
@@ -698,12 +698,12 @@ func TestBuildTripStatus_VehicleIDFormat(t *testing.T) {
 	t.Cleanup(api.GtfsManager.MockResetRealTimeData)
 
 	agencyStatic := mustGetAgencies(t, api)[0]
-	trips := api.GtfsManager.GetTrips()
+	trips := mustGetTrips(t, api)
 
 	tripID := trips[0].ID
 	agencyID := agencyStatic.ID
 	vehicleID := "MOCK_VEHICLE_1"
-	routeID := utils.FormCombinedID(agencyID, trips[0].Route.Id)
+	routeID := utils.FormCombinedID(agencyID, trips[0].RouteID)
 
 	api.GtfsManager.MockAddAgency(agencyID, "unitrans")
 	api.GtfsManager.MockAddRoute(routeID, agencyID, routeID)
@@ -821,7 +821,7 @@ func TestFillStopsFromSchedule_BeforeAllStops(t *testing.T) {
 	defer api.Shutdown()
 	ctx := context.Background()
 
-	trips := api.GtfsManager.GetTrips()
+	trips := mustGetTrips(t, api)
 	require.NotEmpty(t, trips)
 	agencies := mustGetAgencies(t, api)
 	require.NotEmpty(t, agencies)
@@ -849,7 +849,7 @@ func TestFillStopsFromSchedule_AfterAllStops(t *testing.T) {
 	defer api.Shutdown()
 	ctx := context.Background()
 
-	trips := api.GtfsManager.GetTrips()
+	trips := mustGetTrips(t, api)
 	require.NotEmpty(t, trips)
 	agencies := mustGetAgencies(t, api)
 	require.NotEmpty(t, agencies)
@@ -1033,7 +1033,7 @@ func TestBuildTripStatus_VehicleWithStopID_FindsStops(t *testing.T) {
 	require.NotEmpty(t, agencies)
 	agencyID := agencies[0].ID
 
-	trips := api.GtfsManager.GetTrips()
+	trips := mustGetTrips(t, api)
 	require.NotEmpty(t, trips)
 
 	// Find a trip with at least 3 stop times so we can place the vehicle mid-trip
@@ -1061,7 +1061,7 @@ func TestBuildTripStatus_VehicleWithStopID_FindsStops(t *testing.T) {
 	lat := float32(stops[0].Lat)
 	lon := float32(stops[0].Lon)
 
-	routeID := trips[0].Route.Id
+	routeID := trips[0].RouteID
 	vehicleID := "VEHICLE_STOPID_TEST"
 
 	// Mark the vehicle as STOPPED_AT to exercise the StopID + isStoppedAt branch
@@ -1112,7 +1112,7 @@ func TestBuildTripStatus_PreResolvedVehicle(t *testing.T) {
 	require.NotEmpty(t, agencies)
 	agencyID := agencies[0].ID
 
-	trips := api.GtfsManager.GetTrips()
+	trips := mustGetTrips(t, api)
 	require.NotEmpty(t, trips)
 
 	var tripID string
@@ -1169,7 +1169,7 @@ func TestBuildTripStatus_CanceledTrip(t *testing.T) {
 	require.NotEmpty(t, agencies)
 	agencyID := agencies[0].ID
 
-	trips := api.GtfsManager.GetTrips()
+	trips := mustGetTrips(t, api)
 	require.NotEmpty(t, trips)
 	tripID := trips[0].ID
 
@@ -1221,14 +1221,14 @@ func BenchmarkCalculatePreciseDistanceAlongTrip(b *testing.B) {
 	ctx := context.Background()
 
 	// Find a trip with shape data
-	trips := api.GtfsManager.GetTrips()
+	trips := mustGetTrips(t, api)
 	if len(trips) == 0 {
 		b.Skip("No trips available for benchmark")
 	}
 
 	var testTripID string
 	for _, trip := range trips {
-		if trip.Shape != nil && len(trip.Shape.Points) > 0 {
+		if trip.ShapeID.Valid && trip.ShapeID.String != "" {
 			testTripID = trip.ID
 			break
 		}
@@ -1273,7 +1273,7 @@ func BenchmarkBuildTripSchedule(b *testing.B) {
 	ctx := context.Background()
 
 	// Find a trip
-	trips := api.GtfsManager.GetTrips()
+	trips := mustGetTrips(t, api)
 	if len(trips) == 0 {
 		b.Skip("No trips available")
 	}
@@ -1312,7 +1312,7 @@ func BenchmarkBuildTripSchedule_VaryingShapeSize(b *testing.B) {
 	defer api.Shutdown()
 	ctx := context.Background()
 
-	trips := api.GtfsManager.GetTrips()
+	trips := mustGetTrips(t, api)
 	if len(trips) == 0 {
 		b.Skip("No trips available")
 	}
@@ -1798,19 +1798,19 @@ func TestGetFirstStopOfNextTripInBlock_WithBlockContinuation(t *testing.T) {
 	ctx := context.Background()
 
 	// Find a trip that belongs to a block with at least two trips.
-	trips := api.GtfsManager.GetTrips()
+	trips := mustGetTrips(t, api)
 	require.NotEmpty(t, trips, "need at least one trip in test data")
 
 	// Locate a trip that has a block ID and more than one trip in the block.
 	var targetTripID string
 	for _, trip := range trips {
-		if trip.BlockID == "" {
+		if !trip.BlockID.Valid || trip.BlockID.String == "" {
 			continue
 		}
-		blockID := trip.BlockID
+		blockID := trip.BlockID.String
 		count := 0
 		for _, other := range trips {
-			if other.BlockID == blockID {
+			if other.BlockID.String == blockID {
 				count++
 			}
 		}

--- a/internal/restapi/trips_helper_test.go
+++ b/internal/restapi/trips_helper_test.go
@@ -195,7 +195,8 @@ func TestCalculatePreciseDistanceAlongTrip(t *testing.T) {
 	ctx := context.Background()
 
 	// Get a test trip with shape data
-	trips := mustGetTrips(t, api)
+	trips, err := api.GtfsManager.GetTrips(ctx, 100)
+	require.NoError(t, err)
 	require.NotEmpty(t, trips, "Should have test trips")
 
 	var testTripID string
@@ -269,7 +270,8 @@ func TestCalculatePreciseDistanceAlongTrip_EdgeCases(t *testing.T) {
 
 	t.Run("Single shape point", func(t *testing.T) {
 		// Get a valid stop
-		trips := mustGetTrips(t, api)
+		trips, err := api.GtfsManager.GetTrips(ctx, 100)
+		require.NoError(t, err)
 		require.NotEmpty(t, trips)
 
 		stopTimes, err := api.GtfsManager.GtfsDB.Queries.GetStopTimesForTrip(ctx, trips[0].ID)
@@ -301,10 +303,9 @@ func TestCalculatePreciseDistanceAlongTrip_Correctness(t *testing.T) {
 	}
 
 	// Get a real stop to test with (we'll use its ID but override the coordinates conceptually)
-	trips := mustGetTrips(t, api)
-	require.NotEmpty(t, trips)
+	trip := mustGetTrip(t, api)
 
-	stopTimes, err := api.GtfsManager.GtfsDB.Queries.GetStopTimesForTrip(ctx, trips[0].ID)
+	stopTimes, err := api.GtfsManager.GtfsDB.Queries.GetStopTimesForTrip(ctx, trip.ID)
 	require.NoError(t, err)
 	require.NotEmpty(t, stopTimes)
 
@@ -425,15 +426,14 @@ func TestBuildStopTimesList_ErrorHandling(t *testing.T) {
 	ctx := context.Background()
 
 	// Get real stop times to work with
-	trips := mustGetTrips(t, api)
-	require.NotEmpty(t, trips)
+	trip := mustGetTrip(t, api)
 
-	stopTimes, err := api.GtfsManager.GtfsDB.Queries.GetStopTimesForTrip(ctx, trips[0].ID)
+	stopTimes, err := api.GtfsManager.GtfsDB.Queries.GetStopTimesForTrip(ctx, trip.ID)
 	require.NoError(t, err)
 	require.NotEmpty(t, stopTimes)
 
 	// Get shape points
-	shapeRows, err := api.GtfsManager.GtfsDB.Queries.GetShapePointsByTripID(ctx, trips[0].ID)
+	shapeRows, err := api.GtfsManager.GtfsDB.Queries.GetShapePointsByTripID(ctx, trip.ID)
 	require.NoError(t, err)
 
 	shapePoints := make([]gtfs.ShapePoint, len(shapeRows))
@@ -508,7 +508,8 @@ func TestBuildTripStatus_VehicleWithPosition_FindsStops(t *testing.T) {
 	require.NotEmpty(t, agencies)
 	agencyID := agencies[0].ID
 
-	trips := mustGetTrips(t, api)
+	trips, err := api.GtfsManager.GetTrips(ctx, 100)
+	require.NoError(t, err)
 	require.NotEmpty(t, trips)
 
 	// Find a trip with stop times so we can exercise the stop-finding branch
@@ -573,10 +574,9 @@ func TestBuildTripStatus_ScheduleDeviation_SetsPredicted(t *testing.T) {
 	require.NotEmpty(t, agencies)
 	agencyID := agencies[0].ID
 
-	trips := mustGetTrips(t, api)
-	require.NotEmpty(t, trips)
-	tripID := trips[0].ID
-	routeID := trips[0].RouteID
+	trip := mustGetTrip(t, api)
+	tripID := trip.ID
+	routeID := trip.RouteID
 
 	// Add a trip update with a 120-second delay (no vehicle, just trip update)
 	delay := 120 * time.Second
@@ -609,9 +609,8 @@ func TestBuildTripStatus_NoRealtimeData_SetsScheduled(t *testing.T) {
 	require.NotEmpty(t, agencies)
 	agencyID := agencies[0].ID
 
-	trips := mustGetTrips(t, api)
-	require.NotEmpty(t, trips)
-	tripID := trips[0].ID
+	trip := mustGetTrip(t, api)
+	tripID := trip.ID
 
 	serviceDate := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
 	currentTime := serviceDate.Add(8 * time.Hour)
@@ -639,7 +638,8 @@ func TestBuildTripStatus_ShapeData_ComputesDistanceAlongTrip(t *testing.T) {
 	agencyID := agencies[0].ID
 
 	// Find a trip that has both shape data and stop times
-	trips := mustGetTrips(t, api)
+	trips, err := api.GtfsManager.GetTrips(ctx, 100)
+	require.NoError(t, err)
 	require.NotEmpty(t, trips)
 
 	var tripID, routeID string
@@ -698,12 +698,12 @@ func TestBuildTripStatus_VehicleIDFormat(t *testing.T) {
 	t.Cleanup(api.GtfsManager.MockResetRealTimeData)
 
 	agencyStatic := mustGetAgencies(t, api)[0]
-	trips := mustGetTrips(t, api)
+	trip := mustGetTrip(t, api)
 
-	tripID := trips[0].ID
+	tripID := trip.ID
 	agencyID := agencyStatic.ID
 	vehicleID := "MOCK_VEHICLE_1"
-	routeID := utils.FormCombinedID(agencyID, trips[0].RouteID)
+	routeID := utils.FormCombinedID(agencyID, trip.RouteID)
 
 	api.GtfsManager.MockAddAgency(agencyID, "unitrans")
 	api.GtfsManager.MockAddRoute(routeID, agencyID, routeID)
@@ -821,13 +821,12 @@ func TestFillStopsFromSchedule_BeforeAllStops(t *testing.T) {
 	defer api.Shutdown()
 	ctx := context.Background()
 
-	trips := mustGetTrips(t, api)
-	require.NotEmpty(t, trips)
+	trip := mustGetTrip(t, api)
 	agencies := mustGetAgencies(t, api)
 	require.NotEmpty(t, agencies)
 
 	agencyID := agencies[0].ID
-	tripID := trips[0].ID
+	tripID := trip.ID
 
 	stopTimes, err := api.GtfsManager.GtfsDB.Queries.GetStopTimesForTrip(ctx, tripID)
 	require.NoError(t, err)
@@ -849,13 +848,12 @@ func TestFillStopsFromSchedule_AfterAllStops(t *testing.T) {
 	defer api.Shutdown()
 	ctx := context.Background()
 
-	trips := mustGetTrips(t, api)
-	require.NotEmpty(t, trips)
+	trip := mustGetTrip(t, api)
 	agencies := mustGetAgencies(t, api)
 	require.NotEmpty(t, agencies)
 
 	agencyID := agencies[0].ID
-	tripID := trips[0].ID
+	tripID := trip.ID
 
 	stopTimes, err := api.GtfsManager.GtfsDB.Queries.GetStopTimesForTrip(ctx, tripID)
 	require.NoError(t, err)
@@ -1033,7 +1031,8 @@ func TestBuildTripStatus_VehicleWithStopID_FindsStops(t *testing.T) {
 	require.NotEmpty(t, agencies)
 	agencyID := agencies[0].ID
 
-	trips := mustGetTrips(t, api)
+	trips, err := api.GtfsManager.GetTrips(ctx, 100)
+	require.NoError(t, err)
 	require.NotEmpty(t, trips)
 
 	// Find a trip with at least 3 stop times so we can place the vehicle mid-trip
@@ -1112,7 +1111,8 @@ func TestBuildTripStatus_PreResolvedVehicle(t *testing.T) {
 	require.NotEmpty(t, agencies)
 	agencyID := agencies[0].ID
 
-	trips := mustGetTrips(t, api)
+	trips, err := api.GtfsManager.GetTrips(ctx, 100)
+	require.NoError(t, err)
 	require.NotEmpty(t, trips)
 
 	var tripID string
@@ -1169,9 +1169,8 @@ func TestBuildTripStatus_CanceledTrip(t *testing.T) {
 	require.NotEmpty(t, agencies)
 	agencyID := agencies[0].ID
 
-	trips := mustGetTrips(t, api)
-	require.NotEmpty(t, trips)
-	tripID := trips[0].ID
+	trip := mustGetTrip(t, api)
+	tripID := trip.ID
 
 	now := time.Now()
 	canceledRelationship := gtfsrt.TripDescriptor_CANCELED
@@ -1221,7 +1220,10 @@ func BenchmarkCalculatePreciseDistanceAlongTrip(b *testing.B) {
 	ctx := context.Background()
 
 	// Find a trip with shape data
-	trips := mustGetTrips(t, api)
+	trips, err := api.GtfsManager.GetTrips(ctx, 100)
+	if err != nil {
+		b.Fatal(err)
+	}
 	if len(trips) == 0 {
 		b.Skip("No trips available for benchmark")
 	}
@@ -1273,7 +1275,10 @@ func BenchmarkBuildTripSchedule(b *testing.B) {
 	ctx := context.Background()
 
 	// Find a trip
-	trips := mustGetTrips(t, api)
+	trips, err := api.GtfsManager.GetTrips(ctx, 100)
+	if err != nil {
+		b.Fatal(err)
+	}
 	if len(trips) == 0 {
 		b.Skip("No trips available")
 	}
@@ -1312,7 +1317,10 @@ func BenchmarkBuildTripSchedule_VaryingShapeSize(b *testing.B) {
 	defer api.Shutdown()
 	ctx := context.Background()
 
-	trips := mustGetTrips(t, api)
+	trips, err := api.GtfsManager.GetTrips(ctx, 100)
+	if err != nil {
+		b.Fatal(err)
+	}
 	if len(trips) == 0 {
 		b.Skip("No trips available")
 	}
@@ -1798,7 +1806,8 @@ func TestGetFirstStopOfNextTripInBlock_WithBlockContinuation(t *testing.T) {
 	ctx := context.Background()
 
 	// Find a trip that belongs to a block with at least two trips.
-	trips := mustGetTrips(t, api)
+	trips, err := api.GtfsManager.GetTrips(ctx, 100)
+	require.NoError(t, err)
 	require.NotEmpty(t, trips, "need at least one trip in test data")
 
 	// Locate a trip that has a block ID and more than one trip in the block.

--- a/internal/restapi/vehicles_for_agency_handler_test.go
+++ b/internal/restapi/vehicles_for_agency_handler_test.go
@@ -305,10 +305,10 @@ func TestVehiclesForAgencyHandler_OccupancyPropagation(t *testing.T) {
 	require.NotEmpty(t, agencies)
 	agencyID := agencies[0].ID
 
-	trips := api.GtfsManager.GetTrips()
+	trips := mustGetTrips(t, api)
 	require.NotEmpty(t, trips)
 
-	rawRouteID := trips[0].Route.Id
+	rawRouteID := trips[0].RouteID
 	tripID := trips[0].ID
 
 	occ := gtfsrt.VehiclePosition_OccupancyStatus(gtfsrt.VehiclePosition_MANY_SEATS_AVAILABLE)
@@ -350,9 +350,9 @@ func TestVehiclesForAgencyHandler_VehicleWithoutTrip(t *testing.T) {
 	require.NotEmpty(t, agencies)
 	agencyID := agencies[0].ID
 
-	trips := api.GtfsManager.GetTrips()
+	trips := mustGetTrips(t, api)
 	require.NotEmpty(t, trips)
-	rawRouteID := trips[0].Route.Id
+	rawRouteID := trips[0].RouteID
 
 	// Inject a vehicle with Trip == nil. It shares a routeID with static data so that
 	// if the nil-Trip filter is removed, the vehicle would propagate to the handler.
@@ -387,9 +387,9 @@ func TestVehiclesForAgencyHandler_VehicleWithNilID(t *testing.T) {
 	require.NotEmpty(t, agencies)
 	agencyID := agencies[0].ID
 
-	trips := api.GtfsManager.GetTrips()
+	trips := mustGetTrips(t, api)
 	require.NotEmpty(t, trips)
-	rawRouteID := trips[0].Route.Id
+	rawRouteID := trips[0].RouteID
 
 	api.GtfsManager.MockAddVehicleWithOptions("", trips[0].ID, rawRouteID, gtfs.MockVehicleOptions{
 		NoID: true,

--- a/internal/restapi/vehicles_for_agency_handler_test.go
+++ b/internal/restapi/vehicles_for_agency_handler_test.go
@@ -305,11 +305,10 @@ func TestVehiclesForAgencyHandler_OccupancyPropagation(t *testing.T) {
 	require.NotEmpty(t, agencies)
 	agencyID := agencies[0].ID
 
-	trips := mustGetTrips(t, api)
-	require.NotEmpty(t, trips)
+	trip := mustGetTrip(t, api)
 
-	rawRouteID := trips[0].RouteID
-	tripID := trips[0].ID
+	rawRouteID := trip.RouteID
+	tripID := trip.ID
 
 	occ := gtfsrt.VehiclePosition_OccupancyStatus(gtfsrt.VehiclePosition_MANY_SEATS_AVAILABLE)
 	api.GtfsManager.MockAddVehicleWithOptions("v_occ_test", tripID, rawRouteID, gtfs.MockVehicleOptions{
@@ -350,9 +349,8 @@ func TestVehiclesForAgencyHandler_VehicleWithoutTrip(t *testing.T) {
 	require.NotEmpty(t, agencies)
 	agencyID := agencies[0].ID
 
-	trips := mustGetTrips(t, api)
-	require.NotEmpty(t, trips)
-	rawRouteID := trips[0].RouteID
+	trip := mustGetTrip(t, api)
+	rawRouteID := trip.RouteID
 
 	// Inject a vehicle with Trip == nil. It shares a routeID with static data so that
 	// if the nil-Trip filter is removed, the vehicle would propagate to the handler.
@@ -387,11 +385,10 @@ func TestVehiclesForAgencyHandler_VehicleWithNilID(t *testing.T) {
 	require.NotEmpty(t, agencies)
 	agencyID := agencies[0].ID
 
-	trips := mustGetTrips(t, api)
-	require.NotEmpty(t, trips)
-	rawRouteID := trips[0].RouteID
+	trip := mustGetTrip(t, api)
+	rawRouteID := trip.RouteID
 
-	api.GtfsManager.MockAddVehicleWithOptions("", trips[0].ID, rawRouteID, gtfs.MockVehicleOptions{
+	api.GtfsManager.MockAddVehicleWithOptions("", trip.ID, rawRouteID, gtfs.MockVehicleOptions{
 		NoID: true,
 	})
 


### PR DESCRIPTION
Fixes: #826 
Part of: #820 

## Summary
- Removes in-memory `GetTrips()` (which loaded all trips from `gtfsData.Trips`) and replaces it with `GetTrips(ctx, limit)` backed by a new `ListTripsWithLimit` SQL query
- Adds `ListTripsWithLimit` to `query.sql` — uses `LIMIT ?` to avoid full-table scans, especially important for large merged feeds
- Updates all test call sites to use `mustGetTrips(t, api)` helper (limit 100) and maps flat `gtfsdb.Trip` fields (`RouteID`, `ServiceID`, `TripHeadsign`, etc.) replacing the old nested `gtfs.ScheduledTrip` fields (`Route.Id`, `Service.Id`, `Headsign`, etc.)
- Fixes pre-existing `errcheck` lint issue in `stops_rtree.go`

