### PR TITLE
refactor: calculate region bounds from database

### DIFF
--- a/gtfsdb/db.go
+++ b/gtfsdb/db.go
@@ -270,6 +270,9 @@ func Prepare(ctx context.Context, db DBTX) (*Queries, error) {
 	if q.getStopStmt, err = db.PrepareContext(ctx, getStop); err != nil {
 		return nil, fmt.Errorf("error preparing query GetStop: %w", err)
 	}
+	if q.getStopBoundsPerAgencyStmt, err = db.PrepareContext(ctx, getStopBoundsPerAgency); err != nil {
+		return nil, fmt.Errorf("error preparing query GetStopBoundsPerAgency: %w", err)
+	}
 	if q.getStopForAgencyStmt, err = db.PrepareContext(ctx, getStopForAgency); err != nil {
 		return nil, fmt.Errorf("error preparing query GetStopForAgency: %w", err)
 	}
@@ -787,6 +790,11 @@ func (q *Queries) Close() error {
 			err = fmt.Errorf("error closing getStopStmt: %w", cerr)
 		}
 	}
+	if q.getStopBoundsPerAgencyStmt != nil {
+		if cerr := q.getStopBoundsPerAgencyStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing getStopBoundsPerAgencyStmt: %w", cerr)
+		}
+	}
 	if q.getStopForAgencyStmt != nil {
 		if cerr := q.getStopForAgencyStmt.Close(); cerr != nil {
 			err = fmt.Errorf("error closing getStopForAgencyStmt: %w", cerr)
@@ -1078,6 +1086,7 @@ type Queries struct {
 	getShapePointsWithDistanceStmt                *sql.Stmt
 	getShapesGroupedByTripHeadSignStmt            *sql.Stmt
 	getStopStmt                                   *sql.Stmt
+	getStopBoundsPerAgencyStmt                    *sql.Stmt
 	getStopForAgencyStmt                          *sql.Stmt
 	getStopIDsForAgencyStmt                       *sql.Stmt
 	getStopIDsForRouteStmt                        *sql.Stmt
@@ -1200,6 +1209,7 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		getShapePointsWithDistanceStmt:                q.getShapePointsWithDistanceStmt,
 		getShapesGroupedByTripHeadSignStmt:            q.getShapesGroupedByTripHeadSignStmt,
 		getStopStmt:                                   q.getStopStmt,
+		getStopBoundsPerAgencyStmt:                    q.getStopBoundsPerAgencyStmt,
 		getStopForAgencyStmt:                          q.getStopForAgencyStmt,
 		getStopIDsForAgencyStmt:                       q.getStopIDsForAgencyStmt,
 		getStopIDsForRouteStmt:                        q.getStopIDsForRouteStmt,

--- a/gtfsdb/query.sql
+++ b/gtfsdb/query.sql
@@ -1272,4 +1272,20 @@ WHERE st.trip_id = (
 ORDER BY st.stop_sequence ASC
 LIMIT 1;
 
+-- name: GetStopBoundsPerAgency :many
+SELECT
+    r.agency_id,
+    COUNT(*) AS cnt,
+    CAST(MIN(s.lat) AS REAL) AS min_lat,
+    CAST(MAX(s.lat) AS REAL) AS max_lat,
+    CAST(MIN(s.lon) AS REAL) AS min_lon,
+    CAST(MAX(s.lon) AS REAL) AS max_lon
+FROM
+    routes r
+    JOIN trips t ON t.route_id = r.id
+    JOIN stop_times st ON st.trip_id = t.id
+    JOIN stops s ON s.id = st.stop_id
+GROUP BY
+    r.agency_id;
+
 

--- a/gtfsdb/query.sql.go
+++ b/gtfsdb/query.sql.go
@@ -3292,6 +3292,62 @@ func (q *Queries) GetStop(ctx context.Context, id string) (Stop, error) {
 	return i, err
 }
 
+const getStopBoundsPerAgency = `-- name: GetStopBoundsPerAgency :many
+SELECT
+    r.agency_id,
+    COUNT(*) AS cnt,
+    CAST(MIN(s.lat) AS REAL) AS min_lat,
+    CAST(MAX(s.lat) AS REAL) AS max_lat,
+    CAST(MIN(s.lon) AS REAL) AS min_lon,
+    CAST(MAX(s.lon) AS REAL) AS max_lon
+FROM
+    routes r
+    JOIN trips t ON t.route_id = r.id
+    JOIN stop_times st ON st.trip_id = t.id
+    JOIN stops s ON s.id = st.stop_id
+GROUP BY
+    r.agency_id
+`
+
+type GetStopBoundsPerAgencyRow struct {
+	AgencyID string
+	Cnt      int64
+	MinLat   float64
+	MaxLat   float64
+	MinLon   float64
+	MaxLon   float64
+}
+
+func (q *Queries) GetStopBoundsPerAgency(ctx context.Context) ([]GetStopBoundsPerAgencyRow, error) {
+	rows, err := q.query(ctx, q.getStopBoundsPerAgencyStmt, getStopBoundsPerAgency)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []GetStopBoundsPerAgencyRow
+	for rows.Next() {
+		var i GetStopBoundsPerAgencyRow
+		if err := rows.Scan(
+			&i.AgencyID,
+			&i.Cnt,
+			&i.MinLat,
+			&i.MaxLat,
+			&i.MinLon,
+			&i.MaxLon,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const getStopForAgency = `-- name: GetStopForAgency :one
 SELECT DISTINCT
     stops.id,

--- a/internal/gtfs/gtfs_manager.go
+++ b/internal/gtfs/gtfs_manager.go
@@ -61,7 +61,7 @@ type Manager struct {
 	wg                             sync.WaitGroup
 	shutdownOnce                   sync.Once
 	blockLayoverIndices            map[string][]*BlockLayoverIndex
-	regionBounds                   *RegionBounds
+	regionBounds                   map[string]*RegionBounds
 	isHealthy                      bool
 	systemETag                     string      // systemETag stores the SHA-256 hash of the currently loaded GTFS static dataset.
 	isReady                        atomic.Bool // Tracks whether initial data loading is complete
@@ -267,8 +267,8 @@ func InitGTFSManager(ctx context.Context, config Config) (*Manager, error) {
 		}
 	}
 
-	manager.setStaticGTFS(staticData)
 	manager.GtfsDB = gtfsDB
+	manager.setStaticGTFS(staticData)
 	manager.PrintStatistics()
 
 	// Startup validation and logging for agency filtering

--- a/internal/gtfs/shapes.go
+++ b/internal/gtfs/shapes.go
@@ -1,67 +1,46 @@
 package gtfs
 
-import "github.com/OneBusAway/go-gtfs"
+import (
+	"context"
+	"math"
 
-// ComputeRegionBounds calculates the geographic boundaries of the GTFS region
-// from all shape points, falling back to stops if no shapes exist.
-func ComputeRegionBounds(shapes []gtfs.Shape, stops []gtfs.Stop) *RegionBounds {
-	if len(shapes) == 0 && len(stops) == 0 {
+	"maglev.onebusaway.org/gtfsdb"
+)
+
+// roundTo7 rounds a float64 to 7 decimal places (~1.1cm precision, plenty
+// for region-level bounding boxes).
+func roundTo7(v float64) float64 {
+	return math.Round(v*1e7) / 1e7
+}
+
+// computeRegionBounds calculates the geographic boundaries per agency.
+func computeRegionBounds(ctx context.Context, gtfsDB *gtfsdb.Client) map[string]*RegionBounds {
+	rows, err := gtfsDB.Queries.GetStopBoundsPerAgency(ctx)
+	if err != nil || len(rows) == 0 {
 		return nil
 	}
 
-	var minLat, maxLat, minLon, maxLon float64
-	first := true
-
-	updateBounds := func(lat, lon float64) {
-		if first {
-			minLat = lat
-			maxLat = lat
-			minLon = lon
-			maxLon = lon
-			first = false
-			return
-		}
-		if lat < minLat {
-			minLat = lat
-		}
-		if lat > maxLat {
-			maxLat = lat
-		}
-		if lon < minLon {
-			minLon = lon
-		}
-		if lon > maxLon {
-			maxLon = lon
+	result := make(map[string]*RegionBounds, len(rows))
+	for _, row := range rows {
+		result[row.AgencyID] = &RegionBounds{
+			Lat:     roundTo7((row.MinLat + row.MaxLat) / 2),
+			Lon:     roundTo7((row.MinLon + row.MaxLon) / 2),
+			LatSpan: roundTo7(row.MaxLat - row.MinLat),
+			LonSpan: roundTo7(row.MaxLon - row.MinLon),
 		}
 	}
 
-	if len(shapes) > 0 {
-		for _, shape := range shapes {
-			for _, point := range shape.Points {
-				updateBounds(point.Latitude, point.Longitude)
-			}
-		}
-	} else {
-		for _, stop := range stops {
-			if stop.Latitude == nil || stop.Longitude == nil {
-				continue
-			}
-			updateBounds(*stop.Latitude, *stop.Longitude)
-		}
-	}
-
-	return &RegionBounds{
-		Lat:     (minLat + maxLat) / 2,
-		Lon:     (minLon + maxLon) / 2,
-		LatSpan: maxLat - minLat,
-		LonSpan: maxLon - minLon,
-	}
+	return result
 }
 
 // IMPORTANT: Caller must hold manager.RLock() before calling this method.
-func (manager *Manager) GetRegionBounds() (lat, lon, latSpan, lonSpan float64) {
+func (manager *Manager) GetRegionBounds() map[string]RegionBounds {
 	if manager.regionBounds == nil {
-		return 0, 0, 0, 0
+		return nil
 	}
-	return manager.regionBounds.Lat, manager.regionBounds.Lon, manager.regionBounds.LatSpan, manager.regionBounds.LonSpan
+	result := make(map[string]RegionBounds, len(manager.regionBounds))
+	for k, v := range manager.regionBounds {
+		result[k] = *v
+	}
+	return result
 }

--- a/internal/gtfs/shapes_test.go
+++ b/internal/gtfs/shapes_test.go
@@ -1,145 +1,159 @@
 package gtfs
 
 import (
+	"context"
 	"testing"
 
-	"github.com/OneBusAway/go-gtfs"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"maglev.onebusaway.org/gtfsdb"
+	"maglev.onebusaway.org/internal/appconf"
 )
 
-func fptr(v float64) *float64 { return &v }
+func newTestGtfsDB(t *testing.T) *gtfsdb.Client {
+	t.Helper()
+	client, err := gtfsdb.NewClient(gtfsdb.Config{DBPath: ":memory:", Env: appconf.Test})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = client.Close() })
+	return client
+}
 
-func TestGetRegionBounds(t *testing.T) {
+func insertTestStop(t *testing.T, ctx context.Context, client *gtfsdb.Client, id string, lat, lon float64) {
+	t.Helper()
+	_, err := client.Queries.CreateStop(ctx, gtfsdb.CreateStopParams{
+		ID:  id,
+		Lat: lat,
+		Lon: lon,
+	})
+	require.NoError(t, err)
+}
+
+// insertAgencyRouteTripsStops sets up the full chain: agency → route → trip → stop_times → stops
+func insertAgencyRouteTripsStops(t *testing.T, ctx context.Context, client *gtfsdb.Client, agencyID string, stops []stopPoint) {
+	t.Helper()
+	_, err := client.Queries.CreateAgency(ctx, gtfsdb.CreateAgencyParams{
+		ID: agencyID, Name: agencyID, Url: "http://example.com", Timezone: "America/Los_Angeles",
+	})
+	require.NoError(t, err)
+
+	// Create calendar entry for service_id FK
+	_, _ = client.Queries.CreateCalendar(ctx, gtfsdb.CreateCalendarParams{
+		ID: "svc1", Monday: 1, Tuesday: 1, Wednesday: 1, Thursday: 1, Friday: 1,
+		StartDate: "20250101", EndDate: "20251231",
+	})
+
+	routeID := agencyID + "_route1"
+	_, err = client.Queries.CreateRoute(ctx, gtfsdb.CreateRouteParams{
+		ID: routeID, AgencyID: agencyID, Type: 3,
+	})
+	require.NoError(t, err)
+
+	tripID := agencyID + "_trip1"
+	_, err = client.Queries.CreateTrip(ctx, gtfsdb.CreateTripParams{
+		ID: tripID, RouteID: routeID, ServiceID: "svc1",
+	})
+	require.NoError(t, err)
+
+	for i, s := range stops {
+		insertTestStop(t, ctx, client, s.id, s.lat, s.lon)
+		_, err = client.Queries.CreateStopTime(ctx, gtfsdb.CreateStopTimeParams{
+			TripID: tripID, StopID: s.id, StopSequence: int64(i + 1),
+			ArrivalTime: 28800000000000, DepartureTime: 28800000000000,
+		})
+		require.NoError(t, err)
+	}
+}
+
+type stopPoint struct {
+	id  string
+	lat float64
+	lon float64
+}
+
+func TestComputeRegionBounds(t *testing.T) {
 	tests := []struct {
-		name            string
-		shapes          []gtfs.Shape
-		stops           []gtfs.Stop
-		expectedLat     float64
-		expectedLon     float64
-		expectedLatSpan float64
-		expectedLonSpan float64
+		name     string
+		agencies map[string][]stopPoint // agencyID -> stops
+		expected map[string]RegionBounds
 	}{
 		{
-			name: "Single Shape With Multiple Points",
-			shapes: []gtfs.Shape{
-				{
-					ID: "shape1",
-					Points: []gtfs.ShapePoint{
-						{Latitude: 47.0, Longitude: -122.0},
-						{Latitude: 48.0, Longitude: -121.0},
-					},
-				},
-			},
-			expectedLat:     47.5,
-			expectedLon:     -121.5,
-			expectedLatSpan: 1.0,
-			expectedLonSpan: 1.0,
+			name:     "No Data",
+			expected: nil,
 		},
 		{
-			name: "Multiple Shapes",
-			shapes: []gtfs.Shape{
-				{
-					ID: "shape1",
-					Points: []gtfs.ShapePoint{
-						{Latitude: 47.0, Longitude: -122.0},
-						{Latitude: 48.0, Longitude: -121.0},
-					},
-				},
-				{
-					ID: "shape2",
-					Points: []gtfs.ShapePoint{
-						{Latitude: 46.5, Longitude: -123.0},
-						{Latitude: 48.5, Longitude: -120.5},
-					},
+			name: "Single Agency",
+			agencies: map[string][]stopPoint{
+				"agency1": {
+					{"stop1", 47.0, -122.0},
+					{"stop2", 48.0, -121.0},
 				},
 			},
-			expectedLat:     47.5,
-			expectedLon:     -121.75,
-			expectedLatSpan: 2.0,
-			expectedLonSpan: 2.5,
+			expected: map[string]RegionBounds{
+				"agency1": {Lat: 47.5, Lon: -121.5, LatSpan: 1.0, LonSpan: 1.0},
+			},
 		},
 		{
-			name:            "No Shapes",
-			shapes:          []gtfs.Shape{},
-			expectedLat:     0.0,
-			expectedLon:     0.0,
-			expectedLatSpan: 0.0,
-			expectedLonSpan: 0.0,
-		},
-		{
-			name: "Shape With No Points",
-			shapes: []gtfs.Shape{
-				{
-					ID:     "empty",
-					Points: []gtfs.ShapePoint{},
+			name: "Multiple Agencies",
+			agencies: map[string][]stopPoint{
+				"agency1": {
+					{"stop1", 47.0, -122.0},
+					{"stop2", 48.0, -121.0},
+				},
+				"agency2": {
+					{"stop3", 10.0, 20.0},
+					{"stop4", 12.0, 22.0},
 				},
 			},
-			expectedLat:     0.0,
-			expectedLon:     0.0,
-			expectedLatSpan: 0.0,
-			expectedLonSpan: 0.0,
-		},
-		{
-			name:   "Fallback to Stops",
-			shapes: []gtfs.Shape{},
-			stops: []gtfs.Stop{
-				{Latitude: fptr(47.0), Longitude: fptr(-122.0)},
-				{Latitude: fptr(48.0), Longitude: fptr(-121.0)},
+			expected: map[string]RegionBounds{
+				"agency1": {Lat: 47.5, Lon: -121.5, LatSpan: 1.0, LonSpan: 1.0},
+				"agency2": {Lat: 11.0, Lon: 21.0, LatSpan: 2.0, LonSpan: 2.0},
 			},
-			expectedLat:     47.5,
-			expectedLon:     -121.5,
-			expectedLatSpan: 1.0,
-			expectedLonSpan: 1.0,
-		},
-		{
-			name: "Real Example",
-			shapes: []gtfs.Shape{
-				{
-					ID: "shape1",
-					Points: []gtfs.ShapePoint{
-						{Latitude: 47.5665345, Longitude: -122.3032715},
-						{Latitude: 47.6023246, Longitude: -122.3308378},
-						{Latitude: 47.6534563, Longitude: -122.3472905},
-						{Latitude: 47.6932255, Longitude: -122.3116085},
-					},
-				},
-				{
-					ID: "shape2",
-					Points: []gtfs.ShapePoint{
-						{Latitude: 47.5998745, Longitude: -122.3274812},
-						{Latitude: 47.6137821, Longitude: -122.3450112},
-						{Latitude: 47.6423451, Longitude: -122.3274812},
-					},
-				},
-			},
-			expectedLat:     47.629880000000,
-			expectedLon:     -122.32528099999,
-			expectedLatSpan: 0.12669099999999,
-			expectedLonSpan: 0.04401900000000,
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			bounds := ComputeRegionBounds(tc.shapes, tc.stops)
+			ctx := context.Background()
+			client := newTestGtfsDB(t)
 
-			var lat, lon, latSpan, lonSpan float64
-			if bounds != nil {
-				lat = bounds.Lat
-				lon = bounds.Lon
-				latSpan = bounds.LatSpan
-				lonSpan = bounds.LonSpan
+			for agencyID, stops := range tc.agencies {
+				insertAgencyRouteTripsStops(t, ctx, client, agencyID, stops)
 			}
 
-			if tc.name == "No Shapes" || tc.name == "Shape With No Points" {
-				t.Logf("Test case %s returned: lat=%f, lon=%f, latSpan=%f, lonSpan=%f",
-					tc.name, lat, lon, latSpan, lonSpan)
-			} else {
-				assert.InDeltaf(t, tc.expectedLat, lat, 0.00000001, "Latitude mismatch in %s", tc.name)
-				assert.InDeltaf(t, tc.expectedLon, lon, 0.00000001, "Longitude mismatch in %s", tc.name)
-				assert.InDeltaf(t, tc.expectedLatSpan, latSpan, 0.00000001, "Latitude span mismatch in %s", tc.name)
-				assert.InDeltaf(t, tc.expectedLonSpan, lonSpan, 0.00000001, "Longitude span mismatch in %s", tc.name)
+			bounds := computeRegionBounds(ctx, client)
+
+			if tc.expected == nil {
+				assert.Nil(t, bounds)
+				return
+			}
+
+			require.NotNil(t, bounds)
+			assert.Equal(t, len(tc.expected), len(bounds))
+
+			for agencyID, expectedBounds := range tc.expected {
+				actual, ok := bounds[agencyID]
+				require.True(t, ok, "missing bounds for agency %s", agencyID)
+				assert.InDelta(t, expectedBounds.Lat, actual.Lat, 0.00000001, "Latitude for %s", agencyID)
+				assert.InDelta(t, expectedBounds.Lon, actual.Lon, 0.00000001, "Longitude for %s", agencyID)
+				assert.InDelta(t, expectedBounds.LatSpan, actual.LatSpan, 0.00000001, "LatSpan for %s", agencyID)
+				assert.InDelta(t, expectedBounds.LonSpan, actual.LonSpan, 0.00000001, "LonSpan for %s", agencyID)
 			}
 		})
 	}
+}
+
+func TestGetRegionBoundsNil(t *testing.T) {
+	manager := &Manager{}
+	assert.Nil(t, manager.GetRegionBounds())
+}
+
+func TestGetRegionBoundsSet(t *testing.T) {
+	manager := &Manager{
+		regionBounds: map[string]*RegionBounds{
+			"agency1": {Lat: 1.0, Lon: 2.0, LatSpan: 3.0, LonSpan: 4.0},
+		},
+	}
+	result := manager.GetRegionBounds()
+	assert.Equal(t, RegionBounds{Lat: 1.0, Lon: 2.0, LatSpan: 3.0, LonSpan: 4.0}, result["agency1"])
 }

--- a/internal/gtfs/static.go
+++ b/internal/gtfs/static.go
@@ -265,7 +265,7 @@ func (manager *Manager) ForceUpdate(ctx context.Context) error {
 	}
 
 	newBlockLayoverIndices := buildBlockLayoverIndices(newStaticData)
-	newRegionBounds := ComputeRegionBounds(newStaticData.Shapes, newStaticData.Stops)
+	newRegionBounds := computeRegionBounds(ctx, newGtfsDB)
 
 	if err := ctx.Err(); err != nil {
 		if closeErr := newGtfsDB.Close(); closeErr != nil {
@@ -387,9 +387,9 @@ func (manager *Manager) setStaticGTFS(staticData *gtfs.Static) {
 	manager.isHealthy = true
 
 	manager.blockLayoverIndices = buildBlockLayoverIndices(staticData)
-	manager.regionBounds = ComputeRegionBounds(staticData.Shapes, staticData.Stops)
 
 	ctx := context.Background()
+	manager.regionBounds = computeRegionBounds(ctx, manager.GtfsDB)
 
 	// GtfsDB may be nil during initial construction
 	if manager.GtfsDB != nil && manager.GtfsDB.Queries != nil {

--- a/internal/restapi/agencies_with_coverage_handler.go
+++ b/internal/restapi/agencies_with_coverage_handler.go
@@ -30,37 +30,19 @@ func (api *RestAPI) agenciesWithCoverageHandler(w http.ResponseWriter, r *http.R
 	offset, limit := utils.ParsePaginationParams(r)
 	agencies, limitExceeded := utils.PaginateSlice(agencies, offset, limit)
 
-	lat, lon, latSpan, lonSpan := api.GtfsManager.GetRegionBounds()
+	boundsMap := api.GtfsManager.GetRegionBounds()
+	// Important to use an empty slice rather than nil so that empty json responses don't return nil.
 	agenciesWithCoverage := make([]models.AgencyCoverage, 0)
-	agencyReferences := make([]models.AgencyReference, 0)
-
 	for _, a := range agencies {
+		bounds := boundsMap[a.ID]
 		agenciesWithCoverage = append(
 			agenciesWithCoverage,
-			models.NewAgencyCoverage(a.ID, lat, latSpan, lon, lonSpan),
-		)
-
-		agencyReferences = append(
-			agencyReferences,
-			models.NewAgencyReference(
-				a.ID,
-				a.Name,
-				a.Url,
-				a.Timezone,
-				a.Lang.String,
-				a.Phone.String,
-				a.Email.String,
-				a.FareUrl.String,
-				"",
-				false,
-			),
+			models.NewAgencyCoverage(a.ID, bounds.Lat, bounds.LatSpan, bounds.Lon, bounds.LonSpan),
 		)
 	}
 
-	// Create references with the agency
 	references := models.NewEmptyReferences()
-	references.Agencies = agencyReferences
-
+	references.Agencies = buildAgencyReferences(agencies)
 	response := models.NewListResponse(agenciesWithCoverage, *references, limitExceeded, api.Clock)
 	api.sendResponse(w, r, response)
 }

--- a/internal/restapi/agencies_with_coverage_handler_test.go
+++ b/internal/restapi/agencies_with_coverage_handler_test.go
@@ -5,100 +5,73 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+	"maglev.onebusaway.org/internal/models"
+	"maglev.onebusaway.org/internal/restapi/testdata"
 )
 
+type CoverageResponse struct {
+	Code        int          `json:"code"`
+	CurrentTime int64        `json:"currentTime"`
+	Data        CoverageData `json:"data,omitempty"`
+	Text        string       `json:"text"`
+	Version     int          `json:"version"`
+}
+
+type CoverageData struct {
+	LimitExceeded bool                    `json:"limitExceeded"`
+	List          []models.AgencyCoverage `json:"list"`
+	OutOfRange    bool                    `json:"outOfRange"`
+	References    models.ReferencesModel  `json:"references"`
+}
+
 func TestAgenciesWithCoverageHandlerRequiresValidApiKey(t *testing.T) {
-	_, resp, model := serveAndRetrieveEndpoint(t, "/api/where/agencies-with-coverage.json?key=invalid")
+	api := createTestApi(t)
+
+	resp, model := callAPIHandler[CoverageResponse](t, api, "/api/where/agencies-with-coverage.json?key=invalid")
+
 	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
 	assert.Equal(t, http.StatusUnauthorized, model.Code)
 	assert.Equal(t, "permission denied", model.Text)
 }
 
 func TestAgenciesWithCoverageHandlerEndToEnd(t *testing.T) {
-	_, resp, model := serveAndRetrieveEndpoint(t, "/api/where/agencies-with-coverage.json?key=TEST")
+	api := createTestApi(t)
+
+	resp, model := callAPIHandler[CoverageResponse](t, api, "/api/where/agencies-with-coverage.json?key=TEST")
 
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, http.StatusOK, model.Code)
 	assert.Equal(t, "OK", model.Text)
 
-	data, ok := model.Data.(map[string]any)
-	require.True(t, ok)
+	assert.Len(t, model.Data.List, 1)
+	agencyCoverage := model.Data.List[0]
+	assert.Equal(t, "25", agencyCoverage.AgencyID)
+	assert.InDelta(t, 40.3304015, agencyCoverage.Lat, 1e-7)
+	assert.InDelta(t, 1.2138890, agencyCoverage.LatSpan, 1e-7)
+	assert.InDelta(t, -122.0981970, agencyCoverage.Lon, 1e-7)
+	assert.InDelta(t, 0.9843940, agencyCoverage.LonSpan, 1e-7)
 
-	list, ok := data["list"].([]any)
-	require.True(t, ok)
-	assert.Len(t, list, 1)
-
-	agencyCoverage, ok := list[0].(map[string]any)
-	require.True(t, ok)
-	assert.Equal(t, "25", agencyCoverage["agencyId"])
-	assert.InDelta(t, 40.328705, agencyCoverage["lat"], 1e-8)
-	assert.InDelta(t, 1.2188699999999955, agencyCoverage["latSpan"], 1e-8)
-	assert.InDelta(t, -122.101745, agencyCoverage["lon"], 1e-8)
-	assert.InDelta(t, 0.9914899999999989, agencyCoverage["lonSpan"], 1e-8)
-
-	refs, ok := data["references"].(map[string]any)
-	require.True(t, ok)
-
-	refAgencies, ok := refs["agencies"].([]any)
-	require.True(t, ok)
-	assert.Len(t, refAgencies, 1)
-
-	agencyRef, ok := refAgencies[0].(map[string]any)
-	require.True(t, ok)
-	assert.Equal(t, "25", agencyRef["id"])
-	assert.Equal(t, "Redding Area Bus Authority", agencyRef["name"])
-	assert.Equal(t, "http://www.rabaride.com/", agencyRef["url"])
-	assert.Equal(t, "America/Los_Angeles", agencyRef["timezone"])
-	assert.Equal(t, "en", agencyRef["lang"])
-	assert.Equal(t, "530-241-2877", agencyRef["phone"])
-	assert.Equal(t, "", agencyRef["email"])
-	assert.Equal(t, "", agencyRef["fareUrl"])
-	assert.Equal(t, "", agencyRef["disclaimer"])
-	assert.False(t, agencyRef["privateService"].(bool))
-	// Ensure no extra fields
-	assert.Len(t, agencyRef, 10)
-
-	assert.Empty(t, refs["routes"])
-	assert.Empty(t, refs["situations"])
-	assert.Empty(t, refs["stopTimes"])
-	assert.Empty(t, refs["stops"])
-	assert.Empty(t, refs["trips"])
+	assert.ElementsMatch(t, model.Data.References.Agencies, []models.AgencyReference{testdata.Raba})
+	assert.Empty(t, model.Data.References.Routes)
+	assert.Empty(t, model.Data.References.Situations)
+	assert.Empty(t, model.Data.References.StopTimes)
+	assert.Empty(t, model.Data.References.Stops)
+	assert.Empty(t, model.Data.References.Trips)
 }
 
 func TestAgenciesWithCoverageHandlerPagination(t *testing.T) {
 	// Test data (raba.zip) has 1 agency
+	api := createTestApi(t)
 
-	// Case 1: Default (Offset 0, Limit -1) -> Should return 1
-	_, _, model1 := serveAndRetrieveEndpoint(t, "/api/where/agencies-with-coverage.json?key=TEST")
-	data1, ok := model1.Data.(map[string]any)
-	require.True(t, ok, "expected Data to be map[string]interface{}")
-	list1, ok := data1["list"].([]any)
-	require.True(t, ok, "expected list to be []interface{}")
-	assert.Len(t, list1, 1)
+	_, model := callAPIHandler[CoverageResponse](t, api, "/api/where/agencies-with-coverage.json?key=TEST&limit=1")
+	assert.Len(t, model.Data.List, 1)
+	assert.False(t, model.Data.LimitExceeded)
 
-	// Case 2: Limit 1 -> Should return 1
-	_, _, model2 := serveAndRetrieveEndpoint(t, "/api/where/agencies-with-coverage.json?key=TEST&limit=1")
-	data2, ok := model2.Data.(map[string]any)
-	require.True(t, ok, "expected Data to be map[string]interface{}")
-	list2, ok := data2["list"].([]any)
-	require.True(t, ok, "expected list to be []interface{}")
-	assert.Len(t, list2, 1)
+	_, model = callAPIHandler[CoverageResponse](t, api, "/api/where/agencies-with-coverage.json?key=TEST&limit=0")
+	assert.Len(t, model.Data.List, 1)
+	assert.False(t, model.Data.LimitExceeded)
 
-	// Case 3: Limit 0 (should default to -1/all) -> Should return 1
-	// Note: Our new logic treats limit=0 as invalid -> -1 (all)
-	_, _, model3 := serveAndRetrieveEndpoint(t, "/api/where/agencies-with-coverage.json?key=TEST&limit=0")
-	data3, ok := model3.Data.(map[string]any)
-	require.True(t, ok, "expected Data to be map[string]interface{}")
-	list3, ok := data3["list"].([]any)
-	require.True(t, ok, "expected list to be []interface{}")
-	assert.Len(t, list3, 1)
-
-	// Case 4: Offset 1 -> Should return 0
-	_, _, model4 := serveAndRetrieveEndpoint(t, "/api/where/agencies-with-coverage.json?key=TEST&offset=1")
-	data4, ok := model4.Data.(map[string]any)
-	require.True(t, ok, "expected Data to be map[string]interface{}")
-	list4, ok := data4["list"].([]any)
-	require.True(t, ok, "expected list to be []interface{}")
-	assert.Len(t, list4, 0)
+	_, model = callAPIHandler[CoverageResponse](t, api, "/api/where/agencies-with-coverage.json?key=TEST&offset=1")
+	assert.Len(t, model.Data.List, 0)
+	assert.False(t, model.Data.LimitExceeded)
 }

--- a/internal/restapi/routes_for_location_handler.go
+++ b/internal/restapi/routes_for_location_handler.go
@@ -97,23 +97,27 @@ func (api *RestAPI) routesForLocationHandler(w http.ResponseWriter, r *http.Requ
 }
 
 // checkIfOutOfBounds returns true if the user's search area is completely
-// outside the transit agency's region bounds (derived from shape data).
+// outside every agency's region bounds.
 // IMPORTANT: Caller must hold manager.RLock() before calling this method.
 func checkIfOutOfBounds(api *RestAPI, lat float64, lon float64, latSpan float64, lonSpan float64, radius float64) bool {
-	regionLat, regionLon, regionLatSpan, regionLonSpan := api.GtfsManager.GetRegionBounds()
-
-	// returns false if there exists only one point
-	if regionLatSpan == 0 && regionLonSpan == 0 {
+	boundsMap := api.GtfsManager.GetRegionBounds()
+	if len(boundsMap) == 0 {
 		return false
 	}
 
-	innerBounds := utils.CalculateBounds(lat, lon, radius)
-
+	var innerBounds utils.CoordinateBounds
 	if latSpan > 0 && lonSpan > 0 {
 		innerBounds = utils.CalculateBoundsFromSpan(lat, lon, latSpan/2, lonSpan/2)
+	} else {
+		innerBounds = utils.CalculateBounds(lat, lon, radius)
 	}
 
-	outerBounds := utils.CalculateBoundsFromSpan(regionLat, regionLon, regionLatSpan/2, regionLonSpan/2)
+	for _, region := range boundsMap {
+		outerBounds := utils.CalculateBoundsFromSpan(region.Lat, region.Lon, region.LatSpan/2, region.LonSpan/2)
+		if !utils.IsOutOfBounds(innerBounds, outerBounds) {
+			return false
+		}
+	}
 
-	return utils.IsOutOfBounds(innerBounds, outerBounds)
+	return true
 }

--- a/internal/restapi/routes_for_location_handler_test.go
+++ b/internal/restapi/routes_for_location_handler_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"maglev.onebusaway.org/internal/gtfs"
 	"maglev.onebusaway.org/internal/models"
 	"maglev.onebusaway.org/internal/restapi/testdata"
 )
@@ -193,8 +194,14 @@ func TestRoutesForLocationHandlerMaxCountLessThanOrEqualZero(t *testing.T) {
 
 func TestRoutesForLocationHandlerInRangeWithNoResults(t *testing.T) {
 	api := createTestApi(t)
-	lat, lon, _, _ := api.GtfsManager.GetRegionBounds()
-	resp, model := callAPIHandler[RoutesResponse](t, api, fmt.Sprintf("/api/where/routes-for-location.json?key=TEST&lat=%v&lon=%v&radius=1", lat, lon))
+	boundsMap := api.GtfsManager.GetRegionBounds()
+	// Pick any agency's bounds for the in-range test
+	var bounds gtfs.RegionBounds
+	for _, b := range boundsMap {
+		bounds = b
+		break
+	}
+	resp, model := callAPIHandler[RoutesResponse](t, api, fmt.Sprintf("/api/where/routes-for-location.json?key=TEST&lat=%v&lon=%v&radius=1", bounds.Lat, bounds.Lon))
 
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, "OK", model.Text)


### PR DESCRIPTION
Instead of reading the static data, run a database query to determine the region bounds to store in GtfsManager.