### PR TITLE
chore: rename interface{} to any

### DIFF
--- a/cmd/api/app.go
+++ b/cmd/api/app.go
@@ -290,7 +290,7 @@ func dumpConfigJSON(cfg appconf.Config, gtfsCfg gtfs.Config) {
 	}
 
 	// Build JSON config structure
-	jsonConfig := map[string]interface{}{
+	jsonConfig := map[string]any{
 		"port":             cfg.Port,
 		"env":              envStr,
 		"api-keys":         fmt.Sprintf("***REDACTED*** (%d keys)", len(cfg.ApiKeys)),
@@ -300,14 +300,14 @@ func dumpConfigJSON(cfg appconf.Config, gtfsCfg gtfs.Config) {
 		"data-path":        gtfsCfg.GTFSDataPath,
 	}
 
-	var feeds []map[string]interface{}
+	var feeds []map[string]any
 	for _, feedCfg := range gtfsCfg.RTFeeds {
 		redactedHeaders := make(map[string]string)
 		for k := range feedCfg.Headers {
 			redactedHeaders[k] = "***REDACTED***"
 		}
 
-		feed := map[string]interface{}{
+		feed := map[string]any{
 			"id":                    feedCfg.ID,
 			"trip-updates-url":      feedCfg.TripUpdatesURL,
 			"vehicle-positions-url": feedCfg.VehiclePositionsURL,

--- a/cmd/api/app_test.go
+++ b/cmd/api/app_test.go
@@ -590,25 +590,25 @@ func TestDumpConfigJSON_WithExampleFile(t *testing.T) {
 	output := buf.String()
 
 	// Parse and validate json
-	var parsed map[string]interface{}
+	var parsed map[string]any
 
 	err = json.Unmarshal([]byte(output), &parsed)
 	require.NoError(t, err, "Output is not a valid JSON")
 
 	assert.Equal(t, float64(cfg.Port), parsed["port"])
-	staticFeed, ok := parsed["gtfs-static-feed"].(map[string]interface{})
+	staticFeed, ok := parsed["gtfs-static-feed"].(map[string]any)
 	require.True(t, ok, "gtfs-static-feed should be a map")
 	assert.Equal(t, gtfsCfg.GtfsURL, staticFeed["url"])
 
-	feeds, ok := parsed["gtfs-rt-feeds"].([]interface{})
+	feeds, ok := parsed["gtfs-rt-feeds"].([]any)
 	require.True(t, ok, "gtfs-rt-feeds should be an array of maps")
 	assert.Equal(t, len(gtfsCfg.RTFeeds), len(feeds))
 
-	rtFeed, ok := feeds[0].(map[string]interface{})
+	rtFeed, ok := feeds[0].(map[string]any)
 	require.True(t, ok, "feeds[0] should be a map")
 
 	// Check that headers are redacted (:
-	headersMap, ok := rtFeed["headers"].(map[string]interface{})
+	headersMap, ok := rtFeed["headers"].(map[string]any)
 	require.True(t, ok, "headers should be a map")
 	assert.NotEqual(t, "my-secret-api-key", headersMap["X-API-Key"])
 	assert.Equal(t, "***REDACTED***", headersMap["X-API-Key"])

--- a/gtfsdb/helpers.go
+++ b/gtfsdb/helpers.go
@@ -37,7 +37,7 @@ func newMetricsWrapper(db *sql.DB) *metricsWrapper {
 	}
 }
 
-func (s *metricsWrapper) ExecContext(ctx context.Context, query string, args ...interface{}) (sql.Result, error) {
+func (s *metricsWrapper) ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error) {
 	res, err := s.db.ExecContext(ctx, query, args...)
 	s.recordQueryMetrics("exec", query, err)
 	return res, err
@@ -49,13 +49,13 @@ func (s *metricsWrapper) PrepareContext(ctx context.Context, query string) (*sql
 	return s.db.PrepareContext(ctx, query)
 }
 
-func (s *metricsWrapper) QueryContext(ctx context.Context, query string, args ...interface{}) (*sql.Rows, error) {
+func (s *metricsWrapper) QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error) {
 	rows, err := s.db.QueryContext(ctx, query, args...)
 	s.recordQueryMetrics("query", query, err)
 	return rows, err
 }
 
-func (s *metricsWrapper) QueryRowContext(ctx context.Context, query string, args ...interface{}) *sql.Row {
+func (s *metricsWrapper) QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row {
 	row := s.db.QueryRowContext(ctx, query, args...)
 	// Note: QueryRowContext defers errors to row.Scan(), so err is always nil here.
 	// query_row metrics always report status="ok". See PR description for follow-up plan.
@@ -719,7 +719,7 @@ func (c *Client) bulkInsertTrips(ctx context.Context, trips []CreateTripParams, 
 // preparedStopTimeBatch holds a prepared SQL statement with its arguments
 type preparedStopTimeBatch struct {
 	query string
-	args  []interface{}
+	args  []any
 	index int // Original index for ordering
 	end   int // End position for progress logging
 }
@@ -774,7 +774,7 @@ func (c *Client) bulkInsertStopTimes(ctx context.Context, stopTimes []CreateStop
 				// into the query string to prevent SQL injection attacks.
 				var query strings.Builder
 				query.WriteString(baseQuery)
-				args := make([]interface{}, 0, len(batch)*stopTimeFieldsPerRow)
+				args := make([]any, 0, len(batch)*stopTimeFieldsPerRow)
 
 				for j, params := range batch {
 					if j > 0 {
@@ -884,7 +884,7 @@ func (c *Client) bulkInsertStopTimes(ctx context.Context, stopTimes []CreateStop
 // preparedShapeBatch holds a prepared SQL statement with its arguments
 type preparedShapeBatch struct {
 	query string
-	args  []interface{}
+	args  []any
 	index int // Original index for ordering
 	end   int // End position for progress logging
 }
@@ -938,7 +938,7 @@ func (c *Client) bulkInsertShapes(ctx context.Context, shapes []CreateShapeParam
 				// into the query string to prevent SQL injection attacks.
 				var query strings.Builder
 				query.WriteString(baseQuery)
-				args := make([]interface{}, 0, len(batch)*shapeFieldsPerRow)
+				args := make([]any, 0, len(batch)*shapeFieldsPerRow)
 
 				for j, params := range batch {
 					if j > 0 {

--- a/gtfsdb/query_latency_test.go
+++ b/gtfsdb/query_latency_test.go
@@ -355,7 +355,7 @@ func TestExplainQueryPlans(t *testing.T) {
 	plans := []struct {
 		name string
 		sql  string
-		args []interface{}
+		args []any
 	}{
 		{
 			name: "GetStopTimesForStopInWindow",
@@ -371,7 +371,7 @@ WHERE st.stop_id = ?
    OR (st.departure_time BETWEEN ? AND ?)
   )
 ORDER BY st.arrival_time`,
-			args: []interface{}{stopID, windowStart, windowEnd, windowStart, windowEnd},
+			args: []any{stopID, windowStart, windowEnd, windowStart, windowEnd},
 		},
 		{
 			name: "GetScheduleForStopOnDate",
@@ -382,13 +382,13 @@ JOIN trips t ON st.trip_id = t.id
 JOIN routes r ON t.route_id = r.id
 WHERE st.stop_id = ?
 ORDER BY r.id, st.arrival_time`,
-			args: []interface{}{stopID},
+			args: []any{stopID},
 		},
 		{
 			name: "GetStopTimesForTrip",
 			sql: `EXPLAIN QUERY PLAN
 SELECT * FROM stop_times WHERE trip_id = ? ORDER BY stop_sequence`,
-			args: []interface{}{tripID},
+			args: []any{tripID},
 		},
 		{
 			name: "GetActiveRouteIDsForStopsOnDate (stops-for-location batch)",
@@ -399,7 +399,7 @@ FROM stop_times
 JOIN trips  ON stop_times.trip_id  = trips.id
 JOIN routes ON trips.route_id      = routes.id
 WHERE stop_times.stop_id = ?`,
-			args: []interface{}{stopID},
+			args: []any{stopID},
 		},
 		{
 			name: "GetActiveServiceIDsForDate (calendar CTE)",
@@ -414,7 +414,7 @@ base_services AS (
   WHERE c.start_date <= ?1 AND c.end_date >= ?1
 )
 SELECT DISTINCT service_id FROM base_services`,
-			args: []interface{}{dateStr},
+			args: []any{dateStr},
 		},
 	}
 
@@ -433,8 +433,8 @@ SELECT DISTINCT service_id FROM base_services`,
 			continue
 		}
 		for rows.Next() {
-			vals := make([]interface{}, len(cols))
-			ptrs := make([]interface{}, len(cols))
+			vals := make([]any, len(cols))
+			ptrs := make([]any, len(cols))
 			for i := range vals {
 				ptrs[i] = &vals[i]
 			}

--- a/internal/gtfs/advanced_direction_calculator.go
+++ b/internal/gtfs/advanced_direction_calculator.go
@@ -95,7 +95,7 @@ func (adc *AdvancedDirectionCalculator) CalculateStopDirection(ctx context.Conte
 
 	// Fall back to computing from shapes, protected by singleflight
 	// This ensures concurrent requests for the SAME stopID don't hit the DB multiple times.
-	v, _, _ := adc.requestGroup.Do(stopID, func() (interface{}, error) {
+	v, _, _ := adc.requestGroup.Do(stopID, func() (any, error) {
 		// Double-check cache inside the singleflight in case another goroutine just finished it
 		if cached, ok := adc.directionResults.Load(stopID); ok {
 			return cached.(string), nil

--- a/internal/gtfs/hot_swap_test.go
+++ b/internal/gtfs/hot_swap_test.go
@@ -16,7 +16,7 @@ import (
 	"maglev.onebusaway.org/internal/models"
 )
 
-func loggerErrorf(format string, args ...interface{}) error {
+func loggerErrorf(format string, args ...any) error {
 	err := fmt.Errorf(format, args...)
 	return err
 }

--- a/internal/logging/error_handling_test.go
+++ b/internal/logging/error_handling_test.go
@@ -175,11 +175,11 @@ func (m *mockTransaction) Commit() error {
 	return nil
 }
 
-func (m *mockTransaction) Exec(query string, args ...interface{}) (sql.Result, error) {
+func (m *mockTransaction) Exec(query string, args ...any) (sql.Result, error) {
 	return nil, nil
 }
 
-func (m *mockTransaction) ExecContext(ctx context.Context, query string, args ...interface{}) (sql.Result, error) {
+func (m *mockTransaction) ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error) {
 	return nil, nil
 }
 
@@ -191,19 +191,19 @@ func (m *mockTransaction) PrepareContext(ctx context.Context, query string) (*sq
 	return nil, nil
 }
 
-func (m *mockTransaction) Query(query string, args ...interface{}) (*sql.Rows, error) {
+func (m *mockTransaction) Query(query string, args ...any) (*sql.Rows, error) {
 	return nil, nil
 }
 
-func (m *mockTransaction) QueryContext(ctx context.Context, query string, args ...interface{}) (*sql.Rows, error) {
+func (m *mockTransaction) QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error) {
 	return nil, nil
 }
 
-func (m *mockTransaction) QueryRow(query string, args ...interface{}) *sql.Row {
+func (m *mockTransaction) QueryRow(query string, args ...any) *sql.Row {
 	return nil
 }
 
-func (m *mockTransaction) QueryRowContext(ctx context.Context, query string, args ...interface{}) *sql.Row {
+func (m *mockTransaction) QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row {
 	return nil
 }
 

--- a/internal/models/arrival_and_departure.go
+++ b/internal/models/arrival_and_departure.go
@@ -12,17 +12,17 @@ type ArrivalAndDeparture struct {
 	NumberOfStopsAway          int         `json:"numberOfStopsAway"`
 	OccupancyStatus            string      `json:"occupancyStatus"`
 	Predicted                  bool        `json:"predicted"`
-	PredictedArrivalInterval   interface{} `json:"predictedArrivalInterval"`
+	PredictedArrivalInterval   any         `json:"predictedArrivalInterval"`
 	PredictedArrivalTime       int64       `json:"predictedArrivalTime"`
-	PredictedDepartureInterval interface{} `json:"predictedDepartureInterval"`
+	PredictedDepartureInterval any         `json:"predictedDepartureInterval"`
 	PredictedDepartureTime     int64       `json:"predictedDepartureTime"`
 	PredictedOccupancy         string      `json:"predictedOccupancy"`
 	RouteID                    string      `json:"routeId"`
 	RouteLongName              string      `json:"routeLongName"`
 	RouteShortName             string      `json:"routeShortName"`
-	ScheduledArrivalInterval   interface{} `json:"scheduledArrivalInterval"`
+	ScheduledArrivalInterval   any         `json:"scheduledArrivalInterval"`
 	ScheduledArrivalTime       int64       `json:"scheduledArrivalTime"`
-	ScheduledDepartureInterval interface{} `json:"scheduledDepartureInterval"`
+	ScheduledDepartureInterval any         `json:"scheduledDepartureInterval"`
 	ScheduledDepartureTime     int64       `json:"scheduledDepartureTime"`
 	ScheduledTrack             string      `json:"scheduledTrack"`
 	ServiceDate                int64       `json:"serviceDate"`

--- a/internal/models/current_time_test.go
+++ b/internal/models/current_time_test.go
@@ -163,7 +163,7 @@ func TestCurrentTimeDataEndToEnd(t *testing.T) {
 	}
 
 	// Unmarshal back to verify structure
-	var result map[string]interface{}
+	var result map[string]any
 	err = json.Unmarshal(jsonData, &result)
 	if err != nil {
 		t.Fatalf("Failed to unmarshal JSON: %v", err)
@@ -183,13 +183,13 @@ func TestCurrentTimeDataEndToEnd(t *testing.T) {
 	}
 
 	// Check data structure
-	data, ok := result["data"].(map[string]interface{})
+	data, ok := result["data"].(map[string]any)
 	if !ok {
 		t.Fatalf("Expected data to be an object, got %T", result["data"])
 	}
 
 	// Check entry
-	entry, ok := data["entry"].(map[string]interface{})
+	entry, ok := data["entry"].(map[string]any)
 	if !ok {
 		t.Fatalf("Expected entry to be an object, got %T", data["entry"])
 	}
@@ -213,7 +213,7 @@ func TestCurrentTimeDataEndToEnd(t *testing.T) {
 	}
 
 	// Check references
-	references, ok := data["references"].(map[string]interface{})
+	references, ok := data["references"].(map[string]any)
 	if !ok {
 		t.Fatalf("Expected references to be an object, got %T", data["references"])
 	}
@@ -221,7 +221,7 @@ func TestCurrentTimeDataEndToEnd(t *testing.T) {
 	// Check that all reference arrays are present and empty
 	referenceFields := []string{"agencies", "routes", "situations", "stopTimes", "stops", "trips"}
 	for _, field := range referenceFields {
-		arr, ok := references[field].([]interface{})
+		arr, ok := references[field].([]any)
 		if !ok {
 			t.Errorf("Expected %s to be an array, got %T", field, references[field])
 		} else if len(arr) != 0 {

--- a/internal/models/frequency_test.go
+++ b/internal/models/frequency_test.go
@@ -112,7 +112,7 @@ func TestFrequencyJSON(t *testing.T) {
 	assert.Equal(t, expected, unmarshaled)
 
 	// Verify JSON field names
-	var raw map[string]interface{}
+	var raw map[string]any
 	err = json.Unmarshal(jsonData, &raw)
 	require.NoError(t, err)
 	assert.Contains(t, raw, "startTime")

--- a/internal/models/response.go
+++ b/internal/models/response.go
@@ -6,20 +6,20 @@ import (
 
 // ResponseModel Base response structure that can be reused
 type ResponseModel struct {
-	Code        int         `json:"code"`
-	CurrentTime int64       `json:"currentTime"`
-	Data        interface{} `json:"data,omitempty"`
-	Text        string      `json:"text"`
-	Version     int         `json:"version"`
+	Code        int    `json:"code"`
+	CurrentTime int64  `json:"currentTime"`
+	Data        any    `json:"data,omitempty"`
+	Text        string `json:"text"`
+	Version     int    `json:"version"`
 }
 
 // NewOKResponse creates a successful response using the provided clock.
-func NewOKResponse(data interface{}, c clock.Clock) ResponseModel {
+func NewOKResponse(data any, c clock.Clock) ResponseModel {
 	return NewResponse(200, data, "OK", c)
 }
 
-func NewListResponse(list interface{}, references ReferencesModel, limitExceeded bool, c clock.Clock) ResponseModel {
-	data := map[string]interface{}{
+func NewListResponse(list any, references ReferencesModel, limitExceeded bool, c clock.Clock) ResponseModel {
+	data := map[string]any{
 		"limitExceeded": limitExceeded,
 		"list":          list,
 		"references":    references,
@@ -27,8 +27,8 @@ func NewListResponse(list interface{}, references ReferencesModel, limitExceeded
 	return NewOKResponse(data, c)
 }
 
-func NewListResponseWithRange(list interface{}, references ReferencesModel, outOfRange bool, c clock.Clock, isLimitExceeded bool) ResponseModel {
-	data := map[string]interface{}{
+func NewListResponseWithRange(list any, references ReferencesModel, outOfRange bool, c clock.Clock, isLimitExceeded bool) ResponseModel {
+	data := map[string]any{
 		"limitExceeded": isLimitExceeded,
 		"list":          list,
 		"outOfRange":    outOfRange,
@@ -37,22 +37,22 @@ func NewListResponseWithRange(list interface{}, references ReferencesModel, outO
 	return NewOKResponse(data, c)
 }
 
-func NewEntryResponse(entry interface{}, references ReferencesModel, c clock.Clock) ResponseModel {
-	data := map[string]interface{}{
+func NewEntryResponse(entry any, references ReferencesModel, c clock.Clock) ResponseModel {
+	data := map[string]any{
 		"entry":      entry,
 		"references": references,
 	}
 	return NewOKResponse(data, c)
 }
 
-func NewArrivalsAndDepartureResponse(arrivalsAndDepartures interface{}, references ReferencesModel, nearbyStopIds []string, situationIds []string, stopId string, c clock.Clock) ResponseModel {
-	entryData := map[string]interface{}{
+func NewArrivalsAndDepartureResponse(arrivalsAndDepartures any, references ReferencesModel, nearbyStopIds []string, situationIds []string, stopId string, c clock.Clock) ResponseModel {
+	entryData := map[string]any{
 		"arrivalsAndDepartures": arrivalsAndDepartures,
 		"nearbyStopIds":         nearbyStopIds,
 		"situationIds":          situationIds,
 		"stopId":                stopId,
 	}
-	data := map[string]interface{}{
+	data := map[string]any{
 		"entry":      entryData,
 		"references": references,
 	}
@@ -60,7 +60,7 @@ func NewArrivalsAndDepartureResponse(arrivalsAndDepartures interface{}, referenc
 }
 
 // NewResponse creates a standard response using the provided clock.
-func NewResponse(code int, data interface{}, text string, c clock.Clock) ResponseModel {
+func NewResponse(code int, data any, text string, c clock.Clock) ResponseModel {
 	return ResponseModel{
 		Code:        code,
 		CurrentTime: ResponseCurrentTime(c),

--- a/internal/models/response_test.go
+++ b/internal/models/response_test.go
@@ -43,7 +43,7 @@ func TestNewEntryResponse(t *testing.T) {
 	assert.Equal(t, 2, response.Version)
 	assert.InDelta(t, time.Now().UnixNano()/int64(time.Millisecond), response.CurrentTime, 100)
 
-	responseData, ok := response.Data.(map[string]interface{})
+	responseData, ok := response.Data.(map[string]any)
 	assert.True(t, ok, "Response data should be a map")
 	assert.Equal(t, entryData, responseData["entry"], "Entry in response data should match input entry")
 	assert.Equal(t, *references, responseData["references"], "References in response data should match input references")
@@ -77,7 +77,7 @@ func TestNewListResponse(t *testing.T) {
 	assert.Equal(t, 2, response.Version)
 	assert.InDelta(t, time.Now().UnixNano()/int64(time.Millisecond), response.CurrentTime, 100)
 
-	responseData, ok := response.Data.(map[string]interface{})
+	responseData, ok := response.Data.(map[string]any)
 	assert.True(t, ok, "Response data should be a map")
 	assert.Equal(t, itemList, responseData["list"], "List in response data should match input list")
 	assert.Equal(t, *references, responseData["references"], "References in response data should match input references")
@@ -99,7 +99,7 @@ func TestNewListResponseWithRange(t *testing.T) {
 	assert.Equal(t, 2, response.Version)
 	assert.InDelta(t, time.Now().UnixNano()/int64(time.Millisecond), response.CurrentTime, 100)
 
-	responseData, ok := response.Data.(map[string]interface{})
+	responseData, ok := response.Data.(map[string]any)
 	assert.True(t, ok, "Response data should be a map")
 	assert.Equal(t, itemList, responseData["list"], "List in response data should match input list")
 	assert.Equal(t, *references, responseData["references"], "References in response data should match input references")
@@ -115,7 +115,7 @@ func TestNewListResponseWithRangeFalseFlag(t *testing.T) {
 
 	response := NewListResponseWithRange(itemList, *references, false, clock, false)
 
-	responseData, ok := response.Data.(map[string]interface{})
+	responseData, ok := response.Data.(map[string]any)
 	assert.True(t, ok, "Response data should be a map")
 	assert.False(t, responseData["limitExceeded"].(bool), "limitExceeded should be false")
 	assert.False(t, responseData["outOfRange"].(bool), "outOfRange should be false")
@@ -148,11 +148,11 @@ func TestNewArrivalsAndDepartureResponse(t *testing.T) {
 	assert.Equal(t, 2, response.Version)
 	assert.InDelta(t, time.Now().UnixNano()/int64(time.Millisecond), response.CurrentTime, 100)
 
-	responseData, ok := response.Data.(map[string]interface{})
+	responseData, ok := response.Data.(map[string]any)
 	assert.True(t, ok, "Response data should be a map")
 	assert.Equal(t, *references, responseData["references"], "References in response data should match input references")
 
-	entryData, ok := responseData["entry"].(map[string]interface{})
+	entryData, ok := responseData["entry"].(map[string]any)
 	assert.True(t, ok, "Entry should be a map")
 	assert.Equal(t, arrivalsAndDepartures, entryData["arrivalsAndDepartures"])
 	assert.Equal(t, nearbyStopIDs, entryData["nearbyStopIds"])
@@ -171,10 +171,10 @@ func TestNewArrivalsAndDepartureResponseEmptyArrays(t *testing.T) {
 
 	response := NewArrivalsAndDepartureResponse(arrivalsAndDepartures, *references, nearbyStopIDs, situationIDs, stopID, clock)
 
-	responseData, ok := response.Data.(map[string]interface{})
+	responseData, ok := response.Data.(map[string]any)
 	assert.True(t, ok, "Response data should be a map")
 
-	entryData, ok := responseData["entry"].(map[string]interface{})
+	entryData, ok := responseData["entry"].(map[string]any)
 	assert.True(t, ok, "Entry should be a map")
 	assert.Empty(t, entryData["arrivalsAndDepartures"], "arrivalsAndDepartures should be empty")
 	assert.Empty(t, entryData["nearbyStopIds"], "nearbyStopIds should be empty")
@@ -224,7 +224,7 @@ func TestResponseModelJSON(t *testing.T) {
 	}
 
 	// Check that data was correctly marshaled/unmarshaled
-	responseData, ok := unmarshaledResponse.Data.(map[string]interface{})
+	responseData, ok := unmarshaledResponse.Data.(map[string]any)
 	if !ok {
 		t.Error("Failed to cast unmarshaled response data to map[string]interface{}")
 	} else {

--- a/internal/models/situation.go
+++ b/internal/models/situation.go
@@ -6,8 +6,8 @@ type Situation struct {
 	ActiveWindows      []ActiveWindow    `json:"activeWindows"`
 	AllAffects         []AffectedEntity  `json:"allAffects"`
 	ConsequenceMessage string            `json:"consequenceMessage"`
-	Consequences       []interface{}     `json:"consequences"`
-	PublicationWindows []interface{}     `json:"publicationWindows"`
+	Consequences       []any             `json:"consequences"`
+	PublicationWindows []any             `json:"publicationWindows"`
 	Reason             string            `json:"reason"`
 	Severity           string            `json:"severity"`
 	Summary            *TranslatedString `json:"summary,omitempty"`

--- a/internal/models/trip_test.go
+++ b/internal/models/trip_test.go
@@ -90,7 +90,7 @@ func TestTripJSON(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Ensure JSON contains correct field name
-	var m map[string]interface{}
+	var m map[string]any
 	err = json.Unmarshal(jsonData, &m)
 	assert.NoError(t, err)
 

--- a/internal/models/vehicle_test.go
+++ b/internal/models/vehicle_test.go
@@ -30,7 +30,7 @@ func TestVehicleStatus_JSONFields(t *testing.T) {
 		// Optional fields should be absent at the top level.
 		// Unmarshal to a map to avoid false positives from nested TripStatus JSON
 		// (which has its own phase/status/occupancyStatus without omitempty).
-		var top map[string]interface{}
+		var top map[string]any
 		require.NoError(t, json.Unmarshal(data, &top))
 		assert.Equal(t, float64(0), top["occupancyCapacity"])
 		assert.Equal(t, float64(0), top["occupancyCount"])
@@ -90,7 +90,7 @@ func TestVehicleStatus_JSONFields(t *testing.T) {
 		data, err = json.Marshal(vs)
 		require.NoError(t, err)
 
-		var top map[string]interface{}
+		var top map[string]any
 		require.NoError(t, json.Unmarshal(data, &top))
 
 		assert.Equal(t, float64(0), top["occupancyCapacity"])

--- a/internal/restapi/agencies_with_coverage_handler_test.go
+++ b/internal/restapi/agencies_with_coverage_handler_test.go
@@ -22,14 +22,14 @@ func TestAgenciesWithCoverageHandlerEndToEnd(t *testing.T) {
 	assert.Equal(t, http.StatusOK, model.Code)
 	assert.Equal(t, "OK", model.Text)
 
-	data, ok := model.Data.(map[string]interface{})
+	data, ok := model.Data.(map[string]any)
 	require.True(t, ok)
 
-	list, ok := data["list"].([]interface{})
+	list, ok := data["list"].([]any)
 	require.True(t, ok)
 	assert.Len(t, list, 1)
 
-	agencyCoverage, ok := list[0].(map[string]interface{})
+	agencyCoverage, ok := list[0].(map[string]any)
 	require.True(t, ok)
 	assert.Equal(t, "25", agencyCoverage["agencyId"])
 	assert.InDelta(t, 40.328705, agencyCoverage["lat"], 1e-8)
@@ -37,14 +37,14 @@ func TestAgenciesWithCoverageHandlerEndToEnd(t *testing.T) {
 	assert.InDelta(t, -122.101745, agencyCoverage["lon"], 1e-8)
 	assert.InDelta(t, 0.9914899999999989, agencyCoverage["lonSpan"], 1e-8)
 
-	refs, ok := data["references"].(map[string]interface{})
+	refs, ok := data["references"].(map[string]any)
 	require.True(t, ok)
 
-	refAgencies, ok := refs["agencies"].([]interface{})
+	refAgencies, ok := refs["agencies"].([]any)
 	require.True(t, ok)
 	assert.Len(t, refAgencies, 1)
 
-	agencyRef, ok := refAgencies[0].(map[string]interface{})
+	agencyRef, ok := refAgencies[0].(map[string]any)
 	require.True(t, ok)
 	assert.Equal(t, "25", agencyRef["id"])
 	assert.Equal(t, "Redding Area Bus Authority", agencyRef["name"])
@@ -71,34 +71,34 @@ func TestAgenciesWithCoverageHandlerPagination(t *testing.T) {
 
 	// Case 1: Default (Offset 0, Limit -1) -> Should return 1
 	_, _, model1 := serveAndRetrieveEndpoint(t, "/api/where/agencies-with-coverage.json?key=TEST")
-	data1, ok := model1.Data.(map[string]interface{})
+	data1, ok := model1.Data.(map[string]any)
 	require.True(t, ok, "expected Data to be map[string]interface{}")
-	list1, ok := data1["list"].([]interface{})
+	list1, ok := data1["list"].([]any)
 	require.True(t, ok, "expected list to be []interface{}")
 	assert.Len(t, list1, 1)
 
 	// Case 2: Limit 1 -> Should return 1
 	_, _, model2 := serveAndRetrieveEndpoint(t, "/api/where/agencies-with-coverage.json?key=TEST&limit=1")
-	data2, ok := model2.Data.(map[string]interface{})
+	data2, ok := model2.Data.(map[string]any)
 	require.True(t, ok, "expected Data to be map[string]interface{}")
-	list2, ok := data2["list"].([]interface{})
+	list2, ok := data2["list"].([]any)
 	require.True(t, ok, "expected list to be []interface{}")
 	assert.Len(t, list2, 1)
 
 	// Case 3: Limit 0 (should default to -1/all) -> Should return 1
 	// Note: Our new logic treats limit=0 as invalid -> -1 (all)
 	_, _, model3 := serveAndRetrieveEndpoint(t, "/api/where/agencies-with-coverage.json?key=TEST&limit=0")
-	data3, ok := model3.Data.(map[string]interface{})
+	data3, ok := model3.Data.(map[string]any)
 	require.True(t, ok, "expected Data to be map[string]interface{}")
-	list3, ok := data3["list"].([]interface{})
+	list3, ok := data3["list"].([]any)
 	require.True(t, ok, "expected list to be []interface{}")
 	assert.Len(t, list3, 1)
 
 	// Case 4: Offset 1 -> Should return 0
 	_, _, model4 := serveAndRetrieveEndpoint(t, "/api/where/agencies-with-coverage.json?key=TEST&offset=1")
-	data4, ok := model4.Data.(map[string]interface{})
+	data4, ok := model4.Data.(map[string]any)
 	require.True(t, ok, "expected Data to be map[string]interface{}")
-	list4, ok := data4["list"].([]interface{})
+	list4, ok := data4["list"].([]any)
 	require.True(t, ok, "expected list to be []interface{}")
 	assert.Len(t, list4, 0)
 }

--- a/internal/restapi/agency_handler_test.go
+++ b/internal/restapi/agency_handler_test.go
@@ -20,10 +20,10 @@ func TestAgencyHandlerReturnsAgencyWhenItExists(t *testing.T) {
 	assert.Equal(t, http.StatusOK, model.Code)
 	assert.Equal(t, "OK", model.Text)
 
-	data, ok := model.Data.(map[string]interface{})
+	data, ok := model.Data.(map[string]any)
 	require.True(t, ok)
 
-	entry, ok := data["entry"].(map[string]interface{})
+	entry, ok := data["entry"].(map[string]any)
 	require.True(t, ok)
 
 	assert.Equal(t, agencies[0].ID, entry["id"])

--- a/internal/restapi/arrival_and_departure_for_stop_handler_test.go
+++ b/internal/restapi/arrival_and_departure_for_stop_handler_test.go
@@ -63,11 +63,11 @@ func TestArrivalAndDepartureForStopHandlerEndToEnd(t *testing.T) {
 		assert.Equal(t, http.StatusOK, model.Code)
 		assert.Equal(t, "OK", model.Text)
 
-		data, ok := model.Data.(map[string]interface{})
+		data, ok := model.Data.(map[string]any)
 		assert.True(t, ok)
 		assert.NotEmpty(t, data)
 
-		entry, ok := data["entry"].(map[string]interface{})
+		entry, ok := data["entry"].(map[string]any)
 		assert.True(t, ok)
 
 		// Verify entry fields
@@ -82,23 +82,23 @@ func TestArrivalAndDepartureForStopHandlerEndToEnd(t *testing.T) {
 		assert.NotNil(t, entry["totalStopsInTrip"])
 
 		// Verify references
-		references, ok := data["references"].(map[string]interface{})
+		references, ok := data["references"].(map[string]any)
 		assert.True(t, ok)
 		assert.NotNil(t, references)
 
-		agencies, ok := references["agencies"].([]interface{})
+		agencies, ok := references["agencies"].([]any)
 		assert.True(t, ok)
 		assert.NotEmpty(t, agencies)
 
-		routes, ok := references["routes"].([]interface{})
+		routes, ok := references["routes"].([]any)
 		assert.True(t, ok)
 		assert.NotEmpty(t, routes)
 
-		trips_ref, ok := references["trips"].([]interface{})
+		trips_ref, ok := references["trips"].([]any)
 		assert.True(t, ok)
 		assert.NotEmpty(t, trips_ref)
 
-		stops_ref, ok := references["stops"].([]interface{})
+		stops_ref, ok := references["stops"].([]any)
 		assert.True(t, ok)
 		assert.NotEmpty(t, stops_ref)
 	case http.StatusNotFound:
@@ -158,10 +158,10 @@ func TestArrivalAndDepartureForStopHandlerWithTimeParameter(t *testing.T) {
 	case http.StatusOK:
 		assert.Equal(t, http.StatusOK, model.Code)
 
-		data, ok := model.Data.(map[string]interface{})
+		data, ok := model.Data.(map[string]any)
 		assert.True(t, ok)
 
-		entry, ok := data["entry"].(map[string]interface{})
+		entry, ok := data["entry"].(map[string]any)
 		assert.True(t, ok)
 
 		// The response should be successful
@@ -271,9 +271,9 @@ func TestArrivalAndDepartureForStopHandlerWithStopSequence(t *testing.T) {
 	switch resp.StatusCode {
 	case http.StatusOK:
 		assert.Equal(t, http.StatusOK, model.Code)
-		data, ok := model.Data.(map[string]interface{})
+		data, ok := model.Data.(map[string]any)
 		assert.True(t, ok)
-		entry, ok := data["entry"].(map[string]interface{})
+		entry, ok := data["entry"].(map[string]any)
 		assert.True(t, ok)
 		assert.Equal(t, stopID, entry["stopId"])
 	case http.StatusNotFound:
@@ -411,10 +411,10 @@ func TestArrivalAndDepartureForStopHandlerWithValidTripStopCombination(t *testin
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, http.StatusOK, model.Code)
 
-	data, ok := model.Data.(map[string]interface{})
+	data, ok := model.Data.(map[string]any)
 	require.True(t, ok)
 
-	entry, ok := data["entry"].(map[string]interface{})
+	entry, ok := data["entry"].(map[string]any)
 	require.True(t, ok)
 
 	// Verify all the important fields
@@ -435,22 +435,22 @@ func TestArrivalAndDepartureForStopHandlerWithValidTripStopCombination(t *testin
 	assert.NotNil(t, entry["totalStopsInTrip"])
 
 	// Verify references
-	references, ok := data["references"].(map[string]interface{})
+	references, ok := data["references"].(map[string]any)
 	require.True(t, ok)
 
-	agencies, ok := references["agencies"].([]interface{})
+	agencies, ok := references["agencies"].([]any)
 	require.True(t, ok)
 	assert.NotEmpty(t, agencies)
 
-	routes, ok := references["routes"].([]interface{})
+	routes, ok := references["routes"].([]any)
 	require.True(t, ok)
 	assert.NotEmpty(t, routes)
 
-	trips_ref, ok := references["trips"].([]interface{})
+	trips_ref, ok := references["trips"].([]any)
 	require.True(t, ok)
 	assert.NotEmpty(t, trips_ref)
 
-	stops_ref, ok := references["stops"].([]interface{})
+	stops_ref, ok := references["stops"].([]any)
 	require.True(t, ok)
 	assert.NotEmpty(t, stops_ref)
 }
@@ -501,10 +501,10 @@ func TestArrivalAndDepartureForStopHandlerWithValidTripAndStopSequence(t *testin
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, http.StatusOK, model.Code)
 
-	data, ok := model.Data.(map[string]interface{})
+	data, ok := model.Data.(map[string]any)
 	require.True(t, ok)
 
-	entry, ok := data["entry"].(map[string]interface{})
+	entry, ok := data["entry"].(map[string]any)
 	require.True(t, ok)
 
 	assert.Equal(t, float64(stopSequence-1), entry["stopSequence"]) // Zero-based
@@ -780,10 +780,10 @@ func TestArrivalAndDepartureForStopHandler_MultiAgency_Regression(t *testing.T) 
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, http.StatusOK, model.Code)
 
-	data, ok := model.Data.(map[string]interface{})
+	data, ok := model.Data.(map[string]any)
 	require.True(t, ok)
 
-	entry, ok := data["entry"].(map[string]interface{})
+	entry, ok := data["entry"].(map[string]any)
 	require.True(t, ok)
 
 	// CRITICAL: Verify routeId uses Agency B prefix (not Agency A)
@@ -794,15 +794,15 @@ func TestArrivalAndDepartureForStopHandler_MultiAgency_Regression(t *testing.T) 
 		"routeId should use the route's agency (AgencyB), not the stop's agency (AgencyA)")
 
 	// Verify references contain both agencies
-	references, ok := data["references"].(map[string]interface{})
+	references, ok := data["references"].(map[string]any)
 	require.True(t, ok)
 
-	agencies, ok := references["agencies"].([]interface{})
+	agencies, ok := references["agencies"].([]any)
 	require.True(t, ok)
 
 	agencyIDs := make(map[string]bool)
 	for _, ag := range agencies {
-		agencyMap := ag.(map[string]interface{})
+		agencyMap := ag.(map[string]any)
 		agencyIDs[agencyMap["id"].(string)] = true
 	}
 
@@ -810,13 +810,13 @@ func TestArrivalAndDepartureForStopHandler_MultiAgency_Regression(t *testing.T) 
 	assert.True(t, agencyIDs[agencyB], "references.agencies should contain Agency B")
 
 	// Verify route is correctly prefixed
-	routes, ok := references["routes"].([]interface{})
+	routes, ok := references["routes"].([]any)
 	require.True(t, ok)
 	require.NotEmpty(t, routes)
 
 	foundCorrectRoute := false
 	for _, r := range routes {
-		routeMap := r.(map[string]interface{})
+		routeMap := r.(map[string]any)
 		if routeMap["id"].(string) == expectedRouteID {
 			foundCorrectRoute = true
 			assert.Equal(t, agencyB, routeMap["agencyId"], "route's agencyId should be AgencyB")
@@ -966,10 +966,10 @@ func TestArrivalAndDepartureForStop_PositiveUTCOffset_ServiceDateRegression(t *t
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 	require.Equal(t, http.StatusOK, model.Code)
 
-	data, ok := model.Data.(map[string]interface{})
+	data, ok := model.Data.(map[string]any)
 	require.True(t, ok, "response should contain data object")
 
-	entry, ok := data["entry"].(map[string]interface{})
+	entry, ok := data["entry"].(map[string]any)
 	require.True(t, ok, "data should contain entry object")
 
 	// Expected: midnight Jan 15 CET + 8 hours = Jan 15 08:00 CET.
@@ -1072,9 +1072,9 @@ func TestArrivalAndDepartureForStopHandler_LoopRouteStopSequence(t *testing.T) {
 	require.Equal(t, http.StatusOK, resp1.StatusCode)
 	require.Equal(t, http.StatusOK, model1.Code)
 
-	data1, ok := model1.Data.(map[string]interface{})
+	data1, ok := model1.Data.(map[string]any)
 	require.True(t, ok)
-	entry1, ok := data1["entry"].(map[string]interface{})
+	entry1, ok := data1["entry"].(map[string]any)
 	require.True(t, ok)
 	assert.Equal(t, float64(1), entry1["stopSequence"], "expected zero-based index for stop_sequence=2")
 
@@ -1082,9 +1082,9 @@ func TestArrivalAndDepartureForStopHandler_LoopRouteStopSequence(t *testing.T) {
 	require.Equal(t, http.StatusOK, resp2.StatusCode)
 	require.Equal(t, http.StatusOK, model2.Code)
 
-	data2, ok := model2.Data.(map[string]interface{})
+	data2, ok := model2.Data.(map[string]any)
 	require.True(t, ok)
-	entry2, ok := data2["entry"].(map[string]interface{})
+	entry2, ok := data2["entry"].(map[string]any)
 	require.True(t, ok)
 	assert.Equal(t, float64(14), entry2["stopSequence"], "expected zero-based index for stop_sequence=15")
 }
@@ -1139,9 +1139,9 @@ func TestArrivalAndDepartureForStop_VehicleWithNilID(t *testing.T) {
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, 200, model.Code)
 
-	data, ok := model.Data.(map[string]interface{})
+	data, ok := model.Data.(map[string]any)
 	require.True(t, ok)
-	entry, ok := data["entry"].(map[string]interface{})
+	entry, ok := data["entry"].(map[string]any)
 	require.True(t, ok)
 	assert.Equal(t, "", entry["vehicleId"], "vehicleId should be empty for vehicle with nil ID")
 }

--- a/internal/restapi/arrivals_and_departures_for_stop_handler_test.go
+++ b/internal/restapi/arrivals_and_departures_for_stop_handler_test.go
@@ -65,11 +65,11 @@ func TestArrivalsAndDeparturesForStopHandlerEndToEnd(t *testing.T) {
 	assert.Equal(t, 2, model.Version)
 	assert.NotZero(t, model.CurrentTime)
 
-	data, ok := model.Data.(map[string]interface{})
+	data, ok := model.Data.(map[string]any)
 	assert.True(t, ok)
 	assert.NotEmpty(t, data)
 
-	entry, ok := data["entry"].(map[string]interface{})
+	entry, ok := data["entry"].(map[string]any)
 	assert.True(t, ok)
 	assert.NotEmpty(t, entry)
 
@@ -79,25 +79,25 @@ func TestArrivalsAndDeparturesForStopHandlerEndToEnd(t *testing.T) {
 	assert.Contains(t, entry, "situationIds")
 	assert.Equal(t, stopID, entry["stopId"])
 
-	arrivalsAndDepartures, ok := entry["arrivalsAndDepartures"].([]interface{})
+	arrivalsAndDepartures, ok := entry["arrivalsAndDepartures"].([]any)
 	assert.True(t, ok)
 
-	_, ok = entry["nearbyStopIds"].([]interface{})
+	_, ok = entry["nearbyStopIds"].([]any)
 	assert.True(t, ok)
 
-	_, ok = entry["situationIds"].([]interface{})
+	_, ok = entry["situationIds"].([]any)
 	assert.True(t, ok)
 
-	references, ok := data["references"].(map[string]interface{})
+	references, ok := data["references"].(map[string]any)
 	assert.True(t, ok)
 	assert.Contains(t, references, "agencies")
 
-	agencies, ok := references["agencies"].([]interface{})
+	agencies, ok := references["agencies"].([]any)
 	assert.True(t, ok)
 	assert.NotEmpty(t, agencies)
 
 	if len(arrivalsAndDepartures) > 0 {
-		firstArrival, ok := arrivalsAndDepartures[0].(map[string]interface{})
+		firstArrival, ok := arrivalsAndDepartures[0].(map[string]any)
 		assert.True(t, ok)
 
 		assert.Contains(t, firstArrival, "stopId")
@@ -119,7 +119,7 @@ func TestArrivalsAndDeparturesForStopHandlerEndToEnd(t *testing.T) {
 		assert.Contains(t, firstArrival, "routeShortName")
 		assert.Contains(t, firstArrival, "routeLongName")
 
-		if tripStatus, ok := firstArrival["tripStatus"].(map[string]interface{}); ok {
+		if tripStatus, ok := firstArrival["tripStatus"].(map[string]any); ok {
 			assert.Contains(t, tripStatus, "activeTripId")
 			assert.Contains(t, tripStatus, "blockTripSequence")
 			assert.Contains(t, tripStatus, "closestStop")
@@ -133,7 +133,7 @@ func TestArrivalsAndDeparturesForStopHandlerEndToEnd(t *testing.T) {
 			assert.Contains(t, tripStatus, "vehicleId")
 
 			if pos := tripStatus["position"]; pos != nil {
-				position := pos.(map[string]interface{})
+				position := pos.(map[string]any)
 				assert.Contains(t, position, "lat")
 				assert.Contains(t, position, "lon")
 			}
@@ -151,15 +151,15 @@ func TestArrivalsAndDeparturesForStopHandlerEndToEnd(t *testing.T) {
 		assert.IsType(t, float64(0), firstArrival["serviceDate"])
 		assert.IsType(t, float64(0), firstArrival["lastUpdateTime"])
 
-		routes, ok := references["routes"].([]interface{})
+		routes, ok := references["routes"].([]any)
 		assert.True(t, ok)
 		assert.NotEmpty(t, routes)
 
-		trips, ok := references["trips"].([]interface{})
+		trips, ok := references["trips"].([]any)
 		assert.True(t, ok)
 		assert.NotEmpty(t, trips)
 
-		stops_ref, ok := references["stops"].([]interface{})
+		stops_ref, ok := references["stops"].([]any)
 		assert.True(t, ok)
 		assert.NotEmpty(t, stops_ref)
 	}
@@ -189,23 +189,23 @@ func TestArrivalsAndDeparturesForStopHandlerWithTimeParameters(t *testing.T) {
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, 200, model.Code)
 
-	data, ok := model.Data.(map[string]interface{})
+	data, ok := model.Data.(map[string]any)
 	assert.True(t, ok)
 
-	entry, ok := data["entry"].(map[string]interface{})
+	entry, ok := data["entry"].(map[string]any)
 	assert.True(t, ok)
 	assert.Equal(t, stopID, entry["stopId"])
 
-	_, ok = entry["arrivalsAndDepartures"].([]interface{})
+	_, ok = entry["arrivalsAndDepartures"].([]any)
 	assert.True(t, ok)
 
-	_, ok = entry["nearbyStopIds"].([]interface{})
+	_, ok = entry["nearbyStopIds"].([]any)
 	assert.True(t, ok)
 
-	_, ok = entry["situationIds"].([]interface{})
+	_, ok = entry["situationIds"].([]any)
 	assert.True(t, ok)
 
-	_, ok = data["references"].(map[string]interface{})
+	_, ok = data["references"].(map[string]any)
 	assert.True(t, ok)
 }
 
@@ -234,10 +234,10 @@ func TestArrivalsAndDeparturesForStopHandlerWithSpecificTime(t *testing.T) {
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, 200, model.Code)
 
-	data, ok := model.Data.(map[string]interface{})
+	data, ok := model.Data.(map[string]any)
 	assert.True(t, ok)
 
-	entry, ok := data["entry"].(map[string]interface{})
+	entry, ok := data["entry"].(map[string]any)
 	assert.True(t, ok)
 	assert.Equal(t, stopID, entry["stopId"])
 
@@ -245,7 +245,7 @@ func TestArrivalsAndDeparturesForStopHandlerWithSpecificTime(t *testing.T) {
 	assert.Contains(t, entry, "nearbyStopIds")
 	assert.Contains(t, entry, "situationIds")
 
-	references, ok := data["references"].(map[string]interface{})
+	references, ok := data["references"].(map[string]any)
 	assert.True(t, ok)
 	assert.Contains(t, references, "agencies")
 }
@@ -302,37 +302,37 @@ func TestArrivalsAndDeparturesForStopHandlerNoActiveServices(t *testing.T) {
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, 200, model.Code)
 
-	data, ok := model.Data.(map[string]interface{})
+	data, ok := model.Data.(map[string]any)
 	assert.True(t, ok)
 
-	entry, ok := data["entry"].(map[string]interface{})
+	entry, ok := data["entry"].(map[string]any)
 	assert.True(t, ok)
 	assert.Equal(t, stopID, entry["stopId"])
 
-	arrivalsAndDepartures, ok := entry["arrivalsAndDepartures"].([]interface{})
+	arrivalsAndDepartures, ok := entry["arrivalsAndDepartures"].([]any)
 	assert.True(t, ok)
 	assert.Empty(t, arrivalsAndDepartures)
 
-	_, ok = entry["nearbyStopIds"].([]interface{})
+	_, ok = entry["nearbyStopIds"].([]any)
 	assert.True(t, ok)
 
-	_, ok = entry["situationIds"].([]interface{})
+	_, ok = entry["situationIds"].([]any)
 	assert.True(t, ok)
 
-	references, ok := data["references"].(map[string]interface{})
+	references, ok := data["references"].(map[string]any)
 	assert.True(t, ok)
 
-	agencies, ok := references["agencies"].([]interface{})
+	agencies, ok := references["agencies"].([]any)
 	assert.True(t, ok)
 	assert.NotEmpty(t, agencies)
 
 	if routes, ok := references["routes"]; ok {
-		if routeArray, ok := routes.([]interface{}); ok {
+		if routeArray, ok := routes.([]any); ok {
 			assert.Empty(t, routeArray)
 		}
 	}
 	if trips, ok := references["trips"]; ok {
-		if tripArray, ok := trips.([]interface{}); ok {
+		if tripArray, ok := trips.([]any); ok {
 			assert.Empty(t, tripArray)
 		}
 	}
@@ -359,10 +359,10 @@ func TestArrivalsAndDeparturesForStopHandlerDefaultParameters(t *testing.T) {
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, 200, model.Code)
 
-	data, ok := model.Data.(map[string]interface{})
+	data, ok := model.Data.(map[string]any)
 	assert.True(t, ok)
 
-	entry, ok := data["entry"].(map[string]interface{})
+	entry, ok := data["entry"].(map[string]any)
 	assert.True(t, ok)
 
 	assert.Contains(t, entry, "arrivalsAndDepartures")
@@ -372,10 +372,10 @@ func TestArrivalsAndDeparturesForStopHandlerDefaultParameters(t *testing.T) {
 
 	assert.Equal(t, stopID, entry["stopId"])
 
-	_, ok = entry["arrivalsAndDepartures"].([]interface{})
+	_, ok = entry["arrivalsAndDepartures"].([]any)
 	assert.True(t, ok)
 
-	_, ok = data["references"].(map[string]interface{})
+	_, ok = data["references"].(map[string]any)
 	assert.True(t, ok)
 }
 
@@ -543,20 +543,20 @@ func TestArrivalsAndDeparturesForStopHandler_MultiAgency_Regression(t *testing.T
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, http.StatusOK, model.Code)
 
-	data, ok := model.Data.(map[string]interface{})
+	data, ok := model.Data.(map[string]any)
 	require.True(t, ok)
 
-	entry, ok := data["entry"].(map[string]interface{})
+	entry, ok := data["entry"].(map[string]any)
 	require.True(t, ok)
 
 	// Verify arrivalsAndDepartures array
-	arrivalsAndDepartures, ok := entry["arrivalsAndDepartures"].([]interface{})
+	arrivalsAndDepartures, ok := entry["arrivalsAndDepartures"].([]any)
 	require.True(t, ok)
 
 	// Fail loudly if no data is returned
 	require.NotEmpty(t, arrivalsAndDepartures, "expected arrivals for multi-agency stop")
 
-	firstArrival := arrivalsAndDepartures[0].(map[string]interface{})
+	firstArrival := arrivalsAndDepartures[0].(map[string]any)
 
 	routeID, ok := firstArrival["routeId"].(string)
 	require.True(t, ok)
@@ -565,15 +565,15 @@ func TestArrivalsAndDeparturesForStopHandler_MultiAgency_Regression(t *testing.T
 		"routeId should use the route's agency (AgencyB), not the stop's agency (AgencyA)")
 
 	// Verify references contain both agencies
-	references, ok := data["references"].(map[string]interface{})
+	references, ok := data["references"].(map[string]any)
 	require.True(t, ok)
 
-	agencies, ok := references["agencies"].([]interface{})
+	agencies, ok := references["agencies"].([]any)
 	require.True(t, ok)
 
 	agencyIDs := make(map[string]bool)
 	for _, ag := range agencies {
-		agencyMap := ag.(map[string]interface{})
+		agencyMap := ag.(map[string]any)
 		agencyIDs[agencyMap["id"].(string)] = true
 	}
 
@@ -581,13 +581,13 @@ func TestArrivalsAndDeparturesForStopHandler_MultiAgency_Regression(t *testing.T
 	assert.True(t, agencyIDs[agencyB], "references.agencies should contain Agency B")
 
 	// Verify route is correctly prefixed
-	routes, ok := references["routes"].([]interface{})
+	routes, ok := references["routes"].([]any)
 	require.True(t, ok)
 	require.NotEmpty(t, routes, "references.routes should not be empty")
 
 	foundCorrectRoute := false
 	for _, r := range routes {
-		routeMap := r.(map[string]interface{})
+		routeMap := r.(map[string]any)
 		if routeMap["id"].(string) == expectedRouteID {
 			foundCorrectRoute = true
 			assert.Equal(t, agencyB, routeMap["agencyId"], "route's agencyId should be AgencyB")
@@ -618,9 +618,9 @@ func TestArrivalsAndDeparturesReturnsResultsNearMidnight(t *testing.T) {
 		resp, model := serveApiAndRetrieveEndpoint(t, api, url)
 
 		if resp.StatusCode == http.StatusOK {
-			if data, ok := model.Data.(map[string]interface{}); ok {
-				if entry, ok := data["entry"].(map[string]interface{}); ok {
-					if arrivals, ok := entry["arrivalsAndDepartures"].([]interface{}); ok && len(arrivals) > 0 {
+			if data, ok := model.Data.(map[string]any); ok {
+				if entry, ok := data["entry"].(map[string]any); ok {
+					if arrivals, ok := entry["arrivalsAndDepartures"].([]any); ok && len(arrivals) > 0 {
 						foundResults = true
 						break
 					}
@@ -740,14 +740,14 @@ func TestPluralArrivals_ExactStopMatch(t *testing.T) {
 	_, model := serveApiAndRetrieveEndpoint(t, api,
 		"/api/where/arrivals-and-departures-for-stop/"+combinedStopID+".json?key=TEST")
 
-	data := model.Data.(map[string]interface{})
-	entry := data["entry"].(map[string]interface{})
-	arrivals := entry["arrivalsAndDepartures"].([]interface{})
+	data := model.Data.(map[string]any)
+	entry := data["entry"].(map[string]any)
+	arrivals := entry["arrivalsAndDepartures"].([]any)
 	require.NotEmpty(t, arrivals, "expected at least one arrival")
 
 	scheduledDepartureMs := scheduledArrivalMs + 300000 // departure is 5 min after arrival
 
-	a := arrivals[0].(map[string]interface{})
+	a := arrivals[0].(map[string]any)
 	assert.True(t, a["predicted"].(bool), "exact stop match should be predicted")
 	assert.Equal(t, float64(scheduledArrivalMs+60000), a["predictedArrivalTime"],
 		"predicted arrival should be scheduled + 60s")
@@ -779,18 +779,18 @@ func TestPluralArrivals_PriorStopPropagation(t *testing.T) {
 	_, model := serveApiAndRetrieveEndpoint(t, api,
 		"/api/where/arrivals-and-departures-for-stop/"+combinedStopID+".json?key=TEST")
 
-	data := model.Data.(map[string]interface{})
-	entry := data["entry"].(map[string]interface{})
-	arrivals := entry["arrivalsAndDepartures"].([]interface{})
+	data := model.Data.(map[string]any)
+	entry := data["entry"].(map[string]any)
+	arrivals := entry["arrivalsAndDepartures"].([]any)
 	require.NotEmpty(t, arrivals, "expected at least one arrival")
 
 	scheduledDepartureMs := scheduledArrivalMs + 300000 // departure is 5 min after arrival
 
 	// The queried stop is at seq=3 (0-based stopSequence=2). Prior tests may have inserted
 	// a stop at seq=2 into the shared DB, so we locate the right arrival explicitly.
-	var propagatedArrival map[string]interface{}
+	var propagatedArrival map[string]any
 	for _, arriv := range arrivals {
-		arr := arriv.(map[string]interface{})
+		arr := arriv.(map[string]any)
 		if int(arr["stopSequence"].(float64)) == 2 { // seq=3 → 0-based index 2
 			propagatedArrival = arr
 			break
@@ -821,14 +821,14 @@ func TestPluralArrivals_TripLevelDelayFallback(t *testing.T) {
 	_, model := serveApiAndRetrieveEndpoint(t, api,
 		"/api/where/arrivals-and-departures-for-stop/"+combinedStopID+".json?key=TEST")
 
-	data := model.Data.(map[string]interface{})
-	entry := data["entry"].(map[string]interface{})
-	arrivals := entry["arrivalsAndDepartures"].([]interface{})
+	data := model.Data.(map[string]any)
+	entry := data["entry"].(map[string]any)
+	arrivals := entry["arrivalsAndDepartures"].([]any)
 	require.NotEmpty(t, arrivals, "expected at least one arrival")
 
 	scheduledDepartureMs := scheduledArrivalMs + 300000 // departure is 5 min after arrival
 
-	a := arrivals[0].(map[string]interface{})
+	a := arrivals[0].(map[string]any)
 	assert.True(t, a["predicted"].(bool), "trip-level delay should mark arrival as predicted")
 	assert.Equal(t, float64(scheduledArrivalMs+120000), a["predictedArrivalTime"],
 		"predicted arrival should be scheduled + trip-level 120s delay")
@@ -855,14 +855,14 @@ func TestPluralArrivals_TripLevelDelayWithoutVehicle(t *testing.T) {
 	_, model := serveApiAndRetrieveEndpoint(t, api,
 		"/api/where/arrivals-and-departures-for-stop/"+combinedStopID+".json?key=TEST")
 
-	data := model.Data.(map[string]interface{})
-	entry := data["entry"].(map[string]interface{})
-	arrivals := entry["arrivalsAndDepartures"].([]interface{})
+	data := model.Data.(map[string]any)
+	entry := data["entry"].(map[string]any)
+	arrivals := entry["arrivalsAndDepartures"].([]any)
 	require.NotEmpty(t, arrivals, "expected at least one arrival")
 
 	scheduledDepartureMs := scheduledArrivalMs + 300000
 
-	a := arrivals[0].(map[string]interface{})
+	a := arrivals[0].(map[string]any)
 	assert.True(t, a["predicted"].(bool),
 		"trip-level delay without vehicle should still be predicted")
 	assert.Equal(t, float64(scheduledArrivalMs+120000), a["predictedArrivalTime"],
@@ -895,12 +895,12 @@ func TestPluralArrivals_NoMatchingOrPriorStop(t *testing.T) {
 	_, model := serveApiAndRetrieveEndpoint(t, api,
 		"/api/where/arrivals-and-departures-for-stop/"+combinedStopID+".json?key=TEST")
 
-	data := model.Data.(map[string]interface{})
-	entry := data["entry"].(map[string]interface{})
-	arrivals := entry["arrivalsAndDepartures"].([]interface{})
+	data := model.Data.(map[string]any)
+	entry := data["entry"].(map[string]any)
+	arrivals := entry["arrivalsAndDepartures"].([]any)
 	require.NotEmpty(t, arrivals, "expected at least one arrival")
 
-	a := arrivals[0].(map[string]interface{})
+	a := arrivals[0].(map[string]any)
 	assert.False(t, a["predicted"].(bool), "update for a later stop should not predict current stop")
 	assert.Equal(t, float64(0), a["predictedArrivalTime"],
 		"predictedArrivalTime should be 0 when not predicted")
@@ -926,12 +926,12 @@ func TestPluralArrivals_VehiclePositionAloneDoesNotPredict(t *testing.T) {
 	_, model := serveApiAndRetrieveEndpoint(t, api,
 		"/api/where/arrivals-and-departures-for-stop/"+combinedStopID+".json?key=TEST")
 
-	data := model.Data.(map[string]interface{})
-	entry := data["entry"].(map[string]interface{})
-	arrivals := entry["arrivalsAndDepartures"].([]interface{})
+	data := model.Data.(map[string]any)
+	entry := data["entry"].(map[string]any)
+	arrivals := entry["arrivalsAndDepartures"].([]any)
 	require.NotEmpty(t, arrivals, "expected at least one arrival")
 
-	a := arrivals[0].(map[string]interface{})
+	a := arrivals[0].(map[string]any)
 	assert.False(t, a["predicted"].(bool),
 		"vehicle position alone should not mark arrival as predicted")
 	assert.Equal(t, float64(0), a["predictedArrivalTime"],
@@ -967,12 +967,12 @@ func TestPluralArrivals_AbsoluteTimeStopEvent(t *testing.T) {
 	_, model := serveApiAndRetrieveEndpoint(t, api,
 		"/api/where/arrivals-and-departures-for-stop/"+combinedStopID+".json?key=TEST")
 
-	data := model.Data.(map[string]interface{})
-	entry := data["entry"].(map[string]interface{})
-	arrivals := entry["arrivalsAndDepartures"].([]interface{})
+	data := model.Data.(map[string]any)
+	entry := data["entry"].(map[string]any)
+	arrivals := entry["arrivalsAndDepartures"].([]any)
 	require.NotEmpty(t, arrivals, "expected at least one arrival")
 
-	a := arrivals[0].(map[string]interface{})
+	a := arrivals[0].(map[string]any)
 	assert.True(t, a["predicted"].(bool), "absolute-time stop match should be predicted")
 	assert.Equal(t, float64(absoluteArrival.Unix()*1000), a["predictedArrivalTime"],
 		"predictedArrivalTime should equal the absolute arrival timestamp")
@@ -1016,16 +1016,16 @@ func TestPluralArrivals_StalePropagatedDelayReset(t *testing.T) {
 	_, model := serveApiAndRetrieveEndpoint(t, api,
 		"/api/where/arrivals-and-departures-for-stop/"+combinedStopID+".json?key=TEST")
 
-	data := model.Data.(map[string]interface{})
-	entry := data["entry"].(map[string]interface{})
-	arrivals := entry["arrivalsAndDepartures"].([]interface{})
+	data := model.Data.(map[string]any)
+	entry := data["entry"].(map[string]any)
+	arrivals := entry["arrivalsAndDepartures"].([]any)
 	require.NotEmpty(t, arrivals, "expected at least one arrival")
 
 	// The queried stop is at seq=3 (0-based stopSequence=2). Prior tests may have inserted
 	// stops at seq=1 and seq=2 into the shared DB, so we locate the right arrival explicitly.
-	var targetArrival map[string]interface{}
+	var targetArrival map[string]any
 	for _, arriv := range arrivals {
-		arr := arriv.(map[string]interface{})
+		arr := arriv.(map[string]any)
 		if int(arr["stopSequence"].(float64)) == 2 { // seq=3 → 0-based index 2
 			targetArrival = arr
 			break
@@ -1189,19 +1189,19 @@ func TestPluralArrivals_TripUpdateWithoutVehicle(t *testing.T) {
 		".json?key=TEST&minutesBefore=60&minutesAfter=60"
 
 	_, model := serveApiAndRetrieveEndpoint(t, api, endpoint)
-	data, ok := model.Data.(map[string]interface{})
+	data, ok := model.Data.(map[string]any)
 	require.True(t, ok)
 
-	entry, ok := data["entry"].(map[string]interface{})
+	entry, ok := data["entry"].(map[string]any)
 	require.True(t, ok)
 
-	arrivalsRaw, ok := entry["arrivalsAndDepartures"].([]interface{})
+	arrivalsRaw, ok := entry["arrivalsAndDepartures"].([]any)
 	require.True(t, ok)
 
 	// Find the arrival for our test trip.
 	var found bool
 	for _, a := range arrivalsRaw {
-		arr := a.(map[string]interface{})
+		arr := a.(map[string]any)
 		_, arrTripID, _ := utils.ExtractAgencyIDAndCodeID(arr["tripId"].(string))
 		if arrTripID == tripID {
 			predicted, _ := arr["predicted"].(bool)
@@ -1317,16 +1317,16 @@ func TestArrivalsAndDeparturesForStop_VehicleWithNilID(t *testing.T) {
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, 200, model.Code)
 
-	data, ok := model.Data.(map[string]interface{})
+	data, ok := model.Data.(map[string]any)
 	require.True(t, ok)
-	entry, ok := data["entry"].(map[string]interface{})
+	entry, ok := data["entry"].(map[string]any)
 	require.True(t, ok)
-	arrivalsRaw, ok := entry["arrivalsAndDepartures"].([]interface{})
+	arrivalsRaw, ok := entry["arrivalsAndDepartures"].([]any)
 	require.True(t, ok)
 
 	var found bool
 	for _, a := range arrivalsRaw {
-		arr := a.(map[string]interface{})
+		arr := a.(map[string]any)
 		_, arrTripID, _ := utils.ExtractAgencyIDAndCodeID(arr["tripId"].(string))
 		if arrTripID == tripID {
 			assert.Equal(t, "", arr["vehicleId"], "vehicleId should be empty for vehicle with nil ID")

--- a/internal/restapi/block_handler_test.go
+++ b/internal/restapi/block_handler_test.go
@@ -20,27 +20,27 @@ func TestBlockHandlerEndToEnd(t *testing.T) {
 	assert.Equal(t, http.StatusOK, model.Code)
 	assert.Equal(t, "OK", model.Text)
 
-	data, ok := model.Data.(map[string]interface{})
+	data, ok := model.Data.(map[string]any)
 	require.True(t, ok)
 
-	entry, ok := data["entry"].(map[string]interface{})
+	entry, ok := data["entry"].(map[string]any)
 	require.True(t, ok)
 
 	if id, exists := entry["id"]; exists {
 		assert.NotEmpty(t, id)
 	}
 
-	configs, ok := entry["configurations"].([]interface{})
+	configs, ok := entry["configurations"].([]any)
 	require.True(t, ok)
 	require.NotEmpty(t, configs)
 
-	config, ok := configs[0].(map[string]interface{})
+	config, ok := configs[0].(map[string]any)
 	require.True(t, ok)
 	assert.Contains(t, config, "activeServiceIds")
 	assert.Contains(t, config, "inactiveServiceIds")
 	assert.Contains(t, config, "trips")
 
-	activeServiceIds, ok := config["activeServiceIds"].([]interface{})
+	activeServiceIds, ok := config["activeServiceIds"].([]any)
 	require.True(t, ok)
 	assert.NotEmpty(t, activeServiceIds)
 
@@ -48,11 +48,11 @@ func TestBlockHandlerEndToEnd(t *testing.T) {
 	require.True(t, ok)
 	assert.Contains(t, serviceId, "_")
 
-	trips, ok := config["trips"].([]interface{})
+	trips, ok := config["trips"].([]any)
 	require.True(t, ok)
 	require.NotEmpty(t, trips)
 
-	trip, ok := trips[0].(map[string]interface{})
+	trip, ok := trips[0].(map[string]any)
 	require.True(t, ok)
 	assert.Contains(t, trip, "tripId")
 	assert.Contains(t, trip, "distanceAlongBlock")
@@ -66,45 +66,45 @@ func TestBlockHandlerEndToEnd(t *testing.T) {
 	_, ok = trip["distanceAlongBlock"].(float64)
 	require.True(t, ok)
 
-	refs, ok := data["references"].(map[string]interface{})
+	refs, ok := data["references"].(map[string]any)
 	require.True(t, ok)
 
-	agencies, ok := refs["agencies"].([]interface{})
+	agencies, ok := refs["agencies"].([]any)
 	require.True(t, ok)
 	assert.NotEmpty(t, agencies)
 
-	agency, ok := agencies[0].(map[string]interface{})
+	agency, ok := agencies[0].(map[string]any)
 	require.True(t, ok)
 	assert.Equal(t, "25", agency["id"])
 	assert.Contains(t, agency, "name")
 	assert.Contains(t, agency, "url")
 	assert.Contains(t, agency, "timezone")
 
-	stops, ok := refs["stops"].([]interface{})
+	stops, ok := refs["stops"].([]any)
 	require.True(t, ok)
 	assert.NotEmpty(t, stops)
 
-	stop, ok := stops[0].(map[string]interface{})
+	stop, ok := stops[0].(map[string]any)
 	require.True(t, ok)
 	assert.Contains(t, stop, "id")
 	assert.Contains(t, stop, "name")
 	assert.Contains(t, stop, "lat")
 	assert.Contains(t, stop, "lon")
 
-	routes, ok := refs["routes"].([]interface{})
+	routes, ok := refs["routes"].([]any)
 	require.True(t, ok)
 	assert.NotEmpty(t, routes)
 
-	route, ok := routes[0].(map[string]interface{})
+	route, ok := routes[0].(map[string]any)
 	require.True(t, ok)
 	assert.Contains(t, route, "id")
 	assert.Contains(t, route, "agencyId")
 
-	tripsRef, ok := refs["trips"].([]interface{})
+	tripsRef, ok := refs["trips"].([]any)
 	require.True(t, ok)
 	assert.NotEmpty(t, tripsRef)
 
-	tripRef, ok := tripsRef[0].(map[string]interface{})
+	tripRef, ok := tripsRef[0].(map[string]any)
 	require.True(t, ok)
 	assert.Contains(t, tripRef, "id")
 	assert.Contains(t, tripRef, "routeId")
@@ -117,27 +117,27 @@ func TestBlockHandlerVerifyBlockStopTimes(t *testing.T) {
 	resp, model := serveApiAndRetrieveEndpoint(t, api, "/api/where/block/25_1.json?key=TEST")
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 
-	data, ok := model.Data.(map[string]interface{})
+	data, ok := model.Data.(map[string]any)
 	require.True(t, ok)
 
-	entry, ok := data["entry"].(map[string]interface{})
+	entry, ok := data["entry"].(map[string]any)
 	require.True(t, ok)
 
-	configs, ok := entry["configurations"].([]interface{})
+	configs, ok := entry["configurations"].([]any)
 	require.True(t, ok)
 	require.NotEmpty(t, configs)
 
-	config, ok := configs[0].(map[string]interface{})
+	config, ok := configs[0].(map[string]any)
 	require.True(t, ok)
 
-	trips, ok := config["trips"].([]interface{})
+	trips, ok := config["trips"].([]any)
 	require.True(t, ok)
 	require.NotEmpty(t, trips)
 
-	trip, ok := trips[0].(map[string]interface{})
+	trip, ok := trips[0].(map[string]any)
 	require.True(t, ok)
 
-	blockStopTimes, ok := trip["blockStopTimes"].([]interface{})
+	blockStopTimes, ok := trip["blockStopTimes"].([]any)
 	require.True(t, ok)
 	require.NotEmpty(t, blockStopTimes)
 
@@ -146,7 +146,7 @@ func TestBlockHandlerVerifyBlockStopTimes(t *testing.T) {
 			continue
 		}
 
-		stopTime, ok := blockStopTimes[rawStopTime].(map[string]interface{})
+		stopTime, ok := blockStopTimes[rawStopTime].(map[string]any)
 		require.True(t, ok)
 		assert.Contains(t, stopTime, "blockSequence")
 		assert.Contains(t, stopTime, "distanceAlongBlock")
@@ -162,7 +162,7 @@ func TestBlockHandlerVerifyBlockStopTimes(t *testing.T) {
 		_, ok = stopTime["accumulatedSlackTime"].(float64)
 		require.True(t, ok, "accumulatedSlackTime should be a number")
 
-		stopTimeDetails, ok := stopTime["stopTime"].(map[string]interface{})
+		stopTimeDetails, ok := stopTime["stopTime"].(map[string]any)
 		require.True(t, ok)
 		assert.Contains(t, stopTimeDetails, "arrivalTime")
 		assert.Contains(t, stopTimeDetails, "departureTime")
@@ -180,9 +180,9 @@ func TestBlockHandlerVerifyBlockStopTimes(t *testing.T) {
 	}
 
 	if len(blockStopTimes) >= 2 {
-		firstStopTime, ok := blockStopTimes[0].(map[string]interface{})
+		firstStopTime, ok := blockStopTimes[0].(map[string]any)
 		require.True(t, ok)
-		lastStopTime, ok := blockStopTimes[len(blockStopTimes)-1].(map[string]interface{})
+		lastStopTime, ok := blockStopTimes[len(blockStopTimes)-1].(map[string]any)
 		require.True(t, ok)
 
 		firstSeq, ok := firstStopTime["blockSequence"].(float64)
@@ -251,13 +251,13 @@ func TestBlockHandlerResponseValidation(t *testing.T) {
 	assert.Greater(t, model.CurrentTime, int64(0), "currentTime should be set")
 	assert.Equal(t, 2, model.Version, "version should be 2")
 
-	data, ok := model.Data.(map[string]interface{})
+	data, ok := model.Data.(map[string]any)
 	require.True(t, ok)
 
 	require.Contains(t, data, "entry")
 	require.Contains(t, data, "references")
 
-	entry, ok := data["entry"].(map[string]interface{})
+	entry, ok := data["entry"].(map[string]any)
 	require.True(t, ok)
 	require.Contains(t, entry, "id")
 	require.Contains(t, entry, "configurations")
@@ -266,28 +266,28 @@ func TestBlockHandlerResponseValidation(t *testing.T) {
 	require.True(t, ok)
 	assert.NotEmpty(t, blockID)
 
-	configs, ok := entry["configurations"].([]interface{})
+	configs, ok := entry["configurations"].([]any)
 	require.True(t, ok)
 	assert.NotEmpty(t, configs, "Block should have at least one configuration")
 
 	for _, rawConfig := range configs {
-		config, ok := rawConfig.(map[string]interface{})
+		config, ok := rawConfig.(map[string]any)
 		require.True(t, ok)
 
 		require.Contains(t, config, "activeServiceIds")
 		require.Contains(t, config, "inactiveServiceIds")
 		require.Contains(t, config, "trips")
 
-		activeServiceIds, ok := config["activeServiceIds"].([]interface{})
+		activeServiceIds, ok := config["activeServiceIds"].([]any)
 		require.True(t, ok)
 		assert.NotEmpty(t, activeServiceIds, "Configuration should have active service IDs")
 
-		trips, ok := config["trips"].([]interface{})
+		trips, ok := config["trips"].([]any)
 		require.True(t, ok)
 		assert.NotEmpty(t, trips, "Configuration should have trips")
 
 		for _, rawTrip := range trips {
-			trip, ok := rawTrip.(map[string]interface{})
+			trip, ok := rawTrip.(map[string]any)
 			require.True(t, ok)
 
 			require.Contains(t, trip, "tripId")
@@ -295,12 +295,12 @@ func TestBlockHandlerResponseValidation(t *testing.T) {
 			require.Contains(t, trip, "blockStopTimes")
 			require.Contains(t, trip, "accumulatedSlackTime")
 
-			blockStopTimes, ok := trip["blockStopTimes"].([]interface{})
+			blockStopTimes, ok := trip["blockStopTimes"].([]any)
 			require.True(t, ok)
 			assert.NotEmpty(t, blockStopTimes, "Trip should have block stop times")
 
 			for _, rawStopTime := range blockStopTimes {
-				stopTime, ok := rawStopTime.(map[string]interface{})
+				stopTime, ok := rawStopTime.(map[string]any)
 				require.True(t, ok)
 
 				require.Contains(t, stopTime, "blockSequence")
@@ -308,7 +308,7 @@ func TestBlockHandlerResponseValidation(t *testing.T) {
 				require.Contains(t, stopTime, "accumulatedSlackTime")
 				require.Contains(t, stopTime, "stopTime")
 
-				st, ok := stopTime["stopTime"].(map[string]interface{})
+				st, ok := stopTime["stopTime"].(map[string]any)
 				require.True(t, ok)
 				require.Contains(t, st, "arrivalTime")
 				require.Contains(t, st, "departureTime")
@@ -319,7 +319,7 @@ func TestBlockHandlerResponseValidation(t *testing.T) {
 		}
 	}
 
-	refs, ok := data["references"].(map[string]interface{})
+	refs, ok := data["references"].(map[string]any)
 	require.True(t, ok)
 	require.Contains(t, refs, "agencies")
 	require.Contains(t, refs, "routes")
@@ -361,17 +361,17 @@ func TestBlockHandlerAgencyIdExtraction(t *testing.T) {
 	resp, model := serveApiAndRetrieveEndpoint(t, api, "/api/where/block/25_1.json?key=TEST")
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 
-	data, ok := model.Data.(map[string]interface{})
+	data, ok := model.Data.(map[string]any)
 	require.True(t, ok)
 
-	refs, ok := data["references"].(map[string]interface{})
+	refs, ok := data["references"].(map[string]any)
 	require.True(t, ok)
 
-	agencies, ok := refs["agencies"].([]interface{})
+	agencies, ok := refs["agencies"].([]any)
 	require.True(t, ok)
 	require.NotEmpty(t, agencies)
 
-	agency, ok := agencies[0].(map[string]interface{})
+	agency, ok := agencies[0].(map[string]any)
 	require.True(t, ok)
 	assert.Equal(t, "25", agency["id"])
 
@@ -386,10 +386,10 @@ func TestBlockHandlerReferencesConsistency(t *testing.T) {
 	resp, model := serveApiAndRetrieveEndpoint(t, api, "/api/where/block/25_1.json?key=TEST")
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 
-	data, ok := model.Data.(map[string]interface{})
+	data, ok := model.Data.(map[string]any)
 	require.True(t, ok)
 
-	refs, ok := data["references"].(map[string]interface{})
+	refs, ok := data["references"].(map[string]any)
 	require.True(t, ok)
 
 	assert.Contains(t, refs, "agencies")
@@ -399,42 +399,42 @@ func TestBlockHandlerReferencesConsistency(t *testing.T) {
 	assert.Contains(t, refs, "stopTimes")
 	assert.Contains(t, refs, "situations")
 
-	entry, ok := data["entry"].(map[string]interface{})
+	entry, ok := data["entry"].(map[string]any)
 	require.True(t, ok)
 
-	configs, ok := entry["configurations"].([]interface{})
+	configs, ok := entry["configurations"].([]any)
 	require.True(t, ok)
 
 	if len(configs) > 0 {
-		config, ok := configs[0].(map[string]interface{})
+		config, ok := configs[0].(map[string]any)
 		require.True(t, ok)
 
-		trips, ok := config["trips"].([]interface{})
+		trips, ok := config["trips"].([]any)
 		require.True(t, ok)
 
 		if len(trips) > 0 {
-			trip, ok := trips[0].(map[string]interface{})
+			trip, ok := trips[0].(map[string]any)
 			require.True(t, ok)
 
-			blockStopTimes, ok := trip["blockStopTimes"].([]interface{})
+			blockStopTimes, ok := trip["blockStopTimes"].([]any)
 			require.True(t, ok)
 
 			if len(blockStopTimes) > 0 {
-				stopTime, ok := blockStopTimes[0].(map[string]interface{})
+				stopTime, ok := blockStopTimes[0].(map[string]any)
 				require.True(t, ok)
 
-				stopTimeDetails, ok := stopTime["stopTime"].(map[string]interface{})
+				stopTimeDetails, ok := stopTime["stopTime"].(map[string]any)
 				require.True(t, ok)
 
 				stopId, ok := stopTimeDetails["stopId"].(string)
 				require.True(t, ok)
 
-				stops, ok := refs["stops"].([]interface{})
+				stops, ok := refs["stops"].([]any)
 				require.True(t, ok)
 
 				found := false
 				for _, rawStop := range stops {
-					stop, ok := rawStop.(map[string]interface{})
+					stop, ok := rawStop.(map[string]any)
 					require.True(t, ok)
 
 					if refStopId, ok := stop["id"].(string); ok && refStopId == stopId {
@@ -495,7 +495,7 @@ func TestBlockHandlerJSONSerialization(t *testing.T) {
 	jsonBytes, err := json.Marshal(model)
 	require.NoError(t, err, "Should be able to marshal response to JSON")
 
-	var unmarshaled map[string]interface{}
+	var unmarshaled map[string]any
 	err = json.Unmarshal(jsonBytes, &unmarshaled)
 	require.NoError(t, err, "Should be able to unmarshal JSON")
 

--- a/internal/restapi/config_handler_test.go
+++ b/internal/restapi/config_handler_test.go
@@ -28,13 +28,13 @@ func TestConfigHandler(t *testing.T) {
 	assert.Equal(t, http.StatusOK, model.Code)
 	assert.Equal(t, "OK", model.Text)
 
-	dataMap, ok := model.Data.(map[string]interface{})
+	dataMap, ok := model.Data.(map[string]any)
 	assert.True(t, ok)
 
-	entry, ok := dataMap["entry"].(map[string]interface{})
+	entry, ok := dataMap["entry"].(map[string]any)
 	assert.True(t, ok)
 
-	gitProps, ok := entry["gitProperties"].(map[string]interface{})
+	gitProps, ok := entry["gitProperties"].(map[string]any)
 	assert.True(t, ok)
 
 	assert.Equal(t, "test-hash-1234567", gitProps["git.commit.id"])

--- a/internal/restapi/current_time_handler_test.go
+++ b/internal/restapi/current_time_handler_test.go
@@ -37,11 +37,11 @@ func TestCurrentTimeHandler(t *testing.T) {
 
 	// Test the data structure
 	// First, we need to cast the interface{} to the expected type
-	responseData, ok := model.Data.(map[string]interface{})
+	responseData, ok := model.Data.(map[string]any)
 	assert.True(t, ok, "could not cast data to expected type")
 
 	// Check that entry exists
-	entry, ok := responseData["entry"].(map[string]interface{})
+	entry, ok := responseData["entry"].(map[string]any)
 	assert.True(t, ok, "could not find entry in response data")
 
 	// Check that time and readableTime exist in entry
@@ -52,13 +52,13 @@ func TestCurrentTimeHandler(t *testing.T) {
 	assert.True(t, ok, "could not find readableTime in entry")
 
 	// Check that references exist and have the expected structure
-	references, ok := responseData["references"].(map[string]interface{})
+	references, ok := responseData["references"].(map[string]any)
 	assert.True(t, ok, "could not find references in response data")
 
 	// Check that all expected arrays exist in references
 	referencesFields := []string{"agencies", "routes", "situations", "stopTimes", "stops", "trips"}
 	for _, field := range referencesFields {
-		array, ok := references[field].([]interface{})
+		array, ok := references[field].([]any)
 		assert.True(t, ok, "could not find %s array in references", field)
 		assert.Equal(t, 0, len(array), "expected empty %s array, got length %d", field, len(array))
 	}
@@ -80,8 +80,8 @@ func TestCurrentTimeHandler_DeterministicTime(t *testing.T) {
 	assert.Equal(t, expectedMs, response.CurrentTime, "Response currentTime should equal mock clock time")
 
 	// Entry time should also match
-	responseData := response.Data.(map[string]interface{})
-	entry := responseData["entry"].(map[string]interface{})
+	responseData := response.Data.(map[string]any)
+	entry := responseData["entry"].(map[string]any)
 	assert.Equal(t, float64(expectedMs), entry["time"], "Entry time should equal mock clock time")
 
 	// Readable time should match

--- a/internal/restapi/errors.go
+++ b/internal/restapi/errors.go
@@ -80,11 +80,11 @@ func (api *RestAPI) validationErrorResponse(w http.ResponseWriter, _ *http.Reque
 	}
 
 	response := struct {
-		Code        int         `json:"code"`
-		CurrentTime int64       `json:"currentTime"`
-		Text        string      `json:"text"`
-		Version     int         `json:"version"`
-		Data        interface{} `json:"data"`
+		Code        int    `json:"code"`
+		CurrentTime int64  `json:"currentTime"`
+		Text        string `json:"text"`
+		Version     int    `json:"version"`
+		Data        any    `json:"data"`
 	}{
 		Code:        http.StatusBadRequest,
 		CurrentTime: models.ResponseCurrentTime(api.Clock),

--- a/internal/restapi/openapi_conformance_test.go
+++ b/internal/restapi/openapi_conformance_test.go
@@ -61,7 +61,7 @@ func getResponseSchema(t *testing.T, doc *openapi3.T, specEndpointPath string) *
 
 // validateJSONAgainstSchema validates a parsed JSON value against an OpenAPI schema.
 // Returns a list of validation errors (empty if conformant).
-func validateJSONAgainstSchema(schema *openapi3.Schema, jsonValue interface{}) []error {
+func validateJSONAgainstSchema(schema *openapi3.Schema, jsonValue any) []error {
 	err := schema.VisitJSON(jsonValue, openapi3.MultiErrors())
 	if err == nil {
 		return nil
@@ -74,7 +74,7 @@ func validateJSONAgainstSchema(schema *openapi3.Schema, jsonValue interface{}) [
 
 // serveAndCaptureRawJSON makes an HTTP request to the test server and returns
 // the status code and parsed JSON body.
-func serveAndCaptureRawJSON(t *testing.T, serverURL string, endpoint string) (int, map[string]interface{}) {
+func serveAndCaptureRawJSON(t *testing.T, serverURL string, endpoint string) (int, map[string]any) {
 	t.Helper()
 
 	client := &http.Client{}
@@ -85,7 +85,7 @@ func serveAndCaptureRawJSON(t *testing.T, serverURL string, endpoint string) (in
 	body, err := io.ReadAll(resp.Body)
 	require.NoError(t, err)
 
-	var parsed map[string]interface{}
+	var parsed map[string]any
 	err = json.Unmarshal(body, &parsed)
 	require.NoError(t, err, "Failed to parse response JSON: %s", string(body))
 

--- a/internal/restapi/problem_reports_for_stop_handler_test.go
+++ b/internal/restapi/problem_reports_for_stop_handler_test.go
@@ -30,10 +30,10 @@ func TestProblemReportsForStop_EmptyList(t *testing.T) {
 	assert.Equal(t, 200, model.Code)
 	assert.Equal(t, "OK", model.Text)
 
-	data, ok := model.Data.(map[string]interface{})
+	data, ok := model.Data.(map[string]any)
 	require.True(t, ok, "Data should be a map")
 
-	list, ok := data["list"].([]interface{})
+	list, ok := data["list"].([]any)
 	require.True(t, ok, "Data should contain a list")
 	assert.Empty(t, list, "List should be empty when no reports exist")
 
@@ -66,15 +66,15 @@ func TestProblemReportsForStop_SubmitThenRetrieve(t *testing.T) {
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, 200, model.Code)
 
-	data, ok := model.Data.(map[string]interface{})
+	data, ok := model.Data.(map[string]any)
 	require.True(t, ok, "Data should be a map")
 
-	list, ok := data["list"].([]interface{})
+	list, ok := data["list"].([]any)
 	require.True(t, ok, "Data should contain a list")
 	require.Len(t, list, 1, "Should have exactly one report")
 
 	// Verify the report contents
-	report, ok := list[0].(map[string]interface{})
+	report, ok := list[0].(map[string]any)
 	require.True(t, ok, "Report should be a map")
 	assert.Equal(t, "75403", report["stopId"])
 	assert.Equal(t, "stop_name_wrong", report["code"])

--- a/internal/restapi/problem_reports_for_trip_handler_test.go
+++ b/internal/restapi/problem_reports_for_trip_handler_test.go
@@ -30,10 +30,10 @@ func TestProblemReportsForTrip_EmptyList(t *testing.T) {
 	assert.Equal(t, 200, model.Code)
 	assert.Equal(t, "OK", model.Text)
 
-	data, ok := model.Data.(map[string]interface{})
+	data, ok := model.Data.(map[string]any)
 	require.True(t, ok, "Data should be a map")
 
-	list, ok := data["list"].([]interface{})
+	list, ok := data["list"].([]any)
 	require.True(t, ok, "Data should contain a list")
 	assert.Empty(t, list, "List should be empty when no reports exist")
 
@@ -66,15 +66,15 @@ func TestProblemReportsForTrip_SubmitThenRetrieve(t *testing.T) {
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, 200, model.Code)
 
-	data, ok := model.Data.(map[string]interface{})
+	data, ok := model.Data.(map[string]any)
 	require.True(t, ok, "Data should be a map")
 
-	list, ok := data["list"].([]interface{})
+	list, ok := data["list"].([]any)
 	require.True(t, ok, "Data should contain a list")
 	require.Len(t, list, 1, "Should have exactly one report")
 
 	// Verify the report contents
-	report, ok := list[0].(map[string]interface{})
+	report, ok := list[0].(map[string]any)
 	require.True(t, ok, "Report should be a map")
 	assert.Equal(t, "12345", report["tripId"])
 	assert.Equal(t, "vehicle_never_came", report["code"])

--- a/internal/restapi/rate_limit_middleware.go
+++ b/internal/restapi/rate_limit_middleware.go
@@ -179,17 +179,17 @@ func (rl *RateLimitMiddleware) sendRateLimitExceeded(w http.ResponseWriter) {
 	w.WriteHeader(http.StatusTooManyRequests)
 
 	// Send JSON error response consistent with OneBusAway API format
-	errorResponse := map[string]interface{}{
+	errorResponse := map[string]any{
 		"code": http.StatusTooManyRequests,
 		"text": "Rate limit exceeded. Please try again later.",
-		"data": map[string]interface{}{
+		"data": map[string]any{
 			"entry": nil,
-			"references": map[string]interface{}{
-				"agencies":  []interface{}{},
-				"routes":    []interface{}{},
-				"stops":     []interface{}{},
-				"trips":     []interface{}{},
-				"stopTimes": []interface{}{},
+			"references": map[string]any{
+				"agencies":  []any{},
+				"routes":    []any{},
+				"stops":     []any{},
+				"trips":     []any{},
+				"stopTimes": []any{},
 			},
 		},
 		"currentTime": rl.clock.Now().UnixMilli(),

--- a/internal/restapi/rate_limit_middleware_test.go
+++ b/internal/restapi/rate_limit_middleware_test.go
@@ -350,7 +350,7 @@ func TestRateLimitMiddleware_RateLimitedResponseFormat(t *testing.T) {
 	assert.Equal(t, "0", w.Header().Get("X-RateLimit-Remaining"), "Should include X-RateLimit-Remaining header")
 
 	// Check response body format
-	var responseBody map[string]interface{}
+	var responseBody map[string]any
 	assert.NoError(t, json.Unmarshal(w.Body.Bytes(), &responseBody))
 
 	assert.Contains(t, responseBody["text"].(string), "Rate limit")

--- a/internal/restapi/reference_utils.go
+++ b/internal/restapi/reference_utils.go
@@ -74,8 +74,8 @@ func (api *RestAPI) BuildSituationReferences(alerts []gtfs.Alert) []models.Situa
 			ActiveWindows:      make([]models.ActiveWindow, 0, len(alert.ActivePeriods)),
 			AllAffects:         make([]models.AffectedEntity, 0, len(alert.InformedEntities)),
 			ConsequenceMessage: "",
-			Consequences:       []interface{}{},
-			PublicationWindows: []interface{}{},
+			Consequences:       []any{},
+			PublicationWindows: []any{},
 			Reason:             mapAlertCauseToReason(alert.Cause),
 			Severity:           mapAlertEffectToSeverity(alert.Effect),
 		}

--- a/internal/restapi/report_problem_with_stop_handler_test.go
+++ b/internal/restapi/report_problem_with_stop_handler_test.go
@@ -30,7 +30,7 @@ func TestReportProblemWithStopEndToEnd(t *testing.T) {
 	assert.Equal(t, 200, model.Code)
 	assert.Equal(t, "OK", model.Text)
 
-	data, ok := model.Data.(map[string]interface{})
+	data, ok := model.Data.(map[string]any)
 	require.True(t, ok, "Data should be a map")
 
 	assert.Empty(t, data, "Data should be an empty object")

--- a/internal/restapi/report_problem_with_trip_handler_test.go
+++ b/internal/restapi/report_problem_with_trip_handler_test.go
@@ -30,7 +30,7 @@ func TestReportProblemWithTripEndToEnd(t *testing.T) {
 	assert.Equal(t, 200, model.Code)
 	assert.Equal(t, "OK", model.Text)
 
-	data, ok := model.Data.(map[string]interface{})
+	data, ok := model.Data.(map[string]any)
 	require.True(t, ok, "Data should be a map")
 
 	assert.Empty(t, data, "Data should be an empty object")

--- a/internal/restapi/route_handler_test.go
+++ b/internal/restapi/route_handler_test.go
@@ -43,11 +43,11 @@ func TestRouteHandlerEndToEnd(t *testing.T) {
 	assert.Equal(t, http.StatusOK, model.Code)
 	assert.Equal(t, "OK", model.Text)
 
-	data, ok := model.Data.(map[string]interface{})
+	data, ok := model.Data.(map[string]any)
 	assert.True(t, ok)
 	assert.NotEmpty(t, data)
 
-	entry, ok := data["entry"].(map[string]interface{})
+	entry, ok := data["entry"].(map[string]any)
 	assert.True(t, ok)
 
 	assert.Equal(t, routeID, entry["id"])
@@ -64,13 +64,13 @@ func TestRouteHandlerEndToEnd(t *testing.T) {
 		assert.Fail(t, "Route type missing or not a number")
 	}
 
-	references, ok := data["references"].(map[string]interface{})
+	references, ok := data["references"].(map[string]any)
 	assert.True(t, ok, "References section should exist")
 	assert.NotEmpty(t, references, "References section should not be nil")
 
-	agenciesRef, ok := references["agencies"].([]interface{})
+	agenciesRef, ok := references["agencies"].([]any)
 	assert.True(t, ok, "Agencies reference should exist and be an array")
-	agencyRef := agenciesRef[0].(map[string]interface{})
+	agencyRef := agenciesRef[0].(map[string]any)
 	assert.Equal(t, agencies[0].ID, agencyRef["id"])
 	assert.NotEmpty(t, agenciesRef, "Agencies reference should not be empty")
 }
@@ -106,17 +106,17 @@ func TestRouteHandlerVerifiesReferences(t *testing.T) {
 	resp, model := serveApiAndRetrieveEndpoint(t, api, "/api/where/route/"+routeID+".json?key=TEST")
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 
-	data, ok := model.Data.(map[string]interface{})
+	data, ok := model.Data.(map[string]any)
 	require.True(t, ok)
 
-	references, ok := data["references"].(map[string]interface{})
+	references, ok := data["references"].(map[string]any)
 	require.True(t, ok)
 
 	// Verify agencies are included
-	agenciesRef, ok := references["agencies"].([]interface{})
+	agenciesRef, ok := references["agencies"].([]any)
 	assert.True(t, ok, "Agencies should be in references")
 	if len(agenciesRef) > 0 {
-		agency, ok := agenciesRef[0].(map[string]interface{})
+		agency, ok := agenciesRef[0].(map[string]any)
 		assert.True(t, ok)
 		assert.NotEmpty(t, agency["id"], "Agency should have an ID")
 		assert.Equal(t, routes[0].AgencyID, agency["id"])
@@ -160,19 +160,19 @@ func TestRouteHandlerWithSituations(t *testing.T) {
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, http.StatusOK, model.Code)
 
-	data, ok := model.Data.(map[string]interface{})
+	data, ok := model.Data.(map[string]any)
 	require.True(t, ok, "Response should have a data object")
 
-	references, ok := data["references"].(map[string]interface{})
+	references, ok := data["references"].(map[string]any)
 	require.True(t, ok, "Data should have a references object")
 
-	situations, ok := references["situations"].([]interface{})
+	situations, ok := references["situations"].([]any)
 	require.True(t, ok, "References should have a situations array")
 
 	require.NotEmpty(t, situations, "Situations array should NOT be empty when alerts exist")
 	require.Len(t, situations, 1, "Should have exactly 1 situation")
 
-	situationMap := situations[0].(map[string]interface{})
+	situationMap := situations[0].(map[string]any)
 	assert.Equal(t, "test-alert-123", situationMap["id"], "The alert ID should match our mocked alert")
 }
 

--- a/internal/restapi/route_ids_for_agency_handler_test.go
+++ b/internal/restapi/route_ids_for_agency_handler_test.go
@@ -28,10 +28,10 @@ func TestRouteIdsForAgencyEndToEnd(t *testing.T) {
 	assert.Equal(t, 200, model.Code)
 	assert.Equal(t, "OK", model.Text)
 
-	data, ok := model.Data.(map[string]interface{})
+	data, ok := model.Data.(map[string]any)
 
 	require.True(t, ok)
-	list, ok := data["list"].([]interface{})
+	list, ok := data["list"].([]any)
 	require.True(t, ok)
 	assert.NotEmpty(t, list)
 
@@ -42,9 +42,9 @@ func TestRouteIdsForAgencyEndToEnd(t *testing.T) {
 			"Route ID should start with agency ID prefix: %s", routeIdStr)
 	}
 
-	refs, ok := data["references"].(map[string]interface{})
+	refs, ok := data["references"].(map[string]any)
 	require.True(t, ok)
-	agencyRefs, ok := refs["agencies"].([]interface{})
+	agencyRefs, ok := refs["agencies"].([]any)
 	require.True(t, ok)
 	assert.Len(t, agencyRefs, 0)
 }

--- a/internal/restapi/route_search_handler_test.go
+++ b/internal/restapi/route_search_handler_test.go
@@ -23,16 +23,16 @@ func TestRouteSearchHandlerEndToEnd(t *testing.T) {
 	assert.Equal(t, http.StatusOK, model.Code)
 	assert.Equal(t, "OK", model.Text)
 
-	data, ok := model.Data.(map[string]interface{})
+	data, ok := model.Data.(map[string]any)
 	require.True(t, ok)
 
-	list, ok := data["list"].([]interface{})
+	list, ok := data["list"].([]any)
 	require.True(t, ok)
 	assert.NotEmpty(t, list)
 
 	found := false
 	for _, item := range list {
-		route, ok := item.(map[string]interface{})
+		route, ok := item.(map[string]any)
 		require.True(t, ok)
 		assert.Contains(t, route, "id")
 		assert.Contains(t, route, "agencyId")
@@ -48,10 +48,10 @@ func TestRouteSearchHandlerEndToEnd(t *testing.T) {
 	}
 	assert.True(t, found, "expected Shasta route to be returned")
 
-	refs, ok := data["references"].(map[string]interface{})
+	refs, ok := data["references"].(map[string]any)
 	require.True(t, ok)
 
-	agencies, ok := refs["agencies"].([]interface{})
+	agencies, ok := refs["agencies"].([]any)
 	require.True(t, ok)
 	assert.NotEmpty(t, agencies)
 }
@@ -72,10 +72,10 @@ func TestRouteSearchHandlerNoResults(t *testing.T) {
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, http.StatusOK, model.Code)
 
-	data, ok := model.Data.(map[string]interface{})
+	data, ok := model.Data.(map[string]any)
 	require.True(t, ok)
 
-	list, ok := data["list"].([]interface{})
+	list, ok := data["list"].([]any)
 	require.True(t, ok)
 	assert.Empty(t, list)
 }

--- a/internal/restapi/routes_for_agency_handler_test.go
+++ b/internal/restapi/routes_for_agency_handler_test.go
@@ -36,17 +36,17 @@ func TestRoutesForAgencyHandlerEndToEnd(t *testing.T) {
 	assert.Equal(t, 200, model.Code)
 	assert.Equal(t, "OK", model.Text)
 
-	data, ok := model.Data.(map[string]interface{})
+	data, ok := model.Data.(map[string]any)
 	require.True(t, ok)
 
 	// Check that we have a list of routes
-	_, ok = data["list"].([]interface{})
+	_, ok = data["list"].([]any)
 	require.True(t, ok)
 
-	refs, ok := data["references"].(map[string]interface{})
+	refs, ok := data["references"].(map[string]any)
 	require.True(t, ok)
 
-	refAgencies, ok := refs["agencies"].([]interface{})
+	refAgencies, ok := refs["agencies"].([]any)
 	require.True(t, ok)
 	assert.Len(t, refAgencies, 1)
 }
@@ -88,15 +88,15 @@ func TestRoutesForAgencyHandlerReturnsCompoundRouteIDs(t *testing.T) {
 
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 
-	data, ok := model.Data.(map[string]interface{})
+	data, ok := model.Data.(map[string]any)
 	require.True(t, ok)
 
-	routes, ok := data["list"].([]interface{})
+	routes, ok := data["list"].([]any)
 	require.True(t, ok)
 	require.NotEmpty(t, routes)
 
 	for _, r := range routes {
-		route, ok := r.(map[string]interface{})
+		route, ok := r.(map[string]any)
 		require.True(t, ok)
 
 		id, ok := route["id"].(string)
@@ -119,9 +119,9 @@ func TestRoutesForAgencyHandlerPagination(t *testing.T) {
 	resp, model := serveApiAndRetrieveEndpoint(t, api, "/api/where/routes-for-agency/"+agencyId+".json?key=TEST&limit=5")
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 
-	data, ok := model.Data.(map[string]interface{})
+	data, ok := model.Data.(map[string]any)
 	require.True(t, ok)
-	list, ok := data["list"].([]interface{})
+	list, ok := data["list"].([]any)
 	require.True(t, ok)
 	assert.Len(t, list, 5)
 	assert.True(t, data["limitExceeded"].(bool), "limitExceeded should be true when more items exist")
@@ -130,24 +130,24 @@ func TestRoutesForAgencyHandlerPagination(t *testing.T) {
 	resp2, model2 := serveApiAndRetrieveEndpoint(t, api, "/api/where/routes-for-agency/"+agencyId+".json?key=TEST&offset=5&limit=5")
 	assert.Equal(t, http.StatusOK, resp2.StatusCode)
 
-	data2, ok := model2.Data.(map[string]interface{})
+	data2, ok := model2.Data.(map[string]any)
 	require.True(t, ok)
-	list2, ok := data2["list"].([]interface{})
+	list2, ok := data2["list"].([]any)
 	require.True(t, ok)
 	assert.Len(t, list2, 5)
 
 	// Verify items are different
-	firstItem1 := list[0].(map[string]interface{})
-	firstItem2 := list2[0].(map[string]interface{})
+	firstItem1 := list[0].(map[string]any)
+	firstItem2 := list2[0].(map[string]any)
 	assert.NotEqual(t, firstItem1["id"], firstItem2["id"])
 
 	// Case 3: Limit 100 (Should return all 13 items, limitExceeded=false)
 	resp3, model3 := serveApiAndRetrieveEndpoint(t, api, "/api/where/routes-for-agency/"+agencyId+".json?key=TEST&limit=100")
 	assert.Equal(t, http.StatusOK, resp3.StatusCode)
 
-	data3, ok := model3.Data.(map[string]interface{})
+	data3, ok := model3.Data.(map[string]any)
 	require.True(t, ok)
-	list3, ok := data3["list"].([]interface{})
+	list3, ok := data3["list"].([]any)
 	require.True(t, ok)
 	// RABA has 13 routes
 	assert.Len(t, list3, 13)

--- a/internal/restapi/schedule_for_route_handler_test.go
+++ b/internal/restapi/schedule_for_route_handler_test.go
@@ -33,10 +33,10 @@ func TestScheduleForRouteHandler(t *testing.T) {
 		assert.Equal(t, http.StatusOK, model.Code)
 		assert.Equal(t, "OK", model.Text)
 
-		data, ok := model.Data.(map[string]interface{})
+		data, ok := model.Data.(map[string]any)
 		require.True(t, ok)
 
-		entry, ok := data["entry"].(map[string]interface{})
+		entry, ok := data["entry"].(map[string]any)
 		require.True(t, ok)
 
 		// ScheduleForRouteEntry has only: routeId, scheduleDate, serviceIds, stopTripGroupings (no top-level stops/trips)
@@ -46,49 +46,49 @@ func TestScheduleForRouteHandler(t *testing.T) {
 		assert.Greater(t, scheduleDate, float64(0))
 
 		// serviceIds should exist
-		svcIds, ok := entry["serviceIds"].([]interface{})
+		svcIds, ok := entry["serviceIds"].([]any)
 		require.True(t, ok)
 		require.NotEmpty(t, svcIds)
 
 		// stopTripGroupings should exist and have expected structure
-		groupings, ok := entry["stopTripGroupings"].([]interface{})
+		groupings, ok := entry["stopTripGroupings"].([]any)
 		require.True(t, ok)
 		require.NotEmpty(t, groupings)
 
-		firstGrouping, ok := groupings[0].(map[string]interface{})
+		firstGrouping, ok := groupings[0].(map[string]any)
 		require.True(t, ok)
 
 		// Check fields inside grouping
 		directionId, hasDir := firstGrouping["directionId"].(string)
 		assert.True(t, hasDir, "directionId should be a string")
 		assert.NotEmpty(t, directionId)
-		ths, hasTH := firstGrouping["tripHeadsigns"].([]interface{})
+		ths, hasTH := firstGrouping["tripHeadsigns"].([]any)
 		assert.True(t, hasTH)
 		assert.NotNil(t, ths)
 
-		stopIds, hasStops := firstGrouping["stopIds"].([]interface{})
+		stopIds, hasStops := firstGrouping["stopIds"].([]any)
 		assert.True(t, hasStops)
 		assert.NotEmpty(t, stopIds)
 
-		tripIds, hasTrips := firstGrouping["tripIds"].([]interface{})
+		tripIds, hasTrips := firstGrouping["tripIds"].([]any)
 		assert.True(t, hasTrips)
 		assert.NotEmpty(t, tripIds)
 
-		tripsWithStopTimes, hasT := firstGrouping["tripsWithStopTimes"].([]interface{})
+		tripsWithStopTimes, hasT := firstGrouping["tripsWithStopTimes"].([]any)
 		assert.True(t, hasT)
 		require.NotEmpty(t, tripsWithStopTimes)
 
-		firstTripWithStops := tripsWithStopTimes[0].(map[string]interface{})
+		firstTripWithStops := tripsWithStopTimes[0].(map[string]any)
 		tid, ok := firstTripWithStops["tripId"].(string)
 		require.True(t, ok)
 		require.Contains(t, tid, "_", "TripID should be combined with agency prefix")
 
-		stopTimesArr, ok := firstTripWithStops["stopTimes"].([]interface{})
+		stopTimesArr, ok := firstTripWithStops["stopTimes"].([]any)
 		require.True(t, ok)
 		require.NotEmpty(t, stopTimesArr)
 
 		// Check a stop time inside entry trip stopTimes (arrival/departure should be numbers in seconds)
-		st0 := stopTimesArr[0].(map[string]interface{})
+		st0 := stopTimesArr[0].(map[string]any)
 		arr, ok := st0["arrivalTime"].(float64)
 		require.True(t, ok)
 		dep, ok := st0["departureTime"].(float64)
@@ -96,15 +96,15 @@ func TestScheduleForRouteHandler(t *testing.T) {
 		require.GreaterOrEqual(t, dep, arr)
 
 		// References should include flattened stopTimes
-		refs, ok := data["references"].(map[string]interface{})
+		refs, ok := data["references"].(map[string]any)
 		require.True(t, ok)
 
-		stopTimesRef, ok := refs["stopTimes"].([]interface{})
+		stopTimesRef, ok := refs["stopTimes"].([]any)
 		require.True(t, ok)
 		require.NotEmpty(t, stopTimesRef)
 
 		// Validate a reference stopTime contains stopId combined IDs
-		firstRefST := stopTimesRef[0].(map[string]interface{})
+		firstRefST := stopTimesRef[0].(map[string]any)
 
 		refTid, ok := firstRefST["tripId"].(string)
 		require.True(t, ok, "tripId should be present and be a string")
@@ -147,9 +147,9 @@ func TestScheduleForRouteHandlerDateParam(t *testing.T) {
 		assert.Equal(t, http.StatusOK, model.Code)
 		assert.Equal(t, "OK", model.Text)
 
-		data, ok := model.Data.(map[string]interface{})
+		data, ok := model.Data.(map[string]any)
 		require.True(t, ok)
-		entry, ok := data["entry"].(map[string]interface{})
+		entry, ok := data["entry"].(map[string]any)
 		require.True(t, ok)
 		scheduleDate, ok := entry["scheduleDate"].(float64)
 		require.True(t, ok, "scheduleDate should be a numeric Unix millisecond timestamp")

--- a/internal/restapi/schedule_for_stop_handler_test.go
+++ b/internal/restapi/schedule_for_stop_handler_test.go
@@ -60,11 +60,11 @@ func TestScheduleForStopHandler(t *testing.T) {
 
 			if tt.expectValidResponse {
 				assert.Equal(t, "OK", model.Text)
-				data, ok := model.Data.(map[string]interface{})
+				data, ok := model.Data.(map[string]any)
 				assert.True(t, ok)
 				assert.NotNil(t, data["entry"])
 
-				entry, ok := data["entry"].(map[string]interface{})
+				entry, ok := data["entry"].(map[string]any)
 				assert.True(t, ok)
 				assert.Equal(t, tt.stopID, entry["stopId"])
 				assert.NotNil(t, entry["date"])
@@ -93,9 +93,9 @@ func TestScheduleForStopHandlerDateParam(t *testing.T) {
 		assert.Equal(t, http.StatusOK, model.Code)
 		assert.Equal(t, "OK", model.Text)
 
-		data, ok := model.Data.(map[string]interface{})
+		data, ok := model.Data.(map[string]any)
 		assert.True(t, ok)
-		entry, ok := data["entry"].(map[string]interface{})
+		entry, ok := data["entry"].(map[string]any)
 		assert.True(t, ok)
 		assert.NotNil(t, entry["date"])
 	})
@@ -117,8 +117,8 @@ func TestScheduleForStopHandlerAgencyTimeZone(t *testing.T) {
 	endpoint := "/api/where/schedule-for-stop/" + stopID + ".json?key=TEST"
 	_, model := serveApiAndRetrieveEndpoint(t, api, endpoint)
 
-	data := model.Data.(map[string]interface{})
-	entry, ok := data["entry"].(map[string]interface{})
+	data := model.Data.(map[string]any)
+	entry, ok := data["entry"].(map[string]any)
 	assert.True(t, ok)
 	assert.NotNil(t, entry["date"])
 
@@ -142,7 +142,7 @@ func TestScheduleForStopHandlerWithDateFiltering(t *testing.T) {
 		name           string
 		date           string
 		expectedStatus int
-		validateResult func(t *testing.T, entry map[string]interface{})
+		validateResult func(t *testing.T, entry map[string]any)
 	}{
 		// NOTE: These dates (2025-06-12, etc.) are chosen to match the validity period of the
 		// test GTFS data loaded in createTestApi. If the test data changes, these dates
@@ -151,7 +151,7 @@ func TestScheduleForStopHandlerWithDateFiltering(t *testing.T) {
 			name:           "Thursday date - query executes successfully",
 			date:           "2025-06-12",
 			expectedStatus: http.StatusOK,
-			validateResult: func(t *testing.T, entry map[string]interface{}) {
+			validateResult: func(t *testing.T, entry map[string]any) {
 				assert.Equal(t, stopID, entry["stopId"])
 				assert.NotNil(t, entry["date"])
 				_, exists := entry["stopRouteSchedules"]
@@ -162,7 +162,7 @@ func TestScheduleForStopHandlerWithDateFiltering(t *testing.T) {
 			name:           "Monday date - query executes successfully",
 			date:           "2025-06-09",
 			expectedStatus: http.StatusOK,
-			validateResult: func(t *testing.T, entry map[string]interface{}) {
+			validateResult: func(t *testing.T, entry map[string]any) {
 				assert.Equal(t, stopID, entry["stopId"])
 				_, exists := entry["stopRouteSchedules"]
 				assert.True(t, exists, "stopRouteSchedules field should exist")
@@ -172,7 +172,7 @@ func TestScheduleForStopHandlerWithDateFiltering(t *testing.T) {
 			name:           "Sunday date - query executes successfully",
 			date:           "2025-06-08",
 			expectedStatus: http.StatusOK,
-			validateResult: func(t *testing.T, entry map[string]interface{}) {
+			validateResult: func(t *testing.T, entry map[string]any) {
 				assert.Equal(t, stopID, entry["stopId"])
 				_, exists := entry["stopRouteSchedules"]
 				assert.True(t, exists, "stopRouteSchedules field should exist")
@@ -189,9 +189,9 @@ func TestScheduleForStopHandlerWithDateFiltering(t *testing.T) {
 			assert.Equal(t, tt.expectedStatus, model.Code)
 
 			if tt.expectedStatus == http.StatusOK {
-				data, ok := model.Data.(map[string]interface{})
+				data, ok := model.Data.(map[string]any)
 				assert.True(t, ok)
-				entry, ok := data["entry"].(map[string]interface{})
+				entry, ok := data["entry"].(map[string]any)
 				assert.True(t, ok)
 
 				tt.validateResult(t, entry)
@@ -215,31 +215,31 @@ func TestScheduleForStopHandlerReferences(t *testing.T) {
 
 		assert.Equal(t, http.StatusOK, resp.StatusCode)
 
-		data, ok := model.Data.(map[string]interface{})
+		data, ok := model.Data.(map[string]any)
 		assert.True(t, ok, "Data should be a map")
 
-		_, ok = data["references"].(map[string]interface{})
+		_, ok = data["references"].(map[string]any)
 		assert.True(t, ok, "References should exist")
 
-		entry, ok := data["entry"].(map[string]interface{})
+		entry, ok := data["entry"].(map[string]any)
 		assert.True(t, ok, "Entry should exist")
 
 		assert.Contains(t, entry, "stopId", "Entry should have stopId")
 		assert.Contains(t, entry, "date", "Entry should have date")
 
-		references := data["references"].(map[string]interface{})
+		references := data["references"].(map[string]any)
 
-		agenciesRef, ok := references["agencies"].([]interface{})
+		agenciesRef, ok := references["agencies"].([]any)
 		assert.True(t, ok, "Agencies should exist")
 		assert.True(t, len(agenciesRef) >= 1, "Should Have at least one Agency")
 
-		stopsRef, ok := references["stops"].([]interface{})
+		stopsRef, ok := references["stops"].([]any)
 		assert.True(t, ok, "Stops should exist in references")
 		assert.Len(t, stopsRef, 1, "Should have exactly one stop")
 
-		_, ok = references["trips"].([]interface{})
+		_, ok = references["trips"].([]any)
 		assert.True(t, ok, "Trips should exist in references")
-		_, ok = references["routes"].([]interface{})
+		_, ok = references["routes"].([]any)
 		assert.True(t, ok, "Routes should exist in references")
 	})
 }
@@ -302,10 +302,10 @@ func TestScheduleForStopHandlerScheduleContent(t *testing.T) {
 
 		assert.Equal(t, http.StatusOK, resp.StatusCode)
 
-		data, ok := model.Data.(map[string]interface{})
+		data, ok := model.Data.(map[string]any)
 		assert.True(t, ok)
 
-		entry, ok := data["entry"].(map[string]interface{})
+		entry, ok := data["entry"].(map[string]any)
 		assert.True(t, ok)
 
 		assert.Contains(t, entry, "stopId")
@@ -330,10 +330,10 @@ func TestScheduleForStopHandlerEmptyRoutes(t *testing.T) {
 
 		assert.Equal(t, http.StatusOK, resp.StatusCode)
 
-		data, ok := model.Data.(map[string]interface{})
+		data, ok := model.Data.(map[string]any)
 		assert.True(t, ok)
 
-		entry, ok := data["entry"].(map[string]interface{})
+		entry, ok := data["entry"].(map[string]any)
 		assert.True(t, ok)
 
 		assert.NotNil(t, entry["stopRouteSchedules"])
@@ -356,11 +356,11 @@ func TestScheduleForStopQueryValidation(t *testing.T) {
 
 		require.Equal(http.StatusOK, resp.StatusCode)
 
-		data, ok := model.Data.(map[string]interface{})
+		data, ok := model.Data.(map[string]any)
 		require.True(ok, "Response data should be a map")
 
 		// Validate references structure
-		references, ok := data["references"].(map[string]interface{})
+		references, ok := data["references"].(map[string]any)
 		require.True(ok, "References should exist and be a map")
 
 		// Check that all reference types exist (even if empty)
@@ -371,7 +371,7 @@ func TestScheduleForStopQueryValidation(t *testing.T) {
 		require.True(hasAgencies || hasRoutes || hasTrips, "At least one reference type should exist")
 
 		// Validate entry structure
-		entry, ok := data["entry"].(map[string]interface{})
+		entry, ok := data["entry"].(map[string]any)
 		require.True(ok, "Entry should exist")
 
 		// Verify critical fields
@@ -383,28 +383,28 @@ func TestScheduleForStopQueryValidation(t *testing.T) {
 		require.True(schedulesExists, "stopRouteSchedules should exist")
 
 		// If schedules exist, validate their structure
-		if scheduleList, ok := schedules.([]interface{}); ok && len(scheduleList) > 0 {
-			firstSchedule := scheduleList[0].(map[string]interface{})
+		if scheduleList, ok := schedules.([]any); ok && len(scheduleList) > 0 {
+			firstSchedule := scheduleList[0].(map[string]any)
 
 			// Verify route schedule has required fields
 			require.Contains(firstSchedule, "routeId", "Route schedule should have routeId")
 			require.Contains(firstSchedule, "stopRouteDirectionSchedules", "Route schedule should have stopRouteDirectionSchedules array")
 
 			// Check direction schedules
-			dirSchedules, ok := firstSchedule["stopRouteDirectionSchedules"].([]interface{})
+			dirSchedules, ok := firstSchedule["stopRouteDirectionSchedules"].([]any)
 			require.True(ok, "stopRouteDirectionSchedules should be an array")
 
 			if len(dirSchedules) > 0 {
-				dirSchedule := dirSchedules[0].(map[string]interface{})
+				dirSchedule := dirSchedules[0].(map[string]any)
 				require.Contains(dirSchedule, "tripHeadsign", "Direction schedule should have tripHeadsign")
 				require.Contains(dirSchedule, "scheduleStopTimes", "Direction schedule should have scheduleStopTimes")
 
 				// Validate stop times
-				stopTimes, ok := dirSchedule["scheduleStopTimes"].([]interface{})
+				stopTimes, ok := dirSchedule["scheduleStopTimes"].([]any)
 				require.True(ok, "scheduleStopTimes should be an array")
 
 				if len(stopTimes) > 0 {
-					stopTime := stopTimes[0].(map[string]interface{})
+					stopTime := stopTimes[0].(map[string]any)
 
 					// Verify all required fields from the new query
 					require.Contains(stopTime, "arrivalTime", "StopTime should have arrivalTime")
@@ -450,10 +450,10 @@ func TestScheduleForStopQueryValidation(t *testing.T) {
 				assert.Equal(t, http.StatusOK, resp.StatusCode, "Query should execute for %s", tt.weekday)
 				assert.Equal(t, http.StatusOK, model.Code, "Model code should be OK for %s", tt.weekday)
 
-				data, ok := model.Data.(map[string]interface{})
+				data, ok := model.Data.(map[string]any)
 				assert.True(t, ok, "Data should be a map for %s", tt.weekday)
 
-				entry, ok := data["entry"].(map[string]interface{})
+				entry, ok := data["entry"].(map[string]any)
 				assert.True(t, ok, "Entry should exist for %s", tt.weekday)
 
 				_, exists := entry["stopRouteSchedules"]
@@ -469,10 +469,10 @@ func TestScheduleForStopQueryValidation(t *testing.T) {
 
 		require.Equal(http.StatusOK, resp.StatusCode)
 
-		data, ok := model.Data.(map[string]interface{})
+		data, ok := model.Data.(map[string]any)
 		require.True(ok)
 
-		entry, ok := data["entry"].(map[string]interface{})
+		entry, ok := data["entry"].(map[string]any)
 		require.True(ok)
 
 		// Verify date is a Unix timestamp in milliseconds
@@ -481,12 +481,12 @@ func TestScheduleForStopQueryValidation(t *testing.T) {
 		require.Greater(date, float64(0), "Date should be positive")
 
 		// Check if we have schedules with stop times
-		if schedules, ok := entry["stopRouteSchedules"].([]interface{}); ok && len(schedules) > 0 {
-			firstSchedule := schedules[0].(map[string]interface{})
-			if dirSchedules, ok := firstSchedule["schedules"].([]interface{}); ok && len(dirSchedules) > 0 {
-				dirSchedule := dirSchedules[0].(map[string]interface{})
-				if stopTimes, ok := dirSchedule["stopTimes"].([]interface{}); ok && len(stopTimes) > 0 {
-					stopTime := stopTimes[0].(map[string]interface{})
+		if schedules, ok := entry["stopRouteSchedules"].([]any); ok && len(schedules) > 0 {
+			firstSchedule := schedules[0].(map[string]any)
+			if dirSchedules, ok := firstSchedule["schedules"].([]any); ok && len(dirSchedules) > 0 {
+				dirSchedule := dirSchedules[0].(map[string]any)
+				if stopTimes, ok := dirSchedule["stopTimes"].([]any); ok && len(stopTimes) > 0 {
+					stopTime := stopTimes[0].(map[string]any)
 
 					// Verify arrival and departure times are timestamps
 					arrivalTime, ok := stopTime["arrivalTime"].(float64)

--- a/internal/restapi/search_stops_handler_test.go
+++ b/internal/restapi/search_stops_handler_test.go
@@ -83,17 +83,17 @@ func TestSearchStopsHandlerEndToEnd(t *testing.T) {
 	assert.Equal(t, http.StatusOK, model.Code)
 	assert.Equal(t, "OK", model.Text)
 
-	data, ok := model.Data.(map[string]interface{})
+	data, ok := model.Data.(map[string]any)
 	require.True(t, ok)
 
 	assert.Equal(t, false, data["limitExceeded"])
 	assert.Equal(t, false, data["outOfRange"])
 
-	list, ok := data["list"].([]interface{})
+	list, ok := data["list"].([]any)
 	require.True(t, ok)
 	assert.NotEmpty(t, list)
 
-	firstResult, ok := list[0].(map[string]interface{})
+	firstResult, ok := list[0].(map[string]any)
 	require.True(t, ok)
 
 	assert.NotEmpty(t, firstResult["id"])
@@ -101,10 +101,10 @@ func TestSearchStopsHandlerEndToEnd(t *testing.T) {
 	assert.NotEmpty(t, firstResult["lat"])
 	assert.NotEmpty(t, firstResult["lon"])
 
-	references, ok := data["references"].(map[string]interface{})
+	references, ok := data["references"].(map[string]any)
 	require.True(t, ok)
 
-	agenciesRef, ok := references["agencies"].([]interface{})
+	agenciesRef, ok := references["agencies"].([]any)
 	assert.True(t, ok)
 	assert.NotEmpty(t, agenciesRef)
 }
@@ -120,10 +120,10 @@ func TestSearchStopsHandlerNoResults(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 
-	data, ok := model.Data.(map[string]interface{})
+	data, ok := model.Data.(map[string]any)
 	require.True(t, ok)
 
-	list, ok := data["list"].([]interface{})
+	list, ok := data["list"].([]any)
 	require.True(t, ok)
 	assert.Empty(t, list)
 }
@@ -160,10 +160,10 @@ func TestSearchStopsHandlerMaxCount(t *testing.T) {
 	err = json.Unmarshal(bodyBytes, &model)
 	require.NoError(t, err)
 
-	data, ok := model.Data.(map[string]interface{})
+	data, ok := model.Data.(map[string]any)
 	require.True(t, ok)
 
-	list, ok := data["list"].([]interface{})
+	list, ok := data["list"].([]any)
 	require.True(t, ok)
 
 	assert.LessOrEqual(t, len(list), 1)
@@ -180,10 +180,10 @@ func TestSearchStopsHandlerWhitespaceOnlyInput(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 
-	data, ok := model.Data.(map[string]interface{})
+	data, ok := model.Data.(map[string]any)
 	require.True(t, ok)
 
-	list, ok := data["list"].([]interface{})
+	list, ok := data["list"].([]any)
 	require.True(t, ok)
 
 	assert.Empty(t, list)
@@ -201,10 +201,10 @@ func TestSearchStopsHandlerSpecialCharactersOnly(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 
-	data, ok := model.Data.(map[string]interface{})
+	data, ok := model.Data.(map[string]any)
 	require.True(t, ok)
 
-	list, ok := data["list"].([]interface{})
+	list, ok := data["list"].([]any)
 	require.True(t, ok)
 
 	assert.Empty(t, list)
@@ -240,10 +240,10 @@ func TestSearchStopsHandlerMaxCountBoundaries(t *testing.T) {
 
 			assert.Equal(t, http.StatusOK, resp.StatusCode)
 
-			data, ok := model.Data.(map[string]interface{})
+			data, ok := model.Data.(map[string]any)
 			require.True(t, ok)
 
-			list, ok := data["list"].([]interface{})
+			list, ok := data["list"].([]any)
 			require.True(t, ok)
 
 			assert.NotEmpty(t, list)
@@ -263,10 +263,10 @@ func TestSearchStopsHandlerFTSInjectionAttempt(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 
-	data, ok := model.Data.(map[string]interface{})
+	data, ok := model.Data.(map[string]any)
 	require.True(t, ok)
 
-	list, ok := data["list"].([]interface{})
+	list, ok := data["list"].([]any)
 	require.True(t, ok)
 
 	assert.Less(t, len(list), 50)

--- a/internal/restapi/servicedate_timezone_regression_test.go
+++ b/internal/restapi/servicedate_timezone_regression_test.go
@@ -158,8 +158,8 @@ func TestServiceDateTimezoneRegression_ArrivalDeparture(t *testing.T) {
 	code, model := serveAndGet(t, api, endpoint)
 	require.Equal(t, http.StatusOK, code)
 
-	data := model.Data.(map[string]interface{})
-	entry := data["entry"].(map[string]interface{})
+	data := model.Data.(map[string]any)
+	entry := data["entry"].(map[string]any)
 
 	// scheduledArrivalTime should use local midnight (March 15 NZDT), not UTC (March 14)
 	expectedMidnight := time.Date(2024, 3, 15, 0, 0, 0, 0, loc)
@@ -240,9 +240,9 @@ func TestServiceDateTimezoneRegression_BlockTripSequence(t *testing.T) {
 			code, model := serveAndGet(t, api, endpoint)
 			require.Equal(t, http.StatusOK, code)
 
-			data := model.Data.(map[string]interface{})
-			entry := data["entry"].(map[string]interface{})
-			status := entry["status"].(map[string]interface{})
+			data := model.Data.(map[string]any)
+			entry := data["entry"].(map[string]any)
+			status := entry["status"].(map[string]any)
 
 			blockTripSeq := int(status["blockTripSequence"].(float64))
 			assert.Equal(t, 1, blockTripSeq,

--- a/internal/restapi/shapes_handler_test.go
+++ b/internal/restapi/shapes_handler_test.go
@@ -86,10 +86,10 @@ func TestShapesHandlerReturnsShapeWhenItExists(t *testing.T) {
 	assert.Equal(t, http.StatusOK, model.Code)
 	assert.Equal(t, "OK", model.Text)
 
-	data, ok := model.Data.(map[string]interface{})
+	data, ok := model.Data.(map[string]any)
 	require.True(t, ok, "model.Data should be a map")
 
-	entry, ok := data["entry"].(map[string]interface{})
+	entry, ok := data["entry"].(map[string]any)
 	require.True(t, ok, "entry should be a map")
 
 	// Verify shape entry has expected fields
@@ -154,10 +154,10 @@ func TestShapesHandlerWithLoopingRoute(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 
-	data, ok := model.Data.(map[string]interface{})
+	data, ok := model.Data.(map[string]any)
 	require.True(t, ok, "model.Data should be a map")
 
-	entry, ok := data["entry"].(map[string]interface{})
+	entry, ok := data["entry"].(map[string]any)
 	require.True(t, ok, "entry should be a map")
 
 	encodedPoints, ok := entry["points"].(string)
@@ -198,10 +198,10 @@ func TestShapesHandlerWithOutAndBackRoute(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 
-	data, ok := model.Data.(map[string]interface{})
+	data, ok := model.Data.(map[string]any)
 	require.True(t, ok, "model.Data should be a map")
 
-	entry, ok := data["entry"].(map[string]interface{})
+	entry, ok := data["entry"].(map[string]any)
 	require.True(t, ok, "entry should be a map")
 
 	encodedPoints, ok := entry["points"].(string)
@@ -245,10 +245,10 @@ func TestShapesHandlerWithConsecutiveDuplicatePoints(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 
-	data, ok := model.Data.(map[string]interface{})
+	data, ok := model.Data.(map[string]any)
 	require.True(t, ok, "model.Data should be a map")
 
-	entry, ok := data["entry"].(map[string]interface{})
+	entry, ok := data["entry"].(map[string]any)
 	require.True(t, ok, "entry should be a map")
 
 	encodedPoints, ok := entry["points"].(string)
@@ -312,10 +312,10 @@ func TestShapesHandlerLengthMatchesDecodedPoints(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 
-	data, ok := model.Data.(map[string]interface{})
+	data, ok := model.Data.(map[string]any)
 	require.True(t, ok, "model.Data should be a map")
 
-	entry, ok := data["entry"].(map[string]interface{})
+	entry, ok := data["entry"].(map[string]any)
 	require.True(t, ok, "entry should be a map")
 
 	assert.Equal(t, float64(7), entry["length"])
@@ -346,10 +346,10 @@ func TestShapesHandlerOrdersBySequence(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 
-	data, ok := model.Data.(map[string]interface{})
+	data, ok := model.Data.(map[string]any)
 	require.True(t, ok)
 
-	entry, ok := data["entry"].(map[string]interface{})
+	entry, ok := data["entry"].(map[string]any)
 	require.True(t, ok)
 
 	assert.Equal(t, float64(6), entry["length"])

--- a/internal/restapi/stop-ids-for-agency_handler_test.go
+++ b/internal/restapi/stop-ids-for-agency_handler_test.go
@@ -30,10 +30,10 @@ func TestStopIdsForAgencyEndToEnd(t *testing.T) {
 	assert.Equal(t, 200, model.Code)
 	assert.Equal(t, "OK", model.Text)
 
-	data, ok := model.Data.(map[string]interface{})
+	data, ok := model.Data.(map[string]any)
 	require.True(t, ok)
 
-	list, ok := data["list"].([]interface{})
+	list, ok := data["list"].([]any)
 	require.True(t, ok)
 	assert.NotEmpty(t, list)
 
@@ -44,10 +44,10 @@ func TestStopIdsForAgencyEndToEnd(t *testing.T) {
 			"Stop ID should start with agency ID prefix: %s", stopIdStr)
 	}
 
-	refs, ok := data["references"].(map[string]interface{})
+	refs, ok := data["references"].(map[string]any)
 	require.True(t, ok)
 
-	agencyRefs, ok := refs["agencies"].([]interface{})
+	agencyRefs, ok := refs["agencies"].([]any)
 	require.True(t, ok)
 	assert.Len(t, agencyRefs, 0)
 }

--- a/internal/restapi/stop_handler_test.go
+++ b/internal/restapi/stop_handler_test.go
@@ -49,11 +49,11 @@ func TestStopHandlerEndToEnd(t *testing.T) {
 	assert.Equal(t, http.StatusOK, model.Code)
 	assert.Equal(t, "OK", model.Text)
 
-	data, ok := model.Data.(map[string]interface{})
+	data, ok := model.Data.(map[string]any)
 	assert.True(t, ok)
 	assert.NotEmpty(t, data)
 
-	entry, ok := data["entry"].(map[string]interface{})
+	entry, ok := data["entry"].(map[string]any)
 	assert.True(t, ok)
 	assert.Equal(t, stopID, entry["id"])
 	assert.Equal(t, stops[0].Name.String, entry["name"])
@@ -64,22 +64,22 @@ func TestStopHandlerEndToEnd(t *testing.T) {
 
 	assert.Contains(t, entry, "direction", "direction field should exist")
 
-	routeIds, ok := entry["routeIds"].([]interface{})
+	routeIds, ok := entry["routeIds"].([]any)
 	assert.True(t, ok, "routeIds should exist and be an array")
 	assert.NotEmpty(t, routeIds, "routeIds should not be empty")
 
-	staticRouteIds, ok := entry["staticRouteIds"].([]interface{})
+	staticRouteIds, ok := entry["staticRouteIds"].([]any)
 	assert.True(t, ok, "staticRouteIds should exist and be an array")
 	assert.NotEmpty(t, staticRouteIds, "staticRouteIds should not be empty")
 
 	assert.Equal(t, len(routeIds), len(staticRouteIds), "routeIds and staticRouteIds should have same length")
 
-	references, ok := data["references"].(map[string]interface{})
+	references, ok := data["references"].(map[string]any)
 
 	assert.True(t, ok, "References section should exist")
 	assert.NotNil(t, references, "References should not be nil")
 
-	routes, ok := references["routes"].([]interface{})
+	routes, ok := references["routes"].([]any)
 	assert.True(t, ok, "Routes section should exist in references")
 	assert.Equal(t, len(routeIds), len(routes), "Number of routes in references should match routeIds")
 }
@@ -114,27 +114,27 @@ func TestStopHandlerVerifiesReferences(t *testing.T) {
 	resp, model := serveApiAndRetrieveEndpoint(t, api, "/api/where/stop/"+stopID+".json?key=TEST")
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 
-	data, ok := model.Data.(map[string]interface{})
+	data, ok := model.Data.(map[string]any)
 	require.True(t, ok)
 
-	references, ok := data["references"].(map[string]interface{})
+	references, ok := data["references"].(map[string]any)
 	require.True(t, ok)
 
 	// Verify routes are included
-	routes, ok := references["routes"].([]interface{})
+	routes, ok := references["routes"].([]any)
 	assert.True(t, ok, "Routes should be in references")
 	if len(routes) > 0 {
-		route, ok := routes[0].(map[string]interface{})
+		route, ok := routes[0].(map[string]any)
 		assert.True(t, ok)
 		assert.NotEmpty(t, route["id"], "Route should have an ID")
 		assert.NotEmpty(t, route["shortName"], "Route should have a short name")
 	}
 
 	// Verify agencies are included
-	agenciesRef, ok := references["agencies"].([]interface{})
+	agenciesRef, ok := references["agencies"].([]any)
 	assert.True(t, ok, "Agencies should be in references")
 	if len(agenciesRef) > 0 {
-		agency, ok := agenciesRef[0].(map[string]interface{})
+		agency, ok := agenciesRef[0].(map[string]any)
 		assert.True(t, ok)
 		assert.NotEmpty(t, agency["id"], "Agency should have an ID")
 		assert.NotEmpty(t, agency["name"], "Agency should have a name")
@@ -264,27 +264,27 @@ func TestStopHandlerMultiAgencyScenario(t *testing.T) {
 	// 6. Assertions
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 
-	data, ok := model.Data.(map[string]interface{})
+	data, ok := model.Data.(map[string]any)
 	require.True(t, ok)
-	entry, ok := data["entry"].(map[string]interface{})
+	entry, ok := data["entry"].(map[string]any)
 	require.True(t, ok)
 
 	// Assert Route IDs use their respective correct Agency prefixes (The fix verification)
-	routeIDs, ok := entry["routeIds"].([]interface{})
+	routeIDs, ok := entry["routeIds"].([]any)
 	require.True(t, ok)
 	assert.Contains(t, routeIDs, agencyB+"_"+routeB_ID, "Route B ID should be prefixed with Agency B")
 	assert.Contains(t, routeIDs, agencyA+"_"+routeA_ID, "Route A ID should be prefixed with Agency A")
 
 	// Assert references.agencies contains BOTH Agency A and Agency B
-	references, ok := data["references"].(map[string]interface{})
+	references, ok := data["references"].(map[string]any)
 	require.True(t, ok)
-	agencies, ok := references["agencies"].([]interface{})
+	agencies, ok := references["agencies"].([]any)
 	require.True(t, ok)
 
 	foundA := false
 	foundB := false
 	for _, a := range agencies {
-		agencyMap := a.(map[string]interface{})
+		agencyMap := a.(map[string]any)
 		if agencyMap["id"] == agencyA {
 			foundA = true
 		}
@@ -326,18 +326,18 @@ func TestStopHandlerWithSituations(t *testing.T) {
 	resp, model := serveApiAndRetrieveEndpoint(t, api, "/api/where/stop/"+combinedStopID+".json?key=TEST")
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 
-	data, ok := model.Data.(map[string]interface{})
+	data, ok := model.Data.(map[string]any)
 	require.True(t, ok, "Response should have a data object")
 
-	references, ok := data["references"].(map[string]interface{})
+	references, ok := data["references"].(map[string]any)
 	require.True(t, ok, "Data should have a references object")
 
-	situations, ok := references["situations"].([]interface{})
+	situations, ok := references["situations"].([]any)
 	require.True(t, ok, "References should have a situations array")
 	require.NotEmpty(t, situations, "Situations array should NOT be empty")
 
 	require.Len(t, situations, 1, "Should have exactly 1 deduplicated situation despite matching multiple entities")
 
-	situationMap := situations[0].(map[string]interface{})
+	situationMap := situations[0].(map[string]any)
 	assert.Equal(t, "test-cross-entity-alert-789", situationMap["id"])
 }

--- a/internal/restapi/stops_for_agency_handler_test.go
+++ b/internal/restapi/stops_for_agency_handler_test.go
@@ -36,16 +36,16 @@ func TestStopsForAgencyEndToEnd(t *testing.T) {
 	assert.Equal(t, 200, model.Code)
 	assert.Equal(t, "OK", model.Text)
 
-	data, ok := model.Data.(map[string]interface{})
+	data, ok := model.Data.(map[string]any)
 	require.True(t, ok)
 
 	// Check list of stops
-	list, ok := data["list"].([]interface{})
+	list, ok := data["list"].([]any)
 	require.True(t, ok)
 	assert.NotEmpty(t, list)
 
 	// Verify first stop has expected fields
-	firstStop := list[0].(map[string]interface{})
+	firstStop := list[0].(map[string]any)
 	assert.NotNil(t, firstStop["id"])
 	assert.NotNil(t, firstStop["lat"])
 	assert.NotNil(t, firstStop["lon"])
@@ -62,7 +62,7 @@ func TestStopsForAgencyEndToEnd(t *testing.T) {
 	validDirections := []string{"N", "NE", "E", "SE", "S", "SW", "W", "NW"}
 	stopsWithDirections := 0
 	for _, stop := range list {
-		stopMap := stop.(map[string]interface{})
+		stopMap := stop.(map[string]any)
 		direction := stopMap["direction"].(string)
 		for _, validDir := range validDirections {
 			if direction == validDir {
@@ -80,7 +80,7 @@ func TestStopsForAgencyEndToEnd(t *testing.T) {
 		"Stop ID should start with agency ID prefix: %s", stopID)
 
 	// Verify route IDs have agency prefix
-	routeIDs := firstStop["routeIds"].([]interface{})
+	routeIDs := firstStop["routeIds"].([]any)
 	if len(routeIDs) > 0 {
 		routeID := routeIDs[0].(string)
 		assert.True(t, strings.HasPrefix(routeID, agencyID+"_"),
@@ -88,32 +88,32 @@ func TestStopsForAgencyEndToEnd(t *testing.T) {
 	}
 
 	// Check references
-	refs, ok := data["references"].(map[string]interface{})
+	refs, ok := data["references"].(map[string]any)
 	require.True(t, ok)
 
 	// Verify agency reference
-	agencyRefs, ok := refs["agencies"].([]interface{})
+	agencyRefs, ok := refs["agencies"].([]any)
 	require.True(t, ok)
 	assert.Len(t, agencyRefs, 1)
 
 	// Verify route references exist (may be empty if stops have no routes)
-	_, ok = refs["routes"].([]interface{})
+	_, ok = refs["routes"].([]any)
 	require.True(t, ok)
 
 	// Verify other reference fields exist but are empty
-	situations, ok := refs["situations"].([]interface{})
+	situations, ok := refs["situations"].([]any)
 	require.True(t, ok)
 	assert.Empty(t, situations)
 
-	stopTimes, ok := refs["stopTimes"].([]interface{})
+	stopTimes, ok := refs["stopTimes"].([]any)
 	require.True(t, ok)
 	assert.Empty(t, stopTimes)
 
-	stops, ok := refs["stops"].([]interface{})
+	stops, ok := refs["stops"].([]any)
 	require.True(t, ok)
 	assert.Empty(t, stops)
 
-	trips, ok := refs["trips"].([]interface{})
+	trips, ok := refs["trips"].([]any)
 	require.True(t, ok)
 	assert.Empty(t, trips)
 

--- a/internal/restapi/stops_for_location_handler_test.go
+++ b/internal/restapi/stops_for_location_handler_test.go
@@ -222,13 +222,13 @@ func TestStopsForLocationHandlerRouteTypeTooManyTokens(t *testing.T) {
 
 	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 
-	data, ok := model.Data.(map[string]interface{})
+	data, ok := model.Data.(map[string]any)
 	require.True(t, ok, "response data should be a map")
 
-	fieldErrors, ok := data["fieldErrors"].(map[string]interface{})
+	fieldErrors, ok := data["fieldErrors"].(map[string]any)
 	require.True(t, ok, "data should contain fieldErrors map")
 
-	routeTypeErrors, ok := fieldErrors["routeType"].([]interface{})
+	routeTypeErrors, ok := fieldErrors["routeType"].([]any)
 	require.True(t, ok, "fieldErrors should contain routeType errors list")
 
 	assert.Len(t, routeTypeErrors, 1, "Should return single error for too many tokens")
@@ -259,13 +259,13 @@ func TestStopsForLocationHandlerRouteTypeMixedValidInvalid(t *testing.T) {
 
 	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 
-	data, ok := model.Data.(map[string]interface{})
+	data, ok := model.Data.(map[string]any)
 	require.True(t, ok, "response data should be a map")
 
-	fieldErrors, ok := data["fieldErrors"].(map[string]interface{})
+	fieldErrors, ok := data["fieldErrors"].(map[string]any)
 	require.True(t, ok, "data should contain fieldErrors map")
 
-	routeTypeErrors, ok := fieldErrors["routeType"].([]interface{})
+	routeTypeErrors, ok := fieldErrors["routeType"].([]any)
 	require.True(t, ok, "fieldErrors should contain routeType errors list")
 
 	assert.Len(t, routeTypeErrors, 1, "Should return a single error for invalid routeType")

--- a/internal/restapi/stops_for_route_handler_test.go
+++ b/internal/restapi/stops_for_route_handler_test.go
@@ -27,96 +27,96 @@ func TestStopsForRouteHandlerEndToEnd(t *testing.T) {
 	assert.Equal(t, 2, model.Version)
 	assert.Greater(t, model.CurrentTime, int64(0))
 
-	data, ok := model.Data.(map[string]interface{})
+	data, ok := model.Data.(map[string]any)
 	require.True(t, ok)
 
-	entry, ok := data["entry"].(map[string]interface{})
+	entry, ok := data["entry"].(map[string]any)
 	require.True(t, ok)
 	assert.Equal(t, "25_151", entry["routeId"])
 
-	polylines, ok := entry["polylines"].([]interface{})
+	polylines, ok := entry["polylines"].([]any)
 	require.True(t, ok)
 	assert.Equal(t, 2, len(polylines))
 
-	firstPolyline, ok := polylines[0].(map[string]interface{})
+	firstPolyline, ok := polylines[0].(map[string]any)
 	require.True(t, ok)
 	assert.Equal(t, 250, int(firstPolyline["length"].(float64)))
 	assert.Equal(t, "", firstPolyline["levels"])
 	assert.Contains(t, firstPolyline["points"], "exhwFlt|")
 
-	secondPolyline, ok := polylines[1].(map[string]interface{})
+	secondPolyline, ok := polylines[1].(map[string]any)
 	require.True(t, ok)
 	assert.Equal(t, 250, int(secondPolyline["length"].(float64)))
 	assert.Equal(t, "", secondPolyline["levels"])
 	assert.Contains(t, secondPolyline["points"], "exhwFlt|")
 
-	stopIds, ok := entry["stopIds"].([]interface{})
+	stopIds, ok := entry["stopIds"].([]any)
 	require.True(t, ok)
 	assert.Equal(t, 39, len(stopIds))
 	// Verify stopGroupings
-	stopGroupings, ok := entry["stopGroupings"].([]interface{})
+	stopGroupings, ok := entry["stopGroupings"].([]any)
 	require.True(t, ok)
 	assert.Equal(t, 1, len(stopGroupings))
 
-	grouping, ok := stopGroupings[0].(map[string]interface{})
+	grouping, ok := stopGroupings[0].(map[string]any)
 	require.True(t, ok)
 	assert.Equal(t, true, grouping["ordered"])
 	assert.Equal(t, "direction", grouping["type"])
 
-	stopGroups, ok := grouping["stopGroups"].([]interface{})
+	stopGroups, ok := grouping["stopGroups"].([]any)
 	require.True(t, ok)
 	assert.Equal(t, 2, len(stopGroups))
 
 	// Verify inbound group (direction 1 in normalized 0-based index)
-	inboundGroup, ok := stopGroups[1].(map[string]interface{})
+	inboundGroup, ok := stopGroups[1].(map[string]any)
 	require.True(t, ok)
 	assert.Equal(t, "1", inboundGroup["id"])
 
-	inboundName, ok := inboundGroup["name"].(map[string]interface{})
+	inboundName, ok := inboundGroup["name"].(map[string]any)
 	require.True(t, ok)
 	assert.Equal(t, "Shasta Lake", inboundName["name"])
 	assert.Equal(t, "destination", inboundName["type"])
 
-	inboundNames, ok := inboundName["names"].([]interface{})
+	inboundNames, ok := inboundName["names"].([]any)
 	require.True(t, ok)
 	assert.Equal(t, 1, len(inboundNames))
 	assert.Equal(t, "Shasta Lake", inboundNames[0])
 
-	inboundStopIds, ok := inboundGroup["stopIds"].([]interface{})
+	inboundStopIds, ok := inboundGroup["stopIds"].([]any)
 	require.True(t, ok)
 
 	// With deterministic sorting, checks should be consistent
 	assert.Equal(t, 22, len(inboundStopIds))
 
-	inboundPolylines, ok := inboundGroup["polylines"].([]interface{})
+	inboundPolylines, ok := inboundGroup["polylines"].([]any)
 	require.True(t, ok)
 	assert.Equal(t, 1, len(inboundPolylines))
 
 	// Verify outbound group (direction 0 in normalized 0-based index)
-	outboundGroup, ok := stopGroups[0].(map[string]interface{})
+	outboundGroup, ok := stopGroups[0].(map[string]any)
 	require.True(t, ok)
 	assert.Equal(t, "0", outboundGroup["id"])
 
-	outboundName, ok := outboundGroup["name"].(map[string]interface{})
+	outboundName, ok := outboundGroup["name"].(map[string]any)
 	require.True(t, ok)
 	assert.Equal(t, "Shasta Lake", outboundName["name"])
 	assert.Equal(t, "destination", outboundName["type"])
 
-	outboundStopIds, ok := outboundGroup["stopIds"].([]interface{})
+	outboundStopIds, ok := outboundGroup["stopIds"].([]any)
 	require.True(t, ok)
 	// With deterministic sorting, checks should be consistent
 	assert.Equal(t, 21, len(outboundStopIds))
 
 	// Verify references
-	refs, ok := data["references"].(map[string]interface{})
+	refs, ok := data["references"].(map[string]any)
 	require.True(t, ok)
 
 	// Verify agencies
-	agencies, ok := refs["agencies"].([]interface{})
+	agencies, ok := refs["agencies"].([]any)
 	require.True(t, ok)
 	assert.Equal(t, 1, len(agencies))
 
-	agency, ok := agencies[0].(map[string]interface{})
+	agency, ok := agencies[0].(map[string]any)
 	require.True(t, ok)
 	assert.Equal(t, "25", agency["id"])
 	assert.Equal(t, "Redding Area Bus Authority", agency["name"])
@@ -126,26 +126,26 @@ func TestStopsForRouteHandlerEndToEnd(t *testing.T) {
 	assert.Equal(t, "530-241-2877", agency["phone"])
 	assert.Equal(t, false, agency["privateService"])
 
-	routes, ok := refs["routes"].([]interface{})
+	routes, ok := refs["routes"].([]any)
 	require.True(t, ok)
 	assert.Equal(t, 13, len(routes))
 
 	// Verify stops
-	stops, ok := refs["stops"].([]interface{})
+	stops, ok := refs["stops"].([]any)
 	require.True(t, ok)
 	assert.Equal(t, 39, len(stops))
 	require.True(t, ok)
 
 	// Verify empty arrays
-	situations, ok := refs["situations"].([]interface{})
+	situations, ok := refs["situations"].([]any)
 	require.True(t, ok)
 	assert.Equal(t, 0, len(situations))
 
-	stopTimes, ok := refs["stopTimes"].([]interface{})
+	stopTimes, ok := refs["stopTimes"].([]any)
 	require.True(t, ok)
 	assert.Equal(t, 0, len(stopTimes))
 
-	trips, ok := refs["trips"].([]interface{})
+	trips, ok := refs["trips"].([]any)
 	require.True(t, ok)
 	assert.Equal(t, 0, len(trips))
 }
@@ -156,26 +156,26 @@ func TestStopsForRouteHandlerEndToEnd(t *testing.T) {
 func TestStopsForRouteNoDuplicateStopGroups(t *testing.T) {
 	_, _, model := serveAndRetrieveEndpoint(t, "/api/where/stops-for-route/25_151.json?key=TEST")
 
-	data, ok := model.Data.(map[string]interface{})
+	data, ok := model.Data.(map[string]any)
 	require.True(t, ok)
-	entry, ok := data["entry"].(map[string]interface{})
+	entry, ok := data["entry"].(map[string]any)
 	require.True(t, ok)
 
-	stopGroupings, ok := entry["stopGroupings"].([]interface{})
+	stopGroupings, ok := entry["stopGroupings"].([]any)
 	require.True(t, ok)
 	require.Equal(t, 1, len(stopGroupings), "expected exactly one stopGrouping")
 
-	grouping, ok := stopGroupings[0].(map[string]interface{})
+	grouping, ok := stopGroupings[0].(map[string]any)
 	require.True(t, ok)
 
-	stopGroups, ok := grouping["stopGroups"].([]interface{})
+	stopGroups, ok := grouping["stopGroups"].([]any)
 	require.True(t, ok)
 	require.Equal(t, 2, len(stopGroups), "expected exactly 2 stop groups (one per direction)")
 
 	// Verify IDs are unique and normalized to "0" and "1"
 	ids := make(map[string]bool)
 	for _, g := range stopGroups {
-		group, ok := g.(map[string]interface{})
+		group, ok := g.(map[string]any)
 		require.True(t, ok)
 		id, ok := group["id"].(string)
 		require.True(t, ok)
@@ -311,31 +311,31 @@ func TestStopsForRouteNullDirectionID(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 
-	data, ok := model.Data.(map[string]interface{})
+	data, ok := model.Data.(map[string]any)
 	require.True(t, ok)
 
-	entry, ok := data["entry"].(map[string]interface{})
+	entry, ok := data["entry"].(map[string]any)
 	require.True(t, ok)
 
-	stopIds, ok := entry["stopIds"].([]interface{})
+	stopIds, ok := entry["stopIds"].([]any)
 	require.True(t, ok)
 	assert.NotEmpty(t, stopIds, "stops-for-route must return stops even when direction_id is NULL")
 
-	stopGroupings, ok := entry["stopGroupings"].([]interface{})
+	stopGroupings, ok := entry["stopGroupings"].([]any)
 	require.True(t, ok)
 	require.Len(t, stopGroupings, 1)
 
-	grouping, ok := stopGroupings[0].(map[string]interface{})
+	grouping, ok := stopGroupings[0].(map[string]any)
 	require.True(t, ok)
 
-	stopGroups, ok := grouping["stopGroups"].([]interface{})
+	stopGroups, ok := grouping["stopGroups"].([]any)
 	require.True(t, ok)
 	require.Len(t, stopGroups, 1, "expected one stop group for the single NULL direction_id")
 
-	group, ok := stopGroups[0].(map[string]interface{})
+	group, ok := stopGroups[0].(map[string]any)
 	require.True(t, ok)
 
-	groupStopIds, ok := group["stopIds"].([]interface{})
+	groupStopIds, ok := group["stopIds"].([]any)
 	require.True(t, ok)
 	assert.Len(t, groupStopIds, 2, "expected both stops to appear in the stop group")
 }

--- a/internal/restapi/test_helper.go
+++ b/internal/restapi/test_helper.go
@@ -9,9 +9,9 @@ type testingFatalf interface {
 // collectAllNestedIdsFromObjects extracts string IDs from a nested array field
 // across all objects in the list. For example, extracting all routeIds from
 // a list of stop objects where each stop has a routeIds array.
-func collectAllNestedIdsFromObjects(t testingFatalf, list []interface{}, key string) (ids []string) {
+func collectAllNestedIdsFromObjects(t testingFatalf, list []any, key string) (ids []string) {
 	for i, item := range list {
-		object, ok := item.(map[string]interface{})
+		object, ok := item.(map[string]any)
 		if !ok {
 			t.Fatalf("item %d is not a map[string]interface{}", i)
 		}
@@ -19,7 +19,7 @@ func collectAllNestedIdsFromObjects(t testingFatalf, list []interface{}, key str
 		if !ok {
 			t.Fatalf("item %d missing key %q", i, key)
 		}
-		objectList, ok := value.([]interface{})
+		objectList, ok := value.([]any)
 		if !ok {
 			t.Fatalf("item %d key %q is not a []interface{}: %T", i, key, value)
 		}
@@ -36,9 +36,9 @@ func collectAllNestedIdsFromObjects(t testingFatalf, list []interface{}, key str
 
 // collectAllIdsFromObjects extracts string IDs from all objects in this list.
 // For example, extracting all agency IDs from a list of agency objects.
-func collectAllIdsFromObjects(t testingFatalf, list []interface{}, key string) (ids []string) {
+func collectAllIdsFromObjects(t testingFatalf, list []any, key string) (ids []string) {
 	for i, item := range list {
-		object, ok := item.(map[string]interface{})
+		object, ok := item.(map[string]any)
 		if !ok {
 			t.Fatalf("item %d is not a map[string]interface{}", i)
 		}

--- a/internal/restapi/test_helper_test.go
+++ b/internal/restapi/test_helper_test.go
@@ -21,9 +21,9 @@ func (m *mockTestingFatalf) Fatalf(format string, args ...any) {
 }
 
 func TestCollectAllNestedIdsFromObjects(t *testing.T) {
-	data := []interface{}{
-		map[string]interface{}{"routes": []interface{}{"234", "235"}},
-		map[string]interface{}{"routes": []interface{}{"345"}},
+	data := []any{
+		map[string]any{"routes": []any{"234", "235"}},
+		map[string]any{"routes": []any{"345"}},
 	}
 	expected := []string{"234", "235", "345"}
 	actual := collectAllNestedIdsFromObjects(t, data, "routes")
@@ -34,34 +34,34 @@ func TestCollectAllNestedIdsFromObjects(t *testing.T) {
 func TestCollectAllNestedIdsFromObjectsFailures(t *testing.T) {
 	tests := []struct {
 		name          string
-		data          []interface{}
+		data          []any
 		expectedError string
 	}{
 		{
 			name: "Invalid object type in the array",
-			data: []interface{}{
-				map[int]interface{}{1: "234"},
+			data: []any{
+				map[int]any{1: "234"},
 			},
 			expectedError: "item 0 is not a map[string]interface{}",
 		},
 		{
 			name: "Missing key from the object",
-			data: []interface{}{
-				map[string]interface{}{"id": "234"},
+			data: []any{
+				map[string]any{"id": "234"},
 			},
 			expectedError: "item 0 missing key \"routes\"",
 		},
 		{
 			name: "Invalid nested object",
-			data: []interface{}{
-				map[string]interface{}{"routes": "234"},
+			data: []any{
+				map[string]any{"routes": "234"},
 			},
 			expectedError: "item 0 key \"routes\" is not a []interface{}: string",
 		},
 		{
 			name: "Invalid nested array type",
-			data: []interface{}{
-				map[string]interface{}{"routes": []interface{}{234}},
+			data: []any{
+				map[string]any{"routes": []any{234}},
 			},
 			expectedError: "item 0 key \"routes\" index 0 is not a string: int",
 		},
@@ -86,9 +86,9 @@ func TestCollectAllNestedIdsFromObjectsFailures(t *testing.T) {
 }
 
 func TestCollectAllIdsFromObjects(t *testing.T) {
-	data := []interface{}{
-		map[string]interface{}{"id": "234"},
-		map[string]interface{}{"id": "345"},
+	data := []any{
+		map[string]any{"id": "234"},
+		map[string]any{"id": "345"},
 	}
 	expected := []string{"234", "345"}
 	actual := collectAllIdsFromObjects(t, data, "id")
@@ -99,27 +99,27 @@ func TestCollectAllIdsFromObjects(t *testing.T) {
 func TestCollectAllIdsFromObjectsFailures(t *testing.T) {
 	tests := []struct {
 		name          string
-		data          []interface{}
+		data          []any
 		expectedError string
 	}{
 		{
 			name: "Invalid object type in the array",
-			data: []interface{}{
-				map[int]interface{}{1: "234"},
+			data: []any{
+				map[int]any{1: "234"},
 			},
 			expectedError: "item 0 is not a map[string]interface{}",
 		},
 		{
 			name: "Missing key from the object",
-			data: []interface{}{
-				map[string]interface{}{"name": "234"},
+			data: []any{
+				map[string]any{"name": "234"},
 			},
 			expectedError: "item 0 missing key \"id\"",
 		},
 		{
 			name: "Invalid nested object",
-			data: []interface{}{
-				map[string]interface{}{"id": 234},
+			data: []any{
+				map[string]any{"id": 234},
 			},
 			expectedError: "item 0 key \"id\" is not a string: int",
 		},

--- a/internal/restapi/trip_details_handler_test.go
+++ b/internal/restapi/trip_details_handler_test.go
@@ -33,11 +33,11 @@ func TestTripDetailsHandlerEndToEnd(t *testing.T) {
 	assert.Equal(t, http.StatusOK, model.Code)
 	assert.Equal(t, "OK", model.Text)
 
-	data, ok := model.Data.(map[string]interface{})
+	data, ok := model.Data.(map[string]any)
 	assert.True(t, ok)
 	assert.NotEmpty(t, data)
 
-	entry, ok := data["entry"].(map[string]interface{})
+	entry, ok := data["entry"].(map[string]any)
 	assert.True(t, ok)
 
 	assert.Equal(t, tripID, entry["tripId"])
@@ -57,16 +57,16 @@ func TestTripDetailsHandlerEndToEnd(t *testing.T) {
 	_, exists := entry["situationIds"]
 	assert.True(t, exists)
 
-	schedule, ok := entry["schedule"].(map[string]interface{})
+	schedule, ok := entry["schedule"].(map[string]any)
 	if ok {
 		assert.NotNil(t, schedule)
 
-		stopTimes, stopTimesOk := schedule["stopTimes"].([]interface{})
+		stopTimes, stopTimesOk := schedule["stopTimes"].([]any)
 		if stopTimesOk {
 			assert.GreaterOrEqual(t, len(stopTimes), 0)
 
 			if len(stopTimes) > 0 {
-				stopTime, ok := stopTimes[0].(map[string]interface{})
+				stopTime, ok := stopTimes[0].(map[string]any)
 				assert.True(t, ok)
 				assert.NotNil(t, stopTime["stopId"])
 				assert.NotNil(t, stopTime["arrivalTime"])
@@ -78,50 +78,50 @@ func TestTripDetailsHandlerEndToEnd(t *testing.T) {
 	}
 
 	// Test status section (if includeStatus=true by default)
-	status, statusOk := entry["status"].(map[string]interface{})
+	status, statusOk := entry["status"].(map[string]any)
 	if statusOk {
 		assert.NotNil(t, status)
 		assert.NotNil(t, status["serviceDate"])
-		assert.Contains(t, []interface{}{"scheduled", "in_progress", "completed"}, status["phase"])
+		assert.Contains(t, []any{"scheduled", "in_progress", "completed"}, status["phase"])
 		assert.NotNil(t, status["predicted"])
 	}
 
-	references, ok := data["references"].(map[string]interface{})
+	references, ok := data["references"].(map[string]any)
 	assert.True(t, ok, "References section should exist")
 	assert.NotNil(t, references, "References should not be nil")
 
 	// Test trip references (if includeTrip=true by default)
-	tripsRef, tripsOk := references["trips"].([]interface{})
+	tripsRef, tripsOk := references["trips"].([]any)
 	if tripsOk {
 		assert.NotEmpty(t, tripsRef, "Trips should not be empty")
 
-		tripRef, ok := tripsRef[0].(map[string]interface{})
+		tripRef, ok := tripsRef[0].(map[string]any)
 		assert.True(t, ok)
 		assert.Equal(t, tripID, tripRef["id"])
 		assert.Equal(t, utils.FormCombinedID(agency.ID, trip.RouteID), tripRef["routeId"])
 		assert.Equal(t, utils.FormCombinedID(agency.ID, trip.ServiceID), tripRef["serviceId"])
 	}
 
-	routes, ok := references["routes"].([]interface{})
+	routes, ok := references["routes"].([]any)
 	assert.True(t, ok, "Routes section should exist in references")
 	assert.NotEmpty(t, routes, "Routes should not be empty")
 
 	assert.True(t, ok)
 	assert.NotEmpty(t, routes)
 
-	agencies, ok := references["agencies"].([]interface{})
+	agencies, ok := references["agencies"].([]any)
 	assert.True(t, ok, "Agencies section should exist in references")
 	assert.NotEmpty(t, agencies, "Agencies should not be empty")
 
-	agencyRef, ok := agencies[0].(map[string]interface{})
+	agencyRef, ok := agencies[0].(map[string]any)
 	assert.True(t, ok)
 	assert.Equal(t, agency.ID, agencyRef["id"])
 	assert.Equal(t, agency.Name, agencyRef["name"])
 
 	// Test stop references (should exist if schedule is included)
-	stops, stopsOk := references["stops"].([]interface{})
+	stops, stopsOk := references["stops"].([]any)
 	if stopsOk && len(stops) > 0 {
-		stop, ok := stops[0].(map[string]interface{})
+		stop, ok := stops[0].(map[string]any)
 		assert.True(t, ok)
 		assert.NotNil(t, stop["id"])
 		assert.NotNil(t, stop["name"])
@@ -159,10 +159,10 @@ func TestTripDetailsHandlerWithServiceDate(t *testing.T) {
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, http.StatusOK, model.Code)
 
-	data, ok := model.Data.(map[string]interface{})
+	data, ok := model.Data.(map[string]any)
 	assert.True(t, ok)
 
-	entry, ok := data["entry"].(map[string]interface{})
+	entry, ok := data["entry"].(map[string]any)
 	assert.True(t, ok)
 	// serviceDate in response is midnight in the agency's timezone, not the raw input epoch.
 	agencyLoc, _ := time.LoadLocation("America/Los_Angeles")
@@ -186,16 +186,16 @@ func TestTripDetailsHandlerWithIncludeTrip(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 
-	data, ok := model.Data.(map[string]interface{})
+	data, ok := model.Data.(map[string]any)
 	assert.True(t, ok)
 
-	references, ok := data["references"].(map[string]interface{})
+	references, ok := data["references"].(map[string]any)
 	assert.True(t, ok)
 
 	// When includeTrip=false, trips section should be empty or not exist
 	trips_ref, tripsOk := references["trips"]
 	if tripsOk {
-		tripsArray, ok := trips_ref.([]interface{})
+		tripsArray, ok := trips_ref.([]any)
 		if ok {
 			assert.Empty(t, tripsArray, "Trips should be empty when includeTrip=false")
 		}
@@ -216,10 +216,10 @@ func TestTripDetailsHandlerWithIncludeSchedule(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 
-	data, ok := model.Data.(map[string]interface{})
+	data, ok := model.Data.(map[string]any)
 	assert.True(t, ok)
 
-	entry, ok := data["entry"].(map[string]interface{})
+	entry, ok := data["entry"].(map[string]any)
 	assert.True(t, ok)
 
 	// When includeSchedule=false, schedule should be nil or not exist
@@ -229,12 +229,12 @@ func TestTripDetailsHandlerWithIncludeSchedule(t *testing.T) {
 	}
 
 	// Stops should also not be included in references
-	references, ok := data["references"].(map[string]interface{})
+	references, ok := data["references"].(map[string]any)
 	assert.True(t, ok)
 
 	stops, stopsOk := references["stops"]
 	if stopsOk {
-		stopsArray, ok := stops.([]interface{})
+		stopsArray, ok := stops.([]any)
 		if ok {
 			assert.Empty(t, stopsArray, "Stops should be empty when includeSchedule=false")
 		}
@@ -255,10 +255,10 @@ func TestTripDetailsHandlerWithIncludeStatus(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 
-	data, ok := model.Data.(map[string]interface{})
+	data, ok := model.Data.(map[string]any)
 	assert.True(t, ok)
 
-	entry, ok := data["entry"].(map[string]interface{})
+	entry, ok := data["entry"].(map[string]any)
 	assert.True(t, ok)
 
 	// When includeStatus=false, status should be nil or not exist
@@ -287,10 +287,10 @@ func TestTripDetailsHandlerWithTimeParameter(t *testing.T) {
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, http.StatusOK, model.Code)
 
-	data, ok := model.Data.(map[string]interface{})
+	data, ok := model.Data.(map[string]any)
 	assert.True(t, ok)
 
-	entry, ok := data["entry"].(map[string]interface{})
+	entry, ok := data["entry"].(map[string]any)
 	assert.True(t, ok)
 
 	// The response should be successful (time parameter affects internal calculations)
@@ -311,10 +311,10 @@ func TestTripDetailsHandlerWithAllParametersFalse(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 
-	data, ok := model.Data.(map[string]interface{})
+	data, ok := model.Data.(map[string]any)
 	assert.True(t, ok)
 
-	entry, ok := data["entry"].(map[string]interface{})
+	entry, ok := data["entry"].(map[string]any)
 	assert.True(t, ok)
 
 	// Basic fields should still exist
@@ -332,15 +332,15 @@ func TestTripDetailsHandlerWithAllParametersFalse(t *testing.T) {
 		assert.Nil(t, status)
 	}
 
-	references, ok := data["references"].(map[string]interface{})
+	references, ok := data["references"].(map[string]any)
 	assert.True(t, ok)
 
 	// Should still have route and agency references, but not trips or stops
-	routes, ok := references["routes"].([]interface{})
+	routes, ok := references["routes"].([]any)
 	assert.True(t, ok)
 	assert.Empty(t, routes)
 
-	agencies, ok := references["agencies"].([]interface{})
+	agencies, ok := references["agencies"].([]any)
 	assert.True(t, ok)
 	assert.NotEmpty(t, agencies)
 }

--- a/internal/restapi/trip_for_vehicle_handler_test.go
+++ b/internal/restapi/trip_for_vehicle_handler_test.go
@@ -89,11 +89,11 @@ func TestTripForVehicleHandlerResponseSchemaValidation(t *testing.T) {
 	assert.Equal(t, 2, model.Version, "Response version should be 2")
 	assert.Greater(t, model.CurrentTime, int64(0), "CurrentTime should be set")
 
-	data, ok := model.Data.(map[string]interface{})
+	data, ok := model.Data.(map[string]any)
 	require.True(t, ok, "Data should be a map")
 
 	// Validate entry structure
-	entry, ok := data["entry"].(map[string]interface{})
+	entry, ok := data["entry"].(map[string]any)
 	require.True(t, ok, "Entry should exist")
 
 	// Required fields in entry
@@ -106,7 +106,7 @@ func TestTripForVehicleHandlerResponseSchemaValidation(t *testing.T) {
 	assert.Greater(t, serviceDate, float64(0), "serviceDate should be positive")
 
 	// Validate references structure
-	references, ok := data["references"].(map[string]interface{})
+	references, ok := data["references"].(map[string]any)
 	require.True(t, ok, "References should exist")
 
 	// Check required reference arrays exist
@@ -143,11 +143,11 @@ func TestTripForVehicleHandlerEndToEnd(t *testing.T) {
 	assert.Equal(t, http.StatusOK, model.Code)
 	assert.Equal(t, "OK", model.Text)
 
-	data, ok := model.Data.(map[string]interface{})
+	data, ok := model.Data.(map[string]any)
 	assert.True(t, ok)
 	assert.NotEmpty(t, data)
 
-	entry, ok := data["entry"].(map[string]interface{})
+	entry, ok := data["entry"].(map[string]any)
 	assert.True(t, ok)
 
 	assert.NotNil(t, entry["tripId"])
@@ -164,34 +164,34 @@ func TestTripForVehicleHandlerEndToEnd(t *testing.T) {
 	expectedServiceDateMillis := expectedServiceDate.Unix() * 1000
 	assert.Equal(t, float64(expectedServiceDateMillis), entry["serviceDate"])
 
-	status, statusOk := entry["status"].(map[string]interface{})
+	status, statusOk := entry["status"].(map[string]any)
 	if statusOk {
 		assert.NotNil(t, status)
 		assert.NotNil(t, status["serviceDate"])
-		assert.Contains(t, []interface{}{"scheduled", "in_progress", "completed"}, status["phase"])
+		assert.Contains(t, []any{"scheduled", "in_progress", "completed"}, status["phase"])
 		assert.NotNil(t, status["predicted"])
 	}
 
-	references, ok := data["references"].(map[string]interface{})
+	references, ok := data["references"].(map[string]any)
 	assert.True(t, ok, "References section should exist")
 	assert.NotNil(t, references, "References should not be nil")
 
-	routes, ok := references["routes"].([]interface{})
+	routes, ok := references["routes"].([]any)
 	assert.True(t, ok, "Routes section should exist in references")
 	assert.NotEmpty(t, routes, "Routes should not be empty")
 
-	agencies, ok := references["agencies"].([]interface{})
+	agencies, ok := references["agencies"].([]any)
 	assert.True(t, ok, "Agencies section should exist in references")
 	assert.NotEmpty(t, agencies, "Agencies should not be empty")
 
 	// Ensure trip is included by default
-	trips, ok := references["trips"].([]interface{})
+	trips, ok := references["trips"].([]any)
 	assert.True(t, ok, "Trips section should exist in references by default")
 	assert.NotEmpty(t, trips, "Trips should not be empty by default")
 
-	stops, stopsOk := references["stops"].([]interface{})
+	stops, stopsOk := references["stops"].([]any)
 	if stopsOk && len(stops) > 0 {
-		stop, ok := stops[0].(map[string]interface{})
+		stop, ok := stops[0].(map[string]any)
 		assert.True(t, ok)
 		assert.NotNil(t, stop["id"])
 		assert.NotNil(t, stop["name"])
@@ -323,10 +323,10 @@ func TestTripForVehicleHandlerWithServiceDate(t *testing.T) {
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, http.StatusOK, model.Code)
 
-	data, ok := model.Data.(map[string]interface{})
+	data, ok := model.Data.(map[string]any)
 	assert.True(t, ok)
 
-	entry, ok := data["entry"].(map[string]interface{})
+	entry, ok := data["entry"].(map[string]any)
 	assert.True(t, ok)
 	// serviceDate in response is midnight in the agency's timezone, not the raw input epoch.
 	agencyLoc, _ := time.LoadLocation("America/Los_Angeles")
@@ -357,10 +357,10 @@ func TestTripForVehicleHandlerWithIncludeStatusFalse(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 
-	data, ok := model.Data.(map[string]interface{})
+	data, ok := model.Data.(map[string]any)
 	assert.True(t, ok)
 
-	entry, ok := data["entry"].(map[string]interface{})
+	entry, ok := data["entry"].(map[string]any)
 	assert.True(t, ok)
 
 	status, statusExists := entry["status"]
@@ -390,17 +390,17 @@ func TestTripForVehicleHandlerWithIncludeTripFalse(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 
-	data, ok := model.Data.(map[string]interface{})
+	data, ok := model.Data.(map[string]any)
 	assert.True(t, ok)
 
-	references, ok := data["references"].(map[string]interface{})
+	references, ok := data["references"].(map[string]any)
 	assert.True(t, ok)
 
 	// Check that trips are NOT in references
 	trips, tripsExists := references["trips"]
 	if tripsExists {
 		// If the key exists, it should be nil or empty list
-		tripsList, isList := trips.([]interface{})
+		tripsList, isList := trips.([]any)
 		if isList {
 			assert.Empty(t, tripsList, "Trips should be empty when includeTrip=false")
 		} else {
@@ -430,10 +430,10 @@ func TestTripForVehicleHandlerWithIncludeScheduleTrue(t *testing.T) {
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, http.StatusOK, model.Code)
 
-	data, ok := model.Data.(map[string]interface{})
+	data, ok := model.Data.(map[string]any)
 	assert.True(t, ok)
 
-	entry, ok := data["entry"].(map[string]interface{})
+	entry, ok := data["entry"].(map[string]any)
 	assert.True(t, ok)
 
 	// When includeSchedule=true, schedule may be present (depends on data)
@@ -465,10 +465,10 @@ func TestTripForVehicleHandlerWithTimeParameter(t *testing.T) {
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, http.StatusOK, model.Code)
 
-	data, ok := model.Data.(map[string]interface{})
+	data, ok := model.Data.(map[string]any)
 	assert.True(t, ok)
 
-	entry, ok := data["entry"].(map[string]interface{})
+	entry, ok := data["entry"].(map[string]any)
 	assert.True(t, ok)
 	assert.NotNil(t, entry["tripId"])
 }
@@ -494,10 +494,10 @@ func TestTripForVehicleHandlerWithAllParametersFalse(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 
-	data, ok := model.Data.(map[string]interface{})
+	data, ok := model.Data.(map[string]any)
 	assert.True(t, ok)
 
-	entry, ok := data["entry"].(map[string]interface{})
+	entry, ok := data["entry"].(map[string]any)
 	assert.True(t, ok)
 
 	// Basic fields should still exist
@@ -515,17 +515,17 @@ func TestTripForVehicleHandlerWithAllParametersFalse(t *testing.T) {
 		assert.Nil(t, status)
 	}
 
-	references, ok := data["references"].(map[string]interface{})
+	references, ok := data["references"].(map[string]any)
 	assert.True(t, ok)
 
-	agencies, ok := references["agencies"].([]interface{})
+	agencies, ok := references["agencies"].([]any)
 	assert.True(t, ok)
 	assert.NotEmpty(t, agencies)
 
 	// Ensure trip is missing from references
 	trips, tripsExists := references["trips"]
 	if tripsExists {
-		tripsList, ok := trips.([]interface{})
+		tripsList, ok := trips.([]any)
 		if ok {
 			assert.Empty(t, tripsList)
 		}
@@ -561,10 +561,10 @@ func TestTripForVehicleHandlerWithCombinedParameters(t *testing.T) {
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, http.StatusOK, model.Code)
 
-	data, ok := model.Data.(map[string]interface{})
+	data, ok := model.Data.(map[string]any)
 	assert.True(t, ok)
 
-	entry, ok := data["entry"].(map[string]interface{})
+	entry, ok := data["entry"].(map[string]any)
 	assert.True(t, ok)
 
 	// serviceDate in response is midnight in the agency's timezone, not the raw input epoch.
@@ -592,18 +592,18 @@ func TestTripForVehicleHandlerAgencyReferenceValidation(t *testing.T) {
 	err = json.NewDecoder(resp.Body).Decode(&model)
 	require.NoError(t, err)
 
-	data, ok := model.Data.(map[string]interface{})
+	data, ok := model.Data.(map[string]any)
 	require.True(t, ok)
 
-	references, ok := data["references"].(map[string]interface{})
+	references, ok := data["references"].(map[string]any)
 	require.True(t, ok)
 
-	agencies, ok := references["agencies"].([]interface{})
+	agencies, ok := references["agencies"].([]any)
 	require.True(t, ok)
 	require.NotEmpty(t, agencies, "At least one agency should be referenced")
 
 	// Validate agency structure
-	agency, ok := agencies[0].(map[string]interface{})
+	agency, ok := agencies[0].(map[string]any)
 	require.True(t, ok)
 
 	assert.Contains(t, agency, "id", "Agency should have id")
@@ -629,18 +629,18 @@ func TestTripForVehicleHandlerTripReferenceValidation(t *testing.T) {
 	err = json.NewDecoder(resp.Body).Decode(&model)
 	require.NoError(t, err)
 
-	data, ok := model.Data.(map[string]interface{})
+	data, ok := model.Data.(map[string]any)
 	require.True(t, ok)
 
-	references, ok := data["references"].(map[string]interface{})
+	references, ok := data["references"].(map[string]any)
 	require.True(t, ok)
 
-	trips, ok := references["trips"].([]interface{})
+	trips, ok := references["trips"].([]any)
 	require.True(t, ok)
 	require.NotEmpty(t, trips, "At least one trip should be referenced")
 
 	// Validate trip structure
-	trip, ok := trips[0].(map[string]interface{})
+	trip, ok := trips[0].(map[string]any)
 	require.True(t, ok)
 
 	assert.Contains(t, trip, "id", "Trip should have id")

--- a/internal/restapi/trip_handler_test.go
+++ b/internal/restapi/trip_handler_test.go
@@ -38,12 +38,12 @@ func TestTripHandlerEndToEnd(t *testing.T) {
 	assert.Equal(t, http.StatusOK, model.Code)
 	assert.Equal(t, "OK", model.Text)
 
-	data, ok := model.Data.(map[string]interface{})
+	data, ok := model.Data.(map[string]any)
 
 	assert.True(t, ok)
 	assert.NotEmpty(t, data)
 
-	entry, ok := data["entry"].(map[string]interface{})
+	entry, ok := data["entry"].(map[string]any)
 	assert.True(t, ok)
 	assert.Equal(t, tripID, entry["id"])
 	assert.Equal(t, utils.FormCombinedID(agency.ID, trip.RouteID), entry["routeId"])
@@ -55,25 +55,25 @@ func TestTripHandlerEndToEnd(t *testing.T) {
 	assert.Equal(t, utils.NullStringOrEmpty(trip.TripShortName), entry["tripShortName"])
 	assert.Equal(t, utils.NullStringOrEmpty(route.ShortName), entry["routeShortName"])
 
-	references, ok := data["references"].(map[string]interface{})
+	references, ok := data["references"].(map[string]any)
 	assert.True(t, ok, "References section should exist")
 	assert.NotNil(t, references, "References should not be nil")
 
-	routes, ok := references["routes"].([]interface{})
+	routes, ok := references["routes"].([]any)
 	assert.True(t, ok, "Routes section should exist in references")
 	assert.NotEmpty(t, routes, "Routes should not be empty")
 
-	routeRef, ok := routes[0].(map[string]interface{})
+	routeRef, ok := routes[0].(map[string]any)
 	assert.True(t, ok)
 	assert.Equal(t, utils.FormCombinedID(agency.ID, trip.RouteID), routeRef["id"])
 	assert.Equal(t, agency.ID, routeRef["agencyId"])
 	assert.Equal(t, utils.NullStringOrEmpty(route.ShortName), routeRef["shortName"])
 
-	agencies, ok := references["agencies"].([]interface{})
+	agencies, ok := references["agencies"].([]any)
 	assert.True(t, ok, "Agencies section should exist in references")
 	assert.NotEmpty(t, agencies, "Agencies should not be empty")
 
-	agencyRef, ok := agencies[0].(map[string]interface{})
+	agencyRef, ok := agencies[0].(map[string]any)
 	assert.True(t, ok)
 	assert.Equal(t, agency.ID, agencyRef["id"])
 	assert.Equal(t, agency.Name, agencyRef["name"])

--- a/internal/restapi/trips_for_location_handler_test.go
+++ b/internal/restapi/trips_for_location_handler_test.go
@@ -54,12 +54,12 @@ func TestTripsForLocationHandler_DifferentAreas(t *testing.T) {
 			resp, model := serveApiAndRetrieveEndpoint(t, api, url)
 			assert.Equal(t, http.StatusOK, resp.StatusCode)
 
-			data := model.Data.(map[string]interface{})
-			list, ok := data["list"].([]interface{})
+			data := model.Data.(map[string]any)
+			list, ok := data["list"].([]any)
 			assert.True(t, ok, "expected 'list' key in response data")
 
 			for _, item := range list {
-				trip, ok := item.(map[string]interface{})
+				trip, ok := item.(map[string]any)
 				require.True(t, ok)
 
 				assert.Contains(t, trip, "frequency")
@@ -67,16 +67,16 @@ func TestTripsForLocationHandler_DifferentAreas(t *testing.T) {
 				assert.Contains(t, trip, "situationIds")
 				assert.Contains(t, trip, "tripId")
 
-				if schedule, hasSchedule := trip["schedule"].(map[string]interface{}); hasSchedule {
+				if schedule, hasSchedule := trip["schedule"].(map[string]any); hasSchedule {
 					assert.Contains(t, schedule, "frequency")
 					assert.Contains(t, schedule, "nextTripId")
 					assert.Contains(t, schedule, "previousTripId")
 					assert.Contains(t, schedule, "timeZone")
 
-					stopTimes, hasStopTimes := schedule["stopTimes"].([]interface{})
+					stopTimes, hasStopTimes := schedule["stopTimes"].([]any)
 					if hasStopTimes {
 						for _, st := range stopTimes {
-							stopTime := st.(map[string]interface{})
+							stopTime := st.(map[string]any)
 
 							assert.Contains(t, stopTime, "arrivalTime")
 							assert.Contains(t, stopTime, "departureTime")
@@ -95,9 +95,9 @@ func TestTripsForLocationHandler_DifferentAreas(t *testing.T) {
 
 				assert.IsType(t, float64(0), trip["serviceDate"])
 				assert.IsType(t, "", trip["tripId"])
-				situationIds, ok := trip["situationIds"].([]interface{})
+				situationIds, ok := trip["situationIds"].([]any)
 				require.True(t, ok)
-				assert.IsType(t, []interface{}{}, situationIds)
+				assert.IsType(t, []any{}, situationIds)
 			}
 
 			assert.GreaterOrEqual(t, len(list), tt.minExpected)
@@ -143,22 +143,22 @@ func TestTripsForLocationHandler_ReferencesContainStopsAndRoutes(t *testing.T) {
 			resp, model := serveApiAndRetrieveEndpoint(t, api, url)
 			assert.Equal(t, http.StatusOK, resp.StatusCode)
 
-			data, ok := model.Data.(map[string]interface{})
+			data, ok := model.Data.(map[string]any)
 			require.True(t, ok, "response data should be a map")
 
-			refs, ok := data["references"].(map[string]interface{})
+			refs, ok := data["references"].(map[string]any)
 			require.True(t, ok, "references should be present in response data")
 
-			stops, ok := refs["stops"].([]interface{})
+			stops, ok := refs["stops"].([]any)
 			require.True(t, ok, "references.stops should be a []interface{}, not null")
 
-			routes, ok := refs["routes"].([]interface{})
+			routes, ok := refs["routes"].([]any)
 			require.True(t, ok, "references.routes should be a []interface{}, not null")
 
 			if len(stops) > 0 {
 				routeIDSet := make(map[string]bool, len(routes))
 				for _, r := range routes {
-					route, ok := r.(map[string]interface{})
+					route, ok := r.(map[string]any)
 					require.True(t, ok, "each route in references.routes should be a map")
 					if id, ok := route["id"].(string); ok {
 						routeIDSet[id] = true
@@ -166,10 +166,10 @@ func TestTripsForLocationHandler_ReferencesContainStopsAndRoutes(t *testing.T) {
 				}
 
 				for _, s := range stops {
-					stop, ok := s.(map[string]interface{})
+					stop, ok := s.(map[string]any)
 					require.True(t, ok, "each stop in references.stops should be a map")
 
-					routeIds, ok := stop["routeIds"].([]interface{})
+					routeIds, ok := stop["routeIds"].([]any)
 					assert.True(t, ok, "stop.routeIds should be a []interface{}, not null (stop: %v)", stop["id"])
 
 					for _, rid := range routeIds {
@@ -213,12 +213,12 @@ func TestTripsForLocationHandler_ScheduleInclusion(t *testing.T) {
 			resp, model := serveApiAndRetrieveEndpoint(t, api, url)
 			assert.Equal(t, http.StatusOK, resp.StatusCode)
 
-			data := model.Data.(map[string]interface{})
-			list := data["list"].([]interface{})
+			data := model.Data.(map[string]any)
+			list := data["list"].([]any)
 
 			for _, item := range list {
-				trip := item.(map[string]interface{})
-				schedule, hasSchedule := trip["schedule"].(map[string]interface{})
+				trip := item.(map[string]any)
+				schedule, hasSchedule := trip["schedule"].(map[string]any)
 
 				if tt.includeSchedule {
 					assert.True(t, hasSchedule)
@@ -265,17 +265,17 @@ func TestTripsForLocationHandler_StopIDsAreCombined(t *testing.T) {
 	resp, model := serveApiAndRetrieveEndpoint(t, api, url)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 
-	data, ok := model.Data.(map[string]interface{})
+	data, ok := model.Data.(map[string]any)
 	require.True(t, ok)
 
-	refs, ok := data["references"].(map[string]interface{})
+	refs, ok := data["references"].(map[string]any)
 	require.True(t, ok, "references should be present")
 
-	stops, ok := refs["stops"].([]interface{})
+	stops, ok := refs["stops"].([]any)
 	require.True(t, ok, "references.stops should be present")
 
 	for _, s := range stops {
-		stop, ok := s.(map[string]interface{})
+		stop, ok := s.(map[string]any)
 		require.True(t, ok)
 		id, ok := stop["id"].(string)
 		require.True(t, ok, "stop id should be a string")
@@ -293,17 +293,17 @@ func TestTripsForLocationHandler_OrphanedStopsNotInResponse(t *testing.T) {
 	resp, model := serveApiAndRetrieveEndpoint(t, api, url)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 
-	data, ok := model.Data.(map[string]interface{})
+	data, ok := model.Data.(map[string]any)
 	require.True(t, ok)
 
-	refs, ok := data["references"].(map[string]interface{})
+	refs, ok := data["references"].(map[string]any)
 	require.True(t, ok, "references should be present")
 
-	stops, ok := refs["stops"].([]interface{})
+	stops, ok := refs["stops"].([]any)
 	require.True(t, ok, "references.stops should be present")
 
 	for _, s := range stops {
-		stop, ok := s.(map[string]interface{})
+		stop, ok := s.(map[string]any)
 		require.True(t, ok)
 		id, ok := stop["id"].(string)
 		require.True(t, ok, "stop id should be a string")
@@ -321,21 +321,21 @@ func TestTripsForLocationHandler_AgenciesExistForAllRoutes(t *testing.T) {
 	resp, model := serveApiAndRetrieveEndpoint(t, api, url)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 
-	data, ok := model.Data.(map[string]interface{})
+	data, ok := model.Data.(map[string]any)
 	require.True(t, ok)
 
-	refs, ok := data["references"].(map[string]interface{})
+	refs, ok := data["references"].(map[string]any)
 	require.True(t, ok, "references should be present")
 
-	agencies, ok := refs["agencies"].([]interface{})
+	agencies, ok := refs["agencies"].([]any)
 	require.True(t, ok, "references.agencies should be present")
 
-	routes, ok := refs["routes"].([]interface{})
+	routes, ok := refs["routes"].([]any)
 	require.True(t, ok, "references.routes should be present")
 
 	agencyIDSet := make(map[string]bool, len(agencies))
 	for _, a := range agencies {
-		agency, ok := a.(map[string]interface{})
+		agency, ok := a.(map[string]any)
 		require.True(t, ok)
 		if id, ok := agency["id"].(string); ok {
 			agencyIDSet[id] = true
@@ -343,7 +343,7 @@ func TestTripsForLocationHandler_AgenciesExistForAllRoutes(t *testing.T) {
 	}
 
 	for _, r := range routes {
-		route, ok := r.(map[string]interface{})
+		route, ok := r.(map[string]any)
 		require.True(t, ok)
 		agencyID, ok := route["agencyId"].(string)
 		require.True(t, ok, "route should have agencyId")
@@ -363,20 +363,20 @@ func TestTripsForLocationHandler_StopDirectionsAreStrings(t *testing.T) {
 	resp, model := serveApiAndRetrieveEndpoint(t, api, url)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 
-	data, ok := model.Data.(map[string]interface{})
+	data, ok := model.Data.(map[string]any)
 	require.True(t, ok)
 
-	refs, ok := data["references"].(map[string]interface{})
+	refs, ok := data["references"].(map[string]any)
 	require.True(t, ok, "references should be present")
 
-	stops, ok := refs["stops"].([]interface{})
+	stops, ok := refs["stops"].([]any)
 	require.True(t, ok, "references.stops should be present")
 
 	require.NotEmpty(t, stops, "expected stops in references to verify directions")
 
 	nonEmptyCount := 0
 	for _, s := range stops {
-		stop, ok := s.(map[string]interface{})
+		stop, ok := s.(map[string]any)
 		require.True(t, ok)
 		_, ok = stop["direction"].(string)
 		assert.True(t, ok, "stop %q direction field should be a string, not absent or null", stop["id"])
@@ -415,14 +415,14 @@ func TestTripsForLocationHandler_StatusInclusion(t *testing.T) {
 			resp, model := serveApiAndRetrieveEndpoint(t, api, url)
 			assert.Equal(t, http.StatusOK, resp.StatusCode)
 
-			data := model.Data.(map[string]interface{})
-			list := data["list"].([]interface{})
+			data := model.Data.(map[string]any)
+			list := data["list"].([]any)
 
 			assert.NotEmpty(t, list, "expected at least one trip in the response to verify status behavior")
 
 			for _, item := range list {
-				trip := item.(map[string]interface{})
-				status, hasStatus := trip["status"].(map[string]interface{})
+				trip := item.(map[string]any)
+				status, hasStatus := trip["status"].(map[string]any)
 
 				if tt.includeStatus {
 					assert.True(t, hasStatus, "expected status to be present when includeStatus=true")

--- a/internal/restapi/trips_for_route_handler_test.go
+++ b/internal/restapi/trips_for_route_handler_test.go
@@ -64,17 +64,17 @@ func TestTripsForRouteHandler_DifferentRoutes(t *testing.T) {
 			assert.Equal(t, "OK", model.Text)
 			assert.Equal(t, 2, model.Version)
 
-			data := model.Data.(map[string]interface{})
+			data := model.Data.(map[string]any)
 			assert.False(t, data["limitExceeded"].(bool))
 			assert.False(t, data["outOfRange"].(bool))
 
-			list, _ := data["list"].([]interface{})
+			list, _ := data["list"].([]any)
 			for _, item := range list {
-				trip := item.(map[string]interface{})
+				trip := item.(map[string]any)
 				verifyTripEntry(t, trip)
 			}
 
-			references := data["references"].(map[string]interface{})
+			references := data["references"].(map[string]any)
 			verifyReferences(t, references)
 
 			assert.GreaterOrEqual(t, len(list), tt.minExpected)
@@ -83,14 +83,14 @@ func TestTripsForRouteHandler_DifferentRoutes(t *testing.T) {
 	}
 }
 
-func verifyTripEntry(t *testing.T, trip map[string]interface{}) {
+func verifyTripEntry(t *testing.T, trip map[string]any) {
 	assert.Contains(t, trip, "frequency")
 	assert.Contains(t, trip, "serviceDate")
 	assert.Contains(t, trip, "situationIds")
 	assert.Contains(t, trip, "tripId")
 	assert.Contains(t, trip, "status")
 
-	status := trip["status"].(map[string]interface{})
+	status := trip["status"].(map[string]any)
 	assert.Contains(t, status, "activeTripId")
 	assert.Contains(t, status, "blockTripSequence")
 	assert.Contains(t, status, "closestStop")
@@ -106,20 +106,20 @@ func verifyTripEntry(t *testing.T, trip map[string]interface{}) {
 	assert.Contains(t, status, "vehicleId")
 
 	if pos := status["position"]; pos != nil {
-		position := pos.(map[string]interface{})
+		position := pos.(map[string]any)
 		assert.Contains(t, position, "lat")
 		assert.Contains(t, position, "lon")
 	}
 
-	if schedule, ok := trip["schedule"].(map[string]interface{}); ok {
+	if schedule, ok := trip["schedule"].(map[string]any); ok {
 		assert.Contains(t, schedule, "frequency")
 		assert.Contains(t, schedule, "nextTripId")
 		assert.Contains(t, schedule, "previousTripId")
 		assert.Contains(t, schedule, "timeZone")
 
-		if stopTimes, ok := schedule["stopTimes"].([]interface{}); ok {
+		if stopTimes, ok := schedule["stopTimes"].([]any); ok {
 			for _, st := range stopTimes {
-				stopTime := st.(map[string]interface{})
+				stopTime := st.(map[string]any)
 				assert.Contains(t, stopTime, "arrivalTime")
 				assert.Contains(t, stopTime, "departureTime")
 				assert.Contains(t, stopTime, "stopId")
@@ -131,10 +131,10 @@ func verifyTripEntry(t *testing.T, trip map[string]interface{}) {
 	}
 }
 
-func verifyReferences(t *testing.T, references map[string]interface{}) {
-	agencies := references["agencies"].([]interface{})
+func verifyReferences(t *testing.T, references map[string]any) {
+	agencies := references["agencies"].([]any)
 	for _, a := range agencies {
-		agency := a.(map[string]interface{})
+		agency := a.(map[string]any)
 		assert.Contains(t, agency, "disclaimer")
 		assert.Contains(t, agency, "id")
 		assert.Contains(t, agency, "lang")
@@ -145,9 +145,9 @@ func verifyReferences(t *testing.T, references map[string]interface{}) {
 		assert.Contains(t, agency, "url")
 	}
 
-	routes := references["routes"].([]interface{})
+	routes := references["routes"].([]any)
 	for _, r := range routes {
-		route := r.(map[string]interface{})
+		route := r.(map[string]any)
 		assert.Contains(t, route, "agencyId")
 		assert.Contains(t, route, "color")
 		assert.Contains(t, route, "description")
@@ -158,9 +158,9 @@ func verifyReferences(t *testing.T, references map[string]interface{}) {
 		assert.Contains(t, route, "type")
 	}
 
-	stops := references["stops"].([]interface{})
+	stops := references["stops"].([]any)
 	for _, s := range stops {
-		stop := s.(map[string]interface{})
+		stop := s.(map[string]any)
 		assert.Contains(t, stop, "code")
 		assert.Contains(t, stop, "direction")
 		assert.Contains(t, stop, "id")
@@ -200,12 +200,12 @@ func TestTripsForRouteHandler_ScheduleInclusion(t *testing.T) {
 			resp, model := serveApiAndRetrieveEndpoint(t, api, url)
 			assert.Equal(t, http.StatusOK, resp.StatusCode)
 
-			data := model.Data.(map[string]interface{})
-			list := data["list"].([]interface{})
+			data := model.Data.(map[string]any)
+			list := data["list"].([]any)
 
 			for _, item := range list {
-				trip := item.(map[string]interface{})
-				schedule, hasSchedule := trip["schedule"].(map[string]interface{})
+				trip := item.(map[string]any)
+				schedule, hasSchedule := trip["schedule"].(map[string]any)
 
 				if tt.includeSchedule {
 					assert.True(t, hasSchedule)

--- a/internal/restapi/vehicles_for_agency_handler_test.go
+++ b/internal/restapi/vehicles_for_agency_handler_test.go
@@ -45,17 +45,17 @@ func TestVehiclesForAgencyHandlerEndToEnd(t *testing.T) {
 	assert.Equal(t, 200, model.Code)
 	assert.Equal(t, "OK", model.Text)
 
-	data, ok := model.Data.(map[string]interface{})
+	data, ok := model.Data.(map[string]any)
 	require.True(t, ok)
 
 	// Check that we have a list of vehicles
-	_, ok = data["list"].([]interface{})
+	_, ok = data["list"].([]any)
 	require.True(t, ok)
 
-	refs, ok := data["references"].(map[string]interface{})
+	refs, ok := data["references"].(map[string]any)
 	require.True(t, ok)
 
-	refAgencies, ok := refs["agencies"].([]interface{})
+	refAgencies, ok := refs["agencies"].([]any)
 	require.True(t, ok)
 	assert.Len(t, refAgencies, 1)
 }
@@ -69,10 +69,10 @@ func TestVehiclesForAgencyHandlerWithNonExistentAgency(t *testing.T) {
 	assert.Equal(t, 200, model.Code)
 	assert.Equal(t, "OK", model.Text)
 
-	data, ok := model.Data.(map[string]interface{})
+	data, ok := model.Data.(map[string]any)
 	require.True(t, ok)
 
-	list, ok := data["list"].([]interface{})
+	list, ok := data["list"].([]any)
 	require.True(t, ok)
 	assert.Len(t, list, 0)
 }
@@ -90,36 +90,36 @@ func TestVehiclesForAgencyHandlerResponseStructure(t *testing.T) {
 	assert.Equal(t, 200, model.Code)
 	assert.Equal(t, "OK", model.Text)
 
-	data, ok := model.Data.(map[string]interface{})
+	data, ok := model.Data.(map[string]any)
 	require.True(t, ok)
 
 	// Verify basic response structure
-	_, ok = data["list"].([]interface{})
+	_, ok = data["list"].([]any)
 	require.True(t, ok)
 
-	refs, ok := data["references"].(map[string]interface{})
+	refs, ok := data["references"].(map[string]any)
 	require.True(t, ok)
 
 	// Should have agency reference
-	refAgencies, ok := refs["agencies"].([]interface{})
+	refAgencies, ok := refs["agencies"].([]any)
 	require.True(t, ok)
 	assert.Len(t, refAgencies, 1)
 
 	// Verify agency reference structure
-	agency := refAgencies[0].(map[string]interface{})
+	agency := refAgencies[0].(map[string]any)
 	assert.Equal(t, agencyId, agency["id"])
 	assert.NotEmpty(t, agency["name"])
 
 	// Verify other reference sections exist (may be empty)
-	_, ok = refs["routes"].([]interface{})
+	_, ok = refs["routes"].([]any)
 	assert.True(t, ok)
-	_, ok = refs["trips"].([]interface{})
+	_, ok = refs["trips"].([]any)
 	assert.True(t, ok)
-	_, ok = refs["situations"].([]interface{})
+	_, ok = refs["situations"].([]any)
 	assert.True(t, ok)
-	_, ok = refs["stops"].([]interface{})
+	_, ok = refs["stops"].([]any)
 	assert.True(t, ok)
-	_, ok = refs["stopTimes"].([]interface{})
+	_, ok = refs["stopTimes"].([]any)
 	assert.True(t, ok)
 }
 
@@ -134,29 +134,29 @@ func TestVehiclesForAgencyHandlerReferencesBuilding(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 
-	data := model.Data.(map[string]interface{})
-	refs := data["references"].(map[string]interface{})
+	data := model.Data.(map[string]any)
+	refs := data["references"].(map[string]any)
 
 	// Test that references are properly built
-	refAgencies := refs["agencies"].([]interface{})
+	refAgencies := refs["agencies"].([]any)
 	assert.Len(t, refAgencies, 1)
 
-	agency := refAgencies[0].(map[string]interface{})
+	agency := refAgencies[0].(map[string]any)
 	assert.Equal(t, agencyId, agency["id"])
 
 	// Test reference deduplication (agency should appear only once)
-	vehiclesList := data["list"].([]interface{})
+	vehiclesList := data["list"].([]any)
 	if len(vehiclesList) > 0 {
 		// Even with multiple vehicles from same agency, only one agency reference
 		assert.Len(t, refAgencies, 1)
 	}
 
 	// Test that route references are built when vehicles have trips
-	refTrips := refs["trips"].([]interface{})
+	refTrips := refs["trips"].([]any)
 
 	vehiclesWithTrips := 0
 	for _, v := range vehiclesList {
-		vehicle := v.(map[string]interface{})
+		vehicle := v.(map[string]any)
 		if vehicle["tripStatus"] != nil {
 			vehiclesWithTrips++
 		}
@@ -168,7 +168,7 @@ func TestVehiclesForAgencyHandlerReferencesBuilding(t *testing.T) {
 
 		// Verify trip reference structure
 		if len(refTrips) > 0 {
-			trip := refTrips[0].(map[string]interface{})
+			trip := refTrips[0].(map[string]any)
 			assert.NotEmpty(t, trip["id"])
 			assert.NotEmpty(t, trip["routeId"])
 		}
@@ -185,14 +185,14 @@ func TestVehiclesForAgencyHandlerEmptyResult(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 
-	data := model.Data.(map[string]interface{})
-	vehiclesList := data["list"].([]interface{})
+	data := model.Data.(map[string]any)
+	vehiclesList := data["list"].([]any)
 
 	// Should handle empty vehicle list gracefully
-	assert.IsType(t, []interface{}{}, vehiclesList)
+	assert.IsType(t, []any{}, vehiclesList)
 
 	// Should still have proper references structure
-	refs := data["references"].(map[string]interface{})
+	refs := data["references"].(map[string]any)
 	assert.Contains(t, refs, "agencies")
 	assert.Contains(t, refs, "routes")
 	assert.Contains(t, refs, "trips")
@@ -210,23 +210,23 @@ func TestVehiclesForAgencyHandlerFieldMapping(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 
-	data := model.Data.(map[string]interface{})
-	vehiclesList := data["list"].([]interface{})
+	data := model.Data.(map[string]any)
+	vehiclesList := data["list"].([]any)
 
 	// Test that the processing loop runs even with empty results
 	// This should still test lines 21-139 in the handler
-	assert.IsType(t, []interface{}{}, vehiclesList)
+	assert.IsType(t, []any{}, vehiclesList)
 
 	// Verify that reference building happens even with empty vehicle list
-	refs := data["references"].(map[string]interface{})
-	refAgencies := refs["agencies"].([]interface{})
+	refs := data["references"].(map[string]any)
+	refAgencies := refs["agencies"].([]any)
 	assert.Len(t, refAgencies, 1)
 
 	// Test that the loop variables are initialized
-	refRoutes := refs["routes"].([]interface{})
-	refTrips := refs["trips"].([]interface{})
-	assert.IsType(t, []interface{}{}, refRoutes)
-	assert.IsType(t, []interface{}{}, refTrips)
+	refRoutes := refs["routes"].([]any)
+	refTrips := refs["trips"].([]any)
+	assert.IsType(t, []any{}, refRoutes)
+	assert.IsType(t, []any{}, refTrips)
 }
 
 func TestVehiclesForAgencyHandlerWithAllAgencies(t *testing.T) {
@@ -241,18 +241,18 @@ func TestVehiclesForAgencyHandlerWithAllAgencies(t *testing.T) {
 		assert.Equal(t, http.StatusOK, resp.StatusCode)
 		assert.Equal(t, 200, model.Code)
 
-		data := model.Data.(map[string]interface{})
-		vehiclesList := data["list"].([]interface{})
-		refs := data["references"].(map[string]interface{})
+		data := model.Data.(map[string]any)
+		vehiclesList := data["list"].([]any)
+		refs := data["references"].(map[string]any)
 
 		// Test that processing always happens
-		assert.IsType(t, []interface{}{}, vehiclesList)
+		assert.IsType(t, []any{}, vehiclesList)
 
 		// Agency reference should always be present
-		refAgencies := refs["agencies"].([]interface{})
+		refAgencies := refs["agencies"].([]any)
 		assert.Len(t, refAgencies, 1)
 
-		agencyRef := refAgencies[0].(map[string]interface{})
+		agencyRef := refAgencies[0].(map[string]any)
 		assert.Equal(t, agencyID, agencyRef["id"])
 	})
 }
@@ -270,10 +270,10 @@ func TestVehiclesForAgencyHandlerDatabaseRouteQueries(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 
-	data := model.Data.(map[string]interface{})
+	data := model.Data.(map[string]any)
 
 	// Test that the handler processes the empty vehicle list and sets up references
-	refs := data["references"].(map[string]interface{})
+	refs := data["references"].(map[string]any)
 
 	// These should all exist even with no vehicles
 	assert.Contains(t, refs, "agencies")
@@ -284,13 +284,13 @@ func TestVehiclesForAgencyHandlerDatabaseRouteQueries(t *testing.T) {
 	assert.Contains(t, refs, "stopTimes")
 
 	// Test that maps are converted to slices properly
-	refAgencies := refs["agencies"].([]interface{})
-	refRoutes := refs["routes"].([]interface{})
-	refTrips := refs["trips"].([]interface{})
+	refAgencies := refs["agencies"].([]any)
+	refRoutes := refs["routes"].([]any)
+	refTrips := refs["trips"].([]any)
 
-	assert.IsType(t, []interface{}{}, refAgencies)
-	assert.IsType(t, []interface{}{}, refRoutes)
-	assert.IsType(t, []interface{}{}, refTrips)
+	assert.IsType(t, []any{}, refAgencies)
+	assert.IsType(t, []any{}, refRoutes)
+	assert.IsType(t, []any{}, refTrips)
 }
 
 // TestVehiclesForAgencyHandler_OccupancyPropagation verifies that when a vehicle
@@ -317,14 +317,14 @@ func TestVehiclesForAgencyHandler_OccupancyPropagation(t *testing.T) {
 
 	_, model := serveApiAndRetrieveEndpoint(t, api, "/api/where/vehicles-for-agency/"+agencyID+".json?key=TEST")
 
-	data, ok := model.Data.(map[string]interface{})
+	data, ok := model.Data.(map[string]any)
 	require.True(t, ok, "response data must be a map")
 
-	vehiclesList, ok := data["list"].([]interface{})
+	vehiclesList, ok := data["list"].([]any)
 	require.True(t, ok, "list must be a slice")
 	require.NotEmpty(t, vehiclesList, "expected at least one vehicle — occupancy mock vehicle not returned by VehiclesForAgencyID")
 
-	vehicle, ok := vehiclesList[0].(map[string]interface{})
+	vehicle, ok := vehiclesList[0].(map[string]any)
 	require.True(t, ok, "vehicle entry must be a map")
 
 	// VehicleStatus.occupancyStatus must be propagated from GTFS-RT
@@ -332,7 +332,7 @@ func TestVehiclesForAgencyHandler_OccupancyPropagation(t *testing.T) {
 		"vehicleStatus.occupancyStatus must receive the GTFS-RT value")
 
 	// TripStatus.occupancyStatus must also be propagated (the handler sets both)
-	tripStatus, ok := vehicle["tripStatus"].(map[string]interface{})
+	tripStatus, ok := vehicle["tripStatus"].(map[string]any)
 	require.True(t, ok, "tripStatus must be present when vehicle has a trip")
 	assert.Equal(t, "MANY_SEATS_AVAILABLE", tripStatus["occupancyStatus"],
 		"tripStatus.occupancyStatus must receive the same GTFS-RT value")
@@ -361,15 +361,15 @@ func TestVehiclesForAgencyHandler_VehicleWithoutTrip(t *testing.T) {
 
 	_, model := serveApiAndRetrieveEndpoint(t, api, "/api/where/vehicles-for-agency/"+agencyID+".json?key=TEST")
 
-	data, ok := model.Data.(map[string]interface{})
+	data, ok := model.Data.(map[string]any)
 	require.True(t, ok, "response data must be a map")
 
-	vehiclesList, ok := data["list"].([]interface{})
+	vehiclesList, ok := data["list"].([]any)
 	require.True(t, ok, "list must be a slice")
 
 	// The nil-Trip vehicle must never appear in the response.
 	for _, item := range vehiclesList {
-		v, ok := item.(map[string]interface{})
+		v, ok := item.(map[string]any)
 		require.True(t, ok)
 		assert.NotEqual(t, noTripVehicleID, v["vehicleId"],
 			"vehicle with Trip==nil must be excluded by VehiclesForAgencyID before reaching the handler")
@@ -398,12 +398,12 @@ func TestVehiclesForAgencyHandler_VehicleWithNilID(t *testing.T) {
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, 200, model.Code)
 
-	data, ok := model.Data.(map[string]interface{})
+	data, ok := model.Data.(map[string]any)
 	require.True(t, ok)
-	list, ok := data["list"].([]interface{})
+	list, ok := data["list"].([]any)
 	require.True(t, ok)
 	for _, item := range list {
-		v := item.(map[string]interface{})
+		v := item.(map[string]any)
 		assert.NotEqual(t, "", v["vehicleId"], "vehicle with nil ID must be skipped, not returned with empty vehicleId")
 	}
 }
@@ -542,10 +542,10 @@ func TestVehiclesForAgencyHandlerWithRealTimeData(t *testing.T) {
 	assert.Equal(t, 200, model.Code)
 	assert.Equal(t, "OK", model.Text)
 
-	data, ok := model.Data.(map[string]interface{})
+	data, ok := model.Data.(map[string]any)
 	require.True(t, ok)
 
-	vehiclesList, ok := data["list"].([]interface{})
+	vehiclesList, ok := data["list"].([]any)
 	require.True(t, ok)
 
 	if len(realTimeVehicles) > 0 {
@@ -554,7 +554,7 @@ func TestVehiclesForAgencyHandlerWithRealTimeData(t *testing.T) {
 		// Now we can test the actual vehicle processing loop
 		if len(vehiclesList) > 0 {
 			// Test first vehicle in detail
-			vehicle := vehiclesList[0].(map[string]interface{})
+			vehicle := vehiclesList[0].(map[string]any)
 
 			// Required fields per OpenAPI spec — must always be present
 			assert.Contains(t, vehicle, "vehicleId", "vehicleId is required")
@@ -576,7 +576,7 @@ func TestVehiclesForAgencyHandlerWithRealTimeData(t *testing.T) {
 
 			// Test location fields (present but may be null when no position data)
 			if vehicle["location"] != nil {
-				location := vehicle["location"].(map[string]interface{})
+				location := vehicle["location"].(map[string]any)
 				assert.Contains(t, location, "lat")
 				assert.Contains(t, location, "lon")
 				assert.IsType(t, float64(0), location["lat"])
@@ -607,7 +607,7 @@ func TestVehiclesForAgencyHandlerWithRealTimeData(t *testing.T) {
 
 			// Test trip status (present but may be null when vehicle has no trip)
 			if vehicle["tripStatus"] != nil {
-				tripStatus := vehicle["tripStatus"].(map[string]interface{})
+				tripStatus := vehicle["tripStatus"].(map[string]any)
 
 				assert.NotEmpty(t, tripStatus["activeTripId"], "TripStatus should have activeTripId")
 				assert.IsType(t, true, tripStatus["scheduled"])
@@ -617,7 +617,7 @@ func TestVehiclesForAgencyHandlerWithRealTimeData(t *testing.T) {
 				}
 
 				if tripStatus["position"] != nil {
-					position := tripStatus["position"].(map[string]interface{})
+					position := tripStatus["position"].(map[string]any)
 					assert.Contains(t, position, "lat")
 					assert.Contains(t, position, "lon")
 				} else {
@@ -634,17 +634,17 @@ func TestVehiclesForAgencyHandlerWithRealTimeData(t *testing.T) {
 		}
 
 		// Test references when vehicles are present
-		refs := data["references"].(map[string]interface{})
+		refs := data["references"].(map[string]any)
 
-		refAgencies := refs["agencies"].([]interface{})
+		refAgencies := refs["agencies"].([]any)
 		assert.Len(t, refAgencies, 1)
 
-		refTrips := refs["trips"].([]interface{})
-		refRoutes := refs["routes"].([]interface{})
+		refTrips := refs["trips"].([]any)
+		refRoutes := refs["routes"].([]any)
 
 		vehiclesWithTrips := 0
 		for _, v := range vehiclesList {
-			vehicle := v.(map[string]interface{})
+			vehicle := v.(map[string]any)
 			if vehicle["tripStatus"] != nil {
 				vehiclesWithTrips++
 			}
@@ -655,14 +655,14 @@ func TestVehiclesForAgencyHandlerWithRealTimeData(t *testing.T) {
 
 			// Test trip reference structure
 			if len(refTrips) > 0 {
-				trip := refTrips[0].(map[string]interface{})
+				trip := refTrips[0].(map[string]any)
 				assert.NotEmpty(t, trip["id"])
 				assert.NotEmpty(t, trip["routeId"])
 			}
 
 			// Test route references (may be present if routes are found)
 			if len(refRoutes) > 0 {
-				route := refRoutes[0].(map[string]interface{})
+				route := refRoutes[0].(map[string]any)
 				assert.NotEmpty(t, route)
 			}
 		}
@@ -690,17 +690,17 @@ func TestVehiclesForAgency_RouteIDUsesCombinedID(t *testing.T) {
 
 	_, model := serveApiAndRetrieveEndpoint(t, api, "/api/where/vehicles-for-agency/"+agencyID+".json?key=TEST")
 
-	data, ok := model.Data.(map[string]interface{})
+	data, ok := model.Data.(map[string]any)
 	require.True(t, ok)
 
-	refs, ok := data["references"].(map[string]interface{})
+	refs, ok := data["references"].(map[string]any)
 	require.True(t, ok)
 
-	tripRefs, ok := refs["trips"].([]interface{})
+	tripRefs, ok := refs["trips"].([]any)
 	require.True(t, ok)
 	require.NotEmpty(t, tripRefs, "expected at least one trip reference — mock vehicle was not returned by VehiclesForAgencyID")
 
-	tripRef := tripRefs[0].(map[string]interface{})
+	tripRef := tripRefs[0].(map[string]any)
 	routeID, ok := tripRef["routeId"].(string)
 	require.True(t, ok, "routeId must be a string")
 

--- a/internal/webui/debug_index_handler.go
+++ b/internal/webui/debug_index_handler.go
@@ -19,7 +19,7 @@ type debugData struct {
 	Pre   string
 }
 
-func writeDebugData(w http.ResponseWriter, title string, data interface{}) {
+func writeDebugData(w http.ResponseWriter, title string, data any) {
 	content := spew.Sdump(data)
 	w.Header().Set("Content-Type", "text/html")
 	tmpl, err := template.ParseFS(templateFS, "debug_index.html")
@@ -50,7 +50,7 @@ func (webUI *WebUI) debugIndexHandler(w http.ResponseWriter, r *http.Request) {
 	ctx := context.Background()
 	queries := webUI.GtfsManager.GtfsDB.Queries
 
-	var data interface{}
+	var data any
 	var title string
 
 	var err error

--- a/internal/webui/debug_index_handler_test.go
+++ b/internal/webui/debug_index_handler_test.go
@@ -53,7 +53,7 @@ func TestWriteDebugData(t *testing.T) {
 	tests := []struct {
 		name           string
 		title          string
-		data           interface{}
+		data           any
 		expectedInBody []string
 	}{
 		{


### PR DESCRIPTION
Any is easier to read, replace it across the codebase.

Change generated with
  `find . -name '*.go' | xargs gofmt -r 'interface{} -> any' -w`