### PR TITLE
refactor: use stricter json schema for a test

### DIFF
--- a/internal/restapi/http_test.go
+++ b/internal/restapi/http_test.go
@@ -131,6 +131,10 @@ func serveAndRetrieveEndpoint(t testing.TB, endpoint string) (*RestAPI, *http.Re
 // serveApiAndRetrieveEndpoint performs the request against an existing API instance
 // Accepts testing.TB to support both *testing.T and *testing.B
 func serveApiAndRetrieveEndpoint(t testing.TB, api *RestAPI, endpoint string) (*http.Response, models.ResponseModel) {
+	return callAPIHandler[models.ResponseModel](t, api, endpoint)
+}
+
+func callAPIHandler[ResponseType any](t testing.TB, api *RestAPI, endpoint string) (*http.Response, ResponseType) {
 	// Use SetupAPIRoutes to ensure global middleware (like compression) is applied
 	server := httptest.NewServer(api.SetupAPIRoutes())
 	defer server.Close()
@@ -140,7 +144,7 @@ func serveApiAndRetrieveEndpoint(t testing.TB, api *RestAPI, endpoint string) (*
 		slog.Default().With(slog.String("component", "test")),
 		"http_response_body")
 
-	var response models.ResponseModel
+	var response ResponseType
 	err = json.NewDecoder(resp.Body).Decode(&response)
 	require.NoError(t, err)
 

--- a/internal/restapi/routes_for_location_handler.go
+++ b/internal/restapi/routes_for_location_handler.go
@@ -4,6 +4,7 @@ import (
 	"maps"
 	"net/http"
 	"slices"
+	"strings"
 	"time"
 
 	"maglev.onebusaway.org/internal/models"
@@ -90,6 +91,11 @@ func (api *RestAPI) routesForLocationHandler(w http.ResponseWriter, r *http.Requ
 	references.Agencies = agencies
 	references.Situations = situations
 
+	// Results must be sorted by ID after maxCount limit is applied.
+	// See how response changes when calling java API with different maxCounts.
+	slices.SortFunc(results, func(a, b models.Route) int {
+		return strings.Compare(a.ID, b.ID)
+	})
 	response := models.NewListResponseWithRange(results, *references, checkIfOutOfBounds(api, loc.Lat, loc.Lon, loc.LatSpan, loc.LonSpan, radius), api.Clock, isLimitExceeded)
 	api.sendResponse(w, r, response)
 }

--- a/internal/restapi/routes_for_location_handler_test.go
+++ b/internal/restapi/routes_for_location_handler_test.go
@@ -6,9 +6,24 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"maglev.onebusaway.org/internal/utils"
+	"maglev.onebusaway.org/internal/models"
+	"maglev.onebusaway.org/internal/restapi/testdata"
 )
+
+type RoutesResponse struct {
+	Code        int    `json:"code"`
+	CurrentTime int64  `json:"currentTime"`
+	Data        Data   `json:"data,omitempty"`
+	Text        string `json:"text"`
+	Version     int    `json:"version"`
+}
+
+type Data struct {
+	LimitExceeded bool                   `json:"limitExceeded"`
+	List          []models.Route         `json:"list"`
+	OutOfRange    bool                   `json:"outOfRange"`
+	References    models.ReferencesModel `json:"references"`
+}
 
 func TestRoutesForLocationHandlerRequiresValidApiKey(t *testing.T) {
 	_, resp, model := serveAndRetrieveEndpoint(t, "/api/where/routes-for-location.json?key=invalid&lat=47.586556&lon=-122.190396")
@@ -18,266 +33,182 @@ func TestRoutesForLocationHandlerRequiresValidApiKey(t *testing.T) {
 }
 
 func TestRoutesForLocationHandlerEndToEnd(t *testing.T) {
-	_, resp, model := serveAndRetrieveEndpoint(t, "/api/where/routes-for-location.json?key=TEST&lat=40.583321&lon=-122.426966")
+	api := createTestApi(t)
+
+	resp, model := callAPIHandler[RoutesResponse](t, api, "/api/where/routes-for-location.json?key=TEST&lat=40.583321&lon=-122.426966")
 
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, http.StatusOK, model.Code)
 	assert.Equal(t, "OK", model.Text)
-
-	data, ok := model.Data.(map[string]interface{})
-	require.True(t, ok)
-
-	list, ok := data["list"].([]interface{})
-	require.True(t, ok)
-	assert.NotEmpty(t, list)
-
-	route, ok := list[0].(map[string]interface{})
-	require.True(t, ok)
-	assert.Contains(t, route, "id")
-	assert.Contains(t, route, "agencyId")
-	assert.Contains(t, route, "shortName")
-	assert.Contains(t, route, "longName")
-	assert.Contains(t, route, "type")
-
-	refs, ok := data["references"].(map[string]interface{})
-	require.True(t, ok)
-
-	agencies, ok := refs["agencies"].([]interface{})
-	require.True(t, ok)
-	assert.NotEmpty(t, agencies)
-
-	agency, ok := agencies[0].(map[string]interface{})
-	require.True(t, ok)
-	assert.Contains(t, agency, "id")
-	assert.Contains(t, agency, "name")
-	assert.Contains(t, agency, "url")
-	assert.Contains(t, agency, "timezone")
-	assert.Contains(t, agency, "lang")
-	assert.Contains(t, agency, "phone")
+	assert.ElementsMatch(t, model.Data.List, []models.Route{testdata.Route19})
+	assert.ElementsMatch(t, model.Data.References.Agencies, []models.AgencyReference{testdata.Raba})
 }
 
 func TestRoutesForLocationQuery(t *testing.T) {
-	_, resp, model := serveAndRetrieveEndpoint(t, "/api/where/routes-for-location.json?key=TEST&lat=40.583321&lon=-122.426966&query=19")
+	api := createTestApi(t)
+
+	// Wider radius includes multiple routes, but query limits response to just 19.
+	resp, model := callAPIHandler[RoutesResponse](t, api, "/api/where/routes-for-location.json?key=TEST&lat=40.583321&lon=-122.426966&radius=2000&query=19")
 
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
-
-	data, ok := model.Data.(map[string]interface{})
-	require.True(t, ok)
-
-	list, ok := data["list"].([]interface{})
-	require.True(t, ok)
-	assert.Len(t, list, 1)
-
-	route, ok := list[0].(map[string]interface{})
-	require.True(t, ok)
-	assert.Equal(t, "19", route["shortName"])
-	assert.Equal(t, "Route 19", route["longName"])
+	assert.ElementsMatch(t, model.Data.List, []models.Route{testdata.Route19})
+	assert.ElementsMatch(t, model.Data.References.Agencies, []models.AgencyReference{testdata.Raba})
 }
 
 func TestRoutesForLocationLatSpanAndLonSpan(t *testing.T) {
-	_, resp, model := serveAndRetrieveEndpoint(t, "/api/where/routes-for-location.json?key=TEST&lat=40.583321&lon=-122.426966&latSpan=0.01&lonSpan=0.01")
+	api := createTestApi(t)
+
+	resp, model := callAPIHandler[RoutesResponse](t, api, "/api/where/routes-for-location.json?key=TEST&lat=40.583321&lon=-122.426966&latSpan=0.01&lonSpan=0.01")
+
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
-	data, ok := model.Data.(map[string]interface{})
-	require.True(t, ok)
-	list, ok := data["list"].([]interface{})
-	require.True(t, ok)
-	assert.Len(t, list, 1)
-	route, ok := list[0].(map[string]interface{})
-	require.True(t, ok)
-	assert.Equal(t, "19", route["shortName"])
-	assert.Equal(t, "Route 19", route["longName"])
+	assert.ElementsMatch(t, model.Data.List, []models.Route{testdata.Route19})
+	assert.ElementsMatch(t, model.Data.References.Agencies, []models.AgencyReference{testdata.Raba})
 }
 
 func TestRoutesForLocationRadius(t *testing.T) {
-	_, resp, model := serveAndRetrieveEndpoint(t, "/api/where/routes-for-location.json?key=TEST&lat=40.583321&lon=-122.426966&radius=2000")
+	api := createTestApi(t)
+
+	resp, model := callAPIHandler[RoutesResponse](t, api, "/api/where/routes-for-location.json?key=TEST&lat=40.583321&lon=-122.426966&radius=2000")
+
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
-	data, ok := model.Data.(map[string]interface{})
-	require.True(t, ok)
-	list, ok := data["list"].([]interface{})
-	require.True(t, ok)
-	assert.Len(t, list, 2)
+	assert.Len(t, model.Data.List, 2)
+	assert.ElementsMatch(t, model.Data.References.Agencies, []models.AgencyReference{testdata.Raba})
 }
 
 func TestRoutesForLocationLatAndLon(t *testing.T) {
-	_, resp, model := serveAndRetrieveEndpoint(t, "/api/where/routes-for-location.json?key=TEST&lat=40.583321&lon=-122.362535")
+	api := createTestApi(t)
+
+	resp, model := callAPIHandler[RoutesResponse](t, api, "/api/where/routes-for-location.json?key=TEST&lat=40.583321&lon=-122.362535")
+
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
-	data, ok := model.Data.(map[string]interface{})
-	require.True(t, ok)
-	list, ok := data["list"].([]interface{})
-	require.True(t, ok)
-	assert.Len(t, list, 3)
+	// Ordering matters! Routes should be sorted by ID.
+	assert.EqualValues(t, model.Data.List, []models.Route{testdata.Route15, testdata.Route11, testdata.Route14})
+	assert.ElementsMatch(t, model.Data.References.Agencies, []models.AgencyReference{testdata.Raba})
 }
 
 func TestRoutesForLocationCaseInsensitiveQuery(t *testing.T) {
 	// Lat/Lon are for stop 2000 from the test data, which is on route 44X
-	_, resp, model := serveAndRetrieveEndpoint(t, "/api/where/routes-for-location.json?key=TEST&lat=40.583170&lon=-122.392586&query=44x")
+	api := createTestApi(t)
+
+	resp, model := callAPIHandler[RoutesResponse](t, api, "/api/where/routes-for-location.json?key=TEST&lat=40.583170&lon=-122.392586&query=44x")
+
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, http.StatusOK, model.Code)
 	assert.Equal(t, "OK", model.Text)
 
-	data, ok := model.Data.(map[string]interface{})
-	require.True(t, ok)
-
-	list, ok := data["list"].([]interface{})
-	require.True(t, ok)
-	assert.Len(t, list, 1)
-
-	route, ok := list[0].(map[string]interface{})
-	require.True(t, ok)
-	routeId, ok := route["id"].(string)
-	require.True(t, ok)
-	agencyId, ok := route["agencyId"].(string)
-	require.True(t, ok)
-	assert.Equal(t, utils.FormCombinedID(agencyId, "44X"), routeId)
+	assert.ElementsMatch(t, model.Data.List, []models.Route{testdata.Route44x})
+	assert.ElementsMatch(t, model.Data.References.Agencies, []models.AgencyReference{testdata.Raba})
 }
 
 func TestRoutesForLocationHandlerValidatesParameters(t *testing.T) {
-	_, resp, _ := serveAndRetrieveEndpoint(t, "/api/where/routes-for-location.json?key=TEST&lat=invalid&lon=-121.74")
+	api := createTestApi(t)
+	resp, model := callAPIHandler[RoutesResponse](t, api, "/api/where/routes-for-location.json?key=TEST&lat=invalid&lon=-121.74")
 	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	assert.Equal(t, http.StatusBadRequest, model.Code)
 }
 
 func TestRoutesForLocationHandlerValidatesLatLon(t *testing.T) {
-	_, resp, _ := serveAndRetrieveEndpoint(t, "/api/where/routes-for-location.json?key=TEST&lat=invalid&lon=invalid")
+	api := createTestApi(t)
+	resp, model := callAPIHandler[RoutesResponse](t, api, "/api/where/routes-for-location.json?key=TEST&lat=invalid&lon=invalid")
 	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	assert.Equal(t, http.StatusBadRequest, model.Code)
 }
 
 func TestRoutesForLocationHandlerValidatesLatLonSpan(t *testing.T) {
-	_, resp, _ := serveAndRetrieveEndpoint(t, "/api/where/routes-for-location.json?key=TEST&lat=40.583321&lon=-122.426966&latSpan=invalid&lonSpan=invalid")
+	api := createTestApi(t)
+	resp, model := callAPIHandler[RoutesResponse](t, api, "/api/where/routes-for-location.json?key=TEST&lat=40.583321&lon=-122.426966&latSpan=invalid&lonSpan=invalid")
 	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	assert.Equal(t, http.StatusBadRequest, model.Code)
 }
 
 func TestRoutesForLocationHandlerValidatesRadius(t *testing.T) {
-	_, resp, _ := serveAndRetrieveEndpoint(t, "/api/where/routes-for-location.json?key=TEST&lat=40.583321&lon=-122.426966&radius=invalid")
+	api := createTestApi(t)
+	resp, model := callAPIHandler[RoutesResponse](t, api, "/api/where/routes-for-location.json?key=TEST&lat=40.583321&lon=-122.426966&radius=invalid")
 	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	assert.Equal(t, http.StatusBadRequest, model.Code)
 }
 
 func TestRoutesForLocationHandlerNoStopsFound(t *testing.T) {
 	// Use coordinates far from any stops to trigger the empty stopIDs case
-	_, resp, model := serveAndRetrieveEndpoint(t, "/api/where/routes-for-location.json?key=TEST&lat=0.0&lon=0.0&radius=100")
+	api := createTestApi(t)
+	resp, model := callAPIHandler[RoutesResponse](t, api, "/api/where/routes-for-location.json?key=TEST&lat=0.0&lon=0.0&radius=100")
 
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, http.StatusOK, model.Code)
 	assert.Equal(t, "OK", model.Text)
 
-	data, ok := model.Data.(map[string]interface{})
-	require.True(t, ok)
+	assert.Empty(t, model.Data.List)
+	assert.False(t, model.Data.LimitExceeded)
+	assert.True(t, model.Data.OutOfRange)
 
-	// Verify empty list
-	list, ok := data["list"].([]interface{})
-	require.True(t, ok)
-	assert.Empty(t, list)
-
-	// Verify limitExceeded is false
-	limitExceeded, ok := data["limitExceeded"].(bool)
-	require.True(t, ok)
-	assert.False(t, limitExceeded)
-
-	// Verify outOfRange is true (no stops found in the location)
-	outOfRange, ok := data["outOfRange"].(bool)
-	require.True(t, ok)
-	assert.True(t, outOfRange)
-
-	// Verify references structure
-	refs, ok := data["references"].(map[string]interface{})
-	require.True(t, ok)
-
-	// All reference arrays should be empty or null
-	// Agencies can be nil (null in JSON) or empty array
-	agencies := refs["agencies"]
-	if agencies != nil {
-		agenciesList, ok := agencies.([]interface{})
-		require.True(t, ok)
-		assert.Empty(t, agenciesList)
-	}
-
-	routes, ok := refs["routes"].([]interface{})
-	require.True(t, ok)
-	assert.Empty(t, routes)
-
-	situations, ok := refs["situations"].([]interface{})
-	require.True(t, ok)
-	assert.Empty(t, situations)
-
-	stopTimes, ok := refs["stopTimes"].([]interface{})
-	require.True(t, ok)
-	assert.Empty(t, stopTimes)
-
-	stops := refs["stops"]
-	if stops != nil {
-		stopsList, ok := stops.([]interface{})
-		require.True(t, ok)
-		assert.Empty(t, stopsList)
-	}
-
-	trips, ok := refs["trips"].([]interface{})
-	require.True(t, ok)
-	assert.Empty(t, trips)
+	refs := model.Data.References
+	assert.Empty(t, refs.Agencies)
+	assert.Empty(t, refs.Routes)
+	assert.Empty(t, refs.Situations)
+	assert.Empty(t, refs.StopTimes)
+	assert.Empty(t, refs.Stops)
+	assert.Empty(t, refs.Trips)
 }
 
 func TestRoutesForLocationHandlerLimitExceeded(t *testing.T) {
-	maxCount := 1
-	_, resp, model := serveAndRetrieveEndpoint(t, "/api/where/routes-for-location.json?key=TEST&lat=40.583321&lon=-122.362535&maxCount=1")
+	api := createTestApi(t)
+
+	resp, model := callAPIHandler[RoutesResponse](t, api, "/api/where/routes-for-location.json?key=TEST&lat=40.583321&lon=-122.362535&maxCount=2")
 
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, "OK", model.Text)
 	assert.Equal(t, http.StatusOK, model.Code)
