### PR TITLE
fix: use raw GTFS direction_id for schedule/stops-for-route groupings

### DIFF
--- a/internal/restapi/schedule_for_route_handler.go
+++ b/internal/restapi/schedule_for_route_handler.go
@@ -277,9 +277,6 @@ func (api *RestAPI) scheduleForRouteHandler(w http.ResponseWriter, r *http.Reque
 
 		for _, t := range tripRows {
 			combinedTripID := utils.FormCombinedID(agencyID, t.ID)
-			// references.trips[].directionId carries the raw GTFS CSV value (0 or 1),
-			// matching Java OBA. stopTripGroupings[].directionId above is the Java-parity
-			// group index — the two fields share a name but have different semantics.
 			tripRef := models.NewTripReference(
 				combinedTripID,
 				t.RouteID,

--- a/internal/restapi/schedule_for_route_handler_test.go
+++ b/internal/restapi/schedule_for_route_handler_test.go
@@ -8,8 +8,20 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"maglev.onebusaway.org/internal/clock"
+	"maglev.onebusaway.org/internal/models"
 	"maglev.onebusaway.org/internal/utils"
 )
+
+type scheduleForRouteResponse struct {
+	Code int                  `json:"code"`
+	Data scheduleForRouteData `json:"data"`
+	Text string               `json:"text"`
+}
+
+type scheduleForRouteData struct {
+	Entry      models.ScheduleForRouteEntry `json:"entry"`
+	References models.ReferencesModel       `json:"references"`
+}
 
 func TestScheduleForRouteHandler(t *testing.T) {
 
@@ -210,48 +222,25 @@ func TestScheduleForRouteHandler_DirectionIDMatchesCSV(t *testing.T) {
 
 	routeID := utils.FormCombinedID("25", "1885")
 	endpoint := "/api/where/schedule-for-route/" + routeID + ".json?key=TEST&date=2025-06-12"
-	resp, model := serveApiAndRetrieveEndpoint(t, api, endpoint)
+	resp, model := callAPIHandler[scheduleForRouteResponse](t, api, endpoint)
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 
-	data, ok := model.Data.(map[string]interface{})
-	require.True(t, ok, "model.Data should be a map")
-	entry, ok := data["entry"].(map[string]interface{})
-	require.True(t, ok, "entry should be a map")
-	groupings, ok := entry["stopTripGroupings"].([]interface{})
-	require.True(t, ok, "stopTripGroupings should be a slice")
-	require.Len(t, groupings, 2)
+	groupings := model.Data.Entry.StopTripGroupings
+	require.Len(t, groupings, 2, "route 25_1885 has trips in both directions")
 
-	refs, ok := data["references"].(map[string]interface{})
-	require.True(t, ok, "references should be a map")
-	tripRefs, ok := refs["trips"].([]interface{})
-	require.True(t, ok, "trips should be a slice")
-
-	tripDirByID := make(map[string]string, len(tripRefs))
-	for _, tr := range tripRefs {
-		trMap, ok := tr.(map[string]interface{})
-		require.True(t, ok, "trip ref should be a map")
-		tid, _ := trMap["id"].(string)
-		dir, _ := trMap["directionId"].(string)
-		tripDirByID[tid] = dir
+	tripDirByID := make(map[string]string, len(model.Data.References.Trips))
+	for _, tr := range model.Data.References.Trips {
+		tripDirByID[tr.ID] = tr.DirectionID
 	}
 
-	first, ok := groupings[0].(map[string]interface{})
-	require.True(t, ok, "first grouping should be a map")
-	second, ok := groupings[1].(map[string]interface{})
-	require.True(t, ok, "second grouping should be a map")
-	assert.Equal(t, "0", first["directionId"])
-	assert.Equal(t, "1", second["directionId"])
+	assert.Equal(t, "0", groupings[0].DirectionID)
+	assert.Equal(t, "1", groupings[1].DirectionID)
 
 	for _, g := range groupings {
-		gMap, ok := g.(map[string]interface{})
-		require.True(t, ok, "grouping should be a map")
-		gid, _ := gMap["directionId"].(string)
-		tripIDs, _ := gMap["tripIds"].([]interface{})
-		require.NotEmpty(t, tripIDs)
-		for _, tid := range tripIDs {
-			ts, _ := tid.(string)
-			assert.Equal(t, gid, tripDirByID[ts],
-				"group %q trip %q should have CSV direction_id %q, got %q", gid, ts, gid, tripDirByID[ts])
+		require.NotEmpty(t, g.TripIDs)
+		for _, tid := range g.TripIDs {
+			assert.Equal(t, g.DirectionID, tripDirByID[tid],
+				"group %q trip %q should have CSV direction_id %q, got %q", g.DirectionID, tid, g.DirectionID, tripDirByID[tid])
 		}
 	}
 }

--- a/internal/restapi/schedule_for_route_handler_test.go
+++ b/internal/restapi/schedule_for_route_handler_test.go
@@ -203,11 +203,7 @@ func TestScheduleForRouteHandler_ServiceIDsScopedToRoute(t *testing.T) {
 		"serviceIds must be scoped to the route's trips, not agency-wide active services")
 }
 
-// Regression: stopTripGroupings must follow the Java-OBA direction_id convention —
-// groups are sorted so the higher CSV direction_id ("1") becomes group "0" and the
-// lower ("0") becomes group "1". Trips inside each group must still carry their
-// original CSV direction_id in the references section.
-func TestScheduleForRouteHandler_DirectionIDJavaParity(t *testing.T) {
+func TestScheduleForRouteHandler_DirectionIDMatchesCSV(t *testing.T) {
 	clk := clock.NewMockClock(time.Date(2025, 6, 12, 12, 0, 0, 0, time.UTC))
 	api := createTestApiWithClock(t, clk)
 	defer api.Shutdown()
@@ -217,20 +213,13 @@ func TestScheduleForRouteHandler_DirectionIDJavaParity(t *testing.T) {
 	resp, model := serveApiAndRetrieveEndpoint(t, api, endpoint)
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 
-	data, ok := model.Data.(map[string]interface{})
-	require.True(t, ok)
-	entry, ok := data["entry"].(map[string]interface{})
-	require.True(t, ok)
+	data, _ := model.Data.(map[string]interface{})
+	entry, _ := data["entry"].(map[string]interface{})
+	groupings, _ := entry["stopTripGroupings"].([]interface{})
+	require.Len(t, groupings, 2)
 
-	groupings, ok := entry["stopTripGroupings"].([]interface{})
-	require.True(t, ok)
-	require.Len(t, groupings, 2, "route 25_1885 has trips in both directions")
-
-	refs, ok := data["references"].(map[string]interface{})
-	require.True(t, ok)
-	tripRefs, ok := refs["trips"].([]interface{})
-	require.True(t, ok)
-
+	refs, _ := data["references"].(map[string]interface{})
+	tripRefs, _ := refs["trips"].([]interface{})
 	tripDirByID := make(map[string]string, len(tripRefs))
 	for _, tr := range tripRefs {
 		trMap := tr.(map[string]interface{})
@@ -239,8 +228,11 @@ func TestScheduleForRouteHandler_DirectionIDJavaParity(t *testing.T) {
 		tripDirByID[tid] = dir
 	}
 
-	// Expected Java-OBA mapping: group "0" ↔ CSV direction_id "1", group "1" ↔ CSV direction_id "0".
-	expected := map[string]string{"0": "1", "1": "0"}
+	first, _ := groupings[0].(map[string]interface{})
+	second, _ := groupings[1].(map[string]interface{})
+	assert.Equal(t, "0", first["directionId"])
+	assert.Equal(t, "1", second["directionId"])
+
 	for _, g := range groupings {
 		gMap := g.(map[string]interface{})
 		gid, _ := gMap["directionId"].(string)
@@ -248,8 +240,8 @@ func TestScheduleForRouteHandler_DirectionIDJavaParity(t *testing.T) {
 		require.NotEmpty(t, tripIDs)
 		for _, tid := range tripIDs {
 			ts, _ := tid.(string)
-			assert.Equal(t, expected[gid], tripDirByID[ts],
-				"group %s trip %s should have CSV direction_id %s", gid, ts, expected[gid])
+			assert.Equal(t, gid, tripDirByID[ts],
+				"group %q trip %q should have CSV direction_id %q, got %q", gid, ts, gid, tripDirByID[ts])
 		}
 	}
 }

--- a/internal/restapi/schedule_for_route_handler_test.go
+++ b/internal/restapi/schedule_for_route_handler_test.go
@@ -213,28 +213,38 @@ func TestScheduleForRouteHandler_DirectionIDMatchesCSV(t *testing.T) {
 	resp, model := serveApiAndRetrieveEndpoint(t, api, endpoint)
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 
-	data, _ := model.Data.(map[string]interface{})
-	entry, _ := data["entry"].(map[string]interface{})
-	groupings, _ := entry["stopTripGroupings"].([]interface{})
+	data, ok := model.Data.(map[string]interface{})
+	require.True(t, ok, "model.Data should be a map")
+	entry, ok := data["entry"].(map[string]interface{})
+	require.True(t, ok, "entry should be a map")
+	groupings, ok := entry["stopTripGroupings"].([]interface{})
+	require.True(t, ok, "stopTripGroupings should be a slice")
 	require.Len(t, groupings, 2)
 
-	refs, _ := data["references"].(map[string]interface{})
-	tripRefs, _ := refs["trips"].([]interface{})
+	refs, ok := data["references"].(map[string]interface{})
+	require.True(t, ok, "references should be a map")
+	tripRefs, ok := refs["trips"].([]interface{})
+	require.True(t, ok, "trips should be a slice")
+
 	tripDirByID := make(map[string]string, len(tripRefs))
 	for _, tr := range tripRefs {
-		trMap := tr.(map[string]interface{})
+		trMap, ok := tr.(map[string]interface{})
+		require.True(t, ok, "trip ref should be a map")
 		tid, _ := trMap["id"].(string)
 		dir, _ := trMap["directionId"].(string)
 		tripDirByID[tid] = dir
 	}
 
-	first, _ := groupings[0].(map[string]interface{})
-	second, _ := groupings[1].(map[string]interface{})
+	first, ok := groupings[0].(map[string]interface{})
+	require.True(t, ok, "first grouping should be a map")
+	second, ok := groupings[1].(map[string]interface{})
+	require.True(t, ok, "second grouping should be a map")
 	assert.Equal(t, "0", first["directionId"])
 	assert.Equal(t, "1", second["directionId"])
 
 	for _, g := range groupings {
-		gMap := g.(map[string]interface{})
+		gMap, ok := g.(map[string]interface{})
+		require.True(t, ok, "grouping should be a map")
 		gid, _ := gMap["directionId"].(string)
 		tripIDs, _ := gMap["tripIds"].([]interface{})
 		require.NotEmpty(t, tripIDs)

--- a/internal/restapi/stops_for_route_handler.go
+++ b/internal/restapi/stops_for_route_handler.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"net/http"
 	"slices"
-	"strings"
 	"time"
 
 	"github.com/twpayne/go-polyline"
@@ -341,7 +340,7 @@ func processTripGroups(
 
 	if len(allStopGroups) > 0 {
 		slices.SortFunc(allStopGroups, func(a, b models.StopGroup) int {
-			return cmp.Compare(strings.Join(a.Name.Names, ""), strings.Join(b.Name.Names, ""))
+			return cmp.Compare(a.Name.Name, b.Name.Name)
 		})
 
 		*stopGroupings = append(*stopGroupings, models.StopGrouping{

--- a/internal/restapi/stops_for_route_handler.go
+++ b/internal/restapi/stops_for_route_handler.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"net/http"
 	"slices"
+	"strings"
 	"time"
 
 	"github.com/twpayne/go-polyline"
@@ -339,8 +340,8 @@ func processTripGroups(
 	}
 
 	if len(allStopGroups) > 0 {
-		slices.SortFunc(*stopGroupings, func(a, b models.StopGrouping) int {
-			return cmp.Compare(a.StopGroups[0].ID, b.StopGroups[0].ID)
+		slices.SortFunc(allStopGroups, func(a, b models.StopGroup) int {
+			return cmp.Compare(strings.Join(a.Name.Names, ""), strings.Join(b.Name.Names, ""))
 		})
 
 		*stopGroupings = append(*stopGroupings, models.StopGrouping{

--- a/internal/restapi/stops_for_route_handler_test.go
+++ b/internal/restapi/stops_for_route_handler_test.go
@@ -67,45 +67,40 @@ func TestStopsForRouteHandlerEndToEnd(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, 2, len(stopGroups))
 
-	// Java-OBA direction_id convention: CSV direction_id=1 maps to group "0"
-	// (first entry), CSV direction_id=0 maps to group "1" (second entry).
-	inboundGroup, ok := stopGroups[0].(map[string]any)
+	outboundGroup, ok := stopGroups[0].(map[string]any)
 	require.True(t, ok)
-	assert.Equal(t, "0", inboundGroup["id"])
-
-	inboundName, ok := inboundGroup["name"].(map[string]any)
-	require.True(t, ok)
-	assert.Equal(t, "Shasta Lake", inboundName["name"])
-	assert.Equal(t, "destination", inboundName["type"])
-
-	inboundNames, ok := inboundName["names"].([]any)
-	require.True(t, ok)
-	assert.Equal(t, 1, len(inboundNames))
-	assert.Equal(t, "Shasta Lake", inboundNames[0])
-
-	inboundStopIds, ok := inboundGroup["stopIds"].([]any)
-	require.True(t, ok)
-
-	// With deterministic sorting, checks should be consistent
-	assert.Equal(t, 22, len(inboundStopIds))
-
-	inboundPolylines, ok := inboundGroup["polylines"].([]any)
-	require.True(t, ok)
-	assert.Equal(t, 1, len(inboundPolylines))
-
-	outboundGroup, ok := stopGroups[1].(map[string]any)
-	require.True(t, ok)
-	assert.Equal(t, "1", outboundGroup["id"])
+	assert.Equal(t, "0", outboundGroup["id"])
 
 	outboundName, ok := outboundGroup["name"].(map[string]any)
 	require.True(t, ok)
 	assert.Equal(t, "Shasta Lake", outboundName["name"])
 	assert.Equal(t, "destination", outboundName["type"])
 
+	outboundNames, ok := outboundName["names"].([]any)
+	require.True(t, ok)
+	assert.Equal(t, 1, len(outboundNames))
+	assert.Equal(t, "Shasta Lake", outboundNames[0])
+
 	outboundStopIds, ok := outboundGroup["stopIds"].([]any)
 	require.True(t, ok)
-	// With deterministic sorting, checks should be consistent
 	assert.Equal(t, 21, len(outboundStopIds))
+
+	outboundPolylines, ok := outboundGroup["polylines"].([]any)
+	require.True(t, ok)
+	assert.Equal(t, 1, len(outboundPolylines))
+
+	inboundGroup, ok := stopGroups[1].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "1", inboundGroup["id"])
+
+	inboundName, ok := inboundGroup["name"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "Shasta Lake", inboundName["name"])
+	assert.Equal(t, "destination", inboundName["type"])
+
+	inboundStopIds, ok := inboundGroup["stopIds"].([]any)
+	require.True(t, ok)
+	assert.Equal(t, 22, len(inboundStopIds))
 
 	// Verify references
 	refs, ok := data["references"].(map[string]any)

--- a/internal/restapi/trips_helper.go
+++ b/internal/restapi/trips_helper.go
@@ -1212,18 +1212,16 @@ func groupTripsByDirection(trips []gtfsdb.Trip) []directionGroup {
 	for dirID := range byDirID {
 		dirIDs = append(dirIDs, dirID)
 	}
-	// Descending so CSV direction_id=1 becomes group "0" and direction_id=0 becomes group "1" (Java OBA parity).
-	sort.Slice(dirIDs, func(i, j int) bool { return dirIDs[i] > dirIDs[j] })
+	sort.Slice(dirIDs, func(i, j int) bool { return dirIDs[i] < dirIDs[j] })
 
 	groups := make([]directionGroup, 0, len(dirIDs))
-	for i, dirID := range dirIDs {
+	for _, dirID := range dirIDs {
 		tripsInGroup := byDirID[dirID]
-		// Sort by trip ID so tripIds in the response is deterministic across runs.
 		sort.Slice(tripsInGroup, func(a, b int) bool {
 			return tripsInGroup[a].ID < tripsInGroup[b].ID
 		})
 		groups = append(groups, directionGroup{
-			GroupID:     strconv.Itoa(i),
+			GroupID:     strconv.FormatInt(dirID, 10),
 			DirectionID: tripsInGroup[0].DirectionID,
 			Trips:       tripsInGroup,
 		})

--- a/internal/restapi/trips_helper_test.go
+++ b/internal/restapi/trips_helper_test.go
@@ -2137,8 +2137,6 @@ func makeTestTrip(id string, directionID sql.NullInt64) gtfsdb.Trip {
 func nullDir() sql.NullInt64    { return sql.NullInt64{Valid: false} }
 func dir(v int64) sql.NullInt64 { return sql.NullInt64{Int64: v, Valid: true} }
 
-// TestGroupTripsByDirection_TwoDirections verifies that direction_id=1 becomes
-// group "0" and direction_id=0 becomes group "1", matching the Java OBA convention.
 func TestGroupTripsByDirection_TwoDirections(t *testing.T) {
 	trips := []gtfsdb.Trip{
 		makeTestTrip("t-inbound-2", dir(0)),
@@ -2151,17 +2149,15 @@ func TestGroupTripsByDirection_TwoDirections(t *testing.T) {
 
 	require.Len(t, groups, 2)
 
-	// Highest direction_id (1) → group "0"
 	assert.Equal(t, "0", groups[0].GroupID)
-	assert.Equal(t, int64(1), groups[0].DirectionID.Int64)
+	assert.Equal(t, int64(0), groups[0].DirectionID.Int64)
 	assert.True(t, groups[0].DirectionID.Valid)
-	assert.Equal(t, []string{"t-outbound-1", "t-outbound-2"}, testTripIDs(groups[0].Trips))
+	assert.Equal(t, []string{"t-inbound-1", "t-inbound-2"}, testTripIDs(groups[0].Trips))
 
-	// direction_id=0 → group "1"
 	assert.Equal(t, "1", groups[1].GroupID)
-	assert.Equal(t, int64(0), groups[1].DirectionID.Int64)
+	assert.Equal(t, int64(1), groups[1].DirectionID.Int64)
 	assert.True(t, groups[1].DirectionID.Valid)
-	assert.Equal(t, []string{"t-inbound-1", "t-inbound-2"}, testTripIDs(groups[1].Trips))
+	assert.Equal(t, []string{"t-outbound-1", "t-outbound-2"}, testTripIDs(groups[1].Trips))
 }
 
 // TestGroupTripsByDirection_SingleDirection verifies single-direction routes produce one group "0".
@@ -2211,14 +2207,14 @@ func TestGroupTripsByDirection_MixedNullAndValid(t *testing.T) {
 	require.Len(t, groups, 2)
 
 	assert.Equal(t, "0", groups[0].GroupID)
-	assert.True(t, groups[0].DirectionID.Valid)
-	assert.Equal(t, int64(1), groups[0].DirectionID.Int64)
-	assert.Equal(t, []string{"t-out"}, testTripIDs(groups[0].Trips))
+	assert.False(t, groups[0].DirectionID.Valid,
+		"NULL direction_id collides with direction_id=0; first trip by ID determines group DirectionID")
+	assert.Equal(t, []string{"a-null", "t-in"}, testTripIDs(groups[0].Trips))
 
 	assert.Equal(t, "1", groups[1].GroupID)
-	assert.False(t, groups[1].DirectionID.Valid,
-		"NULL direction_id collides with direction_id=0; first trip by ID determines group DirectionID")
-	assert.Equal(t, []string{"a-null", "t-in"}, testTripIDs(groups[1].Trips))
+	assert.True(t, groups[1].DirectionID.Valid)
+	assert.Equal(t, int64(1), groups[1].DirectionID.Int64)
+	assert.Equal(t, []string{"t-out"}, testTripIDs(groups[1].Trips))
 }
 
 // TestGroupTripsByDirection_TripsWithinGroupSortedByID verifies deterministic trip order.


### PR DESCRIPTION
Fixes: #882

## Summary
- `groupTripsByDirection` re-indexed groups (descending sort), swapping CSV `direction_id` 0 ↔ 1 in the response.
- Use the raw GTFS `direction_id` string as the group id (Java parity).
- Sort `stops-for-route` stopGroups by headsign name (Java parity).



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stop groups are now ordered by stop/route names for more consistent display.
  * Direction groups are ordered and identified by ascending direction ID for more predictable grouping and accurate trip-to-direction matching.

* **Tests**
  * Updated tests to precisely assert direction-to-group and stop-group assignments and reflect the new ordering and ID behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->