### PR TITLE
refactor: use time types in models

### DIFF
--- a/gtfsdb/bulk_insert_frequency_test.go
+++ b/gtfsdb/bulk_insert_frequency_test.go
@@ -4,12 +4,19 @@ import (
 	"context"
 	"database/sql"
 	"testing"
+	"time"
 
 	_ "github.com/mattn/go-sqlite3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"maglev.onebusaway.org/internal/appconf"
 )
+
+// hoursAfterMidnight returns the int64 nanoseconds-since-midnight value
+// that the database uses to represent a GTFS time of `h:00:00`.
+func hoursAfterMidnight(h int) int64 {
+	return (time.Duration(h) * time.Hour).Nanoseconds()
+}
 
 // createFrequencyTestClient sets up a test client with the prerequisite data
 func createFrequencyTestClient(t *testing.T) *Client {
@@ -102,22 +109,22 @@ func TestBulkInsertFrequencies(t *testing.T) {
 				frequencies = []CreateFrequencyParams{
 					{
 						TripID:      "trip_1",
-						StartTime:   int64(6 * 3600 * 1e9), // 6 AM in nanoseconds
-						EndTime:     int64(9 * 3600 * 1e9), // 9 AM
+						StartTime:   hoursAfterMidnight(6), // 6 AM in nanoseconds
+						EndTime:     hoursAfterMidnight(9), // 9 AM
 						HeadwaySecs: 600,                   // 10 minutes
 						ExactTimes:  0,
 					},
 					{
 						TripID:      "trip_1",
-						StartTime:   int64(11 * 3600 * 1e9), // 11 AM
-						EndTime:     int64(14 * 3600 * 1e9), // 2 PM
+						StartTime:   hoursAfterMidnight(11), // 11 AM
+						EndTime:     hoursAfterMidnight(14), // 2 PM
 						HeadwaySecs: 900,                    // 15 minutes
 						ExactTimes:  0,
 					},
 					{
 						TripID:      "trip_1",
-						StartTime:   int64(16 * 3600 * 1e9), // 4 PM
-						EndTime:     int64(19 * 3600 * 1e9), // 7 PM
+						StartTime:   hoursAfterMidnight(16), // 4 PM
+						EndTime:     hoursAfterMidnight(19), // 7 PM
 						HeadwaySecs: 600,                    // 10 minutes
 						ExactTimes:  1,
 					},
@@ -127,8 +134,8 @@ func TestBulkInsertFrequencies(t *testing.T) {
 				for i := 0; i < tc.count; i++ {
 					frequencies[i] = CreateFrequencyParams{
 						TripID:      "trip_1",
-						StartTime:   int64(i) * int64(3600*1e9), // Each hour
-						EndTime:     int64(i+1) * int64(3600*1e9),
+						StartTime:   hoursAfterMidnight(i),
+						EndTime:     hoursAfterMidnight(i + 1),
 						HeadwaySecs: 600,
 						ExactTimes:  int64(i % 2), // Alternate between 0 and 1
 					}
@@ -175,10 +182,10 @@ func TestBulkInsertFrequencies_MultipleTrips(t *testing.T) {
 	ctx := context.Background()
 
 	frequencies := []CreateFrequencyParams{
-		{TripID: "trip_1", StartTime: int64(6 * 3600 * 1e9), EndTime: int64(9 * 3600 * 1e9), HeadwaySecs: 600, ExactTimes: 0},
-		{TripID: "trip_1", StartTime: int64(16 * 3600 * 1e9), EndTime: int64(19 * 3600 * 1e9), HeadwaySecs: 600, ExactTimes: 0},
-		{TripID: "trip_2", StartTime: int64(7 * 3600 * 1e9), EndTime: int64(10 * 3600 * 1e9), HeadwaySecs: 300, ExactTimes: 1},
-		{TripID: "trip_3", StartTime: int64(8 * 3600 * 1e9), EndTime: int64(12 * 3600 * 1e9), HeadwaySecs: 1200, ExactTimes: 0},
+		{TripID: "trip_1", StartTime: hoursAfterMidnight(6), EndTime: hoursAfterMidnight(9), HeadwaySecs: 600, ExactTimes: 0},
+		{TripID: "trip_1", StartTime: hoursAfterMidnight(16), EndTime: hoursAfterMidnight(19), HeadwaySecs: 600, ExactTimes: 0},
+		{TripID: "trip_2", StartTime: hoursAfterMidnight(7), EndTime: hoursAfterMidnight(10), HeadwaySecs: 300, ExactTimes: 1},
+		{TripID: "trip_3", StartTime: hoursAfterMidnight(8), EndTime: hoursAfterMidnight(12), HeadwaySecs: 1200, ExactTimes: 0},
 	}
 
 	err := client.bulkInsertFrequencies(ctx, frequencies, nil)
@@ -209,10 +216,10 @@ func TestBulkInsertFrequencies_DuplicatePrimaryKey(t *testing.T) {
 
 	ctx := context.Background()
 
-	startTime := int64(6 * 3600 * 1e9)
+	startTime := hoursAfterMidnight(6)
 	frequencies := []CreateFrequencyParams{
-		{TripID: "trip_1", StartTime: startTime, EndTime: int64(9 * 3600 * 1e9), HeadwaySecs: 600, ExactTimes: 0},
-		{TripID: "trip_1", StartTime: startTime, EndTime: int64(10 * 3600 * 1e9), HeadwaySecs: 900, ExactTimes: 1},
+		{TripID: "trip_1", StartTime: startTime, EndTime: hoursAfterMidnight(9), HeadwaySecs: 600, ExactTimes: 0},
+		{TripID: "trip_1", StartTime: startTime, EndTime: hoursAfterMidnight(10), HeadwaySecs: 900, ExactTimes: 1},
 	}
 
 	err := client.bulkInsertFrequencies(ctx, frequencies, nil)
@@ -231,8 +238,8 @@ func TestClearFrequencies(t *testing.T) {
 	ctx := context.Background()
 
 	frequencies := []CreateFrequencyParams{
-		{TripID: "trip_1", StartTime: int64(6 * 3600 * 1e9), EndTime: int64(9 * 3600 * 1e9), HeadwaySecs: 600, ExactTimes: 0},
-		{TripID: "trip_2", StartTime: int64(7 * 3600 * 1e9), EndTime: int64(10 * 3600 * 1e9), HeadwaySecs: 300, ExactTimes: 1},
+		{TripID: "trip_1", StartTime: hoursAfterMidnight(6), EndTime: hoursAfterMidnight(9), HeadwaySecs: 600, ExactTimes: 0},
+		{TripID: "trip_2", StartTime: hoursAfterMidnight(7), EndTime: hoursAfterMidnight(10), HeadwaySecs: 300, ExactTimes: 1},
 	}
 
 	err := client.bulkInsertFrequencies(ctx, frequencies, nil)
@@ -261,9 +268,9 @@ func TestGetFrequenciesForTrips(t *testing.T) {
 	ctx := context.Background()
 
 	frequencies := []CreateFrequencyParams{
-		{TripID: "trip_1", StartTime: int64(6 * 3600 * 1e9), EndTime: int64(9 * 3600 * 1e9), HeadwaySecs: 600, ExactTimes: 0},
-		{TripID: "trip_2", StartTime: int64(7 * 3600 * 1e9), EndTime: int64(10 * 3600 * 1e9), HeadwaySecs: 300, ExactTimes: 1},
-		{TripID: "trip_3", StartTime: int64(8 * 3600 * 1e9), EndTime: int64(12 * 3600 * 1e9), HeadwaySecs: 1200, ExactTimes: 0},
+		{TripID: "trip_1", StartTime: hoursAfterMidnight(6), EndTime: hoursAfterMidnight(9), HeadwaySecs: 600, ExactTimes: 0},
+		{TripID: "trip_2", StartTime: hoursAfterMidnight(7), EndTime: hoursAfterMidnight(10), HeadwaySecs: 300, ExactTimes: 1},
+		{TripID: "trip_3", StartTime: hoursAfterMidnight(8), EndTime: hoursAfterMidnight(12), HeadwaySecs: 1200, ExactTimes: 0},
 	}
 
 	err := client.bulkInsertFrequencies(ctx, frequencies, nil)

--- a/internal/clock/clock.go
+++ b/internal/clock/clock.go
@@ -18,8 +18,6 @@ import (
 type Clock interface {
 	// Now returns the current time
 	Now() time.Time
-	// NowUnixMilli returns the current time as Unix milliseconds
-	NowUnixMilli() int64
 }
 
 // RealClock implements Clock using actual system time.
@@ -29,11 +27,6 @@ type RealClock struct{}
 // Now returns the current system time.
 func (RealClock) Now() time.Time {
 	return time.Now()
-}
-
-// NowUnixMilli returns the current time as Unix milliseconds.
-func (RealClock) NowUnixMilli() int64 {
-	return time.Now().UnixMilli()
 }
 
 // MockClock implements Clock and provides a controllable, thread-safe time for tests.
@@ -53,13 +46,6 @@ func (m *MockClock) Now() time.Time {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	return m.currentTime
-}
-
-// NowUnixMilli returns the mock clock's current time as Unix milliseconds.
-func (m *MockClock) NowUnixMilli() int64 {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	return m.currentTime.UnixMilli()
 }
 
 // Set changes the mock clock's current time.

--- a/internal/clock/clock_test.go
+++ b/internal/clock/clock_test.go
@@ -19,16 +19,6 @@ func TestRealClock_Now(t *testing.T) {
 	assert.False(t, result.After(after), "RealClock.Now() should not be after the call")
 }
 
-func TestRealClock_NowUnixMilli(t *testing.T) {
-	c := RealClock{}
-	before := time.Now().UnixMilli()
-	result := c.NowUnixMilli()
-	after := time.Now().UnixMilli()
-
-	assert.GreaterOrEqual(t, result, before)
-	assert.LessOrEqual(t, result, after)
-}
-
 func TestMockClock_Now(t *testing.T) {
 	fixedTime := time.Date(2024, 6, 15, 8, 30, 0, 0, time.UTC)
 	c := NewMockClock(fixedTime)
@@ -36,14 +26,6 @@ func TestMockClock_Now(t *testing.T) {
 	assert.Equal(t, fixedTime, c.Now())
 	// Should return the same time on repeated calls
 	assert.Equal(t, fixedTime, c.Now())
-}
-
-func TestMockClock_NowUnixMilli(t *testing.T) {
-	fixedTime := time.Date(2024, 6, 15, 8, 30, 0, 0, time.UTC)
-	c := NewMockClock(fixedTime)
-
-	expected := fixedTime.UnixMilli()
-	assert.Equal(t, expected, c.NowUnixMilli())
 }
 
 func TestMockClock_Set(t *testing.T) {
@@ -377,7 +359,6 @@ func TestMockClock_ConcurrentAccess(t *testing.T) {
 			defer wg.Done()
 			for range iterations {
 				_ = c.Now()
-				_ = c.NowUnixMilli()
 			}
 		}()
 	}

--- a/internal/gtfs/gtfs_manager.go
+++ b/internal/gtfs/gtfs_manager.go
@@ -671,11 +671,11 @@ func (manager *Manager) GetTripUpdatesForTrip(tripID string) []gtfs.Trip {
 	return updates
 }
 
-func (manager *Manager) GetVehicleLastUpdateTime(vehicle *gtfs.Vehicle) int64 {
+func (manager *Manager) GetVehicleLastUpdateTime(vehicle *gtfs.Vehicle) time.Time {
 	if vehicle == nil || vehicle.Timestamp == nil {
-		return 0
+		return time.Time{}
 	}
-	return vehicle.Timestamp.UnixMilli()
+	return *vehicle.Timestamp
 }
 
 func (manager *Manager) GetTripUpdateByID(tripID string) (*gtfs.Trip, error) {

--- a/internal/gtfs/gtfs_manager_test.go
+++ b/internal/gtfs/gtfs_manager_test.go
@@ -200,14 +200,14 @@ func TestManager_GetVehicleLastUpdateTime(t *testing.T) {
 
 	manager := &Manager{}
 	timestamp := manager.GetVehicleLastUpdateTime(vehicle)
-	assert.Equal(t, now.UnixMilli(), timestamp)
+	assert.Equal(t, now, timestamp)
 
 	nilTimestamp := manager.GetVehicleLastUpdateTime(nil)
-	assert.Equal(t, int64(0), nilTimestamp)
+	assert.True(t, nilTimestamp.IsZero())
 
 	vehicleNoTimestamp := &gtfs.Vehicle{}
 	noTimestamp := manager.GetVehicleLastUpdateTime(vehicleNoTimestamp)
-	assert.Equal(t, int64(0), noTimestamp)
+	assert.True(t, noTimestamp.IsZero())
 }
 
 func TestManager_GetTripUpdateByID(t *testing.T) {

--- a/internal/models/arrival_and_departure.go
+++ b/internal/models/arrival_and_departure.go
@@ -1,5 +1,9 @@
 package models
 
+import (
+	"time"
+)
+
 type ArrivalAndDeparture struct {
 	ActualTrack                string      `json:"actualTrack"`
 	ArrivalEnabled             bool        `json:"arrivalEnabled"`
@@ -8,24 +12,24 @@ type ArrivalAndDeparture struct {
 	DistanceFromStop           float64     `json:"distanceFromStop"`
 	Frequency                  *Frequency  `json:"frequency"`
 	HistoricalOccupancy        string      `json:"historicalOccupancy"`
-	LastUpdateTime             *int64      `json:"lastUpdateTime,omitempty"`
+	LastUpdateTime             ModelTime   `json:"lastUpdateTime,omitzero"`
 	NumberOfStopsAway          int         `json:"numberOfStopsAway"`
 	OccupancyStatus            string      `json:"occupancyStatus"`
 	Predicted                  bool        `json:"predicted"`
 	PredictedArrivalInterval   any         `json:"predictedArrivalInterval"`
-	PredictedArrivalTime       int64       `json:"predictedArrivalTime"`
+	PredictedArrivalTime       ModelTime   `json:"predictedArrivalTime"`
 	PredictedDepartureInterval any         `json:"predictedDepartureInterval"`
-	PredictedDepartureTime     int64       `json:"predictedDepartureTime"`
+	PredictedDepartureTime     ModelTime   `json:"predictedDepartureTime"`
 	PredictedOccupancy         string      `json:"predictedOccupancy"`
 	RouteID                    string      `json:"routeId"`
 	RouteLongName              string      `json:"routeLongName"`
 	RouteShortName             string      `json:"routeShortName"`
 	ScheduledArrivalInterval   any         `json:"scheduledArrivalInterval"`
-	ScheduledArrivalTime       int64       `json:"scheduledArrivalTime"`
+	ScheduledArrivalTime       ModelTime   `json:"scheduledArrivalTime"`
 	ScheduledDepartureInterval any         `json:"scheduledDepartureInterval"`
-	ScheduledDepartureTime     int64       `json:"scheduledDepartureTime"`
+	ScheduledDepartureTime     ModelTime   `json:"scheduledDepartureTime"`
 	ScheduledTrack             string      `json:"scheduledTrack"`
-	ServiceDate                int64       `json:"serviceDate"`
+	ServiceDate                ModelTime   `json:"serviceDate"`
 	SituationIDs               []string    `json:"situationIds"`
 	Status                     string      `json:"status"`
 	StopID                     string      `json:"stopId"`
@@ -39,8 +43,7 @@ type ArrivalAndDeparture struct {
 
 func NewArrivalAndDeparture(
 	routeID, routeShortName, routeLongName, tripID, tripHeadsign, stopID, vehicleID string,
-	serviceDate, scheduledArrivalTime, scheduledDepartureTime, predictedArrivalTime, predictedDepartureTime int64,
-	lastUpdateTime *int64,
+	serviceDate, scheduledArrivalTime, scheduledDepartureTime, predictedArrivalTime, predictedDepartureTime, lastUpdateTime time.Time,
 	predicted, arrivalEnabled, departureEnabled bool,
 	stopSequence, totalStopsInTrip, numberOfStopsAway, blockTripSequence int,
 	distanceFromStop float64,
@@ -56,24 +59,24 @@ func NewArrivalAndDeparture(
 		DistanceFromStop:           distanceFromStop,
 		Frequency:                  nil,
 		HistoricalOccupancy:        historicalOccupancy,
-		LastUpdateTime:             lastUpdateTime,
+		LastUpdateTime:             NewModelTime(lastUpdateTime),
 		NumberOfStopsAway:          numberOfStopsAway,
 		OccupancyStatus:            occupancyStatus,
 		Predicted:                  predicted,
 		PredictedArrivalInterval:   nil,
-		PredictedArrivalTime:       predictedArrivalTime,
+		PredictedArrivalTime:       NewModelTime(predictedArrivalTime),
 		PredictedDepartureInterval: nil,
-		PredictedDepartureTime:     predictedDepartureTime,
+		PredictedDepartureTime:     NewModelTime(predictedDepartureTime),
 		PredictedOccupancy:         predictedOccupancy,
 		RouteID:                    routeID,
 		RouteLongName:              routeLongName,
 		RouteShortName:             routeShortName,
 		ScheduledArrivalInterval:   nil,
-		ScheduledArrivalTime:       scheduledArrivalTime,
+		ScheduledArrivalTime:       NewModelTime(scheduledArrivalTime),
 		ScheduledDepartureInterval: nil,
-		ScheduledDepartureTime:     scheduledDepartureTime,
+		ScheduledDepartureTime:     NewModelTime(scheduledDepartureTime),
 		ScheduledTrack:             "",
-		ServiceDate:                serviceDate,
+		ServiceDate:                NewModelTime(serviceDate),
 		SituationIDs:               situationIDs,
 		Status:                     status,
 		StopID:                     stopID,

--- a/internal/models/arrival_and_departure_test.go
+++ b/internal/models/arrival_and_departure_test.go
@@ -3,6 +3,7 @@ package models
 import (
 	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -15,12 +16,12 @@ func TestNewArrivalAndDeparture(t *testing.T) {
 	tripHeadsign := "Downtown Terminal"
 	stopID := "stop_456"
 	vehicleID := "vehicle_789"
-	serviceDate := int64(1609459200000)
-	scheduledArrivalTime := int64(1609462800000)
-	scheduledDepartureTime := int64(1609462900000)
-	predictedArrivalTime := int64(1609462850000)
-	predictedDepartureTime := int64(1609462950000)
-	lastUpdateTime := int64(1609462700000)
+	serviceDate := time.UnixMilli(1609459200000)
+	scheduledArrivalTime := time.UnixMilli(1609462800000)
+	scheduledDepartureTime := time.UnixMilli(1609462900000)
+	predictedArrivalTime := time.UnixMilli(1609462850000)
+	predictedDepartureTime := time.UnixMilli(1609462950000)
+	lastUpdateTime := time.UnixMilli(1609462700000)
 	predicted := true
 	arrivalEnabled := true
 	departureEnabled := true
@@ -41,7 +42,7 @@ func TestNewArrivalAndDeparture(t *testing.T) {
 	arrival := NewArrivalAndDeparture(
 		routeID, routeShortName, routeLongName, tripID, tripHeadsign, stopID, vehicleID,
 		serviceDate, scheduledArrivalTime, scheduledDepartureTime, predictedArrivalTime, predictedDepartureTime,
-		&lastUpdateTime,
+		lastUpdateTime,
 		predicted, arrivalEnabled, departureEnabled,
 		stopSequence, totalStopsInTrip, numberOfStopsAway, blockTripSequence,
 		distanceFromStop,
@@ -57,12 +58,12 @@ func TestNewArrivalAndDeparture(t *testing.T) {
 	assert.Equal(t, tripHeadsign, arrival.TripHeadsign)
 	assert.Equal(t, stopID, arrival.StopID)
 	assert.Equal(t, vehicleID, arrival.VehicleID)
-	assert.Equal(t, serviceDate, arrival.ServiceDate)
-	assert.Equal(t, scheduledArrivalTime, arrival.ScheduledArrivalTime)
-	assert.Equal(t, scheduledDepartureTime, arrival.ScheduledDepartureTime)
-	assert.Equal(t, predictedArrivalTime, arrival.PredictedArrivalTime)
-	assert.Equal(t, predictedDepartureTime, arrival.PredictedDepartureTime)
-	assert.Equal(t, lastUpdateTime, *arrival.LastUpdateTime)
+	assert.Equal(t, serviceDate, arrival.ServiceDate.Time)
+	assert.Equal(t, scheduledArrivalTime, arrival.ScheduledArrivalTime.Time)
+	assert.Equal(t, scheduledDepartureTime, arrival.ScheduledDepartureTime.Time)
+	assert.Equal(t, predictedArrivalTime, arrival.PredictedArrivalTime.Time)
+	assert.Equal(t, predictedDepartureTime, arrival.PredictedDepartureTime.Time)
+	assert.Equal(t, lastUpdateTime, arrival.LastUpdateTime.Time)
 	assert.Equal(t, predicted, arrival.Predicted)
 	assert.Equal(t, arrivalEnabled, arrival.ArrivalEnabled)
 	assert.Equal(t, departureEnabled, arrival.DepartureEnabled)
@@ -91,7 +92,7 @@ func TestArrivalAndDepartureJSON(t *testing.T) {
 	tripStatus.VehicleID = "vehicle_789"
 	tripStatus.Status = "in_progress"
 
-	lastUpdateTime := int64(1609462700000)
+	lastUpdateTime := time.UnixMilli(1609462700000)
 	arrival := ArrivalAndDeparture{
 		ActualTrack:                "",
 		ArrivalEnabled:             true,
@@ -100,24 +101,24 @@ func TestArrivalAndDepartureJSON(t *testing.T) {
 		DistanceFromStop:           500.75,
 		Frequency:                  nil,
 		HistoricalOccupancy:        "STANDING_ROOM_ONLY",
-		LastUpdateTime:             &lastUpdateTime,
+		LastUpdateTime:             NewModelTime(lastUpdateTime),
 		NumberOfStopsAway:          3,
 		OccupancyStatus:            "MANY_SEATS_AVAILABLE",
 		Predicted:                  true,
 		PredictedArrivalInterval:   nil,
-		PredictedArrivalTime:       1609462850000,
+		PredictedArrivalTime:       NewModelTime(time.UnixMilli(1609462850000)),
 		PredictedDepartureInterval: nil,
-		PredictedDepartureTime:     1609462950000,
+		PredictedDepartureTime:     NewModelTime(time.UnixMilli(1609462950000)),
 		PredictedOccupancy:         "FEW_SEATS_AVAILABLE",
 		RouteID:                    "unitrans_FMS",
 		RouteLongName:              "Fremont Station",
 		RouteShortName:             "FMS",
 		ScheduledArrivalInterval:   nil,
-		ScheduledArrivalTime:       1609462800000,
+		ScheduledArrivalTime:       NewModelTime(time.UnixMilli(1609462800000)),
 		ScheduledDepartureInterval: nil,
-		ScheduledDepartureTime:     1609462900000,
+		ScheduledDepartureTime:     NewModelTime(time.UnixMilli(1609462900000)),
 		ScheduledTrack:             "",
-		ServiceDate:                1609459200000,
+		ServiceDate:                NewModelTime(time.UnixMilli(1609459200000)),
 		SituationIDs:               []string{"situation_1", "situation_2"},
 		Status:                     "SCHEDULED",
 		StopID:                     "stop_456",
@@ -149,8 +150,8 @@ func TestArrivalAndDepartureJSON(t *testing.T) {
 func TestArrivalAndDepartureWithEmptyValues(t *testing.T) {
 	arrival := NewArrivalAndDeparture(
 		"", "", "", "", "", "", "",
-		0, 0, 0, 0, 0,
-		nil,
+		time.Time{}, time.Time{}, time.Time{}, time.Time{}, time.Time{},
+		time.Time{},
 		false, false, false,
 		0, 0, 0, 0,
 		0.0,
@@ -166,21 +167,25 @@ func TestArrivalAndDepartureWithEmptyValues(t *testing.T) {
 	assert.Equal(t, "", arrival.TripHeadsign)
 	assert.Equal(t, "", arrival.StopID)
 	assert.Equal(t, "", arrival.VehicleID)
-	assert.Equal(t, int64(0), arrival.ServiceDate)
+	assert.Equal(t, time.Time{}, arrival.ServiceDate.Time)
 	assert.Equal(t, false, arrival.Predicted)
 	assert.Equal(t, false, arrival.ArrivalEnabled)
 	assert.Equal(t, false, arrival.DepartureEnabled)
 	assert.Nil(t, arrival.TripStatus)
 	assert.Nil(t, arrival.SituationIDs)
-	assert.Nil(t, arrival.LastUpdateTime)
+	assert.Equal(t, time.Time{}, arrival.LastUpdateTime.Time)
 }
 
 func TestArrivalAndDepartureWithNilTripStatus(t *testing.T) {
-	lastUpdateTime := int64(1609462700000)
+	lastUpdateTime := time.UnixMilli(1609462700000)
 	arrival := NewArrivalAndDeparture(
 		"route_1", "R1", "Route One", "trip_1", "Terminal", "stop_1", "vehicle_1",
-		1609459200000, 1609462800000, 1609462900000, 1609462850000, 1609462950000,
-		&lastUpdateTime,
+		time.UnixMilli(1609459200000),
+		time.UnixMilli(1609462800000),
+		time.UnixMilli(1609462900000),
+		time.UnixMilli(1609462850000),
+		time.UnixMilli(1609462950000),
+		lastUpdateTime,
 		true, true, true,
 		1, 10, 2, 1,
 		250.5,

--- a/internal/models/block.go
+++ b/internal/models/block.go
@@ -12,15 +12,15 @@ type BlockConfiguration struct {
 }
 
 type TripBlock struct {
-	AccumulatedSlackTime float64         `json:"accumulatedSlackTime"`
+	AccumulatedSlackTime ModelDuration   `json:"accumulatedSlackTime"`
 	BlockStopTimes       []BlockStopTime `json:"blockStopTimes"`
 	DistanceAlongBlock   float64         `json:"distanceAlongBlock"`
 	TripId               string          `json:"tripId"`
 }
 
 type BlockStopTime struct {
-	AccumulatedSlackTime float64  `json:"accumulatedSlackTime"`
-	BlockSequence        int      `json:"blockSequence"`
-	DistanceAlongBlock   float64  `json:"distanceAlongBlock"`
-	StopTime             StopTime `json:"stopTime"`
+	AccumulatedSlackTime ModelDuration `json:"accumulatedSlackTime"`
+	BlockSequence        int           `json:"blockSequence"`
+	DistanceAlongBlock   float64       `json:"distanceAlongBlock"`
+	StopTime             StopTime      `json:"stopTime"`
 }

--- a/internal/models/current_time.go
+++ b/internal/models/current_time.go
@@ -4,8 +4,8 @@ import "time"
 
 // CurrentTimeModel Current time specific model
 type CurrentTimeModel struct {
-	ReadableTime string `json:"readableTime"`
-	Time         int64  `json:"time"`
+	ReadableTime string    `json:"readableTime"`
+	Time         ModelTime `json:"time"`
 }
 
 // CurrentTimeData Combined data structure for current time endpoint
@@ -16,12 +16,10 @@ type CurrentTimeData struct {
 
 // NewCurrentTimeData creates a CurrentTimeData structure based on a provided Time
 func NewCurrentTimeData(t time.Time) CurrentTimeData {
-	timeMillis := t.UnixNano() / int64(time.Millisecond)
-
 	return CurrentTimeData{
 		Entry: CurrentTimeModel{
 			ReadableTime: t.Format(time.RFC3339),
-			Time:         timeMillis,
+			Time:         NewModelTime(t),
 		},
 		References: *NewEmptyReferences(),
 	}

--- a/internal/models/current_time_test.go
+++ b/internal/models/current_time_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"maglev.onebusaway.org/internal/clock"
 )
 
@@ -12,7 +13,7 @@ func TestCurrentTimeModel(t *testing.T) {
 	// Create a sample CurrentTimeModel
 	timeModel := CurrentTimeModel{
 		ReadableTime: "2025-05-03T12:00:00Z",
-		Time:         1746324000000, // Unix time in milliseconds
+		Time:         NewModelTime(time.UnixMilli(1746324000000)),
 	}
 
 	// Test JSON marshaling
@@ -34,8 +35,8 @@ func TestCurrentTimeModel(t *testing.T) {
 			timeModel.ReadableTime, unmarshaledModel.ReadableTime)
 	}
 
-	if unmarshaledModel.Time != timeModel.Time {
-		t.Errorf("Expected Time %d, got %d",
+	if !unmarshaledModel.Time.Time.Equal(timeModel.Time.Time) {
+		t.Errorf("Expected Time %v, got %v",
 			timeModel.Time, unmarshaledModel.Time)
 	}
 }
@@ -44,7 +45,7 @@ func TestCurrentTimeData(t *testing.T) {
 	// Create a sample CurrentTimeData
 	entry := CurrentTimeModel{
 		ReadableTime: "2025-05-03T12:00:00Z",
-		Time:         1746324000000,
+		Time:         NewModelTime(time.UnixMilli(1746324000000)),
 	}
 
 	references := NewEmptyReferences()
@@ -73,8 +74,8 @@ func TestCurrentTimeData(t *testing.T) {
 			timeData.Entry.ReadableTime, unmarshaledData.Entry.ReadableTime)
 	}
 
-	if unmarshaledData.Entry.Time != timeData.Entry.Time {
-		t.Errorf("Expected Entry.Time %d, got %d",
+	if !unmarshaledData.Entry.Time.Time.Equal(timeData.Entry.Time.Time) {
+		t.Errorf("Expected Entry.Time %v, got %v",
 			timeData.Entry.Time, unmarshaledData.Entry.Time)
 	}
 
@@ -112,22 +113,13 @@ func TestNewCurrentTimeData(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			// Expected values
-			expectedMillis := tc.testTime.UnixNano() / int64(time.Millisecond)
-			expectedReadable := tc.testTime.Format(time.RFC3339)
-
-			// Call the function being tested
 			result := NewCurrentTimeData(tc.testTime)
 
 			// Verify the time fields
-			if result.Entry.Time != expectedMillis {
-				t.Errorf("Expected time %d, got %d", expectedMillis, result.Entry.Time)
-			}
-
-			if result.Entry.ReadableTime != expectedReadable {
-				t.Errorf("Expected readable time %s, got %s",
-					expectedReadable, result.Entry.ReadableTime)
-			}
+			expectedMillis := tc.testTime.UnixMilli()
+			assert.Equal(t, expectedMillis, result.Entry.Time.UnixMilli())
+			expectedReadable := tc.testTime.Format(time.RFC3339)
+			assert.Equal(t, expectedReadable, result.Entry.ReadableTime)
 
 			// Verify that references is initialized
 			if result.References.Agencies == nil {

--- a/internal/models/frequency.go
+++ b/internal/models/frequency.go
@@ -8,15 +8,15 @@ import (
 
 // Frequency represents a GTFS frequency entry in API responses.
 type Frequency struct {
-	StartTime int64 `json:"startTime"`
-	EndTime   int64 `json:"endTime"`
-	// Headway is the time between departures in seconds
-	Headway int `json:"headway"`
+	StartTime ModelTime `json:"startTime"`
+	EndTime   ModelTime `json:"endTime"`
+	// Headway is the time between departures.
+	Headway ModelDuration `json:"headway"`
 	// ExactTimes is used internally for business logic but omitted from API responses
-	ExactTimes  int    `json:"-"`
-	ServiceDate int64  `json:"serviceDate"`
-	ServiceID   string `json:"serviceId"`
-	TripID      string `json:"tripId"`
+	ExactTimes  int       `json:"-"`
+	ServiceDate ModelTime `json:"serviceDate"`
+	ServiceID   string    `json:"serviceId"`
+	TripID      string    `json:"tripId"`
 }
 
 // NewFrequencyFromDB converts a database Frequency row into an API Frequency model.
@@ -28,9 +28,9 @@ func NewFrequencyFromDB(dbFreq gtfsdb.Frequency, serviceDate time.Time) Frequenc
 	startOfDay := time.Date(serviceDate.Year(), serviceDate.Month(), serviceDate.Day(), 0, 0, 0, 0, serviceDate.Location())
 
 	return Frequency{
-		StartTime:  startOfDay.Add(time.Duration(dbFreq.StartTime)).UnixMilli(),
-		EndTime:    startOfDay.Add(time.Duration(dbFreq.EndTime)).UnixMilli(),
-		Headway:    int(dbFreq.HeadwaySecs),
+		StartTime:  NewModelTime(startOfDay.Add(time.Duration(dbFreq.StartTime))),
+		EndTime:    NewModelTime(startOfDay.Add(time.Duration(dbFreq.EndTime))),
+		Headway:    NewModelDuration(time.Duration(dbFreq.HeadwaySecs) * time.Second),
 		ExactTimes: int(dbFreq.ExactTimes),
 	}
 }

--- a/internal/models/frequency_test.go
+++ b/internal/models/frequency_test.go
@@ -34,12 +34,12 @@ func TestNewFrequencyFromDB(t *testing.T) {
 
 	freq := NewFrequencyFromDB(dbFreq, serviceDate)
 
-	expectedStart := time.Date(2024, 1, 15, 6, 0, 0, 0, loc).UnixMilli()
-	expectedEnd := time.Date(2024, 1, 15, 9, 0, 0, 0, loc).UnixMilli()
+	expectedStart := time.Date(2024, 1, 15, 6, 0, 0, 0, loc)
+	expectedEnd := time.Date(2024, 1, 15, 9, 0, 0, 0, loc)
 
-	assert.Equal(t, expectedStart, freq.StartTime)
-	assert.Equal(t, expectedEnd, freq.EndTime)
-	assert.Equal(t, 600, freq.Headway)
+	assert.Equal(t, expectedStart, freq.StartTime.Time)
+	assert.Equal(t, expectedEnd, freq.EndTime.Time)
+	assert.Equal(t, 600*time.Second, freq.Headway.Duration)
 	assert.Equal(t, 1, freq.ExactTimes)
 }
 
@@ -56,9 +56,9 @@ func TestNewFrequencyFromDB_FrequencyBased(t *testing.T) {
 
 	freq := NewFrequencyFromDB(dbFreq, serviceDate)
 
-	assert.Equal(t, 300, freq.Headway)
+	assert.Equal(t, 300*time.Second, freq.Headway.Duration)
 	assert.Equal(t, 0, freq.ExactTimes)
-	assert.Greater(t, freq.EndTime, freq.StartTime)
+	assert.Greater(t, freq.EndTime.Time, freq.StartTime.Time)
 }
 
 func TestNewFrequencyFromDB_OverMidnight(t *testing.T) {
@@ -81,20 +81,20 @@ func TestNewFrequencyFromDB_OverMidnight(t *testing.T) {
 	freq := NewFrequencyFromDB(dbFreq, serviceDate)
 
 	// Should resolve to Jan 16 at 1:00 AM and 3:00 AM
-	expectedStart := time.Date(2024, 1, 16, 1, 0, 0, 0, time.UTC).UnixMilli()
-	expectedEnd := time.Date(2024, 1, 16, 3, 0, 0, 0, time.UTC).UnixMilli()
+	expectedStart := time.Date(2024, 1, 16, 1, 0, 0, 0, time.UTC)
+	expectedEnd := time.Date(2024, 1, 16, 3, 0, 0, 0, time.UTC)
 
-	assert.Equal(t, expectedStart, freq.StartTime)
-	assert.Equal(t, expectedEnd, freq.EndTime)
+	assert.Equal(t, expectedStart, freq.StartTime.Time)
+	assert.Equal(t, expectedEnd, freq.EndTime.Time)
 }
 
 func TestFrequencyJSON(t *testing.T) {
 	freq := Frequency{
-		StartTime:   1705305600000,
-		EndTime:     1705316400000,
-		Headway:     600,
+		StartTime:   NewModelTime(time.UnixMilli(1705305600000)),
+		EndTime:     NewModelTime(time.UnixMilli(1705316400000)),
+		Headway:     NewModelDuration(600 * time.Second),
 		ExactTimes:  1, // This shouldn't be serialized to API clients
-		ServiceDate: 1705305600000,
+		ServiceDate: NewModelTime(time.UnixMilli(1705305600000)),
 		ServiceID:   "service_123",
 		TripID:      "trip_67",
 	}

--- a/internal/models/response.go
+++ b/internal/models/response.go
@@ -72,5 +72,5 @@ func NewResponse(code int, data any, text string, c clock.Clock) ResponseModel {
 
 // ResponseCurrentTime returns the current time from the provided clock as Unix milliseconds.
 func ResponseCurrentTime(c clock.Clock) int64 {
-	return c.NowUnixMilli()
+	return c.Now().UnixMilli()
 }

--- a/internal/models/schedule_for_route.go
+++ b/internal/models/schedule_for_route.go
@@ -1,14 +1,14 @@
 package models
 
 type RouteStopTime struct {
-	ArrivalEnabled   bool   `json:"arrivalEnabled"`
-	ArrivalTime      int    `json:"arrivalTime"`
-	DepartureEnabled bool   `json:"departureEnabled"`
-	DepartureTime    int    `json:"departureTime"`
-	ServiceID        string `json:"serviceId"`
-	StopHeadsign     string `json:"stopHeadsign"`
-	StopID           string `json:"stopId"`
-	TripID           string `json:"tripId"`
+	ArrivalEnabled   bool          `json:"arrivalEnabled"`
+	ArrivalTime      ModelDuration `json:"arrivalTime"`
+	DepartureEnabled bool          `json:"departureEnabled"`
+	DepartureTime    ModelDuration `json:"departureTime"`
+	ServiceID        string        `json:"serviceId"`
+	StopHeadsign     string        `json:"stopHeadsign"`
+	StopID           string        `json:"stopId"`
+	TripID           string        `json:"tripId"`
 }
 
 type TripStopTimes struct {

--- a/internal/models/schedule_for_trip_details_test.go
+++ b/internal/models/schedule_for_trip_details_test.go
@@ -3,16 +3,23 @@ package models
 import (
 	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func TestNewSchedule(t *testing.T) {
-	freq := &Frequency{StartTime: 1000, EndTime: 2000, Headway: 300, ExactTimes: 0}
+	date := time.Date(2024, 6, 15, 8, 0, 0, 0, time.UTC)
+	freq := &Frequency{
+		StartTime:  NewModelTime(date),
+		EndTime:    NewModelTime(date.Add(time.Hour)),
+		Headway:    NewModelDuration(300 * time.Second),
+		ExactTimes: 0,
+	}
 	nextTripID := "next_trip_123"
 	previousTripID := "prev_trip_456"
-	stopTime1 := NewStopTime(28800, 28900, "stop_1", "Downtown", 100.0, "MANY_SEATS_AVAILABLE")
-	stopTime2 := NewStopTime(29000, 29100, "stop_2", "Uptown", 200.0, "FEW_SEATS_AVAILABLE")
+	stopTime1 := NewStopTime(8*time.Hour, 8*time.Hour+time.Minute, "stop_1", "Downtown", 100.0, "MANY_SEATS_AVAILABLE")
+	stopTime2 := NewStopTime(9*time.Hour, 9*time.Hour+time.Minute, "stop_2", "Uptown", 200.0, "FEW_SEATS_AVAILABLE")
 	stopTimes := []StopTime{stopTime1, stopTime2}
 	timeZone := "America/Los_Angeles"
 
@@ -27,7 +34,7 @@ func TestNewSchedule(t *testing.T) {
 }
 
 func TestScheduleJSON(t *testing.T) {
-	stopTime := NewStopTime(28800, 28900, "stop_1", "Downtown", 100.0, "MANY_SEATS_AVAILABLE")
+	stopTime := NewStopTime(8*time.Hour, 8*time.Hour+time.Minute, "stop_1", "Downtown", 100.0, "MANY_SEATS_AVAILABLE")
 
 	schedule := Schedule{
 		Frequency:      nil,
@@ -64,9 +71,9 @@ func TestScheduleWithEmptyValues(t *testing.T) {
 
 func TestScheduleWithMultipleStopTimes(t *testing.T) {
 	stopTimes := []StopTime{
-		NewStopTime(28800, 28900, "stop_1", "Downtown", 100.0, "MANY_SEATS_AVAILABLE"),
-		NewStopTime(29000, 29100, "stop_2", "Uptown", 200.0, "FEW_SEATS_AVAILABLE"),
-		NewStopTime(29200, 29300, "stop_3", "Midtown", 300.0, "STANDING_ROOM_ONLY"),
+		NewStopTime(8*time.Hour, 8*time.Hour+time.Minute, "stop_1", "Downtown", 100.0, "MANY_SEATS_AVAILABLE"),
+		NewStopTime(9*time.Hour, 9*time.Hour+time.Minute, "stop_2", "Uptown", 200.0, "FEW_SEATS_AVAILABLE"),
+		NewStopTime(10*time.Hour, 10*time.Hour+time.Minute, "stop_3", "Midtown", 300.0, "STANDING_ROOM_ONLY"),
 	}
 
 	schedule := NewSchedule(nil, "trip_next", "trip_prev", stopTimes, "America/New_York")

--- a/internal/models/situation.go
+++ b/internal/models/situation.go
@@ -2,7 +2,7 @@ package models
 
 type Situation struct {
 	ID                 string            `json:"id"`
-	CreationTime       int64             `json:"creationTime"`
+	CreationTime       ModelTime         `json:"creationTime"`
 	ActiveWindows      []ActiveWindow    `json:"activeWindows"`
 	AllAffects         []AffectedEntity  `json:"allAffects"`
 	ConsequenceMessage string            `json:"consequenceMessage"`

--- a/internal/models/stop_time_schedule_test.go
+++ b/internal/models/stop_time_schedule_test.go
@@ -3,6 +3,7 @@ package models
 import (
 	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -199,12 +200,17 @@ func TestScheduleForStopEntryWithEmptyRouteSchedules(t *testing.T) {
 func TestNewStopRouteDirectionSchedule_WithFrequencies(t *testing.T) {
 	schedule := []ScheduleStopTime{}
 	frequencies := []Frequency{
-		{StartTime: 28800, EndTime: 32400, Headway: 600, ExactTimes: 0},
+		{
+			StartTime:  NewModelTime(time.UnixMilli(1609459200000)),
+			EndTime:    NewModelTime(time.UnixMilli(1609459300000)),
+			Headway:    NewModelDuration(600 * time.Second),
+			ExactTimes: 0,
+		},
 	}
 
 	directionSchedule := NewStopRouteDirectionSchedule("trip1", schedule, frequencies)
 
 	assert.NotNil(t, directionSchedule.ScheduleFrequencies)
 	assert.Len(t, directionSchedule.ScheduleFrequencies, 1)
-	assert.Equal(t, 600, directionSchedule.ScheduleFrequencies[0].Headway)
+	assert.Equal(t, 600*time.Second, directionSchedule.ScheduleFrequencies[0].Headway.Duration)
 }

--- a/internal/models/stop_times.go
+++ b/internal/models/stop_times.go
@@ -1,24 +1,26 @@
 package models
 
+import "time"
+
 type StopTimes struct {
 	StopTimes []StopTime `json:"stop_times"`
 }
 
 type StopTime struct {
-	ArrivalTime         int     `json:"arrivalTime"`
-	DepartureTime       int     `json:"departureTime"`
-	DropOffType         int     `json:"dropOffType"`
-	PickupType          int     `json:"pickupType"`
-	StopID              string  `json:"stopId"`
-	StopHeadsign        string  `json:"stopHeadsign"`
-	DistanceAlongTrip   float64 `json:"distanceAlongTrip"`
-	HistoricalOccupancy string  `json:"historicalOccupancy"`
+	ArrivalTime         ModelDuration `json:"arrivalTime"`
+	DepartureTime       ModelDuration `json:"departureTime"`
+	DropOffType         int           `json:"dropOffType"`
+	PickupType          int           `json:"pickupType"`
+	StopID              string        `json:"stopId"`
+	StopHeadsign        string        `json:"stopHeadsign"`
+	DistanceAlongTrip   float64       `json:"distanceAlongTrip"`
+	HistoricalOccupancy string        `json:"historicalOccupancy"`
 }
 
-func NewStopTime(arrivalTime, departureTime int, stopID, stopHeadsign string, distanceAlongTrip float64, historicalOccupancy string) StopTime {
+func NewStopTime(arrivalTime, departureTime time.Duration, stopID, stopHeadsign string, distanceAlongTrip float64, historicalOccupancy string) StopTime {
 	return StopTime{
-		ArrivalTime:         arrivalTime,
-		DepartureTime:       departureTime,
+		ArrivalTime:         NewModelDuration(arrivalTime),
+		DepartureTime:       NewModelDuration(departureTime),
 		StopID:              stopID,
 		StopHeadsign:        stopHeadsign,
 		DistanceAlongTrip:   distanceAlongTrip,

--- a/internal/models/stop_times_test.go
+++ b/internal/models/stop_times_test.go
@@ -3,13 +3,14 @@ package models
 import (
 	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func TestNewStopTime(t *testing.T) {
-	arrivalTime := 28800
-	departureTime := 28900
+	arrivalTime := 8 * time.Hour
+	departureTime := arrivalTime + (100 * time.Second)
 	stopID := "unitrans_22005"
 	stopHeadsign := "Downtown"
 	distanceAlongTrip := 1234.56
@@ -17,8 +18,8 @@ func TestNewStopTime(t *testing.T) {
 
 	stopTime := NewStopTime(arrivalTime, departureTime, stopID, stopHeadsign, distanceAlongTrip, historicalOccupancy)
 
-	assert.Equal(t, arrivalTime, stopTime.ArrivalTime)
-	assert.Equal(t, departureTime, stopTime.DepartureTime)
+	assert.Equal(t, arrivalTime, stopTime.ArrivalTime.Duration)
+	assert.Equal(t, departureTime, stopTime.DepartureTime.Duration)
 	assert.Equal(t, stopID, stopTime.StopID)
 	assert.Equal(t, stopHeadsign, stopTime.StopHeadsign)
 	assert.Equal(t, distanceAlongTrip, stopTime.DistanceAlongTrip)
@@ -27,8 +28,8 @@ func TestNewStopTime(t *testing.T) {
 
 func TestStopTimeJSON(t *testing.T) {
 	stopTime := StopTime{
-		ArrivalTime:         28800,
-		DepartureTime:       28900,
+		ArrivalTime:         NewModelDuration(8 * time.Hour),
+		DepartureTime:       NewModelDuration(8*time.Hour + (100 * time.Second)),
 		DropOffType:         0,
 		PickupType:          0,
 		StopID:              "unitrans_22005",
@@ -55,8 +56,8 @@ func TestStopTimeJSON(t *testing.T) {
 func TestStopTimeWithEmptyValues(t *testing.T) {
 	stopTime := NewStopTime(0, 0, "", "", 0.0, "")
 
-	assert.Equal(t, 0, stopTime.ArrivalTime)
-	assert.Equal(t, 0, stopTime.DepartureTime)
+	assert.Equal(t, time.Duration(0), stopTime.ArrivalTime.Duration)
+	assert.Equal(t, time.Duration(0), stopTime.DepartureTime.Duration)
 	assert.Equal(t, "", stopTime.StopID)
 	assert.Equal(t, "", stopTime.StopHeadsign)
 	assert.Equal(t, 0.0, stopTime.DistanceAlongTrip)
@@ -64,8 +65,8 @@ func TestStopTimeWithEmptyValues(t *testing.T) {
 }
 
 func TestNewStopTimes(t *testing.T) {
-	stopTime1 := NewStopTime(28800, 28900, "stop_1", "Downtown", 100.0, "MANY_SEATS_AVAILABLE")
-	stopTime2 := NewStopTime(29000, 29100, "stop_2", "Uptown", 200.0, "FEW_SEATS_AVAILABLE")
+	stopTime1 := NewStopTime(8*time.Hour, 8*time.Hour+time.Minute, "stop_1", "Downtown", 100.0, "MANY_SEATS_AVAILABLE")
+	stopTime2 := NewStopTime(9*time.Hour, 9*time.Hour+time.Minute, "stop_2", "Uptown", 200.0, "FEW_SEATS_AVAILABLE")
 
 	stopTimes := NewStopTimes([]StopTime{stopTime1, stopTime2})
 
@@ -75,8 +76,8 @@ func TestNewStopTimes(t *testing.T) {
 }
 
 func TestStopTimesJSON(t *testing.T) {
-	stopTime1 := NewStopTime(28800, 28900, "stop_1", "Downtown", 100.0, "MANY_SEATS_AVAILABLE")
-	stopTime2 := NewStopTime(29000, 29100, "stop_2", "Uptown", 200.0, "FEW_SEATS_AVAILABLE")
+	stopTime1 := NewStopTime(8*time.Hour, 8*time.Hour+time.Minute, "stop_1", "Downtown", 100.0, "MANY_SEATS_AVAILABLE")
+	stopTime2 := NewStopTime(9*time.Hour, 9*time.Hour+time.Minute, "stop_2", "Uptown", 200.0, "FEW_SEATS_AVAILABLE")
 
 	stopTimes := StopTimes{
 		StopTimes: []StopTime{stopTime1, stopTime2},

--- a/internal/models/times.go
+++ b/internal/models/times.go
@@ -1,0 +1,59 @@
+package models
+
+import (
+	"strconv"
+	"time"
+)
+
+// ModelTime wraps time.Time and serializes to/from JSON as Unix milliseconds.
+// The zero time value time.Time is serialized as 0, although that's technically
+// incorrect as Unix and golang use different epochs.
+type ModelTime struct {
+	time.Time
+}
+
+func NewModelTime(t time.Time) ModelTime {
+	return ModelTime{Time: t}
+}
+
+func (t ModelTime) MarshalJSON() ([]byte, error) {
+	if t.IsZero() {
+		return []byte("0"), nil
+	}
+	return strconv.AppendInt(nil, t.UnixMilli(), 10), nil
+}
+
+func (t *ModelTime) UnmarshalJSON(data []byte) error {
+	ms, err := strconv.ParseInt(string(data), 10, 64)
+	if err != nil {
+		return err
+	}
+	if ms == 0 {
+		t.Time = time.Time{}
+		return nil
+	}
+	t.Time = time.UnixMilli(ms)
+	return nil
+}
+
+// ModelDuration wraps time.Duration and serializes to/from JSON as seconds.
+type ModelDuration struct {
+	time.Duration
+}
+
+func NewModelDuration(d time.Duration) ModelDuration {
+	return ModelDuration{Duration: d}
+}
+
+func (d ModelDuration) MarshalJSON() ([]byte, error) {
+	return strconv.AppendInt(nil, int64(d.Duration/time.Second), 10), nil
+}
+
+func (d *ModelDuration) UnmarshalJSON(data []byte) error {
+	s, err := strconv.ParseInt(string(data), 10, 64)
+	if err != nil {
+		return err
+	}
+	d.Duration = time.Duration(s) * time.Second
+	return nil
+}

--- a/internal/models/trip_details.go
+++ b/internal/models/trip_details.go
@@ -1,18 +1,20 @@
 package models
 
+import "time"
+
 type TripDetails struct {
 	Frequency    *Frequency  `json:"frequency,omitempty"` // omitempty intentional: trip-details callers expect the field absent when the trip is not frequency-based
 	Schedule     *Schedule   `json:"schedule"`
-	ServiceDate  int64       `json:"serviceDate"`
+	ServiceDate  ModelTime   `json:"serviceDate"`
 	SituationIDs []string    `json:"situationIds"`
 	Status       *TripStatus `json:"status,omitempty"`
 	TripID       string      `json:"tripId"`
 }
 
-func NewTripDetails(tripID string, serviceDate int64, frequency *Frequency, status *TripStatus, schedule *Schedule, situationIDs []string) *TripDetails {
+func NewTripDetails(tripID string, serviceDate time.Time, frequency *Frequency, status *TripStatus, schedule *Schedule, situationIDs []string) *TripDetails {
 	return &TripDetails{
 		TripID:       tripID,
-		ServiceDate:  serviceDate,
+		ServiceDate:  NewModelTime(serviceDate),
 		Frequency:    frequency,
 		Status:       status,
 		Schedule:     schedule,
@@ -24,7 +26,7 @@ func NewTripDetails(tripID string, serviceDate int64, frequency *Frequency, stat
 func NewEmptyTripDetails() *TripDetails {
 	return &TripDetails{
 		TripID:       "",
-		ServiceDate:  0,
+		ServiceDate:  NewModelTime(time.Time{}),
 		Frequency:    nil,
 		Status:       nil,
 		Schedule:     nil,
@@ -42,8 +44,8 @@ type TripStatus struct {
 	LastKnownDistanceAlongTrip float64    `json:"lastKnownDistanceAlongTrip"`
 	LastKnownLocation          *Location  `json:"lastKnownLocation,omitempty"`
 	LastKnownOrientation       float64    `json:"lastKnownOrientation"`
-	LastLocationUpdateTime     int64      `json:"lastLocationUpdateTime"`
-	LastUpdateTime             int64      `json:"lastUpdateTime"`
+	LastLocationUpdateTime     ModelTime  `json:"lastLocationUpdateTime"`
+	LastUpdateTime             ModelTime  `json:"lastUpdateTime"`
 	NextStop                   string     `json:"nextStop"`
 	NextStopTimeOffset         int        `json:"nextStopTimeOffset"`
 	OccupancyCapacity          int        `json:"occupancyCapacity"`
@@ -55,7 +57,7 @@ type TripStatus struct {
 	Predicted                  bool       `json:"predicted"`
 	ScheduleDeviation          int        `json:"scheduleDeviation"`
 	ScheduledDistanceAlongTrip float64    `json:"scheduledDistanceAlongTrip"`
-	ServiceDate                int64      `json:"serviceDate"`
+	ServiceDate                ModelTime  `json:"serviceDate"`
 	SituationIDs               []string   `json:"situationIds"`
 	Status                     string     `json:"status"`
 	TotalDistanceAlongTrip     float64    `json:"totalDistanceAlongTrip"`

--- a/internal/models/trip_details_test.go
+++ b/internal/models/trip_details_test.go
@@ -3,6 +3,7 @@ package models
 import (
 	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -14,13 +15,13 @@ func TestNewTripDetails(t *testing.T) {
 	}
 
 	tripID := trip.ID
-	serviceDate := int64(1609459200000)
+	serviceDate := time.UnixMilli(1609459200000)
 
 	frequency := &Frequency{
-		StartTime:   28800,
-		EndTime:     32400,
-		Headway:     300,
-		ServiceDate: serviceDate,
+		StartTime:   NewModelTime(serviceDate.Add(8 * time.Hour)),
+		EndTime:     NewModelTime(serviceDate.Add(9 * time.Hour)),
+		Headway:     NewModelDuration(300 * time.Second),
+		ServiceDate: NewModelTime(serviceDate),
 		ServiceID:   "service_789",
 		TripID:      tripID,
 	}
@@ -43,7 +44,7 @@ func TestNewTripDetails(t *testing.T) {
 	tripDetails := NewTripDetails(tripID, serviceDate, frequency, status, schedule, situationIDs)
 
 	assert.Equal(t, tripID, tripDetails.TripID)
-	assert.Equal(t, serviceDate, tripDetails.ServiceDate)
+	assert.Equal(t, serviceDate, tripDetails.ServiceDate.Time)
 	assert.Equal(t, frequency, tripDetails.Frequency)
 	assert.Equal(t, status, tripDetails.Status)
 	assert.Equal(t, schedule, tripDetails.Schedule)
@@ -54,7 +55,7 @@ func TestNewEmptyTripDetails(t *testing.T) {
 	tripDetails := NewEmptyTripDetails()
 
 	assert.Equal(t, "", tripDetails.TripID)
-	assert.Equal(t, int64(0), tripDetails.ServiceDate)
+	assert.True(t, tripDetails.ServiceDate.Time.IsZero())
 	assert.Nil(t, tripDetails.Frequency)
 	assert.Nil(t, tripDetails.Status)
 	assert.Nil(t, tripDetails.Schedule)
@@ -63,11 +64,12 @@ func TestNewEmptyTripDetails(t *testing.T) {
 }
 
 func TestTripDetailsJSON(t *testing.T) {
+	serviceDate := time.UnixMilli(1609459200000)
 	frequency := &Frequency{
-		StartTime:   28800,
-		EndTime:     32400,
-		Headway:     300,
-		ServiceDate: 1609459200000,
+		StartTime:   NewModelTime(serviceDate.Add(8 * time.Hour)),
+		EndTime:     NewModelTime(serviceDate.Add(9 * time.Hour)),
+		Headway:     NewModelDuration(300 * time.Second),
+		ServiceDate: NewModelTime(serviceDate),
 		ServiceID:   "service_789",
 		TripID:      "trip_123",
 	}
@@ -86,7 +88,7 @@ func TestTripDetailsJSON(t *testing.T) {
 
 	tripDetails := TripDetails{
 		TripID:       "trip_123",
-		ServiceDate:  1609459200000,
+		ServiceDate:  NewModelTime(serviceDate),
 		Frequency:    frequency,
 		Status:       status,
 		Schedule:     schedule,
@@ -110,11 +112,12 @@ func TestTripDetailsJSON(t *testing.T) {
 
 func TestTripDetailsWithNilValues(t *testing.T) {
 	trip := Trip{ID: "trip_123"}
+	serviceDate := time.UnixMilli(1609459200000)
 
-	tripDetails := NewTripDetails(trip.ID, 1609459200000, nil, nil, nil, nil)
+	tripDetails := NewTripDetails(trip.ID, serviceDate, nil, nil, nil, nil)
 
 	assert.Equal(t, trip.ID, tripDetails.TripID)
-	assert.Equal(t, int64(1609459200000), tripDetails.ServiceDate)
+	assert.Equal(t, serviceDate, tripDetails.ServiceDate.Time)
 	assert.Nil(t, tripDetails.Frequency)
 	assert.Nil(t, tripDetails.Status)
 	assert.Nil(t, tripDetails.Schedule)
@@ -135,8 +138,8 @@ func TestTripStatusJSON(t *testing.T) {
 			Lon: -121.743914,
 		},
 		LastKnownOrientation:   90.0,
-		LastLocationUpdateTime: 1609462700000,
-		LastUpdateTime:         1609462800000,
+		LastLocationUpdateTime: NewModelTime(time.UnixMilli(1609462700000)),
+		LastUpdateTime:         NewModelTime(time.UnixMilli(1609462800000)),
 		NextStop:               "stop_789",
 		NextStopTimeOffset:     240,
 		OccupancyCapacity:      50,
@@ -151,7 +154,7 @@ func TestTripStatusJSON(t *testing.T) {
 		Predicted:                  true,
 		ScheduleDeviation:          60,
 		ScheduledDistanceAlongTrip: 1450.0,
-		ServiceDate:                1609459200000,
+		ServiceDate:                NewModelTime(time.UnixMilli(1609459200000)),
 		SituationIDs:               []string{"situation_1"},
 		Status:                     "SCHEDULED",
 		TotalDistanceAlongTrip:     5000.0,

--- a/internal/models/vehicle.go
+++ b/internal/models/vehicle.go
@@ -2,8 +2,8 @@ package models
 
 type VehicleStatus struct {
 	VehicleID              string      `json:"vehicleId"`
-	LastLocationUpdateTime int64       `json:"lastLocationUpdateTime"`
-	LastUpdateTime         int64       `json:"lastUpdateTime"`
+	LastLocationUpdateTime ModelTime   `json:"lastLocationUpdateTime"`
+	LastUpdateTime         ModelTime   `json:"lastUpdateTime"`
 	Location               *Location   `json:"location"`
 	TripID                 string      `json:"tripId"`
 	TripStatus             *TripStatus `json:"tripStatus"`

--- a/internal/models/vehicle_test.go
+++ b/internal/models/vehicle_test.go
@@ -3,6 +3,7 @@ package models
 import (
 	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -48,7 +49,7 @@ func TestVehicleStatus_JSONFields(t *testing.T) {
 	t.Run("optional fields appear only when set", func(t *testing.T) {
 		capacity := 50
 		count := 30
-		ts := int64(1000)
+		ts := NewModelTime(time.UnixMilli(1000))
 
 		tripStatus := NewTripStatus()
 		tripStatus.ActiveTripID = "trip_1"

--- a/internal/restapi/arrival_and_departure_for_stop_handler.go
+++ b/internal/restapi/arrival_and_departure_for_stop_handler.go
@@ -277,7 +277,6 @@ func (api *RestAPI) arrivalAndDepartureForStopHandler(w http.ResponseWriter, r *
 		0, 0, 0, 0,
 		loc,
 	)
-	serviceDateMillis := serviceMidnight.UnixMilli()
 
 	// Arrival time is stored in nanoseconds since midnight → convert to duration
 	// arrival and departure time is stored in nanoseconds (sqlite)
@@ -288,18 +287,13 @@ func (api *RestAPI) arrivalAndDepartureForStopHandler(w http.ResponseWriter, r *
 	scheduledArrivalTime := serviceMidnight.Add(arrivalOffset)
 	scheduledDepartureTime := serviceMidnight.Add(departureOffset)
 
-	// Convert to ms since epoch
-	scheduledArrivalTimeMs := scheduledArrivalTime.UnixMilli()
-	scheduledDepartureTimeMs := scheduledDepartureTime.UnixMilli()
-
 	// Get real-time data for this trip if available
 	var (
-		predictedArrivalTime, predictedDepartureTime int64
-		predicted                                    bool
-		vehicleID                                    string
-		tripStatus                                   *models.TripStatus
-		distanceFromStop                             float64
-		numberOfStopsAway                            int
+		predicted         bool
+		vehicleID         string
+		tripStatus        *models.TripStatus
+		distanceFromStop  float64
+		numberOfStopsAway int
 	)
 
 	// If vehicleId is provided, validate it matches the trip
@@ -336,11 +330,13 @@ func (api *RestAPI) arrivalAndDepartureForStopHandler(w http.ResponseWriter, r *
 		api.Logger.Warn("BuildTripStatus failed",
 			"tripID", tripID, "error", statusErr)
 	}
+
+	var predictedArrivalTime, predictedDepartureTime time.Time
 	if status != nil {
 		tripStatus = status
 
-		predictedArrivalTime = scheduledArrivalTimeMs
-		predictedDepartureTime = scheduledDepartureTimeMs
+		predictedArrivalTime = scheduledArrivalTime
+		predictedDepartureTime = scheduledDepartureTime
 
 		// getPredictedTimes now returns 3 values (arr, dep, isPredicted)
 		// and includes trip-level Delay fallback for consistency with the plural handler
@@ -371,11 +367,6 @@ func (api *RestAPI) arrivalAndDepartureForStopHandler(w http.ResponseWriter, r *
 	blockTripSequence := api.calculateBlockTripSequence(ctx, tripID, serviceDate)
 
 	lastUpdateTime := api.GtfsManager.GetVehicleLastUpdateTime(vehicle)
-	var lastUpdateTimePtr *int64
-	if lastUpdateTime > 0 {
-		lastUpdateTimePtr = utils.Int64Ptr(lastUpdateTime)
-	}
-
 	situationIDs := api.GetSituationIDsForTrip(r.Context(), tripID)
 
 	arrival := models.NewArrivalAndDeparture(
@@ -386,12 +377,12 @@ func (api *RestAPI) arrivalAndDepartureForStopHandler(w http.ResponseWriter, r *
 		trip.TripHeadsign.String,                       // tripHeadsign
 		stopID,                                         // stopID
 		vehicleID,                                      // vehicleID
-		serviceDateMillis,                              // serviceDate
-		scheduledArrivalTimeMs,                         // scheduledArrivalTime
-		scheduledDepartureTimeMs,                       // scheduledDepartureTime
+		serviceMidnight,                                // serviceDate
+		scheduledArrivalTime,                           // scheduledArrivalTime
+		scheduledDepartureTime,                         // scheduledDepartureTime
 		predictedArrivalTime,                           // predictedArrivalTime
 		predictedDepartureTime,                         // predictedDepartureTime
-		lastUpdateTimePtr,                              // lastUpdateTime
+		lastUpdateTime,                                 // lastUpdateTime
 		predicted,                                      // predicted
 		true,                                           // arrivalEnabled
 		true,                                           // departureEnabled
@@ -620,16 +611,16 @@ func (api *RestAPI) getPredictedTimes(
 	stopCode string,
 	targetStopSequence int64,
 	scheduledArrivalTime, scheduledDepartureTime time.Time,
-) (predictedArrivalTime, predictedDepartureTime int64, predicted bool) {
+) (predictedArrivalTime, predictedDepartureTime time.Time, predicted bool) {
 
 	realTimeTrip, _ := api.GtfsManager.GetTripUpdateByID(tripID)
 	// trip-level delay exists but StopTimeUpdates is empty
 	if realTimeTrip == nil || (len(realTimeTrip.StopTimeUpdates) == 0) && realTimeTrip.Delay == nil {
-		return 0, 0, false
+		return time.Time{}, time.Time{}, false
 	}
 
-	var arrivalOffset, departureOffset *int64
-	var propagatedDelay int64 = 0
+	var arrivalOffset, departureOffset *time.Duration
+	var propagatedDelay time.Duration
 	var closestPriorSequence int64 = -1
 	var foundTarget bool
 
@@ -643,19 +634,19 @@ func (api *RestAPI) getPredictedTimes(
 			foundTarget = true
 			if stu.Arrival != nil {
 				if stu.Arrival.Time != nil {
-					offset := stu.Arrival.Time.Sub(scheduledArrivalTime).Nanoseconds()
+					offset := stu.Arrival.Time.Sub(scheduledArrivalTime)
 					arrivalOffset = &offset
 				} else if stu.Arrival.Delay != nil {
-					offset := int64(*stu.Arrival.Delay)
+					offset := *stu.Arrival.Delay
 					arrivalOffset = &offset
 				}
 			}
 			if stu.Departure != nil {
 				if stu.Departure.Time != nil {
-					offset := stu.Departure.Time.Sub(scheduledDepartureTime).Nanoseconds()
+					offset := stu.Departure.Time.Sub(scheduledDepartureTime)
 					departureOffset = &offset
 				} else if stu.Departure.Delay != nil {
-					offset := int64(*stu.Departure.Delay)
+					offset := *stu.Departure.Delay
 					departureOffset = &offset
 				}
 			}
@@ -666,9 +657,9 @@ func (api *RestAPI) getPredictedTimes(
 			closestPriorSequence = seq
 			propagatedDelay = 0
 			if stu.Departure != nil && stu.Departure.Delay != nil {
-				propagatedDelay = int64(*stu.Departure.Delay)
+				propagatedDelay = *stu.Departure.Delay
 			} else if stu.Arrival != nil && stu.Arrival.Delay != nil {
-				propagatedDelay = int64(*stu.Arrival.Delay)
+				propagatedDelay = *stu.Arrival.Delay
 			}
 		}
 	}
@@ -685,11 +676,11 @@ func (api *RestAPI) getPredictedTimes(
 			departureOffset = &dep
 		} else if realTimeTrip.Delay != nil {
 			// Fallback 2: Trip-level delay — matches plural handler behavior
-			delayNs := realTimeTrip.Delay.Nanoseconds()
-			arrivalOffset = &delayNs
-			departureOffset = &delayNs
+			delay := *realTimeTrip.Delay
+			arrivalOffset = &delay
+			departureOffset = &delay
 		} else {
-			return 0, 0, false
+			return time.Time{}, time.Time{}, false
 		}
 	}
 
@@ -708,16 +699,16 @@ func (api *RestAPI) getPredictedTimes(
 			offset = *departureOffset
 		}
 
-		predictedArrival := scheduledArrivalTime.Add(time.Duration(offset))
-		predictedDeparture := scheduledDepartureTime.Add(time.Duration(offset))
-		return predictedArrival.UnixMilli(), predictedDeparture.UnixMilli(), true
+		predictedArrival := scheduledArrivalTime.Add(offset)
+		predictedDeparture := scheduledDepartureTime.Add(offset)
+		return predictedArrival, predictedDeparture, true
 	}
 
 	// Rule 2: arrival < departure
-	predictedArrival := scheduledArrivalTime.Add(time.Duration(*arrivalOffset))
-	predictedDeparture := scheduledDepartureTime.Add(time.Duration(*departureOffset))
+	predictedArrival := scheduledArrivalTime.Add(*arrivalOffset)
+	predictedDeparture := scheduledDepartureTime.Add(*departureOffset)
 
-	return predictedArrival.UnixMilli(), predictedDeparture.UnixMilli(), true
+	return predictedArrival, predictedDeparture, true
 }
 
 func (api *RestAPI) getNumberOfStopsAway(ctx context.Context, targetTripID string, targetStopSequence int, vehicle *gtfs.Vehicle, serviceDate time.Time) *int {

--- a/internal/restapi/arrival_and_departure_for_stop_handler_test.go
+++ b/internal/restapi/arrival_and_departure_for_stop_handler_test.go
@@ -529,8 +529,8 @@ func TestGetPredictedTimes_NoRealTimeData(t *testing.T) {
 	// When there's no real-time data, should return 0, 0, false
 	predArrival, predDeparture, predicted := api.getPredictedTimes("nonexistent_trip", "nonexistent_stop", 1, scheduledArrival, scheduledDeparture)
 
-	assert.Equal(t, int64(0), predArrival)
-	assert.Equal(t, int64(0), predDeparture)
+	assert.True(t, predArrival.IsZero())
+	assert.True(t, predDeparture.IsZero())
 	assert.False(t, predicted)
 }
 
@@ -546,8 +546,8 @@ func TestGetPredictedTimes_EqualArrivalDeparture(t *testing.T) {
 	predArrival, predDeparture, predicted := api.getPredictedTimes("test_trip", "test_stop", 1, scheduledTime, scheduledTime)
 
 	// Without real-time data, returns 0, 0, false
-	assert.Equal(t, int64(0), predArrival)
-	assert.Equal(t, int64(0), predDeparture)
+	assert.True(t, predArrival.IsZero())
+	assert.True(t, predDeparture.IsZero())
 	assert.False(t, predicted)
 }
 
@@ -853,8 +853,7 @@ func TestGetPredictedTimes_DelayPropagationLogic(t *testing.T) {
 	scheduledTime := time.Now()
 	predArrival, predDeparture, predicted := api.getPredictedTimes(tripID, "test_stop", targetStopSequence, scheduledTime, scheduledTime)
 
-	expectedTime := scheduledTime.Add(delayDuration).UnixMilli()
-
+	expectedTime := scheduledTime.Add(delayDuration)
 	assert.Equal(t, expectedTime, predArrival, "Arrival time should include 120s delay")
 	assert.Equal(t, expectedTime, predDeparture, "Departure time should include 120s delay")
 	assert.True(t, predicted, "Should be predicted when delay propagation is available")
@@ -882,8 +881,7 @@ func TestGetPredictedTimes_TripLevelDelayFallback(t *testing.T) {
 	scheduledTime := time.Now()
 	predArrival, predDeparture, predicted := api.getPredictedTimes(tripID, "test_stop", targetStopSequence, scheduledTime, scheduledTime)
 
-	expectedTime := scheduledTime.Add(delayDuration).UnixMilli()
-
+	expectedTime := scheduledTime.Add(delayDuration)
 	assert.True(t, predicted, "Should be predicted when trip-level delay is available")
 	assert.Equal(t, expectedTime, predArrival, "Arrival time should include 300s trip-level delay")
 	assert.Equal(t, expectedTime, predDeparture, "Departure time should include 300s trip-level delay")

--- a/internal/restapi/arrivals_and_departure_for_stop.go
+++ b/internal/restapi/arrivals_and_departure_for_stop.go
@@ -15,20 +15,20 @@ import (
 
 // Define params structure for the plural handler
 type ArrivalsStopParams struct {
-	MinutesAfter  int
-	MinutesBefore int
-	Time          time.Time
+	After  time.Duration
+	Before time.Duration
+	Time   time.Time
 }
 
 // parseArrivalsAndDeparturesParams parses and validates parameters.
 func (api *RestAPI) parseArrivalsAndDeparturesParams(r *http.Request) (ArrivalsStopParams, map[string][]string) {
-	const maxMinutesBefore = 60
-	const maxMinutesAfter = 240
+	const maxBefore = 60 * time.Minute
+	const maxAfter = 240 * time.Minute
 
 	params := ArrivalsStopParams{
-		MinutesAfter:  35,              // Default
-		MinutesBefore: 5,               // Default
-		Time:          api.Clock.Now(), // Default to current time
+		After:  35 * time.Minute, // Default
+		Before: 5 * time.Minute,  // Default
+		Time:   api.Clock.Now(),  // Default to current time
 	}
 
 	var fieldErrors map[string][]string
@@ -44,12 +44,11 @@ func (api *RestAPI) parseArrivalsAndDeparturesParams(r *http.Request) (ArrivalsS
 
 	if val := query.Get("minutesAfter"); val != "" {
 		if minutes, err := strconv.Atoi(val); err == nil {
-			if minutes > maxMinutesAfter {
-				params.MinutesAfter = maxMinutesAfter
-			} else if minutes >= 0 {
-				params.MinutesAfter = minutes
-			} else {
+			paramAfter := time.Duration(minutes) * time.Minute
+			if paramAfter < 0 {
 				addError("minutesAfter", "must be a non-negative integer")
+			} else {
+				params.After = min(paramAfter, maxAfter)
 			}
 		} else {
 			addError("minutesAfter", "must be a valid integer")
@@ -58,12 +57,11 @@ func (api *RestAPI) parseArrivalsAndDeparturesParams(r *http.Request) (ArrivalsS
 
 	if val := query.Get("minutesBefore"); val != "" {
 		if minutes, err := strconv.Atoi(val); err == nil {
-			if minutes > maxMinutesBefore {
-				params.MinutesBefore = maxMinutesBefore
-			} else if minutes >= 0 {
-				params.MinutesBefore = minutes
-			} else {
+			paramBefore := time.Duration(minutes) * time.Minute
+			if paramBefore < 0 {
 				addError("minutesBefore", "must be a non-negative integer")
+			} else {
+				params.Before = min(paramBefore, maxBefore)
 			}
 		} else {
 			addError("minutesBefore", "must be a valid integer")
@@ -115,8 +113,8 @@ func (api *RestAPI) arrivalsAndDeparturesForStopHandler(w http.ResponseWriter, r
 		return
 	}
 	params.Time = params.Time.In(loc)
-	windowStart := params.Time.Add(-time.Duration(params.MinutesBefore) * time.Minute)
-	windowEnd := params.Time.Add(time.Duration(params.MinutesAfter) * time.Minute)
+	windowStart := params.Time.Add(-params.Before)
+	windowEnd := params.Time.Add(params.After)
 
 	arrivals := make([]models.ArrivalAndDeparture, 0)
 	references := models.NewEmptyReferences()
@@ -166,17 +164,16 @@ func (api *RestAPI) arrivalsAndDeparturesForStopHandler(w http.ResponseWriter, r
 			activeServiceIDSet[sid] = true
 		}
 
-		startNanos := windowStart.Sub(serviceMidnight).Nanoseconds()
-		endNanos := windowEnd.Sub(serviceMidnight).Nanoseconds()
-
-		if endNanos < 0 {
+		startOffset := windowStart.Sub(serviceMidnight)
+		endOffset := windowEnd.Sub(serviceMidnight)
+		if endOffset < 0 {
 			continue
 		}
 
 		stopTimes, err := api.GtfsManager.GtfsDB.Queries.GetStopTimesForStopInWindow(ctx, gtfsdb.GetStopTimesForStopInWindowParams{
 			StopID:           stopCode,
-			WindowStartNanos: startNanos,
-			WindowEndNanos:   endNanos,
+			WindowStartNanos: startOffset.Nanoseconds(),
+			WindowEndNanos:   endOffset.Nanoseconds(),
 		})
 		if err != nil {
 			api.Logger.Warn("failed to query stop times in window",
@@ -271,7 +268,6 @@ func (api *RestAPI) arrivalsAndDeparturesForStopHandler(w http.ResponseWriter, r
 		st := ast.GetStopTimesForStopInWindowRow
 
 		serviceMidnight := ast.ServiceDate
-		serviceDateMillis := serviceMidnight.UnixMilli()
 		if ctx.Err() != nil {
 			api.clientCanceledResponse(w, r, ctx.Err())
 			return
@@ -298,8 +294,8 @@ func (api *RestAPI) arrivalsAndDeparturesForStopHandler(w http.ResponseWriter, r
 		tCopy := trip
 		tripIDSet[trip.ID] = &tCopy
 
-		scheduledArrivalTime := serviceMidnight.Add(time.Duration(st.ArrivalTime)).UnixMilli()
-		scheduledDepartureTime := serviceMidnight.Add(time.Duration(st.DepartureTime)).UnixMilli()
+		scheduledArrivalTime := serviceMidnight.Add(time.Duration(st.ArrivalTime))
+		scheduledDepartureTime := serviceMidnight.Add(time.Duration(st.DepartureTime))
 
 		var (
 			predictedArrivalTime   = scheduledArrivalTime
@@ -403,8 +399,8 @@ func (api *RestAPI) arrivalsAndDeparturesForStopHandler(w http.ResponseWriter, r
 		}
 
 		if !predicted {
-			predictedArrivalTime = 0
-			predictedDepartureTime = 0
+			predictedArrivalTime = time.Time{}
+			predictedDepartureTime = time.Time{}
 		}
 
 		totalStopsInTrip := tripStopCountMap[st.TripID]
@@ -412,10 +408,6 @@ func (api *RestAPI) arrivalsAndDeparturesForStopHandler(w http.ResponseWriter, r
 		blockTripSequence := api.calculateBlockTripSequence(ctx, st.TripID, serviceMidnight)
 
 		lastUpdateTime := api.GtfsManager.GetVehicleLastUpdateTime(vehicle)
-		var lastUpdateTimePtr *int64
-		if lastUpdateTime > 0 {
-			lastUpdateTimePtr = utils.Int64Ptr(lastUpdateTime)
-		}
 
 		tripAlerts := api.GtfsManager.GetAlertsForTrip(r.Context(), st.TripID)
 		situationIDs := make([]string, 0, len(tripAlerts))
@@ -442,12 +434,12 @@ func (api *RestAPI) arrivalsAndDeparturesForStopHandler(w http.ResponseWriter, r
 			st.TripHeadsign.String,                          // tripHeadsign
 			stopID,                                          // stopID
 			vehicleID,                                       // vehicleID
-			serviceDateMillis,                               // serviceDate
+			serviceMidnight,                                 // serviceDate
 			scheduledArrivalTime,                            // scheduledArrivalTime
 			scheduledDepartureTime,                          // scheduledDepartureTime
 			predictedArrivalTime,                            // predictedArrivalTime
 			predictedDepartureTime,                          // predictedDepartureTime
-			lastUpdateTimePtr,                               // lastUpdateTime
+			lastUpdateTime,                                  // lastUpdateTime
 			predicted,                                       // predicted
 			true,                                            // arrivalEnabled
 			true,                                            // departureEnabled

--- a/internal/restapi/arrivals_and_departures_for_stop_handler_test.go
+++ b/internal/restapi/arrivals_and_departures_for_stop_handler_test.go
@@ -400,8 +400,8 @@ func TestParseArrivalsAndDeparturesParams_AllParameters(t *testing.T) {
 	params, errs := api.parseArrivalsAndDeparturesParams(req)
 
 	assert.Nil(t, errs)
-	assert.Equal(t, 60, params.MinutesAfter)
-	assert.Equal(t, 15, params.MinutesBefore)
+	assert.Equal(t, 60*time.Minute, params.After)
+	assert.Equal(t, 15*time.Minute, params.Before)
 	assert.False(t, params.Time.IsZero())
 }
 
@@ -414,8 +414,8 @@ func TestParseArrivalsAndDeparturesParams_DefaultValues(t *testing.T) {
 	params, errs := api.parseArrivalsAndDeparturesParams(req)
 
 	assert.Nil(t, errs)
-	assert.Equal(t, 35, params.MinutesAfter) // Default for plural handler
-	assert.Equal(t, 5, params.MinutesBefore) // Default
+	assert.Equal(t, 35*time.Minute, params.After) // Default for plural handler
+	assert.Equal(t, 5*time.Minute, params.Before) // Default
 	assert.WithinDuration(t, api.Clock.Now(), params.Time, 1*time.Second)
 }
 

--- a/internal/restapi/block_handler.go
+++ b/internal/restapi/block_handler.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"sort"
 	"strconv"
+	"time"
 
 	"maglev.onebusaway.org/gtfsdb"
 	"maglev.onebusaway.org/internal/models"
@@ -123,8 +124,8 @@ func transformBlockToEntry(block []gtfsdb.GetBlockDetailsRow, blockID, agencyID 
 					BlockSequence:      int(stop.StopSequence - 1),
 					DistanceAlongBlock: blockDistance,
 					StopTime: models.StopTime{
-						ArrivalTime:   int(utils.NanosToSeconds(stop.ArrivalTime)),
-						DepartureTime: int(utils.NanosToSeconds(stop.DepartureTime)),
+						ArrivalTime:   models.NewModelDuration(time.Duration(stop.ArrivalTime)),
+						DepartureTime: models.NewModelDuration(time.Duration(stop.DepartureTime)),
 						DropOffType:   int(stop.DropOffType.Int64),
 						PickupType:    int(stop.PickupType.Int64),
 						StopID:        utils.FormCombinedID(agencyID, stop.StopID),
@@ -135,15 +136,15 @@ func transformBlockToEntry(block []gtfsdb.GetBlockDetailsRow, blockID, agencyID 
 
 			blockStopTimes = calculateBlockSlackTimes(blockStopTimes)
 
-			var tripAccumulatedSlack float64
+			var tripAccumulatedSlack time.Duration
 			if len(blockStopTimes) > 0 {
-				tripAccumulatedSlack = blockStopTimes[len(blockStopTimes)-1].AccumulatedSlackTime
+				tripAccumulatedSlack = blockStopTimes[len(blockStopTimes)-1].AccumulatedSlackTime.Duration
 			}
 
 			tripDistance := blockDistance - tripStartDistance
 
 			trip := models.TripBlock{
-				AccumulatedSlackTime: tripAccumulatedSlack,
+				AccumulatedSlackTime: models.NewModelDuration(tripAccumulatedSlack),
 				BlockStopTimes:       blockStopTimes,
 				DistanceAlongBlock:   tripDistance,
 				TripId:               utils.FormCombinedID(agencyID, tripID),
@@ -258,11 +259,11 @@ func (api *RestAPI) getReferences(ctx context.Context, agencyID string, block []
 }
 
 func calculateBlockSlackTimes(blockStopTimes []models.BlockStopTime) []models.BlockStopTime {
-	var accumulatedBlockSlackTime int
+	var accumulatedBlockSlackTime time.Duration
 
 	for i := range blockStopTimes {
-		blockStopTimes[i].AccumulatedSlackTime = float64(accumulatedBlockSlackTime)
-		dwellTime := blockStopTimes[i].StopTime.DepartureTime - blockStopTimes[i].StopTime.ArrivalTime
+		blockStopTimes[i].AccumulatedSlackTime = models.NewModelDuration(accumulatedBlockSlackTime)
+		dwellTime := blockStopTimes[i].StopTime.DepartureTime.Duration - blockStopTimes[i].StopTime.ArrivalTime.Duration
 		accumulatedBlockSlackTime += dwellTime
 	}
 

--- a/internal/restapi/reference_utils.go
+++ b/internal/restapi/reference_utils.go
@@ -2,6 +2,7 @@ package restapi
 
 import (
 	"context"
+	"time"
 
 	"github.com/OneBusAway/go-gtfs"
 	"maglev.onebusaway.org/gtfsdb"
@@ -78,7 +79,7 @@ func (api *RestAPI) BuildSituationReferences(alerts []gtfs.Alert) []models.Situa
 	for _, alert := range alerts {
 		situation := models.Situation{
 			ID:                 alert.ID,
-			CreationTime:       0,
+			CreationTime:       models.NewModelTime(time.Time{}),
 			ActiveWindows:      make([]models.ActiveWindow, 0, len(alert.ActivePeriods)),
 			AllAffects:         make([]models.AffectedEntity, 0, len(alert.InformedEntities)),
 			ConsequenceMessage: "",

--- a/internal/restapi/schedule_for_route_handler.go
+++ b/internal/restapi/schedule_for_route_handler.go
@@ -216,9 +216,9 @@ func (api *RestAPI) scheduleForRouteHandler(w http.ResponseWriter, r *http.Reque
 			for _, st := range stopTimes {
 				stopTimesList = append(stopTimesList, models.RouteStopTime{
 					ArrivalEnabled:   true,
-					ArrivalTime:      int(utils.NanosToSeconds(st.ArrivalTime)),
+					ArrivalTime:      models.NewModelDuration(time.Duration(st.ArrivalTime)),
 					DepartureEnabled: true,
-					DepartureTime:    int(utils.NanosToSeconds(st.DepartureTime)),
+					DepartureTime:    models.NewModelDuration(time.Duration(st.DepartureTime)),
 					ServiceID:        utils.FormCombinedID(agencyID, trip.ServiceID),
 					StopHeadsign:     st.StopHeadsign.String,
 					StopID:           utils.FormCombinedID(agencyID, st.StopID),

--- a/internal/restapi/trip_details_handler.go
+++ b/internal/restapi/trip_details_handler.go
@@ -151,7 +151,7 @@ func (api *RestAPI) tripDetailsHandler(w http.ResponseWriter, r *http.Request) {
 		currentTime = api.Clock.Now().In(loc)
 	}
 
-	serviceDate, serviceDateMillis := utils.ServiceDateMillis(params.ServiceDate, currentTime)
+	serviceDate, midnight := utils.ServiceDateMidnight(params.ServiceDate, currentTime)
 
 	var schedule *models.Schedule
 	var status *models.TripStatus
@@ -198,7 +198,7 @@ func (api *RestAPI) tripDetailsHandler(w http.ResponseWriter, r *http.Request) {
 		// when there are multiple frequency entries for the same trip. In order to adhere to the API contract,
 		// we take the first row which gives us the frequency with the earliest start_time
 		converted := models.NewFrequencyFromDB(freqRows[0], serviceDate)
-		converted.ServiceDate = serviceDateMillis
+		converted.ServiceDate = models.NewModelTime(midnight)
 		converted.ServiceID = utils.FormCombinedID(agencyID, trip.ServiceID)
 		converted.TripID = utils.FormCombinedID(agencyID, trip.ID)
 		frequency = &converted
@@ -206,7 +206,7 @@ func (api *RestAPI) tripDetailsHandler(w http.ResponseWriter, r *http.Request) {
 
 	tripDetails := &models.TripDetails{
 		TripID:       utils.FormCombinedID(agencyID, trip.ID),
-		ServiceDate:  serviceDateMillis,
+		ServiceDate:  models.NewModelTime(midnight),
 		Schedule:     schedule,
 		Frequency:    frequency,
 		SituationIDs: situationsIDs,

--- a/internal/restapi/trip_for_vehicle_handler.go
+++ b/internal/restapi/trip_for_vehicle_handler.go
@@ -67,7 +67,7 @@ func (api *RestAPI) tripForVehicleHandler(w http.ResponseWriter, r *http.Request
 		currentTime = api.Clock.Now().In(loc)
 	}
 
-	serviceDate, serviceDateMillis := utils.ServiceDateMillis(params.ServiceDate, currentTime)
+	serviceDate, midnight := utils.ServiceDateMidnight(params.ServiceDate, currentTime)
 
 	var status *models.TripStatus
 	if params.IncludeStatus {
@@ -120,7 +120,7 @@ func (api *RestAPI) tripForVehicleHandler(w http.ResponseWriter, r *http.Request
 
 	entry := &models.TripDetails{
 		TripID:       utils.FormCombinedID(agencyID, tripID),
-		ServiceDate:  serviceDateMillis,
+		ServiceDate:  models.NewModelTime(midnight),
 		Frequency:    nil,
 		Status:       status,
 		Schedule:     schedule,

--- a/internal/restapi/trips_for_route_handler.go
+++ b/internal/restapi/trips_for_route_handler.go
@@ -55,13 +55,9 @@ func (api *RestAPI) tripsForRouteHandler(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	// Calculate nanoseconds since midnight of the service day
+	// Time since midnight of the service day, as a duration.
 	serviceDayMidnight := time.Date(currentTime.Year(), currentTime.Month(), currentTime.Day(), 0, 0, 0, 0, currentTime.Location())
-	nanosSinceMidnight := currentTime.Sub(serviceDayMidnight).Nanoseconds()
-	if nanosSinceMidnight < 0 {
-		nanosSinceMidnight = 0
-	}
-	currentNanosSinceMidnight := nanosSinceMidnight
+	currentSinceMidnight := max(currentTime.Sub(serviceDayMidnight), 0)
 
 	// Check the previous day's service for trips running past midnight.
 	// GTFS allows departure times > 24:00:00 (e.g., 25:30:00 = 1:30 AM next day).
@@ -69,9 +65,8 @@ func (api *RestAPI) tripsForRouteHandler(w http.ResponseWriter, r *http.Request)
 	// TODO: We should add config for runningLateWindow and runningEarlyWindow like Java OBA
 	// source:https://groups.google.com/g/onebusaway-developers/c/j-G-1UyfbXI/m/J-Su3BArKW0J
 	const (
-		oneDayNanos       = int64(24 * 60 * 60 * 1_000_000_000)
-		runningLateNanos  = int64(30 * 60 * 1_000_000_000) // runningLateWindow
-		runningEarlyNanos = int64(10 * 60 * 1_000_000_000) // runningEarlyWindow
+		runningLate  = 30 * time.Minute // runningLateWindow
+		runningEarly = 10 * time.Minute // runningEarlyWindow
 	)
 	prevDay := currentTime.AddDate(0, 0, -1)
 	prevFormattedDate := prevDay.Format("20060102")
@@ -80,7 +75,8 @@ func (api *RestAPI) tripsForRouteHandler(w http.ResponseWriter, r *http.Request)
 		api.Logger.Warn("trips-for-route: failed to fetch previous-day service IDs", "date", prevFormattedDate, "error", err)
 		prevServiceIDs = nil
 	}
-	prevDayNanosSinceMidnight := currentNanosSinceMidnight + oneDayNanos
+	// I'm confused by adding 24 hours to get the previous day here, but that's the existing behavior.
+	prevDaySinceMidnight := currentSinceMidnight + (24 * time.Hour)
 
 	indexIDs, err := api.GtfsManager.GtfsDB.Queries.GetBlockTripIndexIDsForRoute(ctx, gtfsdb.GetBlockTripIndexIDsForRouteParams{
 		RouteID:    routeID,
@@ -94,10 +90,10 @@ func (api *RestAPI) tripsForRouteHandler(w http.ResponseWriter, r *http.Request)
 	layoverIndices := api.GtfsManager.GetBlockLayoverIndicesForRoute(routeID)
 
 	// Match Java OBA: look back 30 min (catch late vehicles) and ahead 10 min (catch early vehicles).
-	timeRangeStart := currentNanosSinceMidnight - runningLateNanos
-	timeRangeEnd := currentNanosSinceMidnight + runningEarlyNanos
+	timeRangeStart := currentSinceMidnight - runningLate
+	timeRangeEnd := currentSinceMidnight + runningEarly
 
-	layoverBlocks := gtfsInternal.GetBlocksInTimeRange(layoverIndices, timeRangeStart, timeRangeEnd)
+	layoverBlocks := gtfsInternal.GetBlocksInTimeRange(layoverIndices, timeRangeStart.Nanoseconds(), timeRangeEnd.Nanoseconds())
 
 	allLinkedBlocks := make(map[string]bool)
 
@@ -150,8 +146,8 @@ func (api *RestAPI) tripsForRouteHandler(w http.ResponseWriter, r *http.Request)
 	nullBlockTrips, err := api.GtfsManager.GtfsDB.Queries.GetActiveTripsWithNullBlockForRoute(ctx, gtfsdb.GetActiveTripsWithNullBlockForRouteParams{
 		RouteID:        routeID,
 		ServiceIds:     serviceIDs,
-		TimeRangeStart: sql.NullInt64{Int64: timeRangeStart, Valid: true},
-		TimeRangeEnd:   sql.NullInt64{Int64: timeRangeEnd, Valid: true},
+		TimeRangeStart: sql.NullInt64{Int64: timeRangeStart.Nanoseconds(), Valid: true},
+		TimeRangeEnd:   sql.NullInt64{Int64: timeRangeEnd.Nanoseconds(), Valid: true},
 	})
 	if err != nil {
 		api.Logger.Warn("trips-for-route: failed to fetch null-block trips", "route_id", routeID, "error", err)
@@ -162,8 +158,8 @@ func (api *RestAPI) tripsForRouteHandler(w http.ResponseWriter, r *http.Request)
 		prevNullBlockTrips, err := api.GtfsManager.GtfsDB.Queries.GetActiveTripsWithNullBlockForRoute(ctx, gtfsdb.GetActiveTripsWithNullBlockForRouteParams{
 			RouteID:        routeID,
 			ServiceIds:     prevServiceIDs,
-			TimeRangeStart: sql.NullInt64{Int64: prevDayNanosSinceMidnight + timeRangeStart - currentNanosSinceMidnight, Valid: true},
-			TimeRangeEnd:   sql.NullInt64{Int64: prevDayNanosSinceMidnight + timeRangeEnd - currentNanosSinceMidnight, Valid: true},
+			TimeRangeStart: sql.NullInt64{Int64: (prevDaySinceMidnight + timeRangeStart - currentSinceMidnight).Nanoseconds(), Valid: true},
+			TimeRangeEnd:   sql.NullInt64{Int64: (prevDaySinceMidnight + timeRangeEnd - currentSinceMidnight).Nanoseconds(), Valid: true},
 		})
 		if err != nil {
 			api.Logger.Warn("trips-for-route: failed to fetch previous-day null-block trips", "error", err)
@@ -182,16 +178,16 @@ func (api *RestAPI) tripsForRouteHandler(w http.ResponseWriter, r *http.Request)
 	var activeTrips []string
 
 	type serviceDayEntry struct {
-		serviceIDs         []string
-		nanosSinceMidnight int64
+		serviceIDs    []string
+		sinceMidnight time.Duration
 	}
 	serviceDays := []serviceDayEntry{
-		{serviceIDs: serviceIDs, nanosSinceMidnight: currentNanosSinceMidnight},
+		{serviceIDs: serviceIDs, sinceMidnight: currentSinceMidnight},
 	}
 	if len(prevServiceIDs) > 0 {
 		serviceDays = append(serviceDays, serviceDayEntry{
-			serviceIDs:         prevServiceIDs,
-			nanosSinceMidnight: prevDayNanosSinceMidnight,
+			serviceIDs:    prevServiceIDs,
+			sinceMidnight: prevDaySinceMidnight,
 		})
 	}
 
@@ -219,7 +215,7 @@ func (api *RestAPI) tripsForRouteHandler(w http.ResponseWriter, r *http.Request)
 			activeTrip, err := api.GtfsManager.GtfsDB.Queries.GetActiveTripInBlockAtTime(ctx, gtfsdb.GetActiveTripInBlockAtTimeParams{
 				BlockID:     blockIDNullStr,
 				ServiceIds:  sd.serviceIDs,
-				CurrentTime: sql.NullInt64{Int64: sd.nanosSinceMidnight, Valid: true}})
+				CurrentTime: sql.NullInt64{Int64: sd.sinceMidnight.Nanoseconds(), Valid: true}})
 			if err != nil && !errors.Is(err, sql.ErrNoRows) {
 				api.Logger.Warn("trips-for-route: failed to get active trip in block", "block_id", blockID, "error", err)
 				continue
@@ -238,7 +234,7 @@ func (api *RestAPI) tripsForRouteHandler(w http.ResponseWriter, r *http.Request)
 				if len(candidates) == 0 {
 					continue
 				}
-				activeTrip = selectBestTripInBlock(candidates, sd.nanosSinceMidnight)
+				activeTrip = selectBestTripInBlock(candidates, sd.sinceMidnight.Nanoseconds())
 			}
 
 			activeTrips = append(activeTrips, activeTrip)

--- a/internal/restapi/trips_helper.go
+++ b/internal/restapi/trips_helper.go
@@ -41,7 +41,7 @@ func (api *RestAPI) BuildTripStatus(
 		0, 0, 0, 0, serviceDate.Location())
 	status := models.NewTripStatus()
 	status.ActiveTripID = utils.FormCombinedID(agencyID, tripID)
-	status.ServiceDate = sdMidnight.UnixMilli()
+	status.ServiceDate = models.NewModelTime(sdMidnight)
 	status.SituationIDs = api.GetSituationIDsForTrip(ctx, tripID)
 	// OccupancyCapacity and OccupancyCount default to 0 when no data is available.
 
@@ -829,8 +829,8 @@ func (api *RestAPI) calculateBatchStopDistances(
 		for _, stopTime := range timeStops {
 			stopTimesList = append(stopTimesList, models.StopTime{
 				StopID:              utils.FormCombinedID(agencyID, stopTime.StopID),
-				ArrivalTime:         int(utils.NanosToSeconds(stopTime.ArrivalTime)),
-				DepartureTime:       int(utils.NanosToSeconds(stopTime.DepartureTime)),
+				ArrivalTime:         models.NewModelDuration(time.Duration(stopTime.ArrivalTime)),
+				DepartureTime:       models.NewModelDuration(time.Duration(stopTime.DepartureTime)),
 				StopHeadsign:        utils.NullStringOrEmpty(stopTime.StopHeadsign),
 				DistanceAlongTrip:   0.0,
 				HistoricalOccupancy: "",
@@ -845,8 +845,8 @@ func (api *RestAPI) calculateBatchStopDistances(
 		for _, stopTime := range timeStops {
 			stopTimesList = append(stopTimesList, models.StopTime{
 				StopID:              utils.FormCombinedID(agencyID, stopTime.StopID),
-				ArrivalTime:         int(utils.NanosToSeconds(stopTime.ArrivalTime)),
-				DepartureTime:       int(utils.NanosToSeconds(stopTime.DepartureTime)),
+				ArrivalTime:         models.NewModelDuration(time.Duration(stopTime.ArrivalTime)),
+				DepartureTime:       models.NewModelDuration(time.Duration(stopTime.DepartureTime)),
 				StopHeadsign:        utils.NullStringOrEmpty(stopTime.StopHeadsign),
 				DistanceAlongTrip:   0.0,
 				HistoricalOccupancy: "",
@@ -915,8 +915,8 @@ func (api *RestAPI) calculateBatchStopDistances(
 
 		stopTimesList = append(stopTimesList, models.StopTime{
 			StopID:              utils.FormCombinedID(agencyID, stopTime.StopID),
-			ArrivalTime:         int(utils.NanosToSeconds(stopTime.ArrivalTime)),
-			DepartureTime:       int(utils.NanosToSeconds(stopTime.DepartureTime)),
+			ArrivalTime:         models.NewModelDuration(time.Duration(stopTime.ArrivalTime)),
+			DepartureTime:       models.NewModelDuration(time.Duration(stopTime.DepartureTime)),
 			StopHeadsign:        utils.NullStringOrEmpty(stopTime.StopHeadsign),
 			DistanceAlongTrip:   distanceAlongTrip,
 			HistoricalOccupancy: "",

--- a/internal/restapi/vehicles_for_agency_handler.go
+++ b/internal/restapi/vehicles_for_agency_handler.go
@@ -2,7 +2,6 @@ package restapi
 
 import (
 	"net/http"
-	"time"
 
 	"maglev.onebusaway.org/gtfsdb"
 	"maglev.onebusaway.org/internal/models"
@@ -82,14 +81,14 @@ func (api *RestAPI) vehiclesForAgencyHandler(w http.ResponseWriter, r *http.Requ
 		}
 
 		// Set timestamps
-		currentTime := api.Clock.NowUnixMilli()
+		currentTime := models.NewModelTime(api.Clock.Now())
 		vehicleStatus.LastLocationUpdateTime = currentTime
 		vehicleStatus.LastUpdateTime = currentTime
 
 		if vehicle.Timestamp != nil {
-			timestampMs := vehicle.Timestamp.UnixNano() / int64(time.Millisecond)
-			vehicleStatus.LastLocationUpdateTime = timestampMs
-			vehicleStatus.LastUpdateTime = timestampMs
+			ts := models.NewModelTime(*vehicle.Timestamp)
+			vehicleStatus.LastLocationUpdateTime = ts
+			vehicleStatus.LastUpdateTime = ts
 		}
 
 		// Set location if available
@@ -137,13 +136,13 @@ func (api *RestAPI) vehiclesForAgencyHandler(w http.ResponseWriter, r *http.Requ
 			tripStatus.LastLocationUpdateTime = currentTime
 
 			if vehicle.Timestamp != nil {
-				timestampMs := vehicle.Timestamp.UnixNano() / int64(time.Millisecond)
-				tripStatus.LastUpdateTime = timestampMs
-				tripStatus.LastLocationUpdateTime = timestampMs
+				ts := models.NewModelTime(*vehicle.Timestamp)
+				tripStatus.LastUpdateTime = ts
+				tripStatus.LastLocationUpdateTime = ts
 			}
 
 			// Set service date (use current date for now)
-			tripStatus.ServiceDate = api.Clock.NowUnixMilli()
+			tripStatus.ServiceDate = currentTime
 
 			// Propagate occupancy status from GTFS-RT to both TripStatus and VehicleStatus.
 			// There is no source for occupancyCapacity or occupancyCount anywhere in maglev — not in the SQLite DB,

--- a/internal/restapi/vehicles_helper.go
+++ b/internal/restapi/vehicles_helper.go
@@ -114,11 +114,8 @@ func (api *RestAPI) BuildVehicleStatus(
 		return
 	}
 
-	var lastUpdateTime int64
-	if vehicle.Timestamp != nil {
-		lastUpdateTime = api.GtfsManager.GetVehicleLastUpdateTime(vehicle)
-		status.LastUpdateTime = lastUpdateTime
-	}
+	lastUpdateTime := api.GtfsManager.GetVehicleLastUpdateTime(vehicle)
+	status.LastUpdateTime = models.NewModelTime(lastUpdateTime)
 
 	if vehicle.Position != nil && vehicle.Position.Latitude != nil && vehicle.Position.Longitude != nil {
 		actualPosition := models.Location{
@@ -132,9 +129,7 @@ func (api *RestAPI) BuildVehicleStatus(
 		// makes its own GetShapePointsByTripID call; these two fetches are separate.
 		status.Position = actualPosition
 
-		if vehicle.Timestamp != nil {
-			status.LastLocationUpdateTime = lastUpdateTime
-		}
+		status.LastLocationUpdateTime = models.NewModelTime(lastUpdateTime)
 	}
 
 	if vehicle.Position != nil && vehicle.Position.Bearing != nil {

--- a/internal/utils/api.go
+++ b/internal/utils/api.go
@@ -30,7 +30,7 @@ func CalculateServiceDate(currentTime time.Time) time.Time {
 	return time.Date(year, month, day, 0, 0, 0, 0, currentTime.Location())
 }
 
-func ServiceDateMillis(explicitServiceDate *time.Time, currentTime time.Time) (time.Time, int64) {
+func ServiceDateMidnight(explicitServiceDate *time.Time, currentTime time.Time) (time.Time, time.Time) {
 	var serviceDate time.Time
 	if explicitServiceDate != nil {
 		serviceDate = *explicitServiceDate
@@ -41,7 +41,7 @@ func ServiceDateMillis(explicitServiceDate *time.Time, currentTime time.Time) (t
 	// This ensures all endpoints return a consistent serviceDate millis value.
 	midnight := time.Date(serviceDate.Year(), serviceDate.Month(), serviceDate.Day(),
 		0, 0, 0, 0, serviceDate.Location())
-	return serviceDate, midnight.UnixMilli()
+	return serviceDate, midnight
 }
 
 // CalculateSecondsSinceServiceDate returns the number of wall-clock seconds elapsed
@@ -76,7 +76,7 @@ func CalculateSecondsSinceServiceDate(currentTime time.Time, serviceDate time.Ti
 // Converts a GTFS stop-time value (stored as nanoseconds in db since midnight)
 // to seconds since midnight.
 func NanosToSeconds(nanos int64) int64 {
-	return nanos / 1e9
+	return int64(time.Duration(nanos) / time.Second)
 }
 
 // EffectiveStopTimeSeconds returns the effective stop time in seconds since midnight,
@@ -84,9 +84,9 @@ func NanosToSeconds(nanos int64) int64 {
 // Both inputs are nanoseconds since midnight (the GTFS database storage format).
 func EffectiveStopTimeSeconds(arrivalTimeNanos, departureTimeNanos int64) int64 {
 	if arrivalTimeNanos > 0 {
-		return arrivalTimeNanos / 1e9
+		return int64(time.Duration(arrivalTimeNanos) / time.Second)
 	}
-	return departureTimeNanos / 1e9
+	return int64(time.Duration(departureTimeNanos) / time.Second)
 }
 
 // ExtractCodeID extracts the `code_id` from a string in the format `{agency_id}_{code_id}`.

--- a/internal/utils/coverage_test.go
+++ b/internal/utils/coverage_test.go
@@ -13,9 +13,9 @@ func TestTimeAndContextCoverage(t *testing.T) {
 	assert.Equal(t, time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC), svcDate)
 
 	explicit := time.Date(2023, 1, 2, 0, 0, 0, 0, time.UTC)
-	d, m := ServiceDateMillis(&explicit, now)
+	d, m := ServiceDateMidnight(&explicit, now)
 	assert.Equal(t, explicit, d)
-	assert.Equal(t, explicit.Unix()*1000, m)
+	assert.Equal(t, explicit, m)
 
 	sec := CalculateSecondsSinceServiceDate(now, svcDate)
 	assert.Equal(t, int64(12*3600), sec)


### PR DESCRIPTION
In models, replace usages of int/int64 to encode duration in seconds or unix timestamp in millis with two wrapper types, ModelTime and ModelDuration.

These wrap time.Time and time.Duration, handle appropriate serialization logic, and help make the intended data in these models clearer.

Also update many places that create these model types to pass go time types directly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Modernized time/duration handling across the service to use native time and duration types instead of raw numeric timestamps.
  * Added typed time/duration wrappers with consistent JSON serialization and clearer zero-value semantics.
  * Updated APIs and responses to emit standard time/duration values, improving consistency of scheduling, vehicle, and realtime timestamps across endpoints and tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->