### PR TITLE
feat: migrate agencies-with-coverage endpoint to match legacy OBA spec

### DIFF
--- a/gtfsdb/stops_rtree.go
+++ b/gtfsdb/stops_rtree.go
@@ -42,7 +42,7 @@ func (q *Queries) GetActiveStopsWithinBounds(ctx context.Context, arg GetActiveS
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
+	defer rows.Close() //nolint:errcheck
 
 	var items []Stop
 	for rows.Next() {
@@ -95,7 +95,7 @@ func (q *Queries) GetStopIDsWithinBounds(ctx context.Context, arg GetStopIDsWith
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
+	defer rows.Close() //nolint:errcheck
 
 	var ids []string
 	for rows.Next() {
@@ -178,7 +178,7 @@ func (q *Queries) GetActiveRoutesWithinBounds(ctx context.Context, arg GetActive
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
+	defer rows.Close() //nolint:errcheck
 	var items []Route
 	for rows.Next() {
 		var i Route

--- a/internal/models/response.go
+++ b/internal/models/response.go
@@ -8,7 +8,7 @@ import (
 type ResponseModel struct {
 	Code        int    `json:"code"`
 	CurrentTime int64  `json:"currentTime"`
-	Data        any    `json:"data,omitempty"`
+	Data        any    `json:"data"`
 	Text        string `json:"text"`
 	Version     int    `json:"version"`
 }

--- a/internal/restapi/agencies_with_coverage_handler.go
+++ b/internal/restapi/agencies_with_coverage_handler.go
@@ -67,8 +67,8 @@ func (api *RestAPI) agenciesWithCoverageHandler(w http.ResponseWriter, r *http.R
 	}
 
 	if includeReferences {
-	references := models.NewEmptyReferences()
-	references.Agencies = buildAgencyReferences(agencies)
+		references := models.NewEmptyReferences()
+		references.Agencies = buildAgencyReferences(agencies)
 		data["references"] = *references
 	}
 

--- a/internal/restapi/agencies_with_coverage_handler.go
+++ b/internal/restapi/agencies_with_coverage_handler.go
@@ -41,8 +41,25 @@ func (api *RestAPI) agenciesWithCoverageHandler(w http.ResponseWriter, r *http.R
 		)
 	}
 
+	// Parse includeReferences
+	includeReferences := true
+	if val := queryParams.Get("includeReferences"); val != "" {
+		if parsed, parseErr := strconv.ParseBool(val); parseErr == nil {
+			includeReferences = parsed
+		}
+	}
+
+	data := map[string]any{
+		"limitExceeded": limitExceeded,
+		"list":          agenciesWithCoverage,
+	}
+
+	if includeReferences {
 	references := models.NewEmptyReferences()
 	references.Agencies = buildAgencyReferences(agencies)
-	response := models.NewListResponse(agenciesWithCoverage, *references, limitExceeded, api.Clock)
+		data["references"] = *references
+	}
+
+	response := models.NewOKResponse(data, api.Clock)
 	api.sendResponse(w, r, response)
 }

--- a/internal/restapi/agencies_with_coverage_handler.go
+++ b/internal/restapi/agencies_with_coverage_handler.go
@@ -1,7 +1,9 @@
 package restapi
 
 import (
+	"fmt"
 	"net/http"
+	"strconv"
 
 	"maglev.onebusaway.org/internal/models"
 	"maglev.onebusaway.org/internal/utils"
@@ -10,6 +12,16 @@ import (
 // agenciesWithCoverageHandler returns all transit agencies along with their geographic coverage areas.
 func (api *RestAPI) agenciesWithCoverageHandler(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
+	queryParams := r.URL.Query()
+
+	// Validate version parameter
+	if versionStr := queryParams.Get("version"); versionStr != "" {
+		version, err := strconv.Atoi(versionStr)
+		if err != nil || (version != 1 && version != 2) {
+			api.sendError(w, r, http.StatusInternalServerError, fmt.Sprintf("unknown version: %s", versionStr))
+			return
+		}
+	}
 
 	api.GtfsManager.RLock()
 	defer api.GtfsManager.RUnlock()

--- a/internal/restapi/agencies_with_coverage_handler_test.go
+++ b/internal/restapi/agencies_with_coverage_handler_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"maglev.onebusaway.org/internal/models"
 	"maglev.onebusaway.org/internal/restapi/testdata"
 )
@@ -12,7 +13,7 @@ import (
 type CoverageResponse struct {
 	Code        int          `json:"code"`
 	CurrentTime int64        `json:"currentTime"`
-	Data        CoverageData `json:"data,omitempty"`
+	Data        CoverageData `json:"data"`
 	Text        string       `json:"text"`
 	Version     int          `json:"version"`
 }
@@ -74,4 +75,134 @@ func TestAgenciesWithCoverageHandlerPagination(t *testing.T) {
 	_, model = callAPIHandler[CoverageResponse](t, api, "/api/where/agencies-with-coverage.json?key=TEST&offset=1")
 	assert.Len(t, model.Data.List, 0)
 	assert.False(t, model.Data.LimitExceeded)
+}
+
+func TestAgenciesWithCoverageHandlerResponseEnvelope(t *testing.T) {
+	api := createTestApi(t)
+
+	_, model := callAPIHandler[CoverageResponse](t, api, "/api/where/agencies-with-coverage.json?key=TEST")
+
+	assert.Equal(t, 2, model.Version, "envelope version must be 2")
+	assert.Equal(t, 200, model.Code, "code must mirror HTTP status")
+	assert.Equal(t, "OK", model.Text)
+	assert.Greater(t, model.CurrentTime, int64(0), "currentTime must be a positive Unix ms timestamp")
+}
+
+func TestAgenciesWithCoverageHandlerVersionParameter(t *testing.T) {
+	api := createTestApi(t)
+
+	t.Run("version=2 accepted", func(t *testing.T) {
+		resp, model := callAPIHandler[CoverageResponse](t, api, "/api/where/agencies-with-coverage.json?key=TEST&version=2")
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		assert.Equal(t, 200, model.Code)
+		assert.Len(t, model.Data.List, 1)
+	})
+
+	t.Run("version=1 accepted", func(t *testing.T) {
+		resp, model := callAPIHandler[CoverageResponse](t, api, "/api/where/agencies-with-coverage.json?key=TEST&version=1")
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		assert.Equal(t, 200, model.Code)
+	})
+
+	t.Run("version=3 returns 500", func(t *testing.T) {
+		resp, model := callAPIHandler[models.ResponseModel](t, api, "/api/where/agencies-with-coverage.json?key=TEST&version=3")
+		assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+		assert.Equal(t, 500, model.Code)
+		assert.Equal(t, "unknown version: 3", model.Text)
+		assert.Nil(t, model.Data, "data must be null on version error")
+	})
+
+	t.Run("version=0 returns 500", func(t *testing.T) {
+		resp, model := callAPIHandler[models.ResponseModel](t, api, "/api/where/agencies-with-coverage.json?key=TEST&version=0")
+		assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+		assert.Equal(t, "unknown version: 0", model.Text)
+	})
+
+	t.Run("version=abc returns 500", func(t *testing.T) {
+		resp, model := callAPIHandler[models.ResponseModel](t, api, "/api/where/agencies-with-coverage.json?key=TEST&version=abc")
+		assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+		assert.Equal(t, "unknown version: abc", model.Text)
+		assert.Nil(t, model.Data)
+	})
+}
+
+func TestAgenciesWithCoverageHandlerIncludeReferences(t *testing.T) {
+	api := createTestApi(t)
+
+	t.Run("default includes references", func(t *testing.T) {
+		_, model := callAPIHandler[CoverageResponse](t, api, "/api/where/agencies-with-coverage.json?key=TEST")
+		require.NotEmpty(t, model.Data.References.Agencies, "references.agencies must be populated by default")
+		assert.Equal(t, "25", model.Data.References.Agencies[0].ID)
+	})
+
+	t.Run("includeReferences=true includes references", func(t *testing.T) {
+		_, model := callAPIHandler[CoverageResponse](t, api, "/api/where/agencies-with-coverage.json?key=TEST&includeReferences=true")
+		require.NotEmpty(t, model.Data.References.Agencies)
+	})
+
+	t.Run("includeReferences=false omits references", func(t *testing.T) {
+		_, raw := callAPIHandler[map[string]any](t, api, "/api/where/agencies-with-coverage.json?key=TEST&includeReferences=false")
+		data, ok := raw["data"].(map[string]any)
+		require.True(t, ok, "data must be an object")
+
+		_, hasReferences := data["references"]
+		assert.False(t, hasReferences, "references key must be absent when includeReferences=false")
+
+		list, hasList := data["list"].([]any)
+		assert.True(t, hasList, "list must still be present")
+		assert.Len(t, list, 1, "all agencies should still be returned")
+
+		_, hasLimitExceeded := data["limitExceeded"]
+		assert.True(t, hasLimitExceeded, "limitExceeded must still be present")
+	})
+
+	t.Run("includeReferences=false still populates agencyId in list", func(t *testing.T) {
+		_, model := callAPIHandler[CoverageResponse](t, api, "/api/where/agencies-with-coverage.json?key=TEST&includeReferences=false")
+		require.Len(t, model.Data.List, 1)
+		assert.Equal(t, "25", model.Data.List[0].AgencyID, "agencyId must be present even without references")
+	})
+}
+
+func TestAgenciesWithCoverageHandlerMaxCount(t *testing.T) {
+	// Test data has 1 agency — maxCount is accepted via ParsePaginationParams
+	api := createTestApi(t)
+
+	t.Run("maxCount=1 returns all when count fits", func(t *testing.T) {
+		_, model := callAPIHandler[CoverageResponse](t, api, "/api/where/agencies-with-coverage.json?key=TEST&maxCount=1")
+		assert.Len(t, model.Data.List, 1)
+		assert.False(t, model.Data.LimitExceeded)
+	})
+
+	t.Run("maxCount is ignored when invalid", func(t *testing.T) {
+		_, model := callAPIHandler[CoverageResponse](t, api, "/api/where/agencies-with-coverage.json?key=TEST&maxCount=abc")
+		assert.Len(t, model.Data.List, 1, "invalid maxCount should be ignored, returning all")
+	})
+
+	t.Run("maxCount=0 is ignored", func(t *testing.T) {
+		_, model := callAPIHandler[CoverageResponse](t, api, "/api/where/agencies-with-coverage.json?key=TEST&maxCount=0")
+		assert.Len(t, model.Data.List, 1, "maxCount=0 should be ignored, returning all")
+	})
+}
+
+func TestAgenciesWithCoverageHandlerMissingApiKey(t *testing.T) {
+	api := createTestApi(t)
+
+	resp, model := callAPIHandler[models.ResponseModel](t, api, "/api/where/agencies-with-coverage.json")
+	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+	assert.Equal(t, http.StatusUnauthorized, model.Code)
+	assert.Equal(t, "permission denied", model.Text)
+}
+
+func TestAgenciesWithCoverageHandlerLimitExceeded(t *testing.T) {
+	api := createTestApi(t)
+
+	t.Run("false when all agencies fit within limit", func(t *testing.T) {
+		_, model := callAPIHandler[CoverageResponse](t, api, "/api/where/agencies-with-coverage.json?key=TEST")
+		assert.False(t, model.Data.LimitExceeded)
+	})
+
+	t.Run("false when no limit set", func(t *testing.T) {
+		_, model := callAPIHandler[CoverageResponse](t, api, "/api/where/agencies-with-coverage.json?key=TEST&maxCount=100")
+		assert.False(t, model.Data.LimitExceeded)
+	})
 }

--- a/internal/restapi/responses.go
+++ b/internal/restapi/responses.go
@@ -74,6 +74,7 @@ func (api *RestAPI) sendError(w http.ResponseWriter, r *http.Request, code int, 
 		CurrentTime: models.ResponseCurrentTime(api.Clock),
 		Text:        message,
 		Version:     2,
+		Data:        nil,
 	}
 
 	if err := json.NewEncoder(w).Encode(response); err != nil {


### PR DESCRIPTION
This PR validates and completes the migration of the `agencies-with-coverage.json` endpoint to Maglev, ensuring strict behavioral compatibility with the legacy Java OBA API specification, while addressing a known legacy defect.

### Key Changes & Spec Alignment:
* **`version` Parameter Validation:** Added strict validation. Only versions `1` and `2` are accepted. Any other value explicitly returns a `500` status with `data: null` and the exact error text `"unknown version: {n}"`, as required by the spec.
* **`includeReferences` Parameter:** Implemented support to dynamically omit the `references` block from the JSON response when `includeReferences=false`, without breaking the `agencyId` references within the `list`.
* **Error Response Formatting:** Updated the error response envelope mechanism to ensure the `data` field is explicitly serialized as `null` on errors (removed `omitempty`), fixing previous behavior where the field was entirely omitted.
* **Legacy Defect Resolution (`maxCount`):** * *Context:* The legacy Java implementation accepted the `maxCount` parameter but never passed it to the data factory, resulting in a bug where all agencies were returned and `limitExceeded` was always `false`.
  * *Decision (Fix):* Rather than preserving the broken legacy behavior, this PR maintains Maglev's working pagination logic. `maxCount` (and `limit`) correctly caps the results and accurately reflects `limitExceeded = true` when appropriate.

### Testing
Added a comprehensive suite test cases covering all edge cases, including:
- Version parameter validation (valid, invalid numbers, and strings).
- `includeReferences` toggling and JSON structure verification.
- Pagination/maxCount boundaries.
- Error formatting and API key absence.

Fixes #857 