### PR TITLE
refactor: use structs for location params

### DIFF
--- a/internal/gtfs/gtfs_manager.go
+++ b/internal/gtfs/gtfs_manager.go
@@ -333,7 +333,7 @@ func (manager *Manager) GetStopsForLocation(
 	maxCount int,
 	routeTypes []int,
 ) ([]gtfsdb.Stop, bool) {
-	bounds := boundsFromParams(loc)
+	bounds := BoundsFromParams(loc)
 	if ctx.Err() != nil {
 		return []gtfsdb.Stop{}, false
 	}
@@ -410,7 +410,7 @@ func (manager *Manager) GetStopsInBounds(
 	loc *LocationParams,
 	maxCount int,
 ) []gtfsdb.Stop {
-	bounds := boundsFromParams(loc)
+	bounds := BoundsFromParams(loc)
 	stops, err := manager.queryStopsInBounds(ctx, bounds)
 	if err != nil {
 		logger := slog.Default().With(slog.String("component", "gtfs_manager"))
@@ -429,7 +429,7 @@ func (manager *Manager) GetStopIDsWithinBounds(
 	loc *LocationParams,
 	maxCount int,
 ) []string {
-	bounds := boundsFromParams(loc)
+	bounds := BoundsFromParams(loc)
 	ids, err := manager.GtfsDB.Queries.GetStopIDsWithinBounds(ctx, gtfsdb.GetStopIDsWithinBoundsParams{
 		MinLat: bounds.MinLat,
 		MaxLat: bounds.MaxLat,
@@ -473,7 +473,7 @@ func (manager *Manager) GetRoutesForLocation(
 	maxCount int,
 	queryTime time.Time,
 ) ([]gtfsdb.Route, bool) {
-	bounds := boundsFromParams(loc)
+	bounds := BoundsFromParams(loc)
 	routes, limitExceeded, err := manager.queryRoutesInBounds(ctx, bounds, loc.Lat, loc.Lon, maxCount, routeShortName)
 	if err != nil {
 		logger := slog.Default().With(slog.String("component", "gtfs_manager"))

--- a/internal/gtfs/gtfs_manager.go
+++ b/internal/gtfs/gtfs_manager.go
@@ -1,6 +1,7 @@
 package gtfs
 
 import (
+	"cmp"
 	"context"
 	"database/sql"
 	"errors"
@@ -8,14 +9,12 @@ import (
 	"log/slog"
 	"math/rand"
 	"slices"
-	"sort"
 	"sync"
 	"sync/atomic"
 	"time"
 
 	"maglev.onebusaway.org/gtfsdb"
 	"maglev.onebusaway.org/internal/metrics"
-	"maglev.onebusaway.org/internal/models"
 	"maglev.onebusaway.org/internal/utils"
 
 	"github.com/OneBusAway/go-gtfs"
@@ -329,13 +328,12 @@ func (manager *Manager) RoutesForAgencyID(ctx context.Context, agencyID string) 
 // ORDERED_BY_CLOSEST mode (routeTypes present): sorts by distance, filters by route type, then truncates.
 func (manager *Manager) GetStopsForLocation(
 	ctx context.Context,
-	lat, lon, radius, latSpan, lonSpan float64,
+	loc *LocationParams,
 	stopCodeQuery string,
 	maxCount int,
 	routeTypes []int,
 ) ([]gtfsdb.Stop, bool) {
-	bounds := manager.boundsFromParams(lat, lon, radius, latSpan, lonSpan)
-
+	bounds := boundsFromParams(loc)
 	if ctx.Err() != nil {
 		return []gtfsdb.Stop{}, false
 	}
@@ -367,9 +365,10 @@ func (manager *Manager) GetStopsForLocation(
 		}
 	} else {
 		// ORDERED_BY_CLOSEST mode: sort by distance, filter by route type, then truncate.
-		sort.Slice(stops, func(i, j int) bool {
-			return utils.Distance(lat, lon, stops[i].Lat, stops[i].Lon) <
-				utils.Distance(lat, lon, stops[j].Lat, stops[j].Lon)
+		slices.SortFunc(stops, func(a, b gtfsdb.Stop) int {
+			aDist := utils.Distance(loc.Lat, loc.Lon, a.Lat, a.Lon)
+			bDist := utils.Distance(loc.Lat, loc.Lon, b.Lat, b.Lon)
+			return cmp.Compare(aDist, bDist)
 		})
 
 		stopIDs := make([]string, 0, len(stops))
@@ -408,10 +407,10 @@ func (manager *Manager) GetStopsForLocation(
 // or route-type filtering. Used internally by the arrivals and trips-for-location handlers.
 func (manager *Manager) GetStopsInBounds(
 	ctx context.Context,
-	lat, lon, radius, latSpan, lonSpan float64,
+	loc *LocationParams,
 	maxCount int,
 ) []gtfsdb.Stop {
-	bounds := manager.boundsFromParams(lat, lon, radius, latSpan, lonSpan)
+	bounds := boundsFromParams(loc)
 	stops, err := manager.queryStopsInBounds(ctx, bounds)
 	if err != nil {
 		logger := slog.Default().With(slog.String("component", "gtfs_manager"))
@@ -427,10 +426,10 @@ func (manager *Manager) GetStopsInBounds(
 // GetStopIDsWithinBounds returns stop IDs within bounds, optimized for callers that only need IDs.
 func (manager *Manager) GetStopIDsWithinBounds(
 	ctx context.Context,
-	lat, lon, radius, latSpan, lonSpan float64,
+	loc *LocationParams,
 	maxCount int,
 ) []string {
-	bounds := manager.boundsFromParams(lat, lon, radius, latSpan, lonSpan)
+	bounds := boundsFromParams(loc)
 	ids, err := manager.GtfsDB.Queries.GetStopIDsWithinBounds(ctx, gtfsdb.GetStopIDsWithinBoundsParams{
 		MinLat: bounds.MinLat,
 		MaxLat: bounds.MaxLat,
@@ -446,16 +445,6 @@ func (manager *Manager) GetStopIDsWithinBounds(
 		ids = ids[:maxCount]
 	}
 	return ids
-}
-
-func (manager *Manager) boundsFromParams(lat, lon, radius, latSpan, lonSpan float64) utils.CoordinateBounds {
-	if latSpan > 0 && lonSpan > 0 {
-		return utils.CalculateBoundsFromSpan(lat, lon, latSpan/2, lonSpan/2)
-	}
-	if radius == 0 {
-		radius = models.DefaultSearchRadiusInMeters
-	}
-	return utils.CalculateBounds(lat, lon, radius)
 }
 
 // queryStopsInBounds retrieves all active stops within the given geographic bounds
@@ -479,22 +468,13 @@ func (manager *Manager) queryStopsInBounds(ctx context.Context, bounds utils.Coo
 // It supports filtering by route types and querying for specific route shortNames.
 func (manager *Manager) GetRoutesForLocation(
 	ctx context.Context,
-	lat, lon, radius, latSpan, lonSpan float64,
+	loc *LocationParams,
 	routeShortName string,
 	maxCount int,
 	queryTime time.Time,
 ) ([]gtfsdb.Route, bool) {
-	var bounds utils.CoordinateBounds
-	if latSpan > 0 && lonSpan > 0 {
-		bounds = utils.CalculateBoundsFromSpan(lat, lon, latSpan/2, lonSpan/2)
-	} else {
-		if radius == 0 {
-			radius = models.DefaultSearchRadiusInMeters
-		}
-		bounds = utils.CalculateBounds(lat, lon, radius)
-	}
-
-	routes, limitExceeded, err := manager.queryRoutesInBounds(ctx, bounds, lat, lon, maxCount, routeShortName)
+	bounds := boundsFromParams(loc)
+	routes, limitExceeded, err := manager.queryRoutesInBounds(ctx, bounds, loc.Lat, loc.Lon, maxCount, routeShortName)
 	if err != nil {
 		logger := slog.Default().With(slog.String("component", "gtfs_manager"))
 		logging.LogError(logger, "could not query routes within bounds", err)

--- a/internal/gtfs/gtfs_manager_test.go
+++ b/internal/gtfs/gtfs_manager_test.go
@@ -82,7 +82,7 @@ func TestManager_GetStopsForLocation_UsesSpatialIndex(t *testing.T) {
 			assert.NotNil(t, manager)
 
 			// Get stops using the manager method
-			stops := manager.GetStopsInBounds(ctx, tc.lat, tc.lon, tc.radius, 0, 0, 100)
+			stops := manager.GetStopsInBounds(ctx, &LocationParams{Lat: tc.lat, Lon: tc.lon, Radius: tc.radius}, 100)
 
 			// The test expects that the spatial index query is used
 			assert.GreaterOrEqual(t, len(stops), tc.expectedStops, "Should find stops within radius")

--- a/internal/gtfs/location_params.go
+++ b/internal/gtfs/location_params.go
@@ -1,0 +1,48 @@
+package gtfs
+
+import (
+	"maglev.onebusaway.org/internal/models"
+	"maglev.onebusaway.org/internal/utils"
+)
+
+type LocationParams struct {
+	Lat     float64
+	Lon     float64
+	Radius  float64
+	LatSpan float64
+	LonSpan float64
+}
+
+// boundsFromParams converts LocationParams into a CoordinateBounds bounding box.
+// If LatSpan and LonSpan are both positive, they define the box; otherwise the
+// box is computed from Radius (defaulting to DefaultSearchRadiusInMeters).
+func boundsFromParams(loc *LocationParams) utils.CoordinateBounds {
+	if loc.LatSpan > 0 && loc.LonSpan > 0 {
+		return utils.CalculateBoundsFromSpan(loc.Lat, loc.Lon, loc.LatSpan/2, loc.LonSpan/2)
+	}
+	radius := loc.Radius
+	if radius == 0 {
+		radius = models.DefaultSearchRadiusInMeters
+	}
+	return utils.CalculateBounds(loc.Lat, loc.Lon, radius)
+}
+
+// CheckIfOutOfBounds returns true if the user's search area is completely
+// outside every agency's region bounds.
+func (manager *Manager) CheckIfOutOfBounds(loc *LocationParams) bool {
+	boundsMap := manager.GetRegionBounds()
+	if len(boundsMap) == 0 {
+		return false
+	}
+
+	innerBounds := boundsFromParams(loc)
+
+	for _, region := range boundsMap {
+		outerBounds := utils.CalculateBoundsFromSpan(region.Lat, region.Lon, region.LatSpan/2, region.LonSpan/2)
+		if !utils.IsOutOfBounds(innerBounds, outerBounds) {
+			return false
+		}
+	}
+
+	return true
+}

--- a/internal/gtfs/location_params.go
+++ b/internal/gtfs/location_params.go
@@ -13,10 +13,10 @@ type LocationParams struct {
 	LonSpan float64
 }
 
-// boundsFromParams converts LocationParams into a CoordinateBounds bounding box.
+// BoundsFromParams converts LocationParams into a CoordinateBounds bounding box.
 // If LatSpan and LonSpan are both positive, they define the box; otherwise the
 // box is computed from Radius (defaulting to DefaultSearchRadiusInMeters).
-func boundsFromParams(loc *LocationParams) utils.CoordinateBounds {
+func BoundsFromParams(loc *LocationParams) utils.CoordinateBounds {
 	if loc.LatSpan > 0 && loc.LonSpan > 0 {
 		return utils.CalculateBoundsFromSpan(loc.Lat, loc.Lon, loc.LatSpan/2, loc.LonSpan/2)
 	}
@@ -35,7 +35,7 @@ func (manager *Manager) CheckIfOutOfBounds(loc *LocationParams) bool {
 		return false
 	}
 
-	innerBounds := boundsFromParams(loc)
+	innerBounds := BoundsFromParams(loc)
 
 	for _, region := range boundsMap {
 		outerBounds := utils.CalculateBoundsFromSpan(region.Lat, region.Lon, region.LatSpan/2, region.LonSpan/2)

--- a/internal/restapi/arrivals_and_departure_for_stop.go
+++ b/internal/restapi/arrivals_and_departure_for_stop.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/OneBusAway/go-gtfs"
 	"maglev.onebusaway.org/gtfsdb"
+	internalgtfs "maglev.onebusaway.org/internal/gtfs"
 	"maglev.onebusaway.org/internal/models"
 	"maglev.onebusaway.org/internal/utils"
 )
@@ -638,7 +639,8 @@ func (api *RestAPI) arrivalsAndDeparturesForStopHandler(w http.ResponseWriter, r
 }
 
 func getNearbyStopIDs(api *RestAPI, ctx context.Context, lat, lon float64, stopID, fallbackAgencyID string) []string {
-	nearbyIDs := api.GtfsManager.GetStopIDsWithinBounds(ctx, lat, lon, 10000, 100, 100, 5)
+	loc := &internalgtfs.LocationParams{Lat: lat, Lon: lon, Radius: 10000, LatSpan: 100, LonSpan: 100}
+	nearbyIDs := api.GtfsManager.GetStopIDsWithinBounds(ctx, loc, 5)
 	if len(nearbyIDs) == 0 {
 		return nil
 	}

--- a/internal/restapi/arrivals_and_departures_for_stop_handler_test.go
+++ b/internal/restapi/arrivals_and_departures_for_stop_handler_test.go
@@ -1042,7 +1042,7 @@ func TestGetNearbyStopIDs_UsesResolvedAgency(t *testing.T) {
 	ctx := context.Background()
 
 	// RABA test data has stops near Redding, CA (~40.589, -122.39).
-	stops := api.GtfsManager.GetStopsInBounds(ctx, 40.589123, -122.390830, 2000, 0, 0, 10)
+	stops := api.GtfsManager.GetStopsInBounds(ctx, &internalgtfs.LocationParams{Lat: 40.589123, Lon: -122.390830, Radius: 2000}, 10)
 	require.NotEmpty(t, stops, "precondition: RABA should have stops near Redding, CA")
 
 	currentStop := stops[0]
@@ -1067,7 +1067,7 @@ func TestGetNearbyStopIDs_ExcludesCurrentStop(t *testing.T) {
 
 	ctx := context.Background()
 
-	stops := api.GtfsManager.GetStopsInBounds(ctx, 40.589123, -122.390830, 2000, 0, 0, 10)
+	stops := api.GtfsManager.GetStopsInBounds(ctx, &internalgtfs.LocationParams{Lat: 40.589123, Lon: -122.390830, Radius: 2000}, 10)
 	require.NotEmpty(t, stops)
 
 	currentStop := stops[0]

--- a/internal/restapi/context_cancellation_test.go
+++ b/internal/restapi/context_cancellation_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"maglev.onebusaway.org/internal/gtfs"
 )
 
 func TestContextCancellationHandling(t *testing.T) {
@@ -120,7 +121,7 @@ func TestContextCancellationInGetStopsForLocation(t *testing.T) {
 
 	// This test verifies that our current implementation works normally
 	// since it uses context.Background() internally
-	stops := api.GtfsManager.GetStopsInBounds(context.Background(), 38.9, -77.0, 1000, 0, 0, 10)
+	stops := api.GtfsManager.GetStopsInBounds(context.Background(), &gtfs.LocationParams{Lat: 38.9, Lon: -77.0, Radius: 1000}, 10)
 
 	// Current implementation should return a slice (possibly empty)
 	// The function should not panic and should return a valid slice

--- a/internal/restapi/location_params.go
+++ b/internal/restapi/location_params.go
@@ -3,18 +3,11 @@ package restapi
 import (
 	"net/http"
 
+	"maglev.onebusaway.org/internal/gtfs"
 	"maglev.onebusaway.org/internal/utils"
 )
 
-type LocationParams struct {
-	Lat     float64
-	Lon     float64
-	Radius  float64
-	LatSpan float64
-	LonSpan float64
-}
-
-func (api *RestAPI) parseLocationParams(r *http.Request, fieldErrors map[string][]string) (*LocationParams, map[string][]string) {
+func (api *RestAPI) parseLocationParams(r *http.Request, fieldErrors map[string][]string) (*gtfs.LocationParams, map[string][]string) {
 	queryParams := r.URL.Query()
 
 	lat, fieldErrors := utils.ParseRequiredFloatParam(queryParams, "lat", fieldErrors)
@@ -38,7 +31,7 @@ func (api *RestAPI) parseLocationParams(r *http.Request, fieldErrors map[string]
 		return nil, fieldErrors
 	}
 
-	return &LocationParams{
+	return &gtfs.LocationParams{
 		Lat:     lat,
 		Lon:     lon,
 		Radius:  radius,

--- a/internal/restapi/routes_for_location_handler.go
+++ b/internal/restapi/routes_for_location_handler.go
@@ -34,20 +34,18 @@ func (api *RestAPI) routesForLocationHandler(w http.ResponseWriter, r *http.Requ
 		api.validationErrorResponse(w, r, fieldErrors)
 		return
 	}
-	radius := loc.Radius
-	if radius == 0 {
-		radius = models.DefaultSearchRadiusInMeters
+	if loc.Radius == 0 {
+		loc.Radius = models.DefaultSearchRadiusInMeters
 		if query != "" {
-			radius = models.QuerySearchRadiusInMeters
+			loc.Radius = models.QuerySearchRadiusInMeters
 		}
 	}
 
 	ctx := r.Context()
-
-	routes, isLimitExceeded := api.GtfsManager.GetRoutesForLocation(ctx, loc.Lat, loc.Lon, radius, loc.LatSpan, loc.LonSpan, sanitizedQuery, maxCount, time.Time{})
+	routes, isLimitExceeded := api.GtfsManager.GetRoutesForLocation(ctx, loc, sanitizedQuery, maxCount, time.Time{})
 	if len(routes) == 0 {
 		references := models.NewEmptyReferences()
-		response := models.NewListResponseWithRange([]models.Route{}, *references, checkIfOutOfBounds(api, loc.Lat, loc.Lon, loc.LatSpan, loc.LonSpan, radius), api.Clock, false)
+		response := models.NewListResponseWithRange([]models.Route{}, *references, api.GtfsManager.CheckIfOutOfBounds(loc), api.Clock, false)
 		api.sendResponse(w, r, response)
 		return
 	}
@@ -89,31 +87,6 @@ func (api *RestAPI) routesForLocationHandler(w http.ResponseWriter, r *http.Requ
 	slices.SortFunc(results, func(a, b models.Route) int {
 		return strings.Compare(a.ID, b.ID)
 	})
-	response := models.NewListResponseWithRange(results, *references, checkIfOutOfBounds(api, loc.Lat, loc.Lon, loc.LatSpan, loc.LonSpan, radius), api.Clock, isLimitExceeded)
+	response := models.NewListResponseWithRange(results, *references, api.GtfsManager.CheckIfOutOfBounds(loc), api.Clock, isLimitExceeded)
 	api.sendResponse(w, r, response)
-}
-
-// checkIfOutOfBounds returns true if the user's search area is completely
-// outside every agency's region bounds.
-func checkIfOutOfBounds(api *RestAPI, lat float64, lon float64, latSpan float64, lonSpan float64, radius float64) bool {
-	boundsMap := api.GtfsManager.GetRegionBounds()
-	if len(boundsMap) == 0 {
-		return false
-	}
-
-	var innerBounds utils.CoordinateBounds
-	if latSpan > 0 && lonSpan > 0 {
-		innerBounds = utils.CalculateBoundsFromSpan(lat, lon, latSpan/2, lonSpan/2)
-	} else {
-		innerBounds = utils.CalculateBounds(lat, lon, radius)
-	}
-
-	for _, region := range boundsMap {
-		outerBounds := utils.CalculateBoundsFromSpan(region.Lat, region.Lon, region.LatSpan/2, region.LonSpan/2)
-		if !utils.IsOutOfBounds(innerBounds, outerBounds) {
-			return false
-		}
-	}
-
-	return true
 }

--- a/internal/restapi/stops_for_location_handler.go
+++ b/internal/restapi/stops_for_location_handler.go
@@ -98,7 +98,7 @@ func (api *RestAPI) stopsForLocationHandler(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	stops, limitExceeded := api.GtfsManager.GetStopsForLocation(ctx, loc.Lat, loc.Lon, loc.Radius, loc.LatSpan, loc.LonSpan, query, maxCount, routeTypes)
+	stops, limitExceeded := api.GtfsManager.GetStopsForLocation(ctx, loc, query, maxCount, routeTypes)
 
 	// Sort by stop ID for deterministic results
 	sort.SliceStable(stops, func(i, j int) bool {
@@ -131,7 +131,7 @@ func (api *RestAPI) stopsForLocationHandler(w http.ResponseWriter, r *http.Reque
 		references := models.NewEmptyReferences()
 		references.Agencies = agencies
 		references.Routes = routes
-		response := models.NewListResponseWithRange(results, *references, checkIfOutOfBounds(api, loc.Lat, loc.Lon, loc.LatSpan, loc.LonSpan, loc.Radius), api.Clock, false)
+		response := models.NewListResponseWithRange(results, *references, api.GtfsManager.CheckIfOutOfBounds(loc), api.Clock, false)
 		api.sendResponse(w, r, response)
 		return
 	}
@@ -257,6 +257,6 @@ func (api *RestAPI) stopsForLocationHandler(w http.ResponseWriter, r *http.Reque
 	references.Routes = routes
 	references.Situations = situations
 
-	response := models.NewListResponseWithRange(results, *references, checkIfOutOfBounds(api, loc.Lat, loc.Lon, loc.LatSpan, loc.LonSpan, loc.Radius), api.Clock, isLimitExceeded)
+	response := models.NewListResponseWithRange(results, *references, api.GtfsManager.CheckIfOutOfBounds(loc), api.Clock, isLimitExceeded)
 	api.sendResponse(w, r, response)
 }

--- a/internal/restapi/trips_for_location_handler.go
+++ b/internal/restapi/trips_for_location_handler.go
@@ -21,7 +21,7 @@ import (
 func (api *RestAPI) tripsForLocationHandler(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
-	lat, lon, latSpan, lonSpan, includeTrip, includeSchedule, currentLocation, todayMidnight, serviceDate, fieldErrors, err := api.parseAndValidateRequest(r)
+	locationParams, includeTrip, includeSchedule, currentLocation, todayMidnight, serviceDate, fieldErrors, err := api.parseAndValidateRequest(r)
 	if len(fieldErrors) > 0 {
 		api.validationErrorResponse(w, r, fieldErrors)
 		return
@@ -37,7 +37,7 @@ func (api *RestAPI) tripsForLocationHandler(w http.ResponseWriter, r *http.Reque
 	// Note: re-deriving currentTime here rather than returning it from parseAndValidateRequest(line: 150)
 	currentTime := api.Clock.Now().In(currentLocation)
 
-	stops := api.GtfsManager.GetStopsInBounds(ctx, &internalgtfs.LocationParams{Lat: lat, Lon: lon, Radius: -1, LatSpan: latSpan, LonSpan: lonSpan}, 100)
+	stops := api.GtfsManager.GetStopsInBounds(ctx, locationParams, 100)
 	stopIDs := extractStopIDs(stops)
 	stopTimes, err := api.GtfsManager.GtfsDB.Queries.GetStopTimesByStopIDs(ctx, stopIDs)
 	if err != nil {
@@ -46,8 +46,8 @@ func (api *RestAPI) tripsForLocationHandler(w http.ResponseWriter, r *http.Reque
 	}
 
 	activeTrips := api.getActiveTrips(stopTimes, api.GtfsManager.GetRealTimeVehicles())
-	bbox := boundingBox(lat, lon, latSpan, lonSpan)
 
+	bounds := internalgtfs.BoundsFromParams(locationParams)
 	visibleTripIDs := make([]string, 0, len(activeTrips))
 	for _, vehicle := range activeTrips {
 		if ctx.Err() != nil {
@@ -59,7 +59,7 @@ func (api *RestAPI) tripsForLocationHandler(w http.ResponseWriter, r *http.Reque
 			continue
 		}
 		vLat, vLon := float64(*vehicle.Position.Latitude), float64(*vehicle.Position.Longitude)
-		if vLat >= bbox.minLat && vLat <= bbox.maxLat && vLon >= bbox.minLon && vLon <= bbox.maxLon {
+		if vLat >= bounds.MinLat && vLat <= bounds.MaxLat && vLon >= bounds.MinLon && vLon <= bounds.MaxLon {
 			visibleTripIDs = append(visibleTripIDs, vehicle.Trip.ID.ID)
 		}
 	}
@@ -117,12 +117,12 @@ func (api *RestAPI) tripsForLocationHandler(w http.ResponseWriter, r *http.Reque
 		Stops:       stops,
 		Trips:       result,
 	})
-	response := models.NewListResponseWithRange(result, references, api.GtfsManager.CheckIfOutOfBounds(&internalgtfs.LocationParams{Lat: lat, Lon: lon, LatSpan: latSpan, LonSpan: lonSpan}), api.Clock, false)
+	response := models.NewListResponseWithRange(result, references, api.GtfsManager.CheckIfOutOfBounds(locationParams), api.Clock, false)
 	api.sendResponse(w, r, response)
 }
 
 func (api *RestAPI) parseAndValidateRequest(r *http.Request) (
-	lat, lon, latSpan, lonSpan float64,
+	location *internalgtfs.LocationParams,
 	includeTrip, includeSchedule bool,
 	currentLocation *time.Location,
 	todayMidnight time.Time,
@@ -130,15 +130,7 @@ func (api *RestAPI) parseAndValidateRequest(r *http.Request) (
 	fieldErrors map[string][]string,
 	serverErr error,
 ) {
-	var loc *internalgtfs.LocationParams
-	loc, fieldErrors = api.parseLocationParams(r, nil)
-
-	if loc != nil {
-		lat = loc.Lat
-		lon = loc.Lon
-		latSpan = loc.LatSpan
-		lonSpan = loc.LonSpan
-	}
+	loc, fieldErrors := api.parseLocationParams(r, nil)
 
 	queryParams := r.URL.Query()
 
@@ -147,13 +139,13 @@ func (api *RestAPI) parseAndValidateRequest(r *http.Request) (
 
 	agencies, agenciesErr := api.GtfsManager.GetAgencies(r.Context())
 	if agenciesErr != nil || len(agencies) == 0 {
-		return 0, 0, 0, 0, false, false, nil, time.Time{}, time.Time{}, nil, errors.New("no agencies configured in GTFS manager")
+		return nil, false, false, nil, time.Time{}, time.Time{}, nil, errors.New("no agencies configured in GTFS manager")
 	}
 
 	currentAgency := agencies[0]
 	currentLocation, serverErr = loadAgencyLocation(currentAgency.ID, currentAgency.Timezone)
 	if serverErr != nil {
-		return 0, 0, 0, 0, false, false, nil, time.Time{}, time.Time{}, nil, serverErr
+		return nil, false, false, nil, time.Time{}, time.Time{}, nil, serverErr
 	}
 
 	timeParam := queryParams.Get("time")
@@ -171,16 +163,11 @@ func (api *RestAPI) parseAndValidateRequest(r *http.Request) (
 		}
 	}
 
-	ctx := r.Context()
-	if ctx.Err() != nil {
-		return 0, 0, 0, 0, false, false, nil, time.Time{}, time.Time{}, nil, ctx.Err()
-	}
-
 	if len(fieldErrors) > 0 {
-		return 0, 0, 0, 0, false, false, nil, time.Time{}, time.Time{}, fieldErrors, nil
+		return nil, false, false, nil, time.Time{}, time.Time{}, fieldErrors, nil
 	}
 
-	return lat, lon, latSpan, lonSpan, includeTrip, includeSchedule, currentLocation, todayMidnight, serviceDate, nil, nil
+	return loc, includeTrip, includeSchedule, currentLocation, todayMidnight, serviceDate, nil, nil
 }
 
 func extractStopIDs(stops []gtfsdb.Stop) []string {
@@ -203,18 +190,6 @@ func (api *RestAPI) getActiveTrips(stopTimes []gtfsdb.StopTime, realTimeVehicles
 		}
 	}
 	return activeTrips
-}
-
-type boundingBoxStruct struct{ minLat, maxLat, minLon, maxLon float64 }
-
-func boundingBox(lat, lon, latSpan, lonSpan float64) boundingBoxStruct {
-	const epsilon = 1e-6
-	return boundingBoxStruct{
-		minLat: lat - latSpan - epsilon,
-		maxLat: lat + latSpan + epsilon,
-		minLon: lon - lonSpan - epsilon,
-		maxLon: lon + lonSpan + epsilon,
-	}
 }
 
 // buildTripsForLocationEntries builds trip entries from pre-fetched batch data.

--- a/internal/restapi/trips_for_location_handler.go
+++ b/internal/restapi/trips_for_location_handler.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/OneBusAway/go-gtfs"
 	"maglev.onebusaway.org/gtfsdb"
+	internalgtfs "maglev.onebusaway.org/internal/gtfs"
 	"maglev.onebusaway.org/internal/logging"
 	"maglev.onebusaway.org/internal/models"
 	"maglev.onebusaway.org/internal/utils"
@@ -36,7 +37,7 @@ func (api *RestAPI) tripsForLocationHandler(w http.ResponseWriter, r *http.Reque
 	// Note: re-deriving currentTime here rather than returning it from parseAndValidateRequest(line: 150)
 	currentTime := api.Clock.Now().In(currentLocation)
 
-	stops := api.GtfsManager.GetStopsInBounds(ctx, lat, lon, -1, latSpan, lonSpan, 100)
+	stops := api.GtfsManager.GetStopsInBounds(ctx, &internalgtfs.LocationParams{Lat: lat, Lon: lon, Radius: -1, LatSpan: latSpan, LonSpan: lonSpan}, 100)
 	stopIDs := extractStopIDs(stops)
 	stopTimes, err := api.GtfsManager.GtfsDB.Queries.GetStopTimesByStopIDs(ctx, stopIDs)
 	if err != nil {
@@ -116,7 +117,7 @@ func (api *RestAPI) tripsForLocationHandler(w http.ResponseWriter, r *http.Reque
 		Stops:       stops,
 		Trips:       result,
 	})
-	response := models.NewListResponseWithRange(result, references, checkIfOutOfBounds(api, lat, lon, latSpan, lonSpan, 0), api.Clock, false)
+	response := models.NewListResponseWithRange(result, references, api.GtfsManager.CheckIfOutOfBounds(&internalgtfs.LocationParams{Lat: lat, Lon: lon, LatSpan: latSpan, LonSpan: lonSpan}), api.Clock, false)
 	api.sendResponse(w, r, response)
 }
 
@@ -129,7 +130,7 @@ func (api *RestAPI) parseAndValidateRequest(r *http.Request) (
 	fieldErrors map[string][]string,
 	serverErr error,
 ) {
-	var loc *LocationParams
+	var loc *internalgtfs.LocationParams
 	loc, fieldErrors = api.parseLocationParams(r, nil)
 
 	if loc != nil {

--- a/internal/restapi/trips_for_location_handler_test.go
+++ b/internal/restapi/trips_for_location_handler_test.go
@@ -409,7 +409,7 @@ func TestTripsForLocationHandler_StatusInclusion(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			url := fmt.Sprintf("/api/where/trips-for-location.json?key=TEST&lat=40.5865&lon=-122.3917&latSpan=0.1&lonSpan=0.1&includeStatus=%v",
+			url := fmt.Sprintf("/api/where/trips-for-location.json?key=TEST&lat=40.5865&lon=-122.3917&latSpan=0.2&lonSpan=0.2&includeStatus=%v",
 				tt.includeStatus)
 
 			resp, model := serveApiAndRetrieveEndpoint(t, api, url)


### PR DESCRIPTION
Update several functions that passed LocationParams individually to just accept a LocationParams struct directly.

Move checkIfOurOfBounds logic into manager to remove some duplication.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

**Refactors**
- Unified location input across location-based endpoints so handlers accept a single location object for searches.
- Moved out-of-bounds checking into the shared manager to provide consistent range/coverage behavior.
- Improved nearby-results ranking by standardizing distance calculation and sorting for more accurate closest-first ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->