### PR TITLE
refactor: use more response models in unit tests

### DIFF
--- a/internal/restapi/agencies_with_coverage_handler_test.go
+++ b/internal/restapi/agencies_with_coverage_handler_test.go
@@ -9,21 +9,6 @@ import (
 	"maglev.onebusaway.org/internal/restapi/testdata"
 )
 
-type CoverageResponse struct {
-	Code        int          `json:"code"`
-	CurrentTime int64        `json:"currentTime"`
-	Data        CoverageData `json:"data,omitempty"`
-	Text        string       `json:"text"`
-	Version     int          `json:"version"`
-}
-
-type CoverageData struct {
-	LimitExceeded bool                    `json:"limitExceeded"`
-	List          []models.AgencyCoverage `json:"list"`
-	OutOfRange    bool                    `json:"outOfRange"`
-	References    models.ReferencesModel  `json:"references"`
-}
-
 func TestAgenciesWithCoverageHandlerRequiresValidApiKey(t *testing.T) {
 	api := createTestApi(t)
 

--- a/internal/restapi/response_types.go
+++ b/internal/restapi/response_types.go
@@ -1,0 +1,23 @@
+package restapi
+
+import "maglev.onebusaway.org/internal/models"
+
+type Response[T any] struct {
+	Code        int     `json:"code"`
+	CurrentTime int64   `json:"currentTime"`
+	Data        Data[T] `json:"data,omitempty"`
+	Text        string  `json:"text"`
+	Version     int     `json:"version"`
+}
+
+type Data[T any] struct {
+	LimitExceeded bool                   `json:"limitExceeded"`
+	List          []T                    `json:"list"`
+	OutOfRange    bool                   `json:"outOfRange"`
+	References    models.ReferencesModel `json:"references"`
+	FieldErrors   map[string][]string    `json:"fieldErrors"`
+}
+
+type CoverageResponse Response[models.AgencyCoverage]
+type RoutesResponse Response[models.Route]
+type StopsResponse Response[models.Stop]

--- a/internal/restapi/routes_for_agency_handler_test.go
+++ b/internal/restapi/routes_for_agency_handler_test.go
@@ -2,20 +2,20 @@ package restapi
 
 import (
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"maglev.onebusaway.org/internal/models"
+	"maglev.onebusaway.org/internal/restapi/testdata"
 )
 
 func TestRoutesForAgencyHandlerRequiresValidApiKey(t *testing.T) {
 	api := createTestApi(t)
 	defer api.Shutdown()
-	agencies := mustGetAgencies(t, api)
-	require.NotEmpty(t, agencies)
-	agencyId := agencies[0].ID
 
-	resp, model := serveApiAndRetrieveEndpoint(t, api, "/api/where/routes-for-agency/"+agencyId+".json?key=invalid")
+	resp, model := callAPIHandler[RoutesResponse](t, api, "/api/where/routes-for-agency/25.json?key=invalid")
 
 	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
 	assert.Equal(t, http.StatusUnauthorized, model.Code)
@@ -25,30 +25,15 @@ func TestRoutesForAgencyHandlerRequiresValidApiKey(t *testing.T) {
 func TestRoutesForAgencyHandlerEndToEnd(t *testing.T) {
 	api := createTestApi(t)
 	defer api.Shutdown()
-	agencies := mustGetAgencies(t, api)
-	require.NotEmpty(t, agencies)
-	agencyId := agencies[0].ID
 
-	resp, model := serveApiAndRetrieveEndpoint(t, api, "/api/where/routes-for-agency/"+agencyId+".json?key=TEST")
+	resp, model := callAPIHandler[RoutesResponse](t, api, "/api/where/routes-for-agency/25.json?key=TEST")
 
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
-
-	assert.Equal(t, 200, model.Code)
+	assert.Equal(t, http.StatusOK, model.Code)
 	assert.Equal(t, "OK", model.Text)
 
-	data, ok := model.Data.(map[string]any)
-	require.True(t, ok)
-
-	// Check that we have a list of routes
-	_, ok = data["list"].([]any)
-	require.True(t, ok)
-
-	refs, ok := data["references"].(map[string]any)
-	require.True(t, ok)
-
-	refAgencies, ok := refs["agencies"].([]any)
-	require.True(t, ok)
-	assert.Len(t, refAgencies, 1)
+	assert.ElementsMatch(t, testdata.RabaRoutes, model.Data.List)
+	assert.ElementsMatch(t, []models.AgencyReference{testdata.Raba}, model.Data.References.Agencies)
 }
 
 func TestRoutesForAgencyHandlerInvalidID(t *testing.T) {
@@ -58,7 +43,7 @@ func TestRoutesForAgencyHandlerInvalidID(t *testing.T) {
 	malformedID := "11@10"
 	endpoint := "/api/where/routes-for-agency/" + malformedID + ".json?key=TEST"
 
-	resp, model := serveApiAndRetrieveEndpoint(t, api, endpoint)
+	resp, model := callAPIHandler[RoutesResponse](t, api, endpoint)
 
 	assert.Equal(t, http.StatusBadRequest, resp.StatusCode, "Status code should be 400 Bad Request")
 	assert.Equal(t, http.StatusBadRequest, model.Code)
@@ -69,7 +54,7 @@ func TestRoutesForAgencyHandlerNonExistentAgency(t *testing.T) {
 	api := createTestApi(t)
 	defer api.Shutdown()
 
-	resp, model := serveApiAndRetrieveEndpoint(t, api, "/api/where/routes-for-agency/non-existent-agency.json?key=TEST")
+	resp, model := callAPIHandler[RoutesResponse](t, api, "/api/where/routes-for-agency/non-existent-agency.json?key=TEST")
 
 	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
 	assert.Equal(t, http.StatusNotFound, model.Code)
@@ -80,30 +65,13 @@ func TestRoutesForAgencyHandlerReturnsCompoundRouteIDs(t *testing.T) {
 	api := createTestApi(t)
 	defer api.Shutdown()
 
-	agencies := mustGetAgencies(t, api)
-	require.NotEmpty(t, agencies)
-	agencyId := agencies[0].ID
-
-	resp, model := serveApiAndRetrieveEndpoint(t, api, "/api/where/routes-for-agency/"+agencyId+".json?key=TEST")
+	resp, model := callAPIHandler[RoutesResponse](t, api, "/api/where/routes-for-agency/25.json?key=TEST")
 
 	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NotEmpty(t, model.Data.List)
 
-	data, ok := model.Data.(map[string]any)
-	require.True(t, ok)
-
-	routes, ok := data["list"].([]any)
-	require.True(t, ok)
-	require.NotEmpty(t, routes)
-
-	for _, r := range routes {
-		route, ok := r.(map[string]any)
-		require.True(t, ok)
-
-		id, ok := route["id"].(string)
-		require.True(t, ok)
-
-		// Check that agencyId is prepended to id
-		assert.Contains(t, id, agencyId+"_", "route id must be in {agencyId}_{routeId} format")
+	for _, route := range model.Data.List {
+		assert.True(t, strings.HasPrefix(route.ID, "25_"), "route id must be in {agencyId}_{routeId} format")
 	}
 }
 
@@ -111,45 +79,39 @@ func TestRoutesForAgencyHandlerPagination(t *testing.T) {
 	api := createTestApi(t)
 	defer api.Shutdown()
 
-	agencies := mustGetAgencies(t, api)
-	require.NotEmpty(t, agencies)
-	agencyId := agencies[0].ID
-
-	// Case 1: Limit 5 (Should return 5 items, limitExceeded=true)
-	resp, model := serveApiAndRetrieveEndpoint(t, api, "/api/where/routes-for-agency/"+agencyId+".json?key=TEST&limit=5")
+	var results []models.Route
+	resp, model := callAPIHandler[RoutesResponse](t, api, "/api/where/routes-for-agency/25.json?key=TEST&limit=5")
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, http.StatusOK, model.Code)
+	assert.Len(t, model.Data.List, 5)
+	assert.True(t, model.Data.LimitExceeded)
+	results = append(results, model.Data.List...)
 
-	data, ok := model.Data.(map[string]any)
-	require.True(t, ok)
-	list, ok := data["list"].([]any)
-	require.True(t, ok)
-	assert.Len(t, list, 5)
-	assert.True(t, data["limitExceeded"].(bool), "limitExceeded should be true when more items exist")
+	resp, model = callAPIHandler[RoutesResponse](t, api, "/api/where/routes-for-agency/25.json?key=TEST&offset=5&limit=5")
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, http.StatusOK, model.Code)
+	assert.Len(t, model.Data.List, 5)
+	assert.True(t, model.Data.LimitExceeded)
+	results = append(results, model.Data.List...)
 
-	// Case 2: Offset 5, Limit 5 (Should return next 5 items)
-	resp2, model2 := serveApiAndRetrieveEndpoint(t, api, "/api/where/routes-for-agency/"+agencyId+".json?key=TEST&offset=5&limit=5")
-	assert.Equal(t, http.StatusOK, resp2.StatusCode)
+	resp, model = callAPIHandler[RoutesResponse](t, api, "/api/where/routes-for-agency/25.json?key=TEST&offset=10&limit=5")
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, http.StatusOK, model.Code)
+	assert.Len(t, model.Data.List, 3)
+	assert.False(t, model.Data.LimitExceeded)
+	results = append(results, model.Data.List...)
 
-	data2, ok := model2.Data.(map[string]any)
-	require.True(t, ok)
-	list2, ok := data2["list"].([]any)
-	require.True(t, ok)
-	assert.Len(t, list2, 5)
+	assert.ElementsMatch(t, testdata.RabaRoutes, results)
+}
 
-	// Verify items are different
-	firstItem1 := list[0].(map[string]any)
-	firstItem2 := list2[0].(map[string]any)
-	assert.NotEqual(t, firstItem1["id"], firstItem2["id"])
+func TestRoutesForAgencyHandlerLimitExceedsMax(t *testing.T) {
+	api := createTestApi(t)
+	defer api.Shutdown()
 
-	// Case 3: Limit 100 (Should return all 13 items, limitExceeded=false)
-	resp3, model3 := serveApiAndRetrieveEndpoint(t, api, "/api/where/routes-for-agency/"+agencyId+".json?key=TEST&limit=100")
-	assert.Equal(t, http.StatusOK, resp3.StatusCode)
+	resp, model := callAPIHandler[RoutesResponse](t, api, "/api/where/routes-for-agency/25.json?key=TEST&limit=100")
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, http.StatusOK, model.Code)
 
-	data3, ok := model3.Data.(map[string]any)
-	require.True(t, ok)
-	list3, ok := data3["list"].([]any)
-	require.True(t, ok)
-	// RABA has 13 routes
-	assert.Len(t, list3, 13)
-	assert.False(t, data3["limitExceeded"].(bool), "limitExceeded should be false when all items returned")
+	assert.ElementsMatch(t, testdata.RabaRoutes, model.Data.List)
+	assert.False(t, model.Data.LimitExceeded, "limitExceeded should be false when all items returned")
 }

--- a/internal/restapi/routes_for_location_handler_test.go
+++ b/internal/restapi/routes_for_location_handler_test.go
@@ -11,21 +11,6 @@ import (
 	"maglev.onebusaway.org/internal/restapi/testdata"
 )
 
-type RoutesResponse struct {
-	Code        int    `json:"code"`
-	CurrentTime int64  `json:"currentTime"`
-	Data        Data   `json:"data,omitempty"`
-	Text        string `json:"text"`
-	Version     int    `json:"version"`
-}
-
-type Data struct {
-	LimitExceeded bool                   `json:"limitExceeded"`
-	List          []models.Route         `json:"list"`
-	OutOfRange    bool                   `json:"outOfRange"`
-	References    models.ReferencesModel `json:"references"`
-}
-
 func TestRoutesForLocationHandlerRequiresValidApiKey(t *testing.T) {
 	_, resp, model := serveAndRetrieveEndpoint(t, "/api/where/routes-for-location.json?key=invalid&lat=47.586556&lon=-122.190396")
 	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)

--- a/internal/restapi/stops_for_location_handler_test.go
+++ b/internal/restapi/stops_for_location_handler_test.go
@@ -14,22 +14,6 @@ import (
 	"maglev.onebusaway.org/internal/models"
 )
 
-type StopsResponse struct {
-	Code        int       `json:"code"`
-	CurrentTime int64     `json:"currentTime"`
-	Data        StopsData `json:"data,omitempty"`
-	Text        string    `json:"text"`
-	Version     int       `json:"version"`
-}
-
-type StopsData struct {
-	LimitExceeded bool                   `json:"limitExceeded"`
-	Stops         []models.Stop          `json:"list"`
-	OutOfRange    bool                   `json:"outOfRange"`
-	References    models.ReferencesModel `json:"references"`
-	FieldErrors   map[string][]string    `json:"fieldErrors"`
-}
-
 func TestStopsForLocationHandlerRequiresValidApiKey(t *testing.T) {
 	api := createTestApi(t)
 	resp, model := callAPIHandler[StopsResponse](t, api, "/api/where/stops-for-location.json?key=invalid&lat=47.586556&lon=-122.190396")
@@ -52,9 +36,9 @@ func TestStopsForLocationHandlerEndToEnd(t *testing.T) {
 	assert.Equal(t, http.StatusOK, model.Code)
 	assert.Equal(t, "OK", model.Text)
 
-	assert.NotEmpty(t, model.Data.Stops)
+	assert.NotEmpty(t, model.Data.List)
 
-	for i, stop := range model.Data.Stops {
+	for i, stop := range model.Data.List {
 		assert.NotEmpty(t, stop.ID)
 		assert.NotEmpty(t, stop.Name)
 		assert.NotZero(t, stop.Lat)
@@ -63,7 +47,7 @@ func TestStopsForLocationHandlerEndToEnd(t *testing.T) {
 		assert.NotNil(t, stop.StaticRouteIDs)
 
 		if i > 0 {
-			assert.GreaterOrEqualf(t, stop.ID, model.Data.Stops[i-1].ID, "stops should be returned in sorted order by id")
+			assert.GreaterOrEqualf(t, stop.ID, model.Data.List[i-1].ID, "stops should be returned in sorted order by id")
 		}
 	}
 
@@ -73,7 +57,7 @@ func TestStopsForLocationHandlerEndToEnd(t *testing.T) {
 
 	// Verify all referenced route IDs exist in references
 	referencedRouteIDs := make(map[string]bool)
-	for _, stop := range model.Data.Stops {
+	for _, stop := range model.Data.List {
 		for _, id := range stop.RouteIDs {
 			referencedRouteIDs[id] = true
 		}
@@ -113,9 +97,9 @@ func TestStopsForLocationQuery(t *testing.T) {
 	resp, model := callAPIHandler[StopsResponse](t, api, "/api/where/stops-for-location.json?key=TEST&lat=40.583321&lon=-122.426966&query=2042")
 
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
-	assert.Len(t, model.Data.Stops, 1)
-	assert.Equal(t, "2042", model.Data.Stops[0].Code)
-	assert.Equal(t, "Buenaventura Blvd at Eureka Way", model.Data.Stops[0].Name)
+	assert.Len(t, model.Data.List, 1)
+	assert.Equal(t, "2042", model.Data.List[0].Code)
+	assert.Equal(t, "Buenaventura Blvd at Eureka Way", model.Data.List[0].Name)
 }
 
 func TestStopsForLocationLatSpanAndLonSpan(t *testing.T) {
@@ -123,7 +107,7 @@ func TestStopsForLocationLatSpanAndLonSpan(t *testing.T) {
 	api := createTestApiWithClock(t, clock)
 	resp, model := callAPIHandler[StopsResponse](t, api, "/api/where/stops-for-location.json?key=TEST&lat=40.583321&lon=-122.426966&latSpan=0.045&lonSpan=0.059")
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
-	assert.NotEmpty(t, model.Data.Stops)
+	assert.NotEmpty(t, model.Data.List)
 }
 
 func TestStopsForLocationRadius(t *testing.T) {
@@ -131,7 +115,7 @@ func TestStopsForLocationRadius(t *testing.T) {
 	api := createTestApiWithClock(t, clock)
 	resp, model := callAPIHandler[StopsResponse](t, api, "/api/where/stops-for-location.json?key=TEST&lat=40.583321&lon=-122.426966&radius=5000")
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
-	assert.NotEmpty(t, model.Data.Stops)
+	assert.NotEmpty(t, model.Data.List)
 }
 
 func TestStopsForLocationLatAndLan(t *testing.T) {
@@ -139,7 +123,7 @@ func TestStopsForLocationLatAndLan(t *testing.T) {
 	api := createTestApiWithClock(t, clock)
 	resp, model := callAPIHandler[StopsResponse](t, api, "/api/where/stops-for-location.json?key=TEST&lat=40.583321&lon=-122.362535&radius=1000")
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
-	assert.NotEmpty(t, model.Data.Stops)
+	assert.NotEmpty(t, model.Data.List)
 }
 
 func TestStopsForLocationIsLimitExceeded(t *testing.T) {
@@ -147,7 +131,7 @@ func TestStopsForLocationIsLimitExceeded(t *testing.T) {
 	api := createTestApiWithClock(t, clock)
 	resp, model := callAPIHandler[StopsResponse](t, api, "/api/where/stops-for-location.json?key=TEST&lat=40.583321&lon=-122.362535&radius=1000&maxCount=1")
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
-	assert.Len(t, model.Data.Stops, 1)
+	assert.Len(t, model.Data.List, 1)
 	assert.True(t, model.Data.LimitExceeded)
 }
 
@@ -157,7 +141,7 @@ func TestStopsForLocationActiveRoutesOnly(t *testing.T) {
 
 	resp, model := callAPIHandler[StopsResponse](t, api, "/api/where/stops-for-location.json?key=TEST&lat=40.583321&lon=-122.426966&radius=5000")
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
-	assert.Empty(t, model.Data.Stops, "Should return empty stops when no routes are active")
+	assert.Empty(t, model.Data.List, "Should return empty stops when no routes are active")
 }
 
 func TestStopsForLocationHandlerValidatesParameters(t *testing.T) {
@@ -285,7 +269,7 @@ func TestStopsForLocationHandlerRouteTypeValidMultiple(t *testing.T) {
 		"/api/where/stops-for-location.json?key=TEST&lat=40.583321&lon=-122.426966&radius=2500&routeType=1,2,3")
 
 	assert.Equal(t, http.StatusOK, resp.StatusCode, "Valid route types should be accepted")
-	assert.NotNil(t, model.Data.Stops)
+	assert.NotNil(t, model.Data.List)
 	assert.NotEmpty(t, model.Data.References.Agencies)
 	assert.NotEmpty(t, model.Data.References.Routes)
 }
@@ -301,7 +285,7 @@ func TestStopsForLocationQueryOutOfArea(t *testing.T) {
 
 	// curl https://api.pugetsound.onebusaway.org/api/where/stops-for-location.json?key=TEST&lat=0.0&lon=0.0&query=10914
 	// returns no results.
-	assert.Empty(t, model.Data.Stops)
+	assert.Empty(t, model.Data.List)
 }
 
 func TestStopsForLocationMissingLat(t *testing.T) {
@@ -347,7 +331,7 @@ func TestStopsForLocationHandlerWithSituations(t *testing.T) {
 	resp, model := callAPIHandler[StopsResponse](t, api, "/api/where/stops-for-location.json?key=TEST&lat=40.583321&lon=-122.426966&query=2042")
 
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
-	assert.Len(t, model.Data.Stops, 1)
+	assert.Len(t, model.Data.List, 1)
 
 	// Verify references contain the situation we added
 	refs := model.Data.References

--- a/internal/restapi/testdata/models.go
+++ b/internal/restapi/testdata/models.go
@@ -79,3 +79,123 @@ var Route11 = models.Route{
 	Type:              3,
 	URL:               "https://cms3.revize.com/revize/reddingbusauthority/Document%20Center/Services/Bus/Route11.pdf",
 }
+
+var Route1 = models.Route{
+	AgencyID:          "25",
+	Color:             "55d1b0",
+	Description:       "",
+	ID:                "25_151",
+	LongName:          "Route 1",
+	NullSafeShortName: "1",
+	ShortName:         "1",
+	TextColor:         "000000",
+	Type:              3,
+	URL:               "https://rabaride.com/Document%20Center/Services/Bus/Route01.pdf",
+}
+
+var Route299x = models.Route{
+	AgencyID:          "25",
+	Color:             "00dffb",
+	Description:       "",
+	ID:                "25_161",
+	LongName:          "Route 299X",
+	NullSafeShortName: "299X",
+	ShortName:         "299X",
+	TextColor:         "ffffff",
+	Type:              3,
+	URL:               "https://rabaride.com/services/burney_express.php",
+}
+
+var Route17 = models.Route{
+	AgencyID:          "25",
+	Color:             "fbef00",
+	Description:       "",
+	ID:                "25_1885",
+	LongName:          "Shasta View/Shasta College",
+	NullSafeShortName: "17",
+	ShortName:         "17",
+	TextColor:         "0e0e0e",
+	Type:              3,
+	URL:               "https://cms3.revize.com/revize/reddingbusauthority/17.pdf",
+}
+
+var Route3 = models.Route{
+	AgencyID:          "25",
+	Color:             "1bb1f6",
+	Description:       "",
+	ID:                "25_153",
+	LongName:          "Route 3",
+	NullSafeShortName: "3",
+	ShortName:         "3",
+	TextColor:         "ffffff",
+	Type:              3,
+	URL:               "https://cms3.revize.com/revize/reddingbusauthority/Document%20Center/Services/Bus/Route03.pdf",
+}
+
+var Route4 = models.Route{
+	AgencyID:          "25",
+	Color:             "bdadd1",
+	Description:       "",
+	ID:                "25_154",
+	LongName:          "Route 4",
+	NullSafeShortName: "4",
+	ShortName:         "4",
+	TextColor:         "ffffff",
+	Type:              3,
+	URL:               "https://rabaride.com/Document%20Center/Services/Bus/Route04.pdf",
+}
+
+var Route7 = models.Route{
+	AgencyID:          "25",
+	Color:             "1886c7",
+	Description:       "",
+	ID:                "25_157",
+	LongName:          "Route 7",
+	NullSafeShortName: "7",
+	ShortName:         "7",
+	TextColor:         "ffffff",
+	Type:              3,
+	URL:               "https://cms3.revize.com/revize/reddingbusauthority/Document%20Center/Services/Bus/Route07.pdf",
+}
+
+var Route9 = models.Route{
+	AgencyID:          "25",
+	Color:             "ec191c",
+	Description:       "",
+	ID:                "25_6446",
+	LongName:          "Route 9",
+	NullSafeShortName: "9",
+	ShortName:         "9",
+	TextColor:         "000000",
+	Type:              3,
+	URL:               "https://cms3.revize.com/revize/reddingbusauthority/Document%20Center/Services/Bus/Route09.pdf",
+}
+
+var Route99x = models.Route{
+	AgencyID:          "25",
+	Color:             "9F472E",
+	Description:       "",
+	ID:                "25_24",
+	LongName:          "Route 99X/Amtrak Thruway Route 3",
+	NullSafeShortName: "99X",
+	ShortName:         "99X",
+	TextColor:         "FFFFFF",
+	Type:              3,
+	URL:               "",
+}
+
+var RabaRoutes = []models.Route{
+	Route1,
+	Route3,
+	Route4,
+	Route7,
+	Route9,
+	Route11,
+	Route14,
+	Route15,
+	Route17,
+	Route19,
+	Route44x,
+	Route99x,
+	Route299x,
+}


### PR DESCRIPTION
Replace individual response types with a generic type in a new file for testing, response_types.go.

Update routes_for_agency_handler_test to better test behavior/responses

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized internal REST API response type definitions for improved code maintainability.
  * Consolidated test infrastructure and type definitions across API handler tests.

* **Tests**
  * Updated test assertions and test data structures to support refactored API response handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->