### PR TITLE
refactor: use typing in stops-for-location test

### DIFF
--- a/internal/restapi/stops_for_location_handler_test.go
+++ b/internal/restapi/stops_for_location_handler_test.go
@@ -11,10 +11,28 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"maglev.onebusaway.org/internal/clock"
+	"maglev.onebusaway.org/internal/models"
 )
 
+type StopsResponse struct {
+	Code        int       `json:"code"`
+	CurrentTime int64     `json:"currentTime"`
+	Data        StopsData `json:"data,omitempty"`
+	Text        string    `json:"text"`
+	Version     int       `json:"version"`
+}
+
+type StopsData struct {
+	LimitExceeded bool                   `json:"limitExceeded"`
+	Stops         []models.Stop          `json:"list"`
+	OutOfRange    bool                   `json:"outOfRange"`
+	References    models.ReferencesModel `json:"references"`
+	FieldErrors   map[string][]string    `json:"fieldErrors"`
+}
+
 func TestStopsForLocationHandlerRequiresValidApiKey(t *testing.T) {
-	_, resp, model := serveAndRetrieveEndpoint(t, "/api/where/stops-for-location.json?key=invalid&lat=47.586556&lon=-122.190396")
+	api := createTestApi(t)
+	resp, model := callAPIHandler[StopsResponse](t, api, "/api/where/stops-for-location.json?key=invalid&lat=47.586556&lon=-122.190396")
 	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
 	assert.Equal(t, http.StatusUnauthorized, model.Code)
 	assert.Equal(t, "permission denied", model.Text)
@@ -28,86 +46,63 @@ func TestStopsForLocationHandlerEndToEnd(t *testing.T) {
 
 	clock := clock.NewMockClock(time.Date(2025, 12, 26, 14, 00, 00, 0, time.UTC))
 	api := createTestApiWithClock(t, clock)
-	resp, model := serveApiAndRetrieveEndpoint(t, api, "/api/where/stops-for-location.json?key=TEST&lat=40.583321&lon=-122.426966&radius=2500")
+	resp, model := callAPIHandler[StopsResponse](t, api, "/api/where/stops-for-location.json?key=TEST&lat=40.583321&lon=-122.426966&radius=2500")
 
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, http.StatusOK, model.Code)
 	assert.Equal(t, "OK", model.Text)
 
-	data, ok := model.Data.(map[string]interface{})
-	require.True(t, ok)
+	assert.NotEmpty(t, model.Data.Stops)
 
-	list, ok := data["list"].([]interface{})
-	require.True(t, ok)
-	assert.NotEmpty(t, list)
-
-	for i, item := range list {
-		stop, ok := item.(map[string]any)
-		require.True(t, ok)
-		assert.Contains(t, stop, "id")
-		assert.Contains(t, stop, "code")
-		assert.Contains(t, stop, "name")
-		assert.Contains(t, stop, "lat")
-		assert.Contains(t, stop, "lon")
-		assert.Contains(t, stop, "direction")
-		assert.Contains(t, stop, "routeIds")
-		assert.Contains(t, stop, "staticRouteIds")
-		assert.Contains(t, stop, "wheelchairBoarding")
+	for i, stop := range model.Data.Stops {
+		assert.NotEmpty(t, stop.ID)
+		assert.NotEmpty(t, stop.Name)
+		assert.NotZero(t, stop.Lat)
+		assert.NotZero(t, stop.Lon)
+		assert.NotNil(t, stop.RouteIDs)
+		assert.NotNil(t, stop.StaticRouteIDs)
 
 		if i > 0 {
-			previous, ok := list[i-1].(map[string]any)
-			require.True(t, ok)
-			assert.GreaterOrEqualf(t, stop["id"], previous["id"], "stops should be returned in sorted order by id")
+			assert.GreaterOrEqualf(t, stop.ID, model.Data.Stops[i-1].ID, "stops should be returned in sorted order by id")
 		}
 	}
 
-	refs, ok := data["references"].(map[string]interface{})
-	require.True(t, ok)
+	refs := model.Data.References
+	assert.NotEmpty(t, refs.Agencies)
+	assert.NotEmpty(t, refs.Routes)
 
-	agencies, ok := refs["agencies"].([]interface{})
-	require.True(t, ok)
-	assert.NotEmpty(t, agencies)
-
-	agency, ok := agencies[0].(map[string]interface{})
-	require.True(t, ok)
-	assert.Contains(t, agency, "id")
-	assert.Contains(t, agency, "name")
-	assert.Contains(t, agency, "url")
-	assert.Contains(t, agency, "timezone")
-	assert.Contains(t, agency, "lang")
-	assert.Contains(t, agency, "phone")
-
-	routes, ok := refs["routes"].([]interface{})
-	require.True(t, ok)
-	assert.NotEmpty(t, routes)
-
-	route, ok := routes[0].(map[string]interface{})
-	require.True(t, ok)
-	assert.Contains(t, route, "id")
-	assert.Contains(t, route, "agencyId")
-	assert.Contains(t, route, "shortName")
-	assert.Contains(t, route, "longName")
-	assert.Contains(t, route, "type")
-
-	referencedRouteIds := collectAllNestedIdsFromObjects(t, list, "routeIds")
-	referencedRouteIds = append(referencedRouteIds, collectAllNestedIdsFromObjects(t, list, "staticRouteIds")...)
-	require.NotEmpty(t, referencedRouteIds, "Test data must have route references to verify")
-	routeIds := collectAllIdsFromObjects(t, routes, "id")
-	for _, routeId := range referencedRouteIds {
-		assert.Contains(t, routeIds, routeId, "Stop routeId should reference known route")
+	// Verify all referenced route IDs exist in references
+	referencedRouteIDs := make(map[string]bool)
+	for _, stop := range model.Data.Stops {
+		for _, id := range stop.RouteIDs {
+			referencedRouteIDs[id] = true
+		}
+		for _, id := range stop.StaticRouteIDs {
+			referencedRouteIDs[id] = true
+		}
+	}
+	require.NotEmpty(t, referencedRouteIDs, "Test data must have route references to verify")
+	refRouteIDs := make(map[string]bool)
+	for _, route := range refs.Routes {
+		refRouteIDs[route.ID] = true
+	}
+	for routeID := range referencedRouteIDs {
+		assert.Contains(t, refRouteIDs, routeID, "Stop routeId should reference known route")
 	}
 
-	referencedAgencyIds := collectAllIdsFromObjects(t, routes, "agencyId")
-	require.NotEmpty(t, referencedAgencyIds, "Test data must have agency references to verify")
-	agencyIds := collectAllIdsFromObjects(t, agencies, "id")
-	for _, agencyId := range referencedAgencyIds {
-		assert.Contains(t, agencyIds, agencyId, "Route agencyId should reference known agency")
+	// Verify all route agencyIds exist in references
+	refAgencyIDs := make(map[string]bool)
+	for _, agency := range refs.Agencies {
+		refAgencyIDs[agency.ID] = true
+	}
+	for _, route := range refs.Routes {
+		assert.Contains(t, refAgencyIDs, route.AgencyID, "Route agencyId should reference known agency")
 	}
 
-	assert.Empty(t, refs["situations"])
-	assert.Empty(t, refs["stopTimes"])
-	assert.Empty(t, refs["stops"])
-	assert.Empty(t, refs["trips"])
+	assert.Empty(t, refs.Situations)
+	assert.Empty(t, refs.StopTimes)
+	assert.Empty(t, refs.Stops)
+	assert.Empty(t, refs.Trips)
 }
 
 func TestStopsForLocationQuery(t *testing.T) {
@@ -115,144 +110,103 @@ func TestStopsForLocationQuery(t *testing.T) {
 	// Use a Friday within that range to ensure active service.
 	clock := clock.NewMockClock(time.Date(2025, 6, 13, 14, 0, 0, 0, time.UTC))
 	api := createTestApiWithClock(t, clock)
-	resp, model := serveApiAndRetrieveEndpoint(t, api, "/api/where/stops-for-location.json?key=TEST&lat=40.583321&lon=-122.426966&query=2042")
+	resp, model := callAPIHandler[StopsResponse](t, api, "/api/where/stops-for-location.json?key=TEST&lat=40.583321&lon=-122.426966&query=2042")
 
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
-
-	data, ok := model.Data.(map[string]interface{})
-	require.True(t, ok)
-
-	list, ok := data["list"].([]interface{})
-	require.True(t, ok)
-	assert.Len(t, list, 1)
-
-	stop, ok := list[0].(map[string]interface{})
-	require.True(t, ok)
-	assert.Equal(t, "2042", stop["code"])
-	assert.Equal(t, "Buenaventura Blvd at Eureka Way", stop["name"])
+	assert.Len(t, model.Data.Stops, 1)
+	assert.Equal(t, "2042", model.Data.Stops[0].Code)
+	assert.Equal(t, "Buenaventura Blvd at Eureka Way", model.Data.Stops[0].Name)
 }
 
 func TestStopsForLocationLatSpanAndLonSpan(t *testing.T) {
 	clock := clock.NewMockClock(time.Date(2025, 12, 26, 14, 0, 0, 0, time.UTC))
 	api := createTestApiWithClock(t, clock)
-	resp, model := serveApiAndRetrieveEndpoint(t, api, "/api/where/stops-for-location.json?key=TEST&lat=40.583321&lon=-122.426966&latSpan=0.045&lonSpan=0.059")
+	resp, model := callAPIHandler[StopsResponse](t, api, "/api/where/stops-for-location.json?key=TEST&lat=40.583321&lon=-122.426966&latSpan=0.045&lonSpan=0.059")
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
-	data, ok := model.Data.(map[string]interface{})
-	require.True(t, ok)
-	list, ok := data["list"].([]interface{})
-	require.True(t, ok)
-	assert.NotEmpty(t, list)
-	stop, ok := list[0].(map[string]interface{})
-	require.True(t, ok)
-	assert.NotEmpty(t, stop)
+	assert.NotEmpty(t, model.Data.Stops)
 }
 
 func TestStopsForLocationRadius(t *testing.T) {
 	clock := clock.NewMockClock(time.Date(2025, 12, 26, 14, 0, 0, 0, time.UTC))
 	api := createTestApiWithClock(t, clock)
-	resp, model := serveApiAndRetrieveEndpoint(t, api, "/api/where/stops-for-location.json?key=TEST&lat=40.583321&lon=-122.426966&radius=5000")
+	resp, model := callAPIHandler[StopsResponse](t, api, "/api/where/stops-for-location.json?key=TEST&lat=40.583321&lon=-122.426966&radius=5000")
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
-	data, ok := model.Data.(map[string]interface{})
-	require.True(t, ok)
-	list, ok := data["list"].([]interface{})
-	require.True(t, ok)
-	assert.NotEmpty(t, list)
+	assert.NotEmpty(t, model.Data.Stops)
 }
 
 func TestStopsForLocationLatAndLan(t *testing.T) {
 	clock := clock.NewMockClock(time.Date(2025, 12, 26, 14, 0, 0, 0, time.UTC))
 	api := createTestApiWithClock(t, clock)
-	resp, model := serveApiAndRetrieveEndpoint(t, api, "/api/where/stops-for-location.json?key=TEST&lat=40.583321&lon=-122.362535&radius=1000")
+	resp, model := callAPIHandler[StopsResponse](t, api, "/api/where/stops-for-location.json?key=TEST&lat=40.583321&lon=-122.362535&radius=1000")
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
-	data, ok := model.Data.(map[string]interface{})
-	require.True(t, ok)
-	list, ok := data["list"].([]interface{})
-	require.True(t, ok)
-	assert.NotEmpty(t, list)
+	assert.NotEmpty(t, model.Data.Stops)
 }
 
 func TestStopsForLocationIsLimitExceeded(t *testing.T) {
 	clock := clock.NewMockClock(time.Date(2025, 12, 26, 14, 0, 0, 0, time.UTC))
 	api := createTestApiWithClock(t, clock)
-	resp, model := serveApiAndRetrieveEndpoint(t, api, "/api/where/stops-for-location.json?key=TEST&lat=40.583321&lon=-122.362535&radius=1000&maxCount=1")
+	resp, model := callAPIHandler[StopsResponse](t, api, "/api/where/stops-for-location.json?key=TEST&lat=40.583321&lon=-122.362535&radius=1000&maxCount=1")
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
-	data, ok := model.Data.(map[string]interface{})
-	require.True(t, ok)
-	list, ok := data["list"].([]interface{})
-	require.True(t, ok)
-	assert.Len(t, list, 1)
-	isLimitExceeded, ok := data["limitExceeded"].(bool)
-	require.True(t, ok)
-	assert.True(t, isLimitExceeded)
+	assert.Len(t, model.Data.Stops, 1)
+	assert.True(t, model.Data.LimitExceeded)
 }
 
 func TestStopsForLocationActiveRoutesOnly(t *testing.T) {
 	futureClock := clock.NewMockClock(time.Date(2031, 1, 1, 12, 0, 0, 0, time.UTC))
 	api := createTestApiWithClock(t, futureClock)
 
-	resp, model := serveApiAndRetrieveEndpoint(t, api, "/api/where/stops-for-location.json?key=TEST&lat=40.583321&lon=-122.426966&radius=5000")
+	resp, model := callAPIHandler[StopsResponse](t, api, "/api/where/stops-for-location.json?key=TEST&lat=40.583321&lon=-122.426966&radius=5000")
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
-
-	data, ok := model.Data.(map[string]interface{})
-	require.True(t, ok, "Expected data to be a map")
-
-	var list []interface{}
-	if data["list"] != nil {
-		list, ok = data["list"].([]interface{})
-		require.True(t, ok, "Expected list to be an array")
-	}
-	assert.Empty(t, list, "Should return empty stops when no routes are active")
+	assert.Empty(t, model.Data.Stops, "Should return empty stops when no routes are active")
 }
 
 func TestStopsForLocationHandlerValidatesParameters(t *testing.T) {
-	_, resp, _ := serveAndRetrieveEndpoint(t, "/api/where/stops-for-location.json?key=TEST&lat=invalid&lon=-121.74")
+	api := createTestApi(t)
+	resp, model := callAPIHandler[StopsResponse](t, api, "/api/where/stops-for-location.json?key=TEST&lat=invalid&lon=-121.74")
 	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	assert.Equal(t, http.StatusBadRequest, model.Code)
 }
 
 func TestStopsForLocationHandlerValidatesLatLon(t *testing.T) {
-	_, resp, _ := serveAndRetrieveEndpoint(t, "/api/where/stops-for-location.json?key=TEST&lat=invalid&lon=invalid")
+	api := createTestApi(t)
+	resp, model := callAPIHandler[StopsResponse](t, api, "/api/where/stops-for-location.json?key=TEST&lat=invalid&lon=invalid")
 	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	assert.Equal(t, http.StatusBadRequest, model.Code)
 }
 
 func TestStopsForLocationHandlerValidatesLatLonSpan(t *testing.T) {
-	_, resp, _ := serveAndRetrieveEndpoint(t, "/api/where/stops-for-location.json?key=TEST&lat=40.583321&lon=-122.426966&latSpan=invalid&lonSpan=invalid")
+	api := createTestApi(t)
+	resp, model := callAPIHandler[StopsResponse](t, api, "/api/where/stops-for-location.json?key=TEST&lat=40.583321&lon=-122.426966&latSpan=invalid&lonSpan=invalid")
 	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	assert.Equal(t, http.StatusBadRequest, model.Code)
 }
 
 func TestStopsForLocationHandlerValidatesRadius(t *testing.T) {
-	_, resp, _ := serveAndRetrieveEndpoint(t, "/api/where/stops-for-location.json?key=TEST&lat=40.583321&lon=-122.426966&radius=invalid")
+	api := createTestApi(t)
+	resp, model := callAPIHandler[StopsResponse](t, api, "/api/where/stops-for-location.json?key=TEST&lat=40.583321&lon=-122.426966&radius=invalid")
 	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	assert.Equal(t, http.StatusBadRequest, model.Code)
 }
 
 func TestStopsForLocationHandlerValidatesMaxCount(t *testing.T) {
-	_, resp, _ := serveAndRetrieveEndpoint(t, "/api/where/stops-for-location.json?key=TEST&lat=40.583321&lon=-122.426966&maxCount=invalid")
+	api := createTestApi(t)
+	resp, model := callAPIHandler[StopsResponse](t, api, "/api/where/stops-for-location.json?key=TEST&lat=40.583321&lon=-122.426966&maxCount=invalid")
 	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	assert.Equal(t, http.StatusBadRequest, model.Code)
 }
 
 func TestStopsForLocationHandlerRouteTypeErrorLimit(t *testing.T) {
 	invalidTypes := strings.Repeat("bad,", 14) + "bad"
 
 	url := "/api/where/stops-for-location.json?key=TEST&lat=40.583321&lon=-122.426966&routeType=" + invalidTypes
-	_, resp, model := serveAndRetrieveEndpoint(t, url)
+	api := createTestApi(t)
+	resp, model := callAPIHandler[StopsResponse](t, api, url)
 
 	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 
-	data, ok := model.Data.(map[string]interface{})
-	require.True(t, ok, "response data should be a map")
-
-	fieldErrors, ok := data["fieldErrors"].(map[string]interface{})
-	require.True(t, ok, "data should contain fieldErrors map")
-
-	routeTypeErrors, ok := fieldErrors["routeType"].([]interface{})
-	require.True(t, ok, "fieldErrors should contain routeType errors list")
-
+	routeTypeErrors := model.Data.FieldErrors["routeType"]
 	assert.Len(t, routeTypeErrors, 1, "Should return a single error for invalid routeType")
-
-	for _, err := range routeTypeErrors {
-		errStr, ok := err.(string)
-		require.True(t, ok)
-		assert.Contains(t, errStr, "Invalid field value for field", "Error should use standard generic message")
-	}
+	assert.Contains(t, routeTypeErrors[0], "Invalid field value for field", "Error should use standard generic message")
 }
 
 func TestStopsForLocationHandlerRouteTypeTooManyTokens(t *testing.T) {
@@ -263,7 +217,8 @@ func TestStopsForLocationHandlerRouteTypeTooManyTokens(t *testing.T) {
 	manyTokens := strings.Join(tokens, ",")
 
 	url := "/api/where/stops-for-location.json?key=TEST&lat=40.583321&lon=-122.426966&routeType=" + manyTokens
-	_, resp, model := serveAndRetrieveEndpoint(t, url)
+	api := createTestApi(t)
+	resp, model := callAPIHandler[models.ResponseModel](t, api, url)
 
 	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 
@@ -291,13 +246,15 @@ func TestStopsForLocationHandlerRouteTypeAtLimit(t *testing.T) {
 	validTypes := strings.Join(tokens, ",")
 
 	url := "/api/where/stops-for-location.json?key=TEST&lat=40.583321&lon=-122.426966&routeType=" + validTypes
-	_, resp, _ := serveAndRetrieveEndpoint(t, url)
+	api := createTestApi(t)
+	resp, _ := callAPIHandler[StopsResponse](t, api, url)
 
 	assert.Equal(t, http.StatusOK, resp.StatusCode, "100 tokens should be accepted (at the limit)")
 }
 
 func TestStopsForLocationHandlerRouteTypeMixedValidInvalid(t *testing.T) {
-	_, resp, model := serveAndRetrieveEndpoint(t,
+	api := createTestApi(t)
+	resp, model := callAPIHandler[models.ResponseModel](t, api,
 		"/api/where/stops-for-location.json?key=TEST&lat=40.583321&lon=-122.426966&routeType=1,bad,2,invalid,3")
 
 	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
@@ -324,56 +281,46 @@ func TestStopsForLocationHandlerRouteTypeValidMultiple(t *testing.T) {
 	mockClock := clock.NewMockClock(time.Date(2025, 12, 26, 14, 0, 0, 0, time.UTC))
 	api := createTestApiWithClock(t, mockClock)
 
-	resp, model := serveApiAndRetrieveEndpoint(t, api,
+	resp, model := callAPIHandler[StopsResponse](t, api,
 		"/api/where/stops-for-location.json?key=TEST&lat=40.583321&lon=-122.426966&radius=2500&routeType=1,2,3")
 
 	assert.Equal(t, http.StatusOK, resp.StatusCode, "Valid route types should be accepted")
-
-	data, ok := model.Data.(map[string]interface{})
-	require.True(t, ok)
-
-	list, ok := data["list"].([]interface{})
-	require.True(t, ok)
-	assert.NotNil(t, list)
-
-	refs, ok := data["references"].(map[string]interface{})
-	require.True(t, ok)
-	assert.NotNil(t, refs["agencies"])
-	assert.NotNil(t, refs["routes"])
+	assert.NotNil(t, model.Data.Stops)
+	assert.NotEmpty(t, model.Data.References.Agencies)
+	assert.NotEmpty(t, model.Data.References.Routes)
 }
 
 func TestStopsForLocationQueryOutOfArea(t *testing.T) {
 	clock := clock.NewMockClock(time.Date(2025, 6, 13, 14, 0, 0, 0, time.UTC))
 	api := createTestApiWithClock(t, clock)
 	// Use coordinates far from the RABA service area to verify global stop code search
-	resp, model := serveApiAndRetrieveEndpoint(t, api,
+	resp, model := callAPIHandler[StopsResponse](t, api,
 		"/api/where/stops-for-location.json?key=TEST&lat=0.0&lon=0.0&query=2042")
 
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
-	data, ok := model.Data.(map[string]interface{})
-	require.True(t, ok)
-	list, ok := data["list"].([]interface{})
-	require.True(t, ok)
 
 	// curl https://api.pugetsound.onebusaway.org/api/where/stops-for-location.json?key=TEST&lat=0.0&lon=0.0&query=10914
 	// returns no results.
-	assert.Empty(t, list)
+	assert.Empty(t, model.Data.Stops)
 }
 
 func TestStopsForLocationMissingLat(t *testing.T) {
-	_, resp, model := serveAndRetrieveEndpoint(t, "/api/where/stops-for-location.json?key=TEST&lon=-122.426966")
+	api := createTestApi(t)
+	resp, model := callAPIHandler[StopsResponse](t, api, "/api/where/stops-for-location.json?key=TEST&lon=-122.426966")
 	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 	assert.Equal(t, http.StatusBadRequest, model.Code)
 }
 
 func TestStopsForLocationMissingLon(t *testing.T) {
-	_, resp, model := serveAndRetrieveEndpoint(t, "/api/where/stops-for-location.json?key=TEST&lat=40.583321")
+	api := createTestApi(t)
+	resp, model := callAPIHandler[StopsResponse](t, api, "/api/where/stops-for-location.json?key=TEST&lat=40.583321")
 	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 	assert.Equal(t, http.StatusBadRequest, model.Code)
 }
 
 func TestStopsForLocationMissingBothLatAndLon(t *testing.T) {
-	_, resp, model := serveAndRetrieveEndpoint(t, "/api/where/stops-for-location.json?key=TEST")
+	api := createTestApi(t)
+	resp, model := callAPIHandler[StopsResponse](t, api, "/api/where/stops-for-location.json?key=TEST")
 	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 	assert.Equal(t, http.StatusBadRequest, model.Code)
 }
@@ -397,38 +344,21 @@ func TestStopsForLocationHandlerWithSituations(t *testing.T) {
 	api.GtfsManager.AddTestAlert(mockAlert)
 
 	// Call the API and force it to find Stop 2042 using the query parameter
-	resp, model := serveApiAndRetrieveEndpoint(t, api, "/api/where/stops-for-location.json?key=TEST&lat=40.583321&lon=-122.426966&query=2042")
+	resp, model := callAPIHandler[StopsResponse](t, api, "/api/where/stops-for-location.json?key=TEST&lat=40.583321&lon=-122.426966&query=2042")
 
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
-
-	data, ok := model.Data.(map[string]interface{})
-	require.True(t, ok)
-
-	list, ok := data["list"].([]interface{})
-	require.True(t, ok)
-	assert.Len(t, list, 1)
+	assert.Len(t, model.Data.Stops, 1)
 
 	// Verify references contain the situation we added
-	refs, ok := data["references"].(map[string]interface{})
-	require.True(t, ok)
-
-	situations, ok := refs["situations"].([]interface{})
-	require.True(t, ok, "Expected situations array in references")
-	require.NotEmpty(t, situations, "Expected at least one situation to be returned for Stop 2042")
+	refs := model.Data.References
+	require.NotEmpty(t, refs.Situations, "Expected at least one situation to be returned for Stop 2042")
 
 	// Find our specific test alert in the returned situations
 	foundOurAlert := false
-	for _, sRaw := range situations {
-		sit, ok := sRaw.(map[string]interface{})
-		require.True(t, ok)
-
-		descMap, ok := sit["description"].(map[string]interface{})
-		if ok {
-			descText, ok := descMap["value"].(string)
-			if ok && strings.Contains(descText, "Stop 2042 is closed today") {
-				foundOurAlert = true
-				break
-			}
+	for _, sit := range refs.Situations {
+		if sit.Description != nil && strings.Contains(sit.Description.Value, "Stop 2042 is closed today") {
+			foundOurAlert = true
+			break
 		}
 	}
 


### PR DESCRIPTION
Replace generic json response object with a typed response to eliminate verbose type casting in tests.