### PR TITLE
refactor: logging cleanup

### DIFF
--- a/cmd/api/app.go
+++ b/cmd/api/app.go
@@ -31,8 +31,8 @@ func gtfsConfigFromData(gtfsCfgData appconf.GtfsConfigData) gtfs.Config {
 		StaticAuthHeaderValue: gtfsCfgData.StaticAuthHeaderValue,
 		GTFSDataPath:          gtfsCfgData.GTFSDataPath,
 		Env:                   gtfsCfgData.Env,
-		Verbose:               gtfsCfgData.Verbose,
-		EnableGTFSTidy:        gtfsCfgData.EnableGTFSTidy,
+
+		EnableGTFSTidy: gtfsCfgData.EnableGTFSTidy,
 	}
 
 	for _, feedData := range gtfsCfgData.RTFeeds {
@@ -94,6 +94,7 @@ func newLogHandler(format string, level slog.Level) slog.Handler {
 func BuildApplication(ctx context.Context, cfg appconf.Config, gtfsCfg gtfs.Config) (*app.Application, error) {
 	level := parseLogLevel(cfg.LogLevel)
 	logger := slog.New(newLogHandler(cfg.LogFormat, level))
+	slog.SetDefault(logger)
 
 	appMetrics := metrics.NewWithLogger(logger)
 	gtfsCfg.Metrics = appMetrics
@@ -207,9 +208,10 @@ func CreateServer(coreApp *app.Application, cfg appconf.Config) (*http.Server, *
 // Starts the server in a goroutine, waits for shutdown signals (SIGINT, SIGTERM) or context cancellation,
 // and performs graceful shutdown with a 30-second timeout.
 // Returns an error if the server fails to start or shutdown fails.
-func Run(ctx context.Context, srv *http.Server, coreApp *app.Application, api *restapi.RestAPI, logger *slog.Logger) error {
+func Run(ctx context.Context, srv *http.Server, coreApp *app.Application, api *restapi.RestAPI) error {
 	cfg := coreApp.Config
 	tlsEnabled := cfg.TLSCertPath != "" && cfg.TLSKeyPath != ""
+	logger := coreApp.Logger
 	logger.Info("starting server", "addr", srv.Addr, "tls", tlsEnabled)
 
 	// Set up signal handling for graceful shutdown, merging with provided context

--- a/cmd/api/app.go
+++ b/cmd/api/app.go
@@ -92,10 +92,7 @@ func newLogHandler(format string, level slog.Level) slog.Handler {
 // This includes creating the logger, initializing the GTFS manager, and creating the direction calculator.
 // Returns an error if GTFS manager initialization fails.
 func BuildApplication(ctx context.Context, cfg appconf.Config, gtfsCfg gtfs.Config) (*app.Application, error) {
-	level := parseLogLevel(cfg.LogLevel)
-	logger := slog.New(newLogHandler(cfg.LogFormat, level))
-	slog.SetDefault(logger)
-
+	logger := slog.Default()
 	appMetrics := metrics.NewWithLogger(logger)
 	gtfsCfg.Metrics = appMetrics
 

--- a/cmd/api/app_test.go
+++ b/cmd/api/app_test.go
@@ -78,17 +78,16 @@ func TestBuildApplicationWithMemoryDB(t *testing.T) {
 	}
 
 	cfg := appconf.Config{
-		Port:      4000,
-		Env:       appconf.Test,
-		ApiKeys:   []string{"test"},
-		Verbose:   false,
+		Port:    4000,
+		Env:     appconf.Test,
+		ApiKeys: []string{"test"},
+
 		RateLimit: 100,
 	}
 
 	gtfsCfg := gtfs.Config{
 		GTFSDataPath: ":memory:",
 		GtfsURL:      testDataPath,
-		Verbose:      false,
 	}
 
 	coreApp, err := BuildApplication(ctx, cfg, gtfsCfg)
@@ -116,17 +115,16 @@ func TestBuildApplicationWithTestData(t *testing.T) {
 	}
 
 	cfg := appconf.Config{
-		Port:      4000,
-		Env:       appconf.Test,
-		ApiKeys:   []string{"test"},
-		Verbose:   false,
+		Port:    4000,
+		Env:     appconf.Test,
+		ApiKeys: []string{"test"},
+
 		RateLimit: 100,
 	}
 
 	gtfsCfg := gtfs.Config{
 		GTFSDataPath: ":memory:",
 		GtfsURL:      testDataPath,
-		Verbose:      false,
 	}
 
 	coreApp, err := BuildApplication(ctx, cfg, gtfsCfg)
@@ -149,17 +147,16 @@ func TestCreateServer(t *testing.T) {
 	}
 
 	cfg := appconf.Config{
-		Port:      8080,
-		Env:       appconf.Test,
-		ApiKeys:   []string{"test"},
-		Verbose:   false,
+		Port:    8080,
+		Env:     appconf.Test,
+		ApiKeys: []string{"test"},
+
 		RateLimit: 100,
 	}
 
 	gtfsCfg := gtfs.Config{
 		GTFSDataPath: ":memory:",
 		GtfsURL:      testDataPath,
-		Verbose:      false,
 	}
 
 	coreApp, err := BuildApplication(ctx, cfg, gtfsCfg)
@@ -188,17 +185,16 @@ func TestCreateServerHandlerResponds(t *testing.T) {
 	}
 
 	cfg := appconf.Config{
-		Port:      8080,
-		Env:       appconf.Test,
-		ApiKeys:   []string{"test"},
-		Verbose:   false,
+		Port:    8080,
+		Env:     appconf.Test,
+		ApiKeys: []string{"test"},
+
 		RateLimit: 100,
 	}
 
 	gtfsCfg := gtfs.Config{
 		GTFSDataPath: ":memory:",
 		GtfsURL:      testDataPath,
-		Verbose:      false,
 	}
 
 	coreApp, err := BuildApplication(ctx, cfg, gtfsCfg)
@@ -234,17 +230,16 @@ func TestRunServerStartsAndStopsCleanly(t *testing.T) {
 	}
 
 	cfg := appconf.Config{
-		Port:      0, // Use port 0 to get a random available port
-		Env:       appconf.Test,
-		ApiKeys:   []string{"test"},
-		Verbose:   false,
+		Port:    0, // Use port 0 to get a random available port
+		Env:     appconf.Test,
+		ApiKeys: []string{"test"},
+
 		RateLimit: 100,
 	}
 
 	gtfsCfg := gtfs.Config{
 		GTFSDataPath: ":memory:",
 		GtfsURL:      testDataPath,
-		Verbose:      false,
 	}
 
 	coreApp, err := BuildApplication(ctx, cfg, gtfsCfg)
@@ -320,17 +315,16 @@ func TestRunWithPortZeroAndImmediateShutdown(t *testing.T) {
 	}
 
 	cfg := appconf.Config{
-		Port:      0, // Use random port to avoid conflicts
-		Env:       appconf.Test,
-		ApiKeys:   []string{"test"},
-		Verbose:   false,
+		Port:    0, // Use random port to avoid conflicts
+		Env:     appconf.Test,
+		ApiKeys: []string{"test"},
+
 		RateLimit: 100,
 	}
 
 	gtfsCfg := gtfs.Config{
 		GTFSDataPath: ":memory:",
 		GtfsURL:      testDataPath,
-		Verbose:      false,
 	}
 
 	coreApp, err := BuildApplication(ctx, cfg, gtfsCfg)
@@ -374,17 +368,16 @@ func TestBuildApplicationErrorHandling(t *testing.T) {
 
 	t.Run("handles invalid GTFS path", func(t *testing.T) {
 		cfg := appconf.Config{
-			Port:      4000,
-			Env:       appconf.Test,
-			ApiKeys:   []string{"test"},
-			Verbose:   false,
+			Port:    4000,
+			Env:     appconf.Test,
+			ApiKeys: []string{"test"},
+
 			RateLimit: 100,
 		}
 
 		gtfsCfg := gtfs.Config{
 			GTFSDataPath: ":memory:",
 			GtfsURL:      "/nonexistent/path/to/gtfs.zip",
-			Verbose:      false,
 		}
 
 		_, err := BuildApplication(ctx, cfg, gtfsCfg)
@@ -409,11 +402,9 @@ func TestConfigFileLoading(t *testing.T) {
 		assert.Equal(t, appconf.Development, appCfg.Env)
 		assert.Equal(t, []string{"test"}, appCfg.ApiKeys)
 		assert.Equal(t, 100, appCfg.RateLimit)
-		assert.True(t, appCfg.Verbose)
 
 		// Verify GTFS config
 		assert.Equal(t, appconf.Development, gtfsCfgData.Env)
-		assert.True(t, gtfsCfgData.Verbose)
 	})
 
 	t.Run("loads full config file with GTFS-RT feed", func(t *testing.T) {
@@ -521,8 +512,9 @@ func TestRun_GracefulShutdown(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-
-	coreApp := &app.Application{}
+	coreApp := &app.Application{
+		Logger: logger,
+	}
 
 	srv := &http.Server{
 		Addr: "127.0.0.1:0",
@@ -534,7 +526,7 @@ func TestRun_GracefulShutdown(t *testing.T) {
 	errCh := make(chan error, 1)
 
 	go func() {
-		errCh <- Run(ctx, srv, coreApp, nil, logger)
+		errCh <- Run(ctx, srv, coreApp, nil)
 	}()
 
 	// Small delay so ListenAndServe starts

--- a/cmd/api/lock_safety_test.go
+++ b/cmd/api/lock_safety_test.go
@@ -58,7 +58,7 @@ func TestHandlerLockSafety(t *testing.T) {
 
 	serverErrChan := make(chan error, 1)
 	go func() {
-		serverErrChan <- Run(serverCtx, srv, application, api, application.Logger)
+		serverErrChan <- Run(serverCtx, srv, application, api)
 	}()
 
 	// Wait for server to become ready

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -20,10 +20,13 @@ func main() {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
+	// Create a temporary logger for reporting errors during startup.
+	startupLogger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+
 	// Start isolated pprof server on localhost only
 	if os.Getenv("MAGLEV_ENABLE_PPROF") == "1" {
 		go func() {
-			logger := slog.New(slog.NewTextHandler(os.Stdout, nil)).With(slog.String("component", "pprof"))
+			logger := startupLogger.With(slog.String("component", "pprof"))
 			logger.Warn("STARTING PPROF DEBUG SERVER ON localhost:6060 (NOT PUBLIC)")
 			// Listens ONLY on loopback interface using DefaultServeMux
 			if err := http.ListenAndServe("127.0.0.1:6060", nil); err != nil {
@@ -37,8 +40,7 @@ func main() {
 		runtime.SetMutexProfileFraction(1)
 		runtime.SetBlockProfileRate(1)
 
-		logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
-		logger.Warn("MUTEX AND BLOCK PROFILING ENABLED (Performance will be impacted)")
+		startupLogger.Warn("MUTEX AND BLOCK PROFILING ENABLED (Performance will be impacted)")
 	}
 
 	var cfg appconf.Config
@@ -81,8 +83,7 @@ func main() {
 	if configFile != "" && flag.NFlag() > 1 {
 		// Allow -f with --dump-config as a special case
 		if flag.NFlag() != 2 || !dumpConfig {
-			logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
-			logger.Error("the -f flag is mutually exclusive with other configuration flags (except --dump-config)")
+			startupLogger.Error("the -f flag is mutually exclusive with other configuration flags (except --dump-config)")
 			flag.Usage()
 			os.Exit(1)
 		}
@@ -93,8 +94,7 @@ func main() {
 		// Load configuration from JSON file
 		jsonConfig, err := appconf.LoadFromFile(configFile)
 		if err != nil {
-			logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
-			logger.Error("failed to load config file", "error", err)
+			startupLogger.Error("failed to load config file", "error", err)
 			os.Exit(1)
 		}
 
@@ -160,8 +160,6 @@ func main() {
 		gtfsCfg = gtfsConfigFromData(gtfsCfgData)
 
 		// Set verbosity flags (CLI specific)
-		gtfsCfg.Verbose = true
-		cfg.Verbose = true
 		cfg.LogLevel = "info"
 		cfg.LogFormat = "text"
 	}
@@ -175,8 +173,7 @@ func main() {
 	// Build application with dependencies
 	coreApp, err := BuildApplication(ctx, cfg, gtfsCfg)
 	if err != nil {
-		logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
-		logger.Error("failed to build application", "error", err)
+		startupLogger.Error("failed to build application", "error", err)
 		os.Exit(1)
 	}
 
@@ -184,8 +181,8 @@ func main() {
 	srv, api := CreateServer(coreApp, cfg)
 
 	// Run server with graceful shutdown
-	if err := Run(ctx, srv, coreApp, api, coreApp.Logger); err != nil {
-		coreApp.Logger.Error("server error", "error", err)
+	if err := Run(ctx, srv, coreApp, api); err != nil {
+		startupLogger.Error("server error", "error", err)
 		os.Exit(1)
 	}
 }

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -170,10 +170,14 @@ func main() {
 		os.Exit(0)
 	}
 
+	level := parseLogLevel(cfg.LogLevel)
+	logger := slog.New(newLogHandler(cfg.LogFormat, level))
+	slog.SetDefault(logger)
+
 	// Build application with dependencies
 	coreApp, err := BuildApplication(ctx, cfg, gtfsCfg)
 	if err != nil {
-		startupLogger.Error("failed to build application", "error", err)
+		logger.Error("failed to build application", "error", err)
 		os.Exit(1)
 	}
 
@@ -182,7 +186,7 @@ func main() {
 
 	// Run server with graceful shutdown
 	if err := Run(ctx, srv, coreApp, api); err != nil {
-		startupLogger.Error("server error", "error", err)
+		logger.Error("server error", "error", err)
 		os.Exit(1)
 	}
 }

--- a/gtfsdb/client.go
+++ b/gtfsdb/client.go
@@ -3,7 +3,7 @@ package gtfsdb
 import (
 	"database/sql"
 	"fmt"
-	"log"
+	"log/slog"
 	"time"
 )
 
@@ -20,9 +20,8 @@ func NewClient(config Config) (*Client, error) {
 	db, err := createDB(config)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create DB: %w", err)
-	} else if config.verbose {
-		log.Println("Successfully created tables")
 	}
+	slog.Default().Debug("successfully created DB")
 
 	// Wrap DB for query interception (optional metrics).
 	var dbtx DBTX = db

--- a/gtfsdb/conditional_import_test.go
+++ b/gtfsdb/conditional_import_test.go
@@ -43,9 +43,8 @@ func createTestData(t *testing.T) ([]byte, []byte) {
 func TestConditionalImport_InitialImport(t *testing.T) {
 	// Create in-memory database
 	config := Config{
-		DBPath:  ":memory:",
-		Env:     appconf.Test,
-		verbose: true,
+		DBPath: ":memory:",
+		Env:    appconf.Test,
 	}
 
 	client, err := NewClient(config)
@@ -78,9 +77,8 @@ func TestConditionalImport_InitialImport(t *testing.T) {
 func TestConditionalImport_SkipUnchangedData(t *testing.T) {
 	// Create in-memory database
 	config := Config{
-		DBPath:  ":memory:",
-		Env:     appconf.Test,
-		verbose: true,
+		DBPath: ":memory:",
+		Env:    appconf.Test,
 	}
 
 	client, err := NewClient(config)
@@ -134,9 +132,8 @@ func TestConditionalImport_SkipUnchangedData(t *testing.T) {
 func TestConditionalImport_ReloadChangedData(t *testing.T) {
 	// Create in-memory database
 	config := Config{
-		DBPath:  ":memory:",
-		Env:     appconf.Test,
-		verbose: true,
+		DBPath: ":memory:",
+		Env:    appconf.Test,
 	}
 
 	client, err := NewClient(config)
@@ -181,9 +178,8 @@ func TestConditionalImport_ReloadChangedData(t *testing.T) {
 func TestConditionalImport_DifferentSources(t *testing.T) {
 	// Create in-memory database
 	config := Config{
-		DBPath:  ":memory:",
-		Env:     appconf.Test,
-		verbose: true,
+		DBPath: ":memory:",
+		Env:    appconf.Test,
 	}
 
 	client, err := NewClient(config)
@@ -221,9 +217,8 @@ func TestConditionalImport_DifferentSources(t *testing.T) {
 func TestConditionalImport_FileImport(t *testing.T) {
 	// Create in-memory database
 	config := Config{
-		DBPath:  ":memory:",
-		Env:     appconf.Test,
-		verbose: true,
+		DBPath: ":memory:",
+		Env:    appconf.Test,
 	}
 
 	client, err := NewClient(config)
@@ -267,9 +262,8 @@ func TestConditionalImport_FileImport(t *testing.T) {
 func TestClearAllGTFSData(t *testing.T) {
 	// Create in-memory database
 	config := Config{
-		DBPath:  ":memory:",
-		Env:     appconf.Test,
-		verbose: true,
+		DBPath: ":memory:",
+		Env:    appconf.Test,
 	}
 
 	client, err := NewClient(config)

--- a/gtfsdb/config.go
+++ b/gtfsdb/config.go
@@ -15,9 +15,8 @@ const (
 // Config holds configuration options for the Client
 type Config struct {
 	// Database configuration
-	DBPath  string              // Path to SQLite database file
-	Env     appconf.Environment // Environment name: development, test, production.
-	verbose bool                // Enable verbose logging
+	DBPath string              // Path to SQLite database file
+	Env    appconf.Environment // Environment name: development, test, production.
 	// Optional recorder for DB query metrics.
 	QueryMetricsRecorder DBQueryMetricsRecorder
 }
@@ -28,11 +27,10 @@ type DBQueryMetricsRecorder interface {
 	RecordDBQuery(queryName, op string, err error)
 }
 
-func NewConfig(dbPath string, env appconf.Environment, verbose bool) Config {
+func NewConfig(dbPath string, env appconf.Environment) Config {
 	return Config{
-		DBPath:  dbPath,
-		Env:     env,
-		verbose: verbose,
+		DBPath: dbPath,
+		Env:    env,
 	}
 }
 

--- a/gtfsdb/config_test.go
+++ b/gtfsdb/config_test.go
@@ -10,82 +10,70 @@ import (
 func TestNewConfig(t *testing.T) {
 	dbPath := "/path/to/database.db"
 	env := appconf.Production
-	verbose := true
 
-	config := NewConfig(dbPath, env, verbose)
+	config := NewConfig(dbPath, env)
 
 	assert.Equal(t, dbPath, config.DBPath, "DBPath should match input")
 	assert.Equal(t, env, config.Env, "Env should match input")
-	assert.Equal(t, verbose, config.verbose, "verbose should match input")
 }
 
 func TestNewConfigWithDevelopmentEnv(t *testing.T) {
 	dbPath := ":memory:"
 	env := appconf.Development
-	verbose := false
 
-	config := NewConfig(dbPath, env, verbose)
+	config := NewConfig(dbPath, env)
 
 	assert.Equal(t, dbPath, config.DBPath)
 	assert.Equal(t, env, config.Env)
-	assert.Equal(t, false, config.verbose)
 }
 
 func TestNewConfigWithTestEnv(t *testing.T) {
 	dbPath := "test.db"
 	env := appconf.Test
-	verbose := true
 
-	config := NewConfig(dbPath, env, verbose)
+	config := NewConfig(dbPath, env)
 
 	assert.Equal(t, dbPath, config.DBPath)
 	assert.Equal(t, env, config.Env)
-	assert.Equal(t, true, config.verbose)
 }
 
 func TestNewConfigWithEmptyDBPath(t *testing.T) {
 	dbPath := ""
 	env := appconf.Development
-	verbose := false
 
-	config := NewConfig(dbPath, env, verbose)
+	config := NewConfig(dbPath, env)
 
 	assert.Equal(t, "", config.DBPath, "Empty DBPath should be allowed")
 	assert.Equal(t, env, config.Env)
-	assert.Equal(t, verbose, config.verbose)
 }
 
 func TestConfigStruct(t *testing.T) {
 	// Test that Config struct can be created directly
 	config := Config{
-		DBPath:  "/custom/path.db",
-		Env:     appconf.Production,
-		verbose: true,
+		DBPath: "/custom/path.db",
+		Env:    appconf.Production,
 	}
 
 	assert.Equal(t, "/custom/path.db", config.DBPath)
 	assert.Equal(t, appconf.Production, config.Env)
-	assert.Equal(t, true, config.verbose)
 }
 
 func TestNewConfigAllEnvironments(t *testing.T) {
 	tests := []struct {
-		name    string
-		env     appconf.Environment
-		verbose bool
+		name string
+		env  appconf.Environment
 	}{
-		{"Development environment", appconf.Development, false},
-		{"Test environment", appconf.Test, true},
-		{"Production environment", appconf.Production, false},
+		{"Development environment", appconf.Development},
+		{"Test environment", appconf.Test},
+		{"Production environment", appconf.Production},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			config := NewConfig("test.db", tt.env, tt.verbose)
+			config := NewConfig("test.db", tt.env)
 
 			assert.Equal(t, "test.db", config.DBPath)
 			assert.Equal(t, tt.env, config.Env)
-			assert.Equal(t, tt.verbose, config.verbose)
 		})
 	}
 }

--- a/gtfsdb/connection_pool_test.go
+++ b/gtfsdb/connection_pool_test.go
@@ -13,9 +13,8 @@ import (
 func TestDatabaseConnectionPoolSettings(t *testing.T) {
 	// Test that database connection pool is configured with appropriate settings
 	config := Config{
-		DBPath:  ":memory:",
-		Env:     appconf.Test,
-		verbose: false,
+		DBPath: ":memory:",
+		Env:    appconf.Test,
 	}
 
 	client, err := NewClient(config)
@@ -39,9 +38,8 @@ func TestConnectionPoolBehavior(t *testing.T) {
 	// Test connection pool behavior - note that :memory: databases use only 1 connection
 	// so concurrent queries will be serialized
 	config := Config{
-		DBPath:  ":memory:",
-		Env:     appconf.Test,
-		verbose: false,
+		DBPath: ":memory:",
+		Env:    appconf.Test,
 	}
 
 	client, err := NewClient(config)
@@ -72,9 +70,8 @@ func TestConnectionPoolBehavior(t *testing.T) {
 func TestConnectionLifetime(t *testing.T) {
 	// Test that connection max lifetime is configured
 	config := Config{
-		DBPath:  ":memory:",
-		Env:     appconf.Test,
-		verbose: false,
+		DBPath: ":memory:",
+		Env:    appconf.Test,
 	}
 
 	client, err := NewClient(config)

--- a/gtfsdb/error_handling_test.go
+++ b/gtfsdb/error_handling_test.go
@@ -12,9 +12,8 @@ func TestNewClient_InvalidConfigHandling(t *testing.T) {
 	// Test that NewClient returns an error instead of calling log.Fatal
 	// when configuration is invalid (test env with file DB)
 	config := Config{
-		DBPath:  "/tmp/invalid_test_db.sqlite",
-		Env:     appconf.Test,
-		verbose: false,
+		DBPath: "/tmp/invalid_test_db.sqlite",
+		Env:    appconf.Test,
 	}
 
 	client, err := NewClient(config)
@@ -26,9 +25,8 @@ func TestNewClient_InvalidConfigHandling(t *testing.T) {
 func TestNewClient_ValidConfig(t *testing.T) {
 	// Test that NewClient works correctly with valid configuration
 	config := Config{
-		DBPath:  ":memory:",
-		Env:     appconf.Test,
-		verbose: false,
+		DBPath: ":memory:",
+		Env:    appconf.Test,
 	}
 
 	client, err := NewClient(config)
@@ -44,9 +42,8 @@ func TestNewClient_ValidConfig(t *testing.T) {
 func TestTableCounts_ErrorHandling(t *testing.T) {
 	// Create a client with a valid config
 	config := Config{
-		DBPath:  ":memory:",
-		Env:     appconf.Test,
-		verbose: false,
+		DBPath: ":memory:",
+		Env:    appconf.Test,
 	}
 
 	client, err := NewClient(config)
@@ -63,9 +60,8 @@ func TestTableCounts_ErrorHandling(t *testing.T) {
 func TestProcessAndStoreGTFSData_ErrorHandling(t *testing.T) {
 	// Create a client with a valid config
 	config := Config{
-		DBPath:  ":memory:",
-		Env:     appconf.Test,
-		verbose: false,
+		DBPath: ":memory:",
+		Env:    appconf.Test,
 	}
 
 	client, err := NewClient(config)

--- a/gtfsdb/nil_shape_test.go
+++ b/gtfsdb/nil_shape_test.go
@@ -85,9 +85,8 @@ TRIP2,09:15:00,09:15:00,STOP1,2
 func TestProcessGTFSWithoutShapes(t *testing.T) {
 	// Create in-memory database
 	config := Config{
-		DBPath:  ":memory:",
-		Env:     appconf.Test,
-		verbose: true,
+		DBPath: ":memory:",
+		Env:    appconf.Test,
 	}
 
 	client, err := NewClient(config)

--- a/gtfsdb/synthetic_gtfs_frequency_test.go
+++ b/gtfsdb/synthetic_gtfs_frequency_test.go
@@ -85,9 +85,8 @@ func buildSyntheticGTFSZip(t *testing.T, includeFrequencies bool) []byte {
 
 func TestSyntheticGTFS_FrequencyIngestion(t *testing.T) {
 	config := Config{
-		DBPath:  ":memory:",
-		Env:     appconf.Test,
-		verbose: true,
+		DBPath: ":memory:",
+		Env:    appconf.Test,
 	}
 
 	client, err := NewClient(config)
@@ -157,9 +156,8 @@ func TestSyntheticGTFS_FrequencyIngestion(t *testing.T) {
 
 func TestSyntheticGTFS_NoFrequencyFile(t *testing.T) {
 	config := Config{
-		DBPath:  ":memory:",
-		Env:     appconf.Test,
-		verbose: true,
+		DBPath: ":memory:",
+		Env:    appconf.Test,
 	}
 
 	client, err := NewClient(config)
@@ -191,9 +189,8 @@ func TestSyntheticGTFS_NoFrequencyFile(t *testing.T) {
 
 func TestSyntheticGTFS_FrequenciesClearedOnReimport(t *testing.T) {
 	config := Config{
-		DBPath:  ":memory:",
-		Env:     appconf.Test,
-		verbose: true,
+		DBPath: ":memory:",
+		Env:    appconf.Test,
 	}
 
 	client, err := NewClient(config)
@@ -233,9 +230,8 @@ func TestSyntheticGTFS_FrequenciesClearedOnReimport(t *testing.T) {
 
 func TestSyntheticGTFS_TableCountsIncludeFrequencies(t *testing.T) {
 	config := Config{
-		DBPath:  ":memory:",
-		Env:     appconf.Test,
-		verbose: true,
+		DBPath: ":memory:",
+		Env:    appconf.Test,
 	}
 
 	client, err := NewClient(config)

--- a/internal/appconf/config.go
+++ b/internal/appconf/config.go
@@ -11,7 +11,6 @@ type Config struct {
 	ApiKeys          []string
 	ProtectedApiKeys []string
 	ExemptApiKeys    []string
-	Verbose          bool
 	RateLimit        int // Requests per second per API key for rate limiting
 	LogLevel         string
 	LogFormat        string

--- a/internal/appconf/json_config.go
+++ b/internal/appconf/json_config.go
@@ -239,7 +239,6 @@ func (j *JSONConfig) ToAppConfig() Config {
 		ApiKeys:          j.ApiKeys,
 		ProtectedApiKeys: j.ProtectedApiKeys,
 		ExemptApiKeys:    j.ExemptApiKeys,
-		Verbose:          true, // Always set to true like in main.go
 		RateLimit:        j.RateLimit,
 		LogLevel:         j.LogLevel,
 		LogFormat:        j.LogFormat,
@@ -269,7 +268,6 @@ type GtfsConfigData struct {
 	RTFeeds               []RTFeedConfigData
 	GTFSDataPath          string
 	Env                   Environment
-	Verbose               bool
 	EnableGTFSTidy        bool
 }
 
@@ -281,7 +279,6 @@ func (j *JSONConfig) ToGtfsConfigData() (GtfsConfigData, error) {
 		StaticAuthHeaderValue: j.GtfsStaticFeed.AuthHeaderValue,
 		GTFSDataPath:          j.DataPath,
 		Env:                   EnvFlagToEnvironment(j.Env),
-		Verbose:               true, // Always set to true like in main.go
 		EnableGTFSTidy:        j.GtfsStaticFeed.EnableGTFSTidy,
 	}
 

--- a/internal/appconf/json_config_test.go
+++ b/internal/appconf/json_config_test.go
@@ -216,7 +216,6 @@ func TestToAppConfig(t *testing.T) {
 	assert.Equal(t, Production, appConfig.Env)
 	assert.Equal(t, []string{"key1", "key2"}, appConfig.ApiKeys)
 	assert.Equal(t, 50, appConfig.RateLimit)
-	assert.True(t, appConfig.Verbose)
 	assert.Equal(t, []string{"exempt-key-1"}, appConfig.ExemptApiKeys)
 }
 
@@ -267,7 +266,6 @@ func TestToGtfsConfigData_NoFeeds(t *testing.T) {
 	assert.Equal(t, "secret123", gtfsConfig.StaticAuthHeaderValue)
 	assert.Equal(t, "/data/gtfs.db", gtfsConfig.GTFSDataPath)
 	assert.Equal(t, Development, gtfsConfig.Env)
-	assert.True(t, gtfsConfig.Verbose)
 
 	// No feeds should result in empty RTFeeds
 	assert.Empty(t, gtfsConfig.RTFeeds)

--- a/internal/gtfs/config.go
+++ b/internal/gtfs/config.go
@@ -28,7 +28,6 @@ type Config struct {
 	RTFeeds               []RTFeedConfig
 	GTFSDataPath          string
 	Env                   appconf.Environment
-	Verbose               bool
 	EnableGTFSTidy        bool
 	StartupRetries        []time.Duration
 	Metrics               *metrics.Metrics

--- a/internal/gtfs/realtime.go
+++ b/internal/gtfs/realtime.go
@@ -468,7 +468,7 @@ func (manager *Manager) updateFeedRealtime(ctx context.Context, feedCfg RTFeedCo
 		}
 
 		if fullSuccess {
-			logger.Info("updated realtime feed successfully",
+			logger.Debug("updated realtime feed successfully",
 				slog.String("feed", feedID),
 				slog.Int("trips", len(manager.feedTrips[feedID])),
 				slog.Int("vehicles", len(manager.feedVehicles[feedID])),

--- a/internal/gtfs/realtime_test.go
+++ b/internal/gtfs/realtime_test.go
@@ -421,7 +421,7 @@ func TestVehicleMerge_StaleIgnored(t *testing.T) {
 
 	// capture logs for verification
 	var buf bytes.Buffer
-	logger := logging.NewStructuredLogger(&buf, slog.LevelInfo)
+	logger := logging.NewStructuredLogger(&buf, slog.LevelDebug)
 	ctx = logging.WithLogger(ctx, logger)
 
 	// create a server whose response can be modified between polls

--- a/internal/gtfs/shutdown_test.go
+++ b/internal/gtfs/shutdown_test.go
@@ -20,7 +20,6 @@ func TestManagerShutdown(t *testing.T) {
 		GtfsURL:      testDataPath,
 		GTFSDataPath: ":memory:",
 		Env:          appconf.Test,
-		Verbose:      false,
 	}
 
 	// Initialize manager
@@ -66,8 +65,7 @@ func TestManagerShutdownWithRealtime(t *testing.T) {
 				Enabled:             true,
 			},
 		},
-		Env:     appconf.Test,
-		Verbose: false,
+		Env: appconf.Test,
 	}
 
 	// Initialize manager
@@ -103,7 +101,6 @@ func TestManagerShutdownIdempotent(t *testing.T) {
 		GtfsURL:      testDataPath,
 		GTFSDataPath: ":memory:",
 		Env:          appconf.Test,
-		Verbose:      false,
 	}
 
 	// Initialize manager

--- a/internal/gtfs/static.go
+++ b/internal/gtfs/static.go
@@ -116,7 +116,7 @@ func importStaticIntoDB(ctx context.Context, client *gtfsdb.Client, data *gtfsdb
 }
 
 func newGTFSDBConfig(dbPath string, config Config) gtfsdb.Config {
-	dbConfig := gtfsdb.NewConfig(dbPath, config.Env, config.Verbose)
+	dbConfig := gtfsdb.NewConfig(dbPath, config.Env)
 	if config.Metrics != nil {
 		dbConfig.QueryMetricsRecorder = config.Metrics
 	}

--- a/internal/logging/structured_logging.go
+++ b/internal/logging/structured_logging.go
@@ -51,7 +51,7 @@ func LogOperation(logger *slog.Logger, operation string, attrs ...slog.Attr) {
 		args = append(args, attr)
 	}
 
-	logger.Info(operation, args...)
+	logger.Debug(operation, args...)
 }
 
 // LogHTTPRequest logs HTTP request details

--- a/internal/logging/structured_logging_test.go
+++ b/internal/logging/structured_logging_test.go
@@ -85,7 +85,7 @@ func TestLoggerHelpers(t *testing.T) {
 
 	t.Run("LogOperation logs structured operation info", func(t *testing.T) {
 		var buf bytes.Buffer
-		logger := NewStructuredLogger(&buf, slog.LevelInfo)
+		logger := NewStructuredLogger(&buf, slog.LevelDebug)
 
 		LogOperation(logger, "gtfs_data_imported",
 			slog.String("source", "file.zip"),
@@ -93,7 +93,7 @@ func TestLoggerHelpers(t *testing.T) {
 			slog.Duration("duration", 0)) // Will be ignored if zero
 
 		output := buf.String()
-		assert.Contains(t, output, `"level":"INFO"`)
+		assert.Contains(t, output, `"level":"DEBUG"`)
 		assert.Contains(t, output, `"msg":"gtfs_data_imported"`)
 		assert.Contains(t, output, `"source":"file.zip"`)
 		assert.Contains(t, output, `"stops_count":150`)


### PR DESCRIPTION
* Move some extra verbose logs to be Debug instead of Info
* Remove the Verbose config fields since they were only used for a single log message.
* Set the global logger when building the application so that slog.Default() applies the application's config.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Removed the verbose configuration option; logging is now controlled by LogLevel/LogFormat and a single runtime logger.
  * Several informational messages were demoted to debug to reduce noise at normal verbosity; startup warnings now use a dedicated early-start logger.

* **Tests**
  * Test suite updated to match the logging and configuration changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->