### PR TITLE
refactor: add EntryResponse[T] and migrate agency tests

### DIFF
--- a/internal/restapi/agency_handler_test.go
+++ b/internal/restapi/agency_handler_test.go
@@ -5,48 +5,39 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+	"maglev.onebusaway.org/internal/models"
+	"maglev.onebusaway.org/internal/restapi/testdata"
 )
 
 func TestAgencyHandlerReturnsAgencyWhenItExists(t *testing.T) {
 	api := createTestApi(t)
 	defer api.Shutdown()
-	agencies := mustGetAgencies(t, api)
-	require.NotEmpty(t, agencies)
-	agencyID := agencies[0].ID
-	resp, model := serveApiAndRetrieveEndpoint(t, api, "/api/where/agency/"+agencyID+".json?key=TEST")
+
+	resp, model := callAPIHandler[AgencyEntryResponse](t, api, "/api/where/agency/"+testdata.Raba.ID+".json?key=TEST")
 
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, http.StatusOK, model.Code)
 	assert.Equal(t, "OK", model.Text)
-
-	data, ok := model.Data.(map[string]any)
-	require.True(t, ok)
-
-	entry, ok := data["entry"].(map[string]any)
-	require.True(t, ok)
-
-	assert.Equal(t, agencies[0].ID, entry["id"])
-	assert.Equal(t, agencies[0].Name, entry["name"])
-	assert.Equal(t, agencies[0].Url, entry["url"])
-	assert.Equal(t, agencies[0].Timezone, entry["timezone"])
+	assert.Equal(t, testdata.Raba, model.Data.Entry)
 }
 
 func TestAgencyHandlerReturnsNullWhenAgencyDoesNotExist(t *testing.T) {
-	_, resp, model := serveAndRetrieveEndpoint(t, "/api/where/agency/non-existent-id.json?key=TEST")
+	api := createTestApi(t)
+	defer api.Shutdown()
+
+	resp, model := callAPIHandler[AgencyEntryResponse](t, api, "/api/where/agency/non-existent-id.json?key=TEST")
+
 	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
 	assert.Equal(t, http.StatusNotFound, model.Code)
 	assert.Equal(t, "resource not found", model.Text)
-	assert.Nil(t, model.Data)
+	assert.Equal(t, EntryData[models.AgencyReference]{}, model.Data)
 }
 
 func TestAgencyHandlerRequiresValidApiKey(t *testing.T) {
 	api := createTestApi(t)
 	defer api.Shutdown()
-	agencies := mustGetAgencies(t, api)
-	require.NotEmpty(t, agencies)
-	agencyID := agencies[0].ID
-	resp, model := serveApiAndRetrieveEndpoint(t, api, "/api/where/agency/"+agencyID+".json?key=INVALID")
+
+	resp, model := callAPIHandler[AgencyEntryResponse](t, api, "/api/where/agency/"+testdata.Raba.ID+".json?key=INVALID")
 
 	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
 	assert.Equal(t, http.StatusUnauthorized, model.Code)

--- a/internal/restapi/response_types.go
+++ b/internal/restapi/response_types.go
@@ -2,15 +2,15 @@ package restapi
 
 import "maglev.onebusaway.org/internal/models"
 
-type Response[T any] struct {
-	Code        int     `json:"code"`
-	CurrentTime int64   `json:"currentTime"`
-	Data        Data[T] `json:"data,omitempty"`
-	Text        string  `json:"text"`
-	Version     int     `json:"version"`
+type ListResponse[T any] struct {
+	Code        int         `json:"code"`
+	CurrentTime int64       `json:"currentTime"`
+	Data        ListData[T] `json:"data,omitempty"`
+	Text        string      `json:"text"`
+	Version     int         `json:"version"`
 }
 
-type Data[T any] struct {
+type ListData[T any] struct {
 	LimitExceeded bool                   `json:"limitExceeded"`
 	List          []T                    `json:"list"`
 	OutOfRange    bool                   `json:"outOfRange"`
@@ -18,6 +18,21 @@ type Data[T any] struct {
 	FieldErrors   map[string][]string    `json:"fieldErrors"`
 }
 
-type CoverageResponse Response[models.AgencyCoverage]
-type RoutesResponse Response[models.Route]
-type StopsResponse Response[models.Stop]
+type EntryResponse[T any] struct {
+	Code        int          `json:"code"`
+	CurrentTime int64        `json:"currentTime"`
+	Data        EntryData[T] `json:"data,omitempty"`
+	Text        string       `json:"text"`
+	Version     int          `json:"version"`
+}
+
+type EntryData[T any] struct {
+	Entry       T                      `json:"entry"`
+	References  models.ReferencesModel `json:"references"`
+	FieldErrors map[string][]string    `json:"fieldErrors,omitempty"`
+}
+
+type CoverageResponse ListResponse[models.AgencyCoverage]
+type RoutesResponse ListResponse[models.Route]
+type StopsResponse ListResponse[models.Stop]
+type AgencyEntryResponse EntryResponse[models.AgencyReference]


### PR DESCRIPTION
Fixes: #899

- Extends the typed response pattern to entry-style endpoints. Adds `EntryResponse[T]` / `EntryData[T]` to
`response_types.go`, renames `Response[T]` / `Data[T]` to  `ListResponse[T]` / `ListData[T]`
- Migrate the agency endpoint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal API response structure organization for better type consistency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->