### PR TITLE
feat: add SSL support to maglev

### DIFF
--- a/cmd/api/app.go
+++ b/cmd/api/app.go
@@ -210,7 +210,9 @@ func CreateServer(coreApp *app.Application, cfg appconf.Config) (*http.Server, *
 // and performs graceful shutdown with a 30-second timeout.
 // Returns an error if the server fails to start or shutdown fails.
 func Run(ctx context.Context, srv *http.Server, coreApp *app.Application, api *restapi.RestAPI, logger *slog.Logger) error {
-	logger.Info("starting server", "addr", srv.Addr)
+	cfg := coreApp.Config
+	tlsEnabled := cfg.TLSCertPath != "" && cfg.TLSKeyPath != ""
+	logger.Info("starting server", "addr", srv.Addr, "tls", tlsEnabled)
 
 	// Set up signal handling for graceful shutdown, merging with provided context
 	ctx, stop := signal.NotifyContext(ctx, os.Interrupt, syscall.SIGTERM)
@@ -221,7 +223,13 @@ func Run(ctx context.Context, srv *http.Server, coreApp *app.Application, api *r
 
 	// Start server in a goroutine
 	go func() {
-		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		var err error
+		if tlsEnabled {
+			err = srv.ListenAndServeTLS(cfg.TLSCertPath, cfg.TLSKeyPath)
+		} else {
+			err = srv.ListenAndServe()
+		}
+		if err != nil && err != http.ErrServerClosed {
 			serverErrors <- err
 		}
 	}()

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -73,6 +73,8 @@ func main() {
 	flag.StringVar(&cliFeedAuthHeaderValue, "realtime-auth-header-value", "", "Optional header value for GTFS-RT auth")
 	flag.StringVar(&cliFeedServiceAlertsURL, "service-alerts-url", "", "URL for a GTFS-RT service alerts feed")
 	flag.StringVar(&gtfsCfg.GTFSDataPath, "data-path", "./gtfs.db", "Path to the SQLite database containing GTFS data")
+	flag.StringVar(&cfg.TLSCertPath, "tls-cert-path", "", "Path to TLS certificate file (enables HTTPS when set with tls-key-path)")
+	flag.StringVar(&cfg.TLSKeyPath, "tls-key-path", "", "Path to TLS private key file (enables HTTPS when set with tls-cert-path)")
 	flag.Parse()
 
 	// Enforce mutual exclusivity between -f and other flags (except --dump-config)
@@ -134,7 +136,9 @@ func main() {
 					RefreshInterval:         30,
 				},
 			},
-			DataPath: gtfsCfg.GTFSDataPath,
+			DataPath:    gtfsCfg.GTFSDataPath,
+			TLSCertPath: cfg.TLSCertPath,
+			TLSKeyPath:  cfg.TLSKeyPath,
 		}
 
 		// Run the shared validation logic

--- a/config.schema.json
+++ b/config.schema.json
@@ -171,7 +171,19 @@
       "type": "string",
       "description": "Path to the SQLite database containing GTFS data (cannot contain '..' for security)",
       "default": "./gtfs.db"
+    },
+    "tls-cert-path": {
+      "type": "string",
+      "description": "Path to TLS certificate file. When set together with tls-key-path, the server serves HTTPS."
+    },
+    "tls-key-path": {
+      "type": "string",
+      "description": "Path to TLS private key file. When set together with tls-cert-path, the server serves HTTPS."
     }
+  },
+  "dependencies": {
+    "tls-cert-path": ["tls-key-path"],
+    "tls-key-path": ["tls-cert-path"]
   },
   "additionalProperties": false,
   "examples": [

--- a/internal/appconf/config.go
+++ b/internal/appconf/config.go
@@ -15,6 +15,8 @@ type Config struct {
 	RateLimit        int // Requests per second per API key for rate limiting
 	LogLevel         string
 	LogFormat        string
+	TLSCertPath      string
+	TLSKeyPath       string
 }
 
 // Environment is an enumerated type representing various stages or configurations in the system's lifecycle.

--- a/internal/appconf/json_config.go
+++ b/internal/appconf/json_config.go
@@ -44,6 +44,8 @@ type JSONConfig struct {
 	DataPath         string         `json:"data-path"`
 	LogLevel         string         `json:"log-level"`
 	LogFormat        string         `json:"log-format"`
+	TLSCertPath      string         `json:"tls-cert-path"`
+	TLSKeyPath       string         `json:"tls-key-path"`
 }
 
 // setDefaults applies default values to the JSON config if fields are missing or zero
@@ -162,6 +164,17 @@ func (j *JSONConfig) Validate() error {
 		return err
 	}
 
+	// TLS: both cert and key must be provided together
+	if (j.TLSCertPath != "" && j.TLSKeyPath == "") || (j.TLSCertPath == "" && j.TLSKeyPath != "") {
+		return fmt.Errorf("both tls-cert-path and tls-key-path must be provided together")
+	}
+	if err := validatePath(j.TLSCertPath, "tls-cert-path"); err != nil {
+		return err
+	}
+	if err := validatePath(j.TLSKeyPath, "tls-key-path"); err != nil {
+		return err
+	}
+
 	// Validate that both auth header fields are provided together or neither
 	if (j.GtfsStaticFeed.AuthHeaderName != "" && j.GtfsStaticFeed.AuthHeaderValue == "") ||
 		(j.GtfsStaticFeed.AuthHeaderName == "" && j.GtfsStaticFeed.AuthHeaderValue != "") {
@@ -230,6 +243,8 @@ func (j *JSONConfig) ToAppConfig() Config {
 		RateLimit:        j.RateLimit,
 		LogLevel:         j.LogLevel,
 		LogFormat:        j.LogFormat,
+		TLSCertPath:      j.TLSCertPath,
+		TLSKeyPath:       j.TLSKeyPath,
 	}
 }
 


### PR DESCRIPTION
Add new config items that can be used to pass SSL certs to maglev.  When provided, they can be used to test maglev instances directly from the OBA App.