### PR TITLE
fix: match Java's stop distribution behavior in stops-for-location

### DIFF
--- a/gtfsdb/db.go
+++ b/gtfsdb/db.go
@@ -303,9 +303,6 @@ func Prepare(ctx context.Context, db DBTX) (*Queries, error) {
 	if q.getStopsForRouteStmt, err = db.PrepareContext(ctx, getStopsForRoute); err != nil {
 		return nil, fmt.Errorf("error preparing query GetStopsForRoute: %w", err)
 	}
-	if q.getStopsWithActiveServiceOnDateStmt, err = db.PrepareContext(ctx, getStopsWithActiveServiceOnDate); err != nil {
-		return nil, fmt.Errorf("error preparing query GetStopsWithActiveServiceOnDate: %w", err)
-	}
 	if q.getStopsWithShapeContextStmt, err = db.PrepareContext(ctx, getStopsWithShapeContext); err != nil {
 		return nil, fmt.Errorf("error preparing query GetStopsWithShapeContext: %w", err)
 	}
@@ -845,11 +842,6 @@ func (q *Queries) Close() error {
 			err = fmt.Errorf("error closing getStopsForRouteStmt: %w", cerr)
 		}
 	}
-	if q.getStopsWithActiveServiceOnDateStmt != nil {
-		if cerr := q.getStopsWithActiveServiceOnDateStmt.Close(); cerr != nil {
-			err = fmt.Errorf("error closing getStopsWithActiveServiceOnDateStmt: %w", cerr)
-		}
-	}
 	if q.getStopsWithShapeContextStmt != nil {
 		if cerr := q.getStopsWithShapeContextStmt.Close(); cerr != nil {
 			err = fmt.Errorf("error closing getStopsWithShapeContextStmt: %w", cerr)
@@ -1097,7 +1089,6 @@ type Queries struct {
 	getStopTimesForTripIDsStmt                    *sql.Stmt
 	getStopsByIDsStmt                             *sql.Stmt
 	getStopsForRouteStmt                          *sql.Stmt
-	getStopsWithActiveServiceOnDateStmt           *sql.Stmt
 	getStopsWithShapeContextStmt                  *sql.Stmt
 	getStopsWithShapeContextByIDsStmt             *sql.Stmt
 	getStopsWithTripContextStmt                   *sql.Stmt
@@ -1220,7 +1211,6 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		getStopTimesForTripIDsStmt:                    q.getStopTimesForTripIDsStmt,
 		getStopsByIDsStmt:                             q.getStopsByIDsStmt,
 		getStopsForRouteStmt:                          q.getStopsForRouteStmt,
-		getStopsWithActiveServiceOnDateStmt:           q.getStopsWithActiveServiceOnDateStmt,
 		getStopsWithShapeContextStmt:                  q.getStopsWithShapeContextStmt,
 		getStopsWithShapeContextByIDsStmt:             q.getStopsWithShapeContextByIDsStmt,
 		getStopsWithTripContextStmt:                   q.getStopsWithTripContextStmt,

--- a/gtfsdb/query.sql
+++ b/gtfsdb/query.sql
@@ -665,14 +665,6 @@ FROM
 WHERE
     stop_times.stop_id IN (sqlc.slice('stop_ids'));
 
--- name: GetStopsWithActiveServiceOnDate :many
--- Returns stop IDs that have at least one trip with active service on the given date
-SELECT DISTINCT st.stop_id
-FROM stop_times st
-JOIN trips t ON st.trip_id = t.id
-WHERE st.stop_id IN (sqlc.slice('stop_ids'))
-  AND t.service_id IN (sqlc.slice('service_ids'));
-
 -- name: GetStopTimesForTrip :many
 SELECT
     *

--- a/gtfsdb/query.sql.go
+++ b/gtfsdb/query.sql.go
@@ -3877,61 +3877,6 @@ func (q *Queries) GetStopsForRoute(ctx context.Context, id string) ([]GetStopsFo
 	return items, nil
 }
 
-const getStopsWithActiveServiceOnDate = `-- name: GetStopsWithActiveServiceOnDate :many
-SELECT DISTINCT st.stop_id
-FROM stop_times st
-JOIN trips t ON st.trip_id = t.id
-WHERE st.stop_id IN (/*SLICE:stop_ids*/?)
-  AND t.service_id IN (/*SLICE:service_ids*/?)
-`
-
-type GetStopsWithActiveServiceOnDateParams struct {
-	StopIds    []string
-	ServiceIds []string
-}
-
-// Returns stop IDs that have at least one trip with active service on the given date
-func (q *Queries) GetStopsWithActiveServiceOnDate(ctx context.Context, arg GetStopsWithActiveServiceOnDateParams) ([]string, error) {
-	query := getStopsWithActiveServiceOnDate
-	var queryParams []interface{}
-	if len(arg.StopIds) > 0 {
-		for _, v := range arg.StopIds {
-			queryParams = append(queryParams, v)
-		}
-		query = strings.Replace(query, "/*SLICE:stop_ids*/?", strings.Repeat(",?", len(arg.StopIds))[1:], 1)
-	} else {
-		query = strings.Replace(query, "/*SLICE:stop_ids*/?", "NULL", 1)
-	}
-	if len(arg.ServiceIds) > 0 {
-		for _, v := range arg.ServiceIds {
-			queryParams = append(queryParams, v)
-		}
-		query = strings.Replace(query, "/*SLICE:service_ids*/?", strings.Repeat(",?", len(arg.ServiceIds))[1:], 1)
-	} else {
-		query = strings.Replace(query, "/*SLICE:service_ids*/?", "NULL", 1)
-	}
-	rows, err := q.query(ctx, nil, query, queryParams...)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	var items []string
-	for rows.Next() {
-		var stop_id string
-		if err := rows.Scan(&stop_id); err != nil {
-			return nil, err
-		}
-		items = append(items, stop_id)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
-}
-
 const getStopsWithShapeContext = `-- name: GetStopsWithShapeContext :many
 SELECT
     s.id, s.lat, s.lon, s.name, s.code, s.direction,

--- a/gtfsdb/stops_rtree.go
+++ b/gtfsdb/stops_rtree.go
@@ -73,6 +73,44 @@ func (q *Queries) GetActiveStopsWithinBounds(ctx context.Context, arg GetActiveS
 	return items, nil
 }
 
+const getStopIDsWithinBounds = `
+SELECT s.id
+FROM stops s
+INNER JOIN stops_rtree sr ON sr.id = s.rowid
+WHERE sr.min_lat >= ? AND sr.max_lat <= ?
+  AND sr.min_lon >= ? AND sr.max_lon <= ?
+  AND EXISTS (SELECT 1 FROM stop_times st WHERE st.stop_id = s.id)
+`
+
+type GetStopIDsWithinBoundsParams struct {
+	MinLat float64
+	MaxLat float64
+	MinLon float64
+	MaxLon float64
+}
+
+func (q *Queries) GetStopIDsWithinBounds(ctx context.Context, arg GetStopIDsWithinBoundsParams) ([]string, error) {
+	rows, err := q.db.QueryContext(ctx, getStopIDsWithinBounds,
+		arg.MinLat, arg.MaxLat, arg.MinLon, arg.MaxLon)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var ids []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		ids = append(ids, id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return ids, nil
+}
+
 const getActiveRoutesWithinBounds = `
 -- Calculate stop distance once per stop (not once per stop_time).
 WITH nearby_stops AS (

--- a/gtfsdb/stops_rtree.go
+++ b/gtfsdb/stops_rtree.go
@@ -7,7 +7,7 @@ import (
 // Implemented manually because sqlc doesn't support the virtual tables from the RTree module.
 
 const getActiveStopsWithinBounds = `
-SELECT DISTINCT
+SELECT
     s.id,
     s.code,
     s.name,
@@ -23,10 +23,10 @@ SELECT DISTINCT
     s.direction,
     s.parent_station
 FROM stops s
-INNER JOIN stop_times st ON s.id = st.stop_id
-INNER JOIN stops_rtree r ON r.id = s.rowid
-WHERE r.min_lat >= ? AND r.max_lat <= ?
-  AND r.min_lon >= ? AND r.max_lon <= ?
+INNER JOIN stops_rtree sr ON sr.id = s.rowid
+WHERE sr.min_lat >= ? AND sr.max_lat <= ?
+  AND sr.min_lon >= ? AND sr.max_lon <= ?
+  AND EXISTS (SELECT 1 FROM stop_times st WHERE st.stop_id = s.id)
 `
 
 type GetActiveStopsWithinBoundsParams struct {

--- a/internal/gtfs/gtfs_manager.go
+++ b/internal/gtfs/gtfs_manager.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"math/rand"
 	"os"
 	"slices"
 	"sort"
@@ -412,11 +413,6 @@ func (manager *Manager) RoutesForAgencyID(ctx context.Context, agencyID string) 
 	return manager.GtfsDB.Queries.GetRoutesForAgency(ctx, agencyID)
 }
 
-type stopWithDistance struct {
-	stop     gtfsdb.Stop
-	distance float64
-}
-
 // GetStopsForLocation retrieves stops near a given location using the spatial index.
 // It supports filtering by route types and querying for specific stop codes.
 // IMPORTANT: Caller must hold manager.RLock() before calling this method.
@@ -430,8 +426,8 @@ func (manager *Manager) GetStopsForLocation(
 	stopCodeQuery string,
 	maxCount int,
 	routeTypes []int,
-	queryTime time.Time,
-) []gtfsdb.Stop {
+	shuffleBeforeLimit bool,
+) ([]gtfsdb.Stop, bool) {
 	var bounds utils.CoordinateBounds
 	if latSpan > 0 && lonSpan > 0 {
 		bounds = utils.CalculateBoundsFromSpan(lat, lon, latSpan/2, lonSpan/2)
@@ -443,14 +439,14 @@ func (manager *Manager) GetStopsForLocation(
 	}
 
 	if ctx.Err() != nil {
-		return []gtfsdb.Stop{}
+		return []gtfsdb.Stop{}, false
 	}
 
 	stops, err := manager.queryStopsInBounds(ctx, bounds)
 	if err != nil {
 		logger := slog.Default().With(slog.String("component", "gtfs_manager"))
 		logging.LogError(logger, "could not query stops within bounds", err)
-		return []gtfsdb.Stop{}
+		return []gtfsdb.Stop{}, false
 	}
 
 	if stopCodeQuery != "" {
@@ -458,102 +454,75 @@ func (manager *Manager) GetStopsForLocation(
 			return utils.NullStringOrEmpty(stop.Code) == stopCodeQuery
 		})
 		if idx >= 0 {
-			return []gtfsdb.Stop{stops[idx]}
+			return []gtfsdb.Stop{stops[idx]}, false
 		}
-		return nil
+		return nil, false
 	}
 
-	// If the stop does not have any routes actively serving it, don't include it in the results
-	// TODO: move this logic into the first queryStopsInBounds call to avoid 2 db roundtrips. May need
-	// the function split for query logic mentioned above.
-	if len(routeTypes) > 0 {
-		stopIDs := make([]string, 0, len(stops))
-		for _, stop := range stops {
-			stopIDs = append(stopIDs, stop.ID)
+	// Match Java's two query modes:
+	// BOUNDS mode (no routeType filter): shuffle then truncate BEFORE route filtering.
+	// ORDERED_BY_CLOSEST mode (routeType filter active): sort by distance, filter first, truncate AFTER.
+	var limitExceeded bool
+	if len(routeTypes) == 0 {
+		limitExceeded = len(stops) > maxCount
+		if limitExceeded && shuffleBeforeLimit {
+			rand.Shuffle(len(stops), func(i, j int) { stops[i], stops[j] = stops[j], stops[i] })
+		}
+		if limitExceeded {
+			stops = stops[:maxCount]
+		}
+	} else {
+		// ORDERED_BY_CLOSEST: sort by distance from search center before filtering
+		sort.Slice(stops, func(i, j int) bool {
+			di := utils.Distance(lat, lon, stops[i].Lat, stops[i].Lon)
+			dj := utils.Distance(lat, lon, stops[j].Lat, stops[j].Lon)
+			return di < dj
+		})
+	}
+
+	// Get routes for all stops to filter out stops with no routes
+	stopIDs := make([]string, 0, len(stops))
+	for _, stop := range stops {
+		stopIDs = append(stopIDs, stop.ID)
+	}
+
+	routesForStops, err := manager.GtfsDB.Queries.GetRoutesForStops(ctx, stopIDs)
+	if err == nil {
+		stopRouteTypes := make(map[string][]int)
+		for _, r := range routesForStops {
+			stopRouteTypes[r.StopID] = append(stopRouteTypes[r.StopID], int(r.Type))
 		}
 
-		routesForStops, err := manager.GtfsDB.Queries.GetRoutesForStops(ctx, stopIDs)
-		if err == nil {
-			stopRouteTypes := make(map[string][]int)
-			for _, r := range routesForStops {
-				stopRouteTypes[r.StopID] = append(stopRouteTypes[r.StopID], int(r.Type))
+		filteredStops := make([]gtfsdb.Stop, 0, len(stops))
+		for _, stop := range stops {
+			types := stopRouteTypes[stop.ID]
+			if len(types) == 0 {
+				continue
 			}
-
-			filteredStops := make([]gtfsdb.Stop, 0, len(stops))
-			for _, stop := range stops {
-				types := stopRouteTypes[stop.ID]
+			if len(routeTypes) > 0 {
+				hasMatchingRouteType := false
 				for _, rt := range types {
 					if slices.Contains(routeTypes, rt) {
-						filteredStops = append(filteredStops, stop)
+						hasMatchingRouteType = true
 						break
 					}
 				}
-			}
-			stops = filteredStops
-		}
-	}
-
-	// Filter by service date - only include stops with active service on current date
-	if len(stops) > 0 {
-		var currentDate string
-		if !queryTime.IsZero() {
-			currentDate = queryTime.Format("20060102")
-		} else {
-			currentDate = time.Now().Format("20060102")
-		}
-
-		activeServiceIDs, err := manager.GtfsDB.Queries.GetActiveServiceIDsForDate(ctx, currentDate)
-		if err != nil {
-			logger := slog.Default().With(slog.String("component", "gtfs_manager"))
-			logging.LogError(logger, "could not get active service IDs for date", err, slog.String("date", currentDate))
-		}
-
-		if err == nil && len(activeServiceIDs) > 0 {
-			stopIDs := make([]string, 0, len(stops))
-			for _, stop := range stops {
-				stopIDs = append(stopIDs, stop.ID)
-			}
-
-			stopsWithActiveService, err := manager.GtfsDB.Queries.GetStopsWithActiveServiceOnDate(ctx, gtfsdb.GetStopsWithActiveServiceOnDateParams{
-				StopIds:    stopIDs,
-				ServiceIds: activeServiceIDs,
-			})
-			if err != nil {
-				logger := slog.Default().With(slog.String("component", "gtfs_manager"))
-				logging.LogError(logger, "could not get stops with active service on date", err, slog.String("date", currentDate))
-			}
-
-			if err == nil {
-				stopsWithService := make(map[string]bool)
-				for _, stopID := range stopsWithActiveService {
-					stopsWithService[stopID] = true
+				if !hasMatchingRouteType {
+					continue
 				}
-
-				filteredStops := make([]gtfsdb.Stop, 0, len(stops))
-				for _, stop := range stops {
-					if stopsWithService[stop.ID] {
-						filteredStops = append(filteredStops, stop)
-					}
-				}
-				stops = filteredStops
 			}
+			filteredStops = append(filteredStops, stop)
 		}
+		stops = filteredStops
 	}
 
-	var candidates []stopWithDistance
-	for _, stop := range stops {
-		distance := utils.Distance(lat, lon, stop.Lat, stop.Lon)
-		candidates = append(candidates, stopWithDistance{stop, distance})
-	}
-	sort.Slice(candidates, func(i, j int) bool {
-		return candidates[i].distance < candidates[j].distance
-	})
-	var results []gtfsdb.Stop
-	for i := 0; i < len(candidates) && (i < maxCount); i++ {
-		results = append(results, candidates[i].stop)
+	// ORDERED_BY_CLOSEST: truncate and compute limitExceeded AFTER route filtering
+	if len(routeTypes) > 0 && len(stops) > maxCount {
+		limitExceeded = true
+		stops = stops[:maxCount]
 	}
 
-	return results
+	return stops, limitExceeded
 }
 
 // queryStopsInBounds retrieves all active stops within the given geographic bounds

--- a/internal/gtfs/gtfs_manager.go
+++ b/internal/gtfs/gtfs_manager.go
@@ -517,6 +517,30 @@ func (manager *Manager) GetStopsInBounds(
 	return stops
 }
 
+// GetStopIDsWithinBounds returns stop IDs within bounds, optimized for callers that only need IDs.
+func (manager *Manager) GetStopIDsWithinBounds(
+	ctx context.Context,
+	lat, lon, radius, latSpan, lonSpan float64,
+	maxCount int,
+) []string {
+	bounds := manager.boundsFromParams(lat, lon, radius, latSpan, lonSpan)
+	ids, err := manager.GtfsDB.Queries.GetStopIDsWithinBounds(ctx, gtfsdb.GetStopIDsWithinBoundsParams{
+		MinLat: bounds.MinLat,
+		MaxLat: bounds.MaxLat,
+		MinLon: bounds.MinLon,
+		MaxLon: bounds.MaxLon,
+	})
+	if err != nil {
+		logger := slog.Default().With(slog.String("component", "gtfs_manager"))
+		logging.LogError(logger, "could not query stop IDs within bounds", err)
+		return nil
+	}
+	if maxCount > 0 && len(ids) > maxCount {
+		ids = ids[:maxCount]
+	}
+	return ids
+}
+
 func (manager *Manager) boundsFromParams(lat, lon, radius, latSpan, lonSpan float64) utils.CoordinateBounds {
 	if latSpan > 0 && lonSpan > 0 {
 		return utils.CalculateBoundsFromSpan(lat, lon, latSpan/2, lonSpan/2)

--- a/internal/gtfs/gtfs_manager.go
+++ b/internal/gtfs/gtfs_manager.go
@@ -417,26 +417,17 @@ func (manager *Manager) RoutesForAgencyID(ctx context.Context, agencyID string) 
 // It supports filtering by route types and querying for specific stop codes.
 // IMPORTANT: Caller must hold manager.RLock() before calling this method.
 //
-// TODO: split this into several functions backed by different database queries.
-// Some callers only want stop IDs, while others need to return Stops to the
-// client.
+// GetStopsForLocation is used by the stops-for-location endpoint.
+// BOUNDS mode (no routeTypes): shuffles stops then truncates before route-type filtering.
+// ORDERED_BY_CLOSEST mode (routeTypes present): sorts by distance, filters by route type, then truncates.
 func (manager *Manager) GetStopsForLocation(
 	ctx context.Context,
 	lat, lon, radius, latSpan, lonSpan float64,
 	stopCodeQuery string,
 	maxCount int,
 	routeTypes []int,
-	shuffleBeforeLimit bool,
 ) ([]gtfsdb.Stop, bool) {
-	var bounds utils.CoordinateBounds
-	if latSpan > 0 && lonSpan > 0 {
-		bounds = utils.CalculateBoundsFromSpan(lat, lon, latSpan/2, lonSpan/2)
-	} else {
-		if radius == 0 {
-			radius = models.DefaultSearchRadiusInMeters
-		}
-		bounds = utils.CalculateBounds(lat, lon, radius)
-	}
+	bounds := manager.boundsFromParams(lat, lon, radius, latSpan, lonSpan)
 
 	if ctx.Err() != nil {
 		return []gtfsdb.Stop{}, false
@@ -459,70 +450,81 @@ func (manager *Manager) GetStopsForLocation(
 		return nil, false
 	}
 
-	// Match Java's two query modes:
-	// BOUNDS mode (no routeType filter): shuffle then truncate BEFORE route filtering.
-	// ORDERED_BY_CLOSEST mode (routeType filter active): sort by distance, filter first, truncate AFTER.
 	var limitExceeded bool
 	if len(routeTypes) == 0 {
+		// BOUNDS mode: shuffle then truncate before route filtering.
 		limitExceeded = len(stops) > maxCount
-		if limitExceeded && shuffleBeforeLimit {
-			rand.Shuffle(len(stops), func(i, j int) { stops[i], stops[j] = stops[j], stops[i] })
-		}
 		if limitExceeded {
+			rand.Shuffle(len(stops), func(i, j int) { stops[i], stops[j] = stops[j], stops[i] })
 			stops = stops[:maxCount]
 		}
 	} else {
-		// ORDERED_BY_CLOSEST: sort by distance from search center before filtering
+		// ORDERED_BY_CLOSEST mode: sort by distance, filter by route type, then truncate.
 		sort.Slice(stops, func(i, j int) bool {
-			di := utils.Distance(lat, lon, stops[i].Lat, stops[i].Lon)
-			dj := utils.Distance(lat, lon, stops[j].Lat, stops[j].Lon)
-			return di < dj
+			return utils.Distance(lat, lon, stops[i].Lat, stops[i].Lon) <
+				utils.Distance(lat, lon, stops[j].Lat, stops[j].Lon)
 		})
-	}
 
-	// Get routes for all stops to filter out stops with no routes
-	stopIDs := make([]string, 0, len(stops))
-	for _, stop := range stops {
-		stopIDs = append(stopIDs, stop.ID)
-	}
-
-	routesForStops, err := manager.GtfsDB.Queries.GetRoutesForStops(ctx, stopIDs)
-	if err == nil {
-		stopRouteTypes := make(map[string][]int)
-		for _, r := range routesForStops {
-			stopRouteTypes[r.StopID] = append(stopRouteTypes[r.StopID], int(r.Type))
+		stopIDs := make([]string, 0, len(stops))
+		for _, stop := range stops {
+			stopIDs = append(stopIDs, stop.ID)
 		}
 
-		filteredStops := make([]gtfsdb.Stop, 0, len(stops))
-		for _, stop := range stops {
-			types := stopRouteTypes[stop.ID]
-			if len(types) == 0 {
-				continue
+		routesForStops, err := manager.GtfsDB.Queries.GetRoutesForStops(ctx, stopIDs)
+		if err == nil {
+			stopRouteTypes := make(map[string][]int)
+			for _, r := range routesForStops {
+				stopRouteTypes[r.StopID] = append(stopRouteTypes[r.StopID], int(r.Type))
 			}
-			if len(routeTypes) > 0 {
-				hasMatchingRouteType := false
-				for _, rt := range types {
+			filteredStops := make([]gtfsdb.Stop, 0, len(stops))
+			for _, stop := range stops {
+				for _, rt := range stopRouteTypes[stop.ID] {
 					if slices.Contains(routeTypes, rt) {
-						hasMatchingRouteType = true
+						filteredStops = append(filteredStops, stop)
 						break
 					}
 				}
-				if !hasMatchingRouteType {
-					continue
-				}
 			}
-			filteredStops = append(filteredStops, stop)
+			stops = filteredStops
 		}
-		stops = filteredStops
-	}
 
-	// ORDERED_BY_CLOSEST: truncate and compute limitExceeded AFTER route filtering
-	if len(routeTypes) > 0 && len(stops) > maxCount {
-		limitExceeded = true
-		stops = stops[:maxCount]
+		if len(stops) > maxCount {
+			limitExceeded = true
+			stops = stops[:maxCount]
+		}
 	}
 
 	return stops, limitExceeded
+}
+
+// GetStopsInBounds returns stops within the given bounds up to maxCount, without shuffling
+// or route-type filtering. Used internally by the arrivals and trips-for-location handlers.
+func (manager *Manager) GetStopsInBounds(
+	ctx context.Context,
+	lat, lon, radius, latSpan, lonSpan float64,
+	maxCount int,
+) []gtfsdb.Stop {
+	bounds := manager.boundsFromParams(lat, lon, radius, latSpan, lonSpan)
+	stops, err := manager.queryStopsInBounds(ctx, bounds)
+	if err != nil {
+		logger := slog.Default().With(slog.String("component", "gtfs_manager"))
+		logging.LogError(logger, "could not query stops within bounds", err)
+		return nil
+	}
+	if maxCount > 0 && len(stops) > maxCount {
+		stops = stops[:maxCount]
+	}
+	return stops
+}
+
+func (manager *Manager) boundsFromParams(lat, lon, radius, latSpan, lonSpan float64) utils.CoordinateBounds {
+	if latSpan > 0 && lonSpan > 0 {
+		return utils.CalculateBoundsFromSpan(lat, lon, latSpan/2, lonSpan/2)
+	}
+	if radius == 0 {
+		radius = models.DefaultSearchRadiusInMeters
+	}
+	return utils.CalculateBounds(lat, lon, radius)
 }
 
 // queryStopsInBounds retrieves all active stops within the given geographic bounds

--- a/internal/gtfs/gtfs_manager_test.go
+++ b/internal/gtfs/gtfs_manager_test.go
@@ -84,7 +84,7 @@ func TestManager_GetStopsForLocation_UsesSpatialIndex(t *testing.T) {
 			assert.NotNil(t, manager)
 
 			// Get stops using the manager method
-			stops, _ := manager.GetStopsForLocation(ctx, tc.lat, tc.lon, tc.radius, 0, 0, "", 100, nil, false)
+			stops := manager.GetStopsInBounds(ctx, tc.lat, tc.lon, tc.radius, 0, 0, 100)
 
 			// The test expects that the spatial index query is used
 			assert.GreaterOrEqual(t, len(stops), tc.expectedStops, "Should find stops within radius")

--- a/internal/gtfs/gtfs_manager_test.go
+++ b/internal/gtfs/gtfs_manager_test.go
@@ -84,7 +84,7 @@ func TestManager_GetStopsForLocation_UsesSpatialIndex(t *testing.T) {
 			assert.NotNil(t, manager)
 
 			// Get stops using the manager method
-			stops := manager.GetStopsForLocation(ctx, tc.lat, tc.lon, tc.radius, 0, 0, "", 100, nil, time.Time{})
+			stops, _ := manager.GetStopsForLocation(ctx, tc.lat, tc.lon, tc.radius, 0, 0, "", 100, nil, false)
 
 			// The test expects that the spatial index query is used
 			assert.GreaterOrEqual(t, len(stops), tc.expectedStops, "Should find stops within radius")

--- a/internal/restapi/arrivals_and_departure_for_stop.go
+++ b/internal/restapi/arrivals_and_departure_for_stop.go
@@ -641,7 +641,7 @@ func (api *RestAPI) arrivalsAndDeparturesForStopHandler(w http.ResponseWriter, r
 }
 
 func getNearbyStopIDs(api *RestAPI, ctx context.Context, lat, lon float64, stopID, fallbackAgencyID string) []string {
-	nearbyStops, _ := api.GtfsManager.GetStopsForLocation(ctx, lat, lon, 10000, 100, 100, "", 5, []int{}, false)
+	nearbyStops := api.GtfsManager.GetStopsInBounds(ctx, lat, lon, 10000, 100, 100, 5)
 	if len(nearbyStops) == 0 {
 		return nil
 	}

--- a/internal/restapi/arrivals_and_departure_for_stop.go
+++ b/internal/restapi/arrivals_and_departure_for_stop.go
@@ -641,7 +641,7 @@ func (api *RestAPI) arrivalsAndDeparturesForStopHandler(w http.ResponseWriter, r
 }
 
 func getNearbyStopIDs(api *RestAPI, ctx context.Context, lat, lon float64, stopID, fallbackAgencyID string) []string {
-	nearbyStops := api.GtfsManager.GetStopsForLocation(ctx, lat, lon, 10000, 100, 100, "", 5, []int{}, api.Clock.Now())
+	nearbyStops, _ := api.GtfsManager.GetStopsForLocation(ctx, lat, lon, 10000, 100, 100, "", 5, []int{}, false)
 	if len(nearbyStops) == 0 {
 		return nil
 	}

--- a/internal/restapi/arrivals_and_departure_for_stop.go
+++ b/internal/restapi/arrivals_and_departure_for_stop.go
@@ -641,16 +641,16 @@ func (api *RestAPI) arrivalsAndDeparturesForStopHandler(w http.ResponseWriter, r
 }
 
 func getNearbyStopIDs(api *RestAPI, ctx context.Context, lat, lon float64, stopID, fallbackAgencyID string) []string {
-	nearbyStops := api.GtfsManager.GetStopsInBounds(ctx, lat, lon, 10000, 100, 100, 5)
-	if len(nearbyStops) == 0 {
+	nearbyIDs := api.GtfsManager.GetStopIDsWithinBounds(ctx, lat, lon, 10000, 100, 100, 5)
+	if len(nearbyIDs) == 0 {
 		return nil
 	}
 
-	// Collect nearby stop IDs (excluding the current stop) for a batch agency lookup.
+	// Exclude the current stop from nearby results
 	var candidateIDs []string
-	for _, s := range nearbyStops {
-		if s.ID != stopID {
-			candidateIDs = append(candidateIDs, s.ID)
+	for _, id := range nearbyIDs {
+		if id != stopID {
+			candidateIDs = append(candidateIDs, id)
 		}
 	}
 	if len(candidateIDs) == 0 {

--- a/internal/restapi/arrivals_and_departures_for_stop_handler_test.go
+++ b/internal/restapi/arrivals_and_departures_for_stop_handler_test.go
@@ -1044,7 +1044,7 @@ func TestGetNearbyStopIDs_UsesResolvedAgency(t *testing.T) {
 	// RABA test data has stops near Redding, CA (~40.589, -122.39).
 	// GetStopsForLocation requires the caller to hold RLock.
 	api.GtfsManager.RLock()
-	stops := api.GtfsManager.GetStopsForLocation(ctx, 40.589123, -122.390830, 2000, 0, 0, "", 10, []int{}, mockClock.Now())
+	stops, _ := api.GtfsManager.GetStopsForLocation(ctx, 40.589123, -122.390830, 2000, 0, 0, "", 10, []int{}, false)
 	api.GtfsManager.RUnlock()
 	require.NotEmpty(t, stops, "precondition: RABA should have stops near Redding, CA")
 
@@ -1073,7 +1073,7 @@ func TestGetNearbyStopIDs_ExcludesCurrentStop(t *testing.T) {
 	ctx := context.Background()
 
 	api.GtfsManager.RLock()
-	stops := api.GtfsManager.GetStopsForLocation(ctx, 40.589123, -122.390830, 2000, 0, 0, "", 10, []int{}, mockClock.Now())
+	stops, _ := api.GtfsManager.GetStopsForLocation(ctx, 40.589123, -122.390830, 2000, 0, 0, "", 10, []int{}, false)
 	api.GtfsManager.RUnlock()
 	require.NotEmpty(t, stops)
 

--- a/internal/restapi/arrivals_and_departures_for_stop_handler_test.go
+++ b/internal/restapi/arrivals_and_departures_for_stop_handler_test.go
@@ -1042,10 +1042,7 @@ func TestGetNearbyStopIDs_UsesResolvedAgency(t *testing.T) {
 	ctx := context.Background()
 
 	// RABA test data has stops near Redding, CA (~40.589, -122.39).
-	// GetStopsForLocation requires the caller to hold RLock.
-	api.GtfsManager.RLock()
-	stops, _ := api.GtfsManager.GetStopsForLocation(ctx, 40.589123, -122.390830, 2000, 0, 0, "", 10, []int{}, false)
-	api.GtfsManager.RUnlock()
+	stops := api.GtfsManager.GetStopsInBounds(ctx, 40.589123, -122.390830, 2000, 0, 0, 10)
 	require.NotEmpty(t, stops, "precondition: RABA should have stops near Redding, CA")
 
 	currentStop := stops[0]
@@ -1073,7 +1070,7 @@ func TestGetNearbyStopIDs_ExcludesCurrentStop(t *testing.T) {
 	ctx := context.Background()
 
 	api.GtfsManager.RLock()
-	stops, _ := api.GtfsManager.GetStopsForLocation(ctx, 40.589123, -122.390830, 2000, 0, 0, "", 10, []int{}, false)
+	stops := api.GtfsManager.GetStopsInBounds(ctx, 40.589123, -122.390830, 2000, 0, 0, 10)
 	api.GtfsManager.RUnlock()
 	require.NotEmpty(t, stops)
 

--- a/internal/restapi/context_cancellation_test.go
+++ b/internal/restapi/context_cancellation_test.go
@@ -120,7 +120,7 @@ func TestContextCancellationInGetStopsForLocation(t *testing.T) {
 
 	// This test verifies that our current implementation works normally
 	// since it uses context.Background() internally
-	stops := api.GtfsManager.GetStopsForLocation(context.Background(), 38.9, -77.0, 1000, 0, 0, "", 10, nil, time.Now())
+	stops, _ := api.GtfsManager.GetStopsForLocation(context.Background(), 38.9, -77.0, 1000, 0, 0, "", 10, nil, false)
 
 	// Current implementation should return a slice (possibly empty)
 	// The function should not panic and should return a valid slice

--- a/internal/restapi/context_cancellation_test.go
+++ b/internal/restapi/context_cancellation_test.go
@@ -120,7 +120,7 @@ func TestContextCancellationInGetStopsForLocation(t *testing.T) {
 
 	// This test verifies that our current implementation works normally
 	// since it uses context.Background() internally
-	stops, _ := api.GtfsManager.GetStopsForLocation(context.Background(), 38.9, -77.0, 1000, 0, 0, "", 10, nil, false)
+	stops := api.GtfsManager.GetStopsInBounds(context.Background(), 38.9, -77.0, 1000, 0, 0, 10)
 
 	// Current implementation should return a slice (possibly empty)
 	// The function should not panic and should return a valid slice

--- a/internal/restapi/stops_for_location_handler.go
+++ b/internal/restapi/stops_for_location_handler.go
@@ -101,9 +101,9 @@ func (api *RestAPI) stopsForLocationHandler(w http.ResponseWriter, r *http.Reque
 	api.GtfsManager.RLock()
 	defer api.GtfsManager.RUnlock()
 
-	stops := api.GtfsManager.GetStopsForLocation(ctx, loc.Lat, loc.Lon, loc.Radius, loc.LatSpan, loc.LonSpan, query, maxCount, routeTypes, queryTime)
+	stops, limitExceeded := api.GtfsManager.GetStopsForLocation(ctx, loc.Lat, loc.Lon, loc.Radius, loc.LatSpan, loc.LonSpan, query, maxCount, routeTypes, true)
 
-	// Referenced Java code: "here we sort by distance for possible truncation, but later it will be re-sorted by stopId"
+	// Sort by stop ID for deterministic results
 	sort.SliceStable(stops, func(i, j int) bool {
 		return stops[i].ID < stops[j].ID
 	})
@@ -199,7 +199,7 @@ func (api *RestAPI) stopsForLocationHandler(w http.ResponseWriter, r *http.Reque
 		}
 	}
 
-	isLimitExceeded := false
+	isLimitExceeded := limitExceeded
 	var resultRawStopIDs []string
 
 	// Build results using the pre-fetched data
@@ -234,10 +234,6 @@ func (api *RestAPI) stopsForLocationHandler(w http.ResponseWriter, r *http.Reque
 			rids,
 			rids,
 		))
-		if len(results) >= maxCount {
-			isLimitExceeded = true
-			break
-		}
 	}
 
 	if ctx.Err() != nil {

--- a/internal/restapi/stops_for_location_handler.go
+++ b/internal/restapi/stops_for_location_handler.go
@@ -101,7 +101,7 @@ func (api *RestAPI) stopsForLocationHandler(w http.ResponseWriter, r *http.Reque
 	api.GtfsManager.RLock()
 	defer api.GtfsManager.RUnlock()
 
-	stops, limitExceeded := api.GtfsManager.GetStopsForLocation(ctx, loc.Lat, loc.Lon, loc.Radius, loc.LatSpan, loc.LonSpan, query, maxCount, routeTypes, true)
+	stops, limitExceeded := api.GtfsManager.GetStopsForLocation(ctx, loc.Lat, loc.Lon, loc.Radius, loc.LatSpan, loc.LonSpan, query, maxCount, routeTypes)
 
 	// Sort by stop ID for deterministic results
 	sort.SliceStable(stops, func(i, j int) bool {

--- a/internal/restapi/trips_for_location_handler.go
+++ b/internal/restapi/trips_for_location_handler.go
@@ -39,7 +39,7 @@ func (api *RestAPI) tripsForLocationHandler(w http.ResponseWriter, r *http.Reque
 	// Note: re-deriving currentTime here rather than returning it from parseAndValidateRequest(line: 150)
 	currentTime := api.Clock.Now().In(currentLocation)
 
-	stops, _ := api.GtfsManager.GetStopsForLocation(ctx, lat, lon, -1, latSpan, lonSpan, "", 100, []int{}, false)
+	stops := api.GtfsManager.GetStopsInBounds(ctx, lat, lon, -1, latSpan, lonSpan, 100)
 	stopIDs := extractStopIDs(stops)
 	stopTimes, err := api.GtfsManager.GtfsDB.Queries.GetStopTimesByStopIDs(ctx, stopIDs)
 	if err != nil {

--- a/internal/restapi/trips_for_location_handler.go
+++ b/internal/restapi/trips_for_location_handler.go
@@ -39,7 +39,7 @@ func (api *RestAPI) tripsForLocationHandler(w http.ResponseWriter, r *http.Reque
 	// Note: re-deriving currentTime here rather than returning it from parseAndValidateRequest(line: 150)
 	currentTime := api.Clock.Now().In(currentLocation)
 
-	stops := api.GtfsManager.GetStopsForLocation(ctx, lat, lon, -1, latSpan, lonSpan, "", 100, []int{}, api.Clock.Now())
+	stops, _ := api.GtfsManager.GetStopsForLocation(ctx, lat, lon, -1, latSpan, lonSpan, "", 100, []int{}, false)
 	stopIDs := extractStopIDs(stops)
 	stopTimes, err := api.GtfsManager.GtfsDB.Queries.GetStopTimesByStopIDs(ctx, stopIDs)
 	if err != nil {


### PR DESCRIPTION
Fix: #872

## Summary

Stops returned by `stops-for-location` were clustered in a small geographic area instead of being distributed across the search radius.

### Root cause
The Go implementation was sorting stops by ID before truncating to `maxCount`.  
In the Puget Sound GTFS dataset, lower stop IDs are geographically clustered (e.g., downtown), which caused biased results.

## Changes

- Added `shuffleBeforeLimit` parameter to `GetStopsForLocation`
  - `stops-for-location` now passes `true` to shuffle results before truncating
  - Matches Java behavior in `BeanServiceSupport.checkLimitExceeded()` (BOUNDS mode)

- When a `routeType` filter is active:
  - Sort stops by distance instead of shuffling
  - Apply truncation after route filtering
  - Matches Java's `ORDERED_BY_CLOSEST` mode

- Fixed `limitExceeded` calculation:
  - Previously computed incorrectly in the handler loop
  - Now returned directly from `GetStopsForLocation`

- Removed unused DB query:
  - `GetStopsWithActiveServiceOnDate`
  - Service-date filtering is already handled in the handler via `GetActiveRouteIDsForStopsOnDate`