### PR TITLE
fix: improve performance of routes-for-location

### DIFF
--- a/gtfsdb/stops_rtree.go
+++ b/gtfsdb/stops_rtree.go
@@ -42,6 +42,7 @@ func (q *Queries) GetActiveStopsWithinBounds(ctx context.Context, arg GetActiveS
 	if err != nil {
 		return nil, err
 	}
+	defer rows.Close()
 
 	var items []Stop
 	for rows.Next() {
@@ -66,9 +67,6 @@ func (q *Queries) GetActiveStopsWithinBounds(ctx context.Context, arg GetActiveS
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -76,8 +74,31 @@ func (q *Queries) GetActiveStopsWithinBounds(ctx context.Context, arg GetActiveS
 }
 
 const getActiveRoutesWithinBounds = `
+-- Calculate stop distance once per stop (not once per stop_time).
+WITH nearby_stops AS (
+    SELECT
+        stops.id AS stop_id,
+        -- Haversine distance in km between stop and the query's center.
+        6371 * acos(
+            cos(radians(?1)) *
+            cos(radians(stops.lat)) *
+            cos(radians(stops.lon) - radians(?2)) +
+            sin(radians(?1)) *
+            sin(radians(stops.lat))
+        ) AS distance
+    FROM stops
+    JOIN stops_rtree r ON r.id = stops.rowid
+    WHERE r.min_lat >= ?3 AND r.max_lat <= ?4
+      AND r.min_lon >= ?5 AND r.max_lon <= ?6
+),
+stop_routes AS (
+    SELECT DISTINCT stop_times.stop_id, trips.route_id
+    FROM stop_times
+    JOIN trips ON stop_times.trip_id = trips.id
+    WHERE stop_times.stop_id IN (SELECT stop_id FROM nearby_stops)
+)
 SELECT
-	routes.id,
+    routes.id,
     routes.agency_id,
     routes.short_name,
     routes.long_name,
@@ -88,32 +109,18 @@ SELECT
     routes.text_color,
     routes.continuous_pickup,
     routes.continuous_drop_off,
-    -- Haversine distance in km betweeen stop and the query's center.
-    -- This column is not read from the response
-    MIN(6371 * acos(
-        cos(radians(?1)) *
-        cos(radians(stops.lat)) *
-        cos(radians(stops.lon) - radians(?2)) +
-        sin(radians(?1)) *
-        sin(radians(stops.lat))
-    )) AS min_distance
-FROM
-    stops
-    JOIN stop_times ON stops.id = stop_times.stop_id
-    JOIN stops_rtree r ON r.id = stops.rowid
-    JOIN trips ON stop_times.trip_id = trips.id
-    JOIN routes ON trips.route_id = routes.id
-WHERE
-    r.min_lat >= ?3 AND r.max_lat <= ?4
-    AND r.min_lon >= ?5 AND r.max_lon <= ?6
-    -- use LIKE for case-insensitive compare.
-    AND (?7 == "" OR routes.short_name LIKE ?7)
-GROUP BY
-    routes.id
-ORDER BY
-    min_distance ASC
-LIMIT
-    ?8
+    -- This column is not read from the response.
+    MIN(ns.distance) AS min_distance
+FROM stop_routes sr
+JOIN nearby_stops ns ON ns.stop_id = sr.stop_id
+JOIN routes ON routes.id = sr.route_id
+    -- COLLATE NOCASE gives case-insensitive equality without LIKE's wildcard
+    -- semantics. Note: NOCASE only folds ASCII A-Z; non-ASCII short names
+    -- will not match case-insensitively.
+WHERE ?7 == "" OR routes.short_name = ?7 COLLATE NOCASE
+GROUP BY routes.id
+ORDER BY min_distance ASC
+LIMIT ?8
 `
 
 type GetActiveRoutesWithinBoundsParams struct {
@@ -133,7 +140,7 @@ func (q *Queries) GetActiveRoutesWithinBounds(ctx context.Context, arg GetActive
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close() //nolint:errcheck // closing is also checked explicitly below
+	defer rows.Close()
 	var items []Route
 	for rows.Next() {
 		var i Route
@@ -155,9 +162,6 @@ func (q *Queries) GetActiveRoutesWithinBounds(ctx context.Context, arg GetActive
 			return nil, err
 		}
 		items = append(items, i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err

--- a/internal/gtfs/gtfs_manager.go
+++ b/internal/gtfs/gtfs_manager.go
@@ -615,8 +615,11 @@ func (manager *Manager) GetRoutesForLocation(
 	return routes, limitExceeded
 }
 
-// queryRouteswithinBounds retrieves all routes serving stops within the given geographic bounds
+// queryRoutesInBounds retrieves all routes serving stops within the given geographic bounds
 // from the database's stops_rtree spatial index.
+// Despite the query's name, this doesn't actually check "Active" stops beyond
+// checking that the stop has at least one stop_time. The corresponding GetStopsForLocation
+// checks active service dates as well.
 func (manager *Manager) queryRoutesInBounds(ctx context.Context, bounds utils.CoordinateBounds,
 	lat, lon float64,
 	maxCount int,

--- a/internal/restapi/reference_utils.go
+++ b/internal/restapi/reference_utils.go
@@ -4,9 +4,18 @@ import (
 	"context"
 
 	"github.com/OneBusAway/go-gtfs"
+	"maglev.onebusaway.org/gtfsdb"
 	"maglev.onebusaway.org/internal/models"
 	"maglev.onebusaway.org/internal/utils"
 )
+
+func buildAgencyReferences(agencies []gtfsdb.Agency) []models.AgencyReference {
+	var refs []models.AgencyReference
+	for _, agency := range agencies {
+		refs = append(refs, models.AgencyReferenceFromDatabase(&agency))
+	}
+	return refs
+}
 
 // IMPORTANT: Caller must hold manager.RLock() before calling this method.
 func (api *RestAPI) BuildRouteReferences(ctx context.Context, agencyID string, stops []models.Stop) ([]models.Route, error) {

--- a/internal/restapi/routes_for_location_handler.go
+++ b/internal/restapi/routes_for_location_handler.go
@@ -73,23 +73,19 @@ func (api *RestAPI) routesForLocationHandler(w http.ResponseWriter, r *http.Requ
 			utils.NullStringOrEmpty(route.TextColor)))
 	}
 
-	var agencies []models.AgencyReference
-	for agencyID := range agencyIDs {
-		agency, err := api.GtfsManager.FindAgency(ctx, agencyID)
-		if err != nil {
-			api.serverErrorResponse(w, r, err)
-			return
-		}
-		agencies = append(agencies, models.AgencyReferenceFromDatabase(agency))
+	references := models.NewEmptyReferences()
+
+	agencyIDList := slices.Collect(maps.Keys(agencyIDs))
+	agencies, err := api.GtfsManager.GtfsDB.Queries.GetAgenciesByIDs(ctx, agencyIDList)
+	if err != nil {
+		api.serverErrorResponse(w, r, err)
+		return
 	}
+	references.Agencies = buildAgencyReferences(agencies)
 
 	// Populate situation references for alerts affecting the returned routes
 	alerts := api.collectAlertsForRoutes(slices.Collect(maps.Keys(routeIDs)))
-	situations := api.BuildSituationReferences(alerts)
-
-	references := models.NewEmptyReferences()
-	references.Agencies = agencies
-	references.Situations = situations
+	references.Situations = api.BuildSituationReferences(alerts)
 
 	// Results must be sorted by ID after maxCount limit is applied.
 	// See how response changes when calling java API with different maxCounts.

--- a/internal/restapi/routes_for_location_handler_test.go
+++ b/internal/restapi/routes_for_location_handler_test.go
@@ -100,6 +100,19 @@ func TestRoutesForLocationCaseInsensitiveQuery(t *testing.T) {
 	assert.ElementsMatch(t, model.Data.References.Agencies, []models.AgencyReference{testdata.Raba})
 }
 
+func TestRoutesForLocationWildcardQueryDoesNotMatch(t *testing.T) {
+	// `%` should be treated as a literal character, not a SQL LIKE wildcard.
+	// Lat/Lon are for stop 2000 from the test data, which is on route 44X.
+	api := createTestApi(t)
+
+	resp, model := callAPIHandler[RoutesResponse](t, api, "/api/where/routes-for-location.json?key=TEST&lat=40.583170&lon=-122.392586&query=%25")
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, http.StatusOK, model.Code)
+	assert.Equal(t, "OK", model.Text)
+	assert.Empty(t, model.Data.List)
+}
+
 func TestRoutesForLocationHandlerValidatesParameters(t *testing.T) {
 	api := createTestApi(t)
 	resp, model := callAPIHandler[RoutesResponse](t, api, "/api/where/routes-for-location.json?key=TEST&lat=invalid&lon=-121.74")


### PR DESCRIPTION
Fixes some performance issues in routes-for-location so that it's now faster than the old implementation.

  On the same data:
    Old implementation: 850ms
    New implementation: 1000ms
    With fixes: 450ms

Removes some duplicated distance calculation in the SQL query.
Fixes some edge cases in query matching, documents limitations of matching in SQL.
Switches to batch agency query.