-
-	data, ok := model.Data.(map[string]interface{})
-	require.True(t, ok)
-
-	limitExceeded, ok := data["limitExceeded"].(bool)
-	require.True(t, ok)
-	assert.True(t, limitExceeded)
-
-	list, ok := data["list"].([]interface{})
-	require.True(t, ok)
-	assert.Equal(t, maxCount, len(list))
+	assert.True(t, model.Data.LimitExceeded)
+	// Ordering matters! Routes should be sorted by ID
+	assert.EqualValues(t, model.Data.List, []models.Route{testdata.Route15, testdata.Route14})
+	assert.ElementsMatch(t, model.Data.References.Agencies, []models.AgencyReference{testdata.Raba})
 }
 
 func TestRoutesForLocationHandlerInvalidMaxCount(t *testing.T) {
-	_, resp, _ := serveAndRetrieveEndpoint(t, "/api/where/routes-for-location.json?key=TEST&lat=40.621&lon=-122.571&maxCount=invalid")
+	api := createTestApi(t)
+	resp, model := callAPIHandler[RoutesResponse](t, api, "/api/where/routes-for-location.json?key=TEST&lat=40.621&lon=-122.571&maxCount=invalid")
 	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	assert.Equal(t, http.StatusBadRequest, model.Code)
 }
 
 func TestRoutesForLocationHandlerMaxCountLessThanOrEqualZero(t *testing.T) {
-	_, resp, _ := serveAndRetrieveEndpoint(t, "/api/where/routes-for-location.json?key=TEST&lat=40.621&lon=-122.571&maxCount=0")
+	api := createTestApi(t)
+	resp, model := callAPIHandler[RoutesResponse](t, api, "/api/where/routes-for-location.json?key=TEST&lat=40.621&lon=-122.571&maxCount=0")
 	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	assert.Equal(t, http.StatusBadRequest, model.Code)
 }
 
 func TestRoutesForLocationHandlerInRangeWithNoResults(t *testing.T) {
 	api := createTestApi(t)
 	lat, lon, _, _ := api.GtfsManager.GetRegionBounds()
-	resp, model := serveApiAndRetrieveEndpoint(t, api, fmt.Sprintf("/api/where/routes-for-location.json?key=TEST&lat=%v&lon=%v&radius=1", lat, lon))
+	resp, model := callAPIHandler[RoutesResponse](t, api, fmt.Sprintf("/api/where/routes-for-location.json?key=TEST&lat=%v&lon=%v&radius=1", lat, lon))
+
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, "OK", model.Text)
 	assert.Equal(t, http.StatusOK, model.Code)
 
