### PR TITLE
cleanup: delete query duration logic

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,10 +42,6 @@ All commands are managed through the Makefile:
 
 See `loadtest/README.md`. Start with pprof enabled: `MAGLEV_ENABLE_PPROF=1 make run`, then run `k6 run loadtest/k6/scenarios.js`. Capture CPU profiles with `go tool pprof http://localhost:6060/debug/pprof/profile?seconds=30`.
 
-## Slow Query Logging
-
-Set `MAGLEV_SLOW_QUERY_THRESHOLD_MS=<ms>` to log queries slower than that threshold (`0` disables slow-query logging).
-
 ## Docker Commands
 
 Docker provides a consistent development environment across all platforms:

--- a/config.docker.example.json
+++ b/config.docker.example.json
@@ -12,7 +12,6 @@
     "org.onebusaway.iphone"
   ],
   "_comment": "WARNING: Change 'api-keys' before deploying to production! The default 'test' key is for development only.",
-  "_comment_slow_query": "Set env var MAGLEV_SLOW_QUERY_THRESHOLD_MS=<ms> to log queries slower than that threshold (0 = disabled).",
   "rate-limit": 100,
   "gtfs-static-feed": {
     "url": "https://www.soundtransit.org/GTFS-rail/40_gtfs.zip",

--- a/config.example.json
+++ b/config.example.json
@@ -14,7 +14,6 @@
   "rate-limit": 100,
   "log-level": "info",
   "log-format": "text",
-  "_comment_slow_query": "Set env var MAGLEV_SLOW_QUERY_THRESHOLD_MS=<ms> to log queries slower than that threshold (0 = disabled).",
   "gtfs-static-feed": {
     "url": "https://www.soundtransit.org/GTFS-rail/40_gtfs.zip",
     "enable-gtfs-tidy": false

--- a/gtfsdb/client.go
+++ b/gtfsdb/client.go
@@ -28,17 +28,12 @@ func NewClient(config Config) (*Client, error) {
 		log.Println("Successfully created tables")
 	}
 
-	// Wrap DB for query interception (slow-query logging and optional metrics).
-	// Using New() ensures sqlc queries go through slowQueryDB.
+	// Wrap DB for query interception (optional metrics).
 	var dbtx DBTX = db
-	if slowQueryThreshold > 0 || config.QueryMetricsRecorder != nil {
-		wrapper := newSlowQueryDB(db, slowQueryThreshold)
+	if config.QueryMetricsRecorder != nil {
+		wrapper := newMetricsWrapper(db)
 		wrapper.queryMetrics = config.QueryMetricsRecorder
 		dbtx = wrapper
-
-		if slowQueryThreshold > 0 {
-			log.Printf("Slow query logging enabled (threshold: %s)", slowQueryThreshold)
-		}
 	}
 	queries := New(dbtx)
 

--- a/gtfsdb/config.go
+++ b/gtfsdb/config.go
@@ -2,7 +2,6 @@ package gtfsdb
 
 import (
 	"fmt"
-	"time"
 
 	"maglev.onebusaway.org/internal/appconf"
 )
@@ -26,7 +25,7 @@ type Config struct {
 // DBQueryMetricsRecorder is a minimal abstraction used to emit per-query metrics
 // without coupling gtfsdb to a specific metrics implementation.
 type DBQueryMetricsRecorder interface {
-	RecordDBQuery(queryName, op string, err error, duration time.Duration)
+	RecordDBQuery(queryName, op string, err error)
 }
 
 func NewConfig(dbPath string, env appconf.Environment, verbose bool) Config {

--- a/gtfsdb/helpers.go
+++ b/gtfsdb/helpers.go
@@ -7,9 +7,7 @@ import (
 	_ "embed"
 	"encoding/hex"
 	"fmt"
-	"log"
 	"log/slog"
-	"os"
 	"runtime"
 	"sort"
 	"strconv"
@@ -25,103 +23,48 @@ import (
 //go:embed schema.sql
 var ddl string
 
-// Minimum query duration to log as slow.
-// Controlled by MAGLEV_SLOW_QUERY_THRESHOLD_MS (in ms).
-// Default = 0 → slow query logging disabled.
-const slowQueryThresholdEnv = "MAGLEV_SLOW_QUERY_THRESHOLD_MS"
-
-func parseSlowQueryThreshold(v string, warnf func(format string, args ...any)) time.Duration {
-	if v == "" {
-		return 0
-	}
-
-	ms, err := strconv.ParseInt(v, 10, 64)
-	if err != nil || ms <= 0 {
-		if warnf != nil {
-			warnf("WARNING: ignoring invalid %s=%q (must be a positive integer)", slowQueryThresholdEnv, v)
-		}
-		return 0
-	}
-
-	return time.Duration(ms) * time.Millisecond
-}
-
-var slowQueryThreshold = parseSlowQueryThreshold(os.Getenv(slowQueryThresholdEnv), log.Printf)
-
-// slowQueryDB wraps *sql.DB and logs queries slower than slowQueryThreshold.
-type slowQueryDB struct {
-	db        *sql.DB
-	threshold time.Duration
-	logger    *slog.Logger
-	now       func() time.Time // Overridden in tests to avoid OS timer resolution issues.
-	// Optional per-query metrics recorder.
+// metricsWrapper wraps *sql.DB for metric reporting purposes
+type metricsWrapper struct {
+	db           *sql.DB
+	logger       *slog.Logger
 	queryMetrics DBQueryMetricsRecorder
 }
 
-func newSlowQueryDB(db *sql.DB, threshold time.Duration) *slowQueryDB {
-	return &slowQueryDB{
-		db:        db,
-		threshold: threshold,
-		logger:    slog.Default().With(slog.String("component", "slow_query")),
-		now:       time.Now,
+func newMetricsWrapper(db *sql.DB) *metricsWrapper {
+	return &metricsWrapper{
+		db:     db,
+		logger: slog.Default().With(slog.String("component", "db_metrics_wrapper")),
 	}
 }
 
-func (s *slowQueryDB) ExecContext(ctx context.Context, query string, args ...interface{}) (sql.Result, error) {
-	start := s.now()
+func (s *metricsWrapper) ExecContext(ctx context.Context, query string, args ...interface{}) (sql.Result, error) {
 	res, err := s.db.ExecContext(ctx, query, args...)
-	elapsed := s.now().Sub(start)
-	s.maybeLog("ExecContext", query, elapsed, err)
-	s.recordQueryMetrics("exec", query, elapsed, err)
+	s.recordQueryMetrics("exec", query, err)
 	return res, err
 }
 
-func (s *slowQueryDB) PrepareContext(ctx context.Context, query string) (*sql.Stmt, error) {
+func (s *metricsWrapper) PrepareContext(ctx context.Context, query string) (*sql.Stmt, error) {
 	// PrepareContext is not instrumented; latency-significant work happens
 	// at execution time via ExecContext/QueryContext/QueryRowContext.
 	return s.db.PrepareContext(ctx, query)
 }
 
-func (s *slowQueryDB) QueryContext(ctx context.Context, query string, args ...interface{}) (*sql.Rows, error) {
-	start := s.now()
+func (s *metricsWrapper) QueryContext(ctx context.Context, query string, args ...interface{}) (*sql.Rows, error) {
 	rows, err := s.db.QueryContext(ctx, query, args...)
-	elapsed := s.now().Sub(start)
-	s.maybeLog("QueryContext", query, elapsed, err)
-	s.recordQueryMetrics("query", query, elapsed, err)
+	s.recordQueryMetrics("query", query, err)
 	return rows, err
 }
 
-func (s *slowQueryDB) QueryRowContext(ctx context.Context, query string, args ...interface{}) *sql.Row {
-	start := s.now()
+func (s *metricsWrapper) QueryRowContext(ctx context.Context, query string, args ...interface{}) *sql.Row {
 	row := s.db.QueryRowContext(ctx, query, args...)
-	elapsed := s.now().Sub(start)
-	s.maybeLog("QueryRowContext", query, elapsed, nil)
 	// Note: QueryRowContext defers errors to row.Scan(), so err is always nil here.
 	// query_row metrics always report status="ok". See PR description for follow-up plan.
-	s.recordQueryMetrics("query_row", query, elapsed, nil)
+	s.recordQueryMetrics("query_row", query, nil)
 	return row
 }
 
-func (s *slowQueryDB) maybeLog(op, query string, elapsed time.Duration, err error) {
-	if s.threshold <= 0 || elapsed < s.threshold {
-		return
-	}
-	attrs := []any{
-		slog.String("op", op),
-		slog.Duration("duration", elapsed),
-		slog.String("query", trimQuery(query)),
-	}
-	if err != nil {
-		attrs = append(attrs, slog.String("error", err.Error()))
-	}
-	s.logger.Warn("slow_query", attrs...)
-}
-
-func (s *slowQueryDB) recordQueryMetrics(op, query string, elapsed time.Duration, err error) {
-	if s.queryMetrics == nil {
-		return
-	}
-	s.queryMetrics.RecordDBQuery(extractQueryName(query), op, err, elapsed)
+func (s *metricsWrapper) recordQueryMetrics(op, query string, err error) {
+	s.queryMetrics.RecordDBQuery(extractQueryName(query), op, err)
 }
 
 func extractQueryName(query string) string {

--- a/gtfsdb/helpers_test.go
+++ b/gtfsdb/helpers_test.go
@@ -5,10 +5,8 @@ import (
 	"bytes"
 	"context"
 	"database/sql"
-	"log/slog"
 	"os"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -130,136 +128,6 @@ func TestProcessAndStoreGTFSData_ValidationFailurePreservesData(t *testing.T) {
 	assert.Equal(t, originalRouteCount, countsAfter["routes"], "Database should remain intact after validation failure")
 }
 
-// TestSlowQueryDB_LogsSlowQueries verifies that slowQueryDB emits a log record
-// when a query exceeds the threshold, and is silent when it does not.
-func TestSlowQueryDB_LogsSlowQueries(t *testing.T) {
-	db, err := sql.Open(DriverName, ":memory:")
-	require.NoError(t, err)
-	defer func() { _ = db.Close() }()
-
-	_, err = db.Exec("CREATE TABLE IF NOT EXISTS t (v INTEGER)")
-	require.NoError(t, err)
-
-	// Capture slog output via a custom handler.
-	logger, captured := newCaptureLogger(t)
-
-	ctx := context.Background()
-
-	// Threshold of 0 → logging disabled; no records should be emitted.
-	wrapper := newSlowQueryDB(db, 0)
-	wrapper.logger = logger
-	rows, err := wrapper.QueryContext(ctx, "SELECT 1")
-	require.NoError(t, err)
-	require.NoError(t, rows.Close())
-	assert.Empty(t, *captured, "threshold=0 must not emit any log records")
-
-	// Use a fake clock advancing 10 ms per call to ensure the query exceeds
-	// the threshold and avoid Windows timer resolution issues.
-	t0 := time.Unix(0, 0)
-	call := 0
-	wrapper.now = func() time.Time {
-		call++
-		return t0.Add(time.Duration(call) * 10 * time.Millisecond)
-	}
-	wrapper.threshold = 1 * time.Nanosecond
-	rows, err = wrapper.QueryContext(ctx, "SELECT 1")
-	require.NoError(t, err)
-	require.NoError(t, rows.Close())
-	require.NotEmpty(t, *captured, "threshold=1ns must emit a slow_query record")
-	rec := (*captured)[0]
-	assert.Equal(t, "slow_query", rec.msg)
-	assert.Equal(t, slog.LevelWarn, rec.level)
-	assert.Equal(t, "QueryContext", rec.attrs["op"])
-	assert.Contains(t, rec.attrs, "duration")
-	assert.Contains(t, rec.attrs, "query")
-}
-
-func TestSlowQueryDB_LogsSlowExecContext(t *testing.T) {
-	db, err := sql.Open(DriverName, ":memory:")
-	require.NoError(t, err)
-	defer func() { _ = db.Close() }()
-
-	_, err = db.Exec("CREATE TABLE IF NOT EXISTS t (v INTEGER)")
-	require.NoError(t, err)
-
-	logger, captured := newCaptureLogger(t)
-
-	wrapper := newSlowQueryDB(db, 1*time.Nanosecond)
-	wrapper.logger = logger
-	t0 := time.Unix(0, 0)
-	call := 0
-	wrapper.now = func() time.Time {
-		call++
-		return t0.Add(time.Duration(call) * 10 * time.Millisecond)
-	}
-
-	_, err = wrapper.ExecContext(context.Background(), "INSERT INTO t(v) VALUES (1)")
-	require.NoError(t, err)
-	require.Len(t, *captured, 1)
-	rec := (*captured)[0]
-	assert.Equal(t, "slow_query", rec.msg)
-	assert.Equal(t, "ExecContext", rec.attrs["op"])
-	assert.Contains(t, rec.attrs, "duration")
-	assert.Contains(t, rec.attrs, "query")
-}
-
-func TestSlowQueryDB_LogsSlowQueryRowContext(t *testing.T) {
-	db, err := sql.Open(DriverName, ":memory:")
-	require.NoError(t, err)
-	defer func() { _ = db.Close() }()
-
-	logger, captured := newCaptureLogger(t)
-
-	wrapper := newSlowQueryDB(db, 1*time.Nanosecond)
-	wrapper.logger = logger
-	t0 := time.Unix(0, 0)
-	call := 0
-	wrapper.now = func() time.Time {
-		call++
-		return t0.Add(time.Duration(call) * 10 * time.Millisecond)
-	}
-
-	var v int
-	err = wrapper.QueryRowContext(context.Background(), "SELECT 1").Scan(&v)
-	require.NoError(t, err)
-	assert.Equal(t, 1, v)
-	require.Len(t, *captured, 1)
-	rec := (*captured)[0]
-	assert.Equal(t, "slow_query", rec.msg)
-	assert.Equal(t, "QueryRowContext", rec.attrs["op"])
-	assert.Contains(t, rec.attrs, "duration")
-	assert.Contains(t, rec.attrs, "query")
-}
-
-func TestSlowQueryDB_LogsSlowErrorsWithErrorAttribute(t *testing.T) {
-	db, err := sql.Open(DriverName, ":memory:")
-	require.NoError(t, err)
-	defer func() { _ = db.Close() }()
-
-	logger, captured := newCaptureLogger(t)
-
-	wrapper := newSlowQueryDB(db, 1*time.Nanosecond)
-	wrapper.logger = logger
-	t0 := time.Unix(0, 0)
-	call := 0
-	wrapper.now = func() time.Time {
-		call++
-		return t0.Add(time.Duration(call) * 10 * time.Millisecond)
-	}
-
-	_, err = wrapper.QueryContext(context.Background(), "SELECT * FROM missing_table")
-	require.Error(t, err)
-	require.Len(t, *captured, 1)
-	rec := (*captured)[0]
-	assert.Equal(t, "slow_query", rec.msg)
-	assert.Equal(t, "QueryContext", rec.attrs["op"])
-	assert.Contains(t, rec.attrs, "duration")
-	assert.Contains(t, rec.attrs, "query")
-	errAttr, ok := rec.attrs["error"].(string)
-	require.True(t, ok)
-	assert.Contains(t, errAttr, "no such table")
-}
-
 type queryMetricCall struct {
 	queryName string
 	op        string
@@ -270,7 +138,7 @@ type testQueryMetricsRecorder struct {
 	calls []queryMetricCall
 }
 
-func (r *testQueryMetricsRecorder) RecordDBQuery(queryName, op string, err error, _ time.Duration) {
+func (r *testQueryMetricsRecorder) RecordDBQuery(queryName, op string, err error) {
 	r.calls = append(r.calls, queryMetricCall{
 		queryName: queryName,
 		op:        op,
@@ -286,7 +154,7 @@ func TestSlowQueryDB_RecordsQueryMetrics(t *testing.T) {
 	ctx := context.Background()
 	recorder := &testQueryMetricsRecorder{}
 
-	wrapper := newSlowQueryDB(db, 0)
+	wrapper := newMetricsWrapper(db)
 	wrapper.queryMetrics = recorder
 
 	_, err = wrapper.QueryContext(ctx, "-- name: ListAgencies :many\nSELECT 1")
@@ -307,11 +175,6 @@ func TestSlowQueryDB_RecordsQueryMetrics(t *testing.T) {
 }
 
 func TestNewClient_RecordsQueryMetricsWhenOnlyMetricsEnabled(t *testing.T) {
-	originalThreshold := slowQueryThreshold
-	slowQueryThreshold = 0
-	t.Cleanup(func() {
-		slowQueryThreshold = originalThreshold
-	})
 	originalDDL := ddl
 	ddl = `
 	CREATE TABLE IF NOT EXISTS agencies (
@@ -385,36 +248,6 @@ func TestExtractQueryName(t *testing.T) {
 	}
 }
 
-func TestParseSlowQueryThreshold(t *testing.T) {
-	t.Run("empty value disables logging", func(t *testing.T) {
-		warned := false
-		got := parseSlowQueryThreshold("", func(string, ...any) { warned = true })
-		assert.Equal(t, time.Duration(0), got)
-		assert.False(t, warned)
-	})
-
-	t.Run("valid positive integer enables logging", func(t *testing.T) {
-		warned := false
-		got := parseSlowQueryThreshold("25", func(string, ...any) { warned = true })
-		assert.Equal(t, 25*time.Millisecond, got)
-		assert.False(t, warned)
-	})
-
-	t.Run("invalid value logs warning and disables logging", func(t *testing.T) {
-		warned := false
-		got := parseSlowQueryThreshold("50ms", func(string, ...any) { warned = true })
-		assert.Equal(t, time.Duration(0), got)
-		assert.True(t, warned)
-	})
-
-	t.Run("non-positive value logs warning and disables logging", func(t *testing.T) {
-		warned := false
-		got := parseSlowQueryThreshold("-5", func(string, ...any) { warned = true })
-		assert.Equal(t, time.Duration(0), got)
-		assert.True(t, warned)
-	})
-}
-
 // TestTrimQuery verifies whitespace collapse and truncation.
 func TestTrimQuery(t *testing.T) {
 	long := "SELECT " + string(make([]byte, 200))
@@ -423,36 +256,3 @@ func TestTrimQuery(t *testing.T) {
 	assert.True(t, len(trimQuery("  SELECT\n  1  ")) < len("  SELECT\n  1  "),
 		"trimQuery must collapse whitespace")
 }
-
-// logRecord holds the fields of a single captured slog log entry.
-type logRecord struct {
-	msg   string
-	level slog.Level
-	attrs map[string]any
-}
-
-// newCaptureLogger returns a *slog.Logger and a pointer to the slice of
-// captured records. Every entry written to the logger is appended to *records.
-func newCaptureLogger(t *testing.T) (*slog.Logger, *[]logRecord) {
-	t.Helper()
-	var records []logRecord
-	h := &captureHandler{fn: func(r slog.Record) {
-		attrs := make(map[string]any)
-		r.Attrs(func(a slog.Attr) bool {
-			attrs[a.Key] = a.Value.Any()
-			return true
-		})
-		records = append(records, logRecord{msg: r.Message, level: r.Level, attrs: attrs})
-	}}
-	return slog.New(h), &records
-}
-
-// captureHandler is a minimal slog.Handler that calls fn for every record.
-type captureHandler struct {
-	fn func(slog.Record)
-}
-
-func (h *captureHandler) Enabled(_ context.Context, _ slog.Level) bool  { return true }
-func (h *captureHandler) WithAttrs(_ []slog.Attr) slog.Handler          { return h }
-func (h *captureHandler) WithGroup(_ string) slog.Handler               { return h }
-func (h *captureHandler) Handle(_ context.Context, r slog.Record) error { h.fn(r); return nil }

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -27,7 +27,6 @@ type Metrics struct {
 	DBConnectionsIdle  prometheus.Gauge
 	DBWaitSecondsTotal prometheus.Counter
 	DBQueryTotal       *prometheus.CounterVec
-	DBQueryDuration    *prometheus.HistogramVec
 
 	// GTFS-RT metrics
 	FeedLastSuccessfulFetchTime *prometheus.GaugeVec
@@ -54,8 +53,6 @@ type Metrics struct {
 func New() *Metrics {
 	return NewWithLogger(nil)
 }
-
-var dbQueryDurationBuckets = []float64{0.0001, 0.0005, 0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1}
 
 // NewWithLogger creates metrics with a logger for error reporting.
 func NewWithLogger(logger *slog.Logger) *Metrics {
@@ -106,15 +103,6 @@ func NewWithLogger(logger *slog.Logger) *Metrics {
 		[]string{"query_name", "op", "status"},
 	)
 
-	dbQueryDuration := prometheus.NewHistogramVec(
-		prometheus.HistogramOpts{
-			Name:    "maglev_db_query_duration_seconds",
-			Help:    "Database query latency distribution by query name, operation, and status",
-			Buckets: dbQueryDurationBuckets,
-		},
-		[]string{"query_name", "op", "status"},
-	)
-
 	feedLastSuccessfulFetchTime := prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "maglev_feed_last_successful_fetch_time",
@@ -159,7 +147,6 @@ func NewWithLogger(logger *slog.Logger) *Metrics {
 		dbConnectionsIdle,
 		dbWaitSecondsTotal,
 		dbQueryTotal,
-		dbQueryDuration,
 		feedLastSuccessfulFetchTime,
 		feedConsecutiveErrors,
 		feedFetchDuration,
@@ -175,7 +162,6 @@ func NewWithLogger(logger *slog.Logger) *Metrics {
 		DBConnectionsIdle:           dbConnectionsIdle,
 		DBWaitSecondsTotal:          dbWaitSecondsTotal,
 		DBQueryTotal:                dbQueryTotal,
-		DBQueryDuration:             dbQueryDuration,
 		FeedLastSuccessfulFetchTime: feedLastSuccessfulFetchTime,
 		FeedConsecutiveErrors:       feedConsecutiveErrors,
 		FeedFetchDuration:           feedFetchDuration,
@@ -184,9 +170,9 @@ func NewWithLogger(logger *slog.Logger) *Metrics {
 	}
 }
 
-// RecordDBQuery records per-query DB counters and latency histograms.
-func (m *Metrics) RecordDBQuery(queryName, op string, err error, duration time.Duration) {
-	if m == nil || m.DBQueryTotal == nil || m.DBQueryDuration == nil {
+// RecordDBQuery records per-query DB counters.
+func (m *Metrics) RecordDBQuery(queryName, op string, err error) {
+	if m == nil || m.DBQueryTotal == nil {
 		return
 	}
 
@@ -203,7 +189,6 @@ func (m *Metrics) RecordDBQuery(queryName, op string, err error, duration time.D
 	}
 
 	m.DBQueryTotal.WithLabelValues(queryName, op, status).Inc()
-	m.DBQueryDuration.WithLabelValues(queryName, op, status).Observe(duration.Seconds())
 }
 
 // StartDBStatsCollector starts a goroutine that periodically collects database

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -24,7 +24,6 @@ func TestNew(t *testing.T) {
 	assert.NotNil(t, m.DBConnectionsIdle)
 	assert.NotNil(t, m.DBWaitSecondsTotal)
 	assert.NotNil(t, m.DBQueryTotal)
-	assert.NotNil(t, m.DBQueryDuration)
 
 	// GTFS-RT metrics
 	assert.NotNil(t, m.FeedLastSuccessfulFetchTime)
@@ -209,9 +208,9 @@ func TestHTTPMetrics_RecordRequest(t *testing.T) {
 func TestRecordDBQuery(t *testing.T) {
 	m := New()
 
-	m.RecordDBQuery("GetTrip", "query", nil, 250*time.Millisecond)
-	m.RecordDBQuery("GetTrip", "query", assert.AnError, 500*time.Millisecond)
-	m.RecordDBQuery("", "", nil, 0)
+	m.RecordDBQuery("GetTrip", "query", nil)
+	m.RecordDBQuery("GetTrip", "query", assert.AnError)
+	m.RecordDBQuery("", "", nil)
 
 	okTotal := testutil.ToFloat64(m.DBQueryTotal.WithLabelValues("GetTrip", "query", "ok"))
 	errTotal := testutil.ToFloat64(m.DBQueryTotal.WithLabelValues("GetTrip", "query", "error"))
@@ -220,11 +219,9 @@ func TestRecordDBQuery(t *testing.T) {
 	assert.Equal(t, float64(1), okTotal)
 	assert.Equal(t, float64(1), errTotal)
 	assert.Equal(t, float64(1), unknownTotal)
-
-	assert.GreaterOrEqual(t, testutil.CollectAndCount(m.DBQueryDuration), 1)
 }
 
 func TestRecordDBQuery_NilReceiverNoPanic(t *testing.T) {
 	var m *Metrics
-	m.RecordDBQuery("GetTrip", "query", nil, time.Millisecond)
+	m.RecordDBQuery("GetTrip", "query", nil)
 }


### PR DESCRIPTION
This slow query detector doesn't work. The bulk of query duration happens after the wrapped calls, when fetching rows from the query. Remove this and the query latency histogram since it's only going to give misleading information.