-	data, ok := model.Data.(map[string]interface{})
-	require.True(t, ok)
-
-	outOfRange, ok := data["outOfRange"].(bool)
-	require.True(t, ok)
-	assert.False(t, outOfRange)
-
-	list, ok := data["list"].([]interface{})
-	require.True(t, ok)
-	assert.Equal(t, 0, len(list))
+	assert.False(t, model.Data.OutOfRange)
+	assert.Empty(t, model.Data.List)
+	assert.Empty(t, model.Data.References.Agencies)
 }
 
 func TestRoutesForLocationMissingLat(t *testing.T) {
-	_, resp, model := serveAndRetrieveEndpoint(t, "/api/where/routes-for-location.json?key=TEST&lon=-122.426966")
+	api := createTestApi(t)
+	resp, model := callAPIHandler[RoutesResponse](t, api, "/api/where/routes-for-location.json?key=TEST&lon=-122.426966")
 	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 	assert.Equal(t, http.StatusBadRequest, model.Code)
 }
 
 func TestRoutesForLocationMissingLon(t *testing.T) {
-	_, resp, model := serveAndRetrieveEndpoint(t, "/api/where/routes-for-location.json?key=TEST&lat=40.583321")
+	api := createTestApi(t)
+	resp, model := callAPIHandler[RoutesResponse](t, api, "/api/where/routes-for-location.json?key=TEST&lat=40.583321")
 	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 	assert.Equal(t, http.StatusBadRequest, model.Code)
 }
 
 func TestRoutesForLocationMissingBothLatAndLon(t *testing.T) {
-	_, resp, model := serveAndRetrieveEndpoint(t, "/api/where/routes-for-location.json?key=TEST")
+	api := createTestApi(t)
+	resp, model := callAPIHandler[RoutesResponse](t, api, "/api/where/routes-for-location.json?key=TEST")
 	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 	assert.Equal(t, http.StatusBadRequest, model.Code)
 }

--- a/internal/restapi/testdata/models.go
+++ b/internal/restapi/testdata/models.go
@@ -1,0 +1,81 @@
+package testdata
+
+import "maglev.onebusaway.org/internal/models"
+
+var Raba = models.AgencyReference{
+	Disclaimer:     "",
+	Email:          "",
+	FareUrl:        "",
+	ID:             "25",
+	Lang:           "en",
+	Name:           "Redding Area Bus Authority",
+	Phone:          "530-241-2877",
+	PrivateService: false,
+	Timezone:       "America/Los_Angeles",
+	URL:            "http://www.rabaride.com/",
+}
+
+var Route19 = models.Route{
+	AgencyID:          "25",
+	Color:             "2738ec",
+	Description:       "",
+	ID:                "25_3779",
+	LongName:          "Route 19",
+	NullSafeShortName: "19",
+	ShortName:         "19",
+	TextColor:         "ffffff",
+	Type:              3,
+	URL:               "https://cms3.revize.com/revize/reddingbusauthority/Document%20Center/Services/SRTA_BeachBus_20230302_ful.pdf",
+}
+
+var Route44x = models.Route{
+	AgencyID:          "25",
+	Color:             "F84DF7",
+	Description:       "",
+	ID:                "25_44X",
+	LongName:          "Shingletown Flex",
+	NullSafeShortName: "44X",
+	ShortName:         "44X",
+	TextColor:         "000000",
+	Type:              3,
+	URL:               "",
+}
+
+var Route15 = models.Route{
+	AgencyID:          "25",
+	Color:             "800000",
+	Description:       "",
+	ID:                "25_15",
+	LongName:          "Churn Creek/Knightson/Airport",
+	NullSafeShortName: "15",
+	ShortName:         "15",
+	TextColor:         "FFFFFF",
+	Type:              3,
+	URL:               "https://cms3.revize.com/revize/reddingbusauthority/Document%20Center/Services/Bus/15-18.pdf",
+}
+
+var Route14 = models.Route{
+	AgencyID:          "25",
+	Color:             "8c08b1",
+	Description:       "",
+	ID:                "25_160",
+	LongName:          "Route 14",
+	NullSafeShortName: "14",
+	ShortName:         "14",
+	TextColor:         "ffffff",
+	Type:              3,
+	URL:               "https://cms3.revize.com/revize/reddingbusauthority/Document%20Center/Services/Bus/Route14.pdf",
+}
+
+var Route11 = models.Route{
+	AgencyID:          "25",
+	Color:             "93ea5f",
+	Description:       "",
+	ID:                "25_159",
+	LongName:          "Route 11",
+	NullSafeShortName: "11",
+	ShortName:         "11",
+	TextColor:         "000000",
+	Type:              3,
+	URL:               "https://cms3.revize.com/revize/reddingbusauthority/Document%20Center/Services/Bus/Route11.pdf",
+}


### PR DESCRIPTION
Delete a bunch of field casting/validation in the test code by using a stricter response type, so that the json decode handles it for us.