### PR TITLE
refactor: update route and stop IDs response types to match the new response model

### DIFF
--- a/internal/restapi/response_types.go
+++ b/internal/restapi/response_types.go
@@ -35,4 +35,6 @@ type EntryData[T any] struct {
 type CoverageResponse ListResponse[models.AgencyCoverage]
 type RoutesResponse ListResponse[models.Route]
 type StopsResponse ListResponse[models.Stop]
+type RouteIDsForAgencyResponse ListResponse[string]
+type StopIDsForAgencyResponse ListResponse[string]
 type AgencyEntryResponse EntryResponse[models.AgencyReference]

--- a/internal/restapi/route_ids_for_agency_handler_test.go
+++ b/internal/restapi/route_ids_for_agency_handler_test.go
@@ -46,3 +46,13 @@ func TestInvalidAgencyIdForRouteIds(t *testing.T) {
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, "", model.Text)
 }
+
+func TestMalformedAgencyIdForRouteIds(t *testing.T) {
+	api := createTestApi(t)
+	defer api.Shutdown()
+
+	resp, model := callAPIHandler[RouteIDsForAgencyResponse](t, api, "/api/where/route-ids-for-agency/bad@agency.json?key=TEST")
+
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	assert.Equal(t, http.StatusBadRequest, model.Code)
+}

--- a/internal/restapi/route_ids_for_agency_handler_test.go
+++ b/internal/restapi/route_ids_for_agency_handler_test.go
@@ -2,15 +2,18 @@ package restapi
 
 import (
 	"net/http"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+	"maglev.onebusaway.org/internal/restapi/testdata"
 )
 
 func TestRouteIdsForAgencyRequiresValidApiKey(t *testing.T) {
-	_, resp, model := serveAndRetrieveEndpoint(t, "/api/where/route-ids-for-agency/test.json?key=invalid")
+	api := createTestApi(t)
+	defer api.Shutdown()
+
+	resp, model := callAPIHandler[RouteIDsForAgencyResponse](t, api, "/api/where/route-ids-for-agency/test.json?key=invalid")
+
 	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
 	assert.Equal(t, http.StatusUnauthorized, model.Code)
 	assert.Equal(t, "permission denied", model.Text)
@@ -19,38 +22,27 @@ func TestRouteIdsForAgencyRequiresValidApiKey(t *testing.T) {
 func TestRouteIdsForAgencyEndToEnd(t *testing.T) {
 	api := createTestApi(t)
 	defer api.Shutdown()
-	agencies := mustGetAgencies(t, api)
-	require.NotEmpty(t, agencies)
-	agencyId := agencies[0].ID
 
-	resp, model := serveApiAndRetrieveEndpoint(t, api, "/api/where/route-ids-for-agency/"+agencyId+".json?key=TEST")
+	resp, model := callAPIHandler[RouteIDsForAgencyResponse](t, api, "/api/where/route-ids-for-agency/"+testdata.Raba.ID+".json?key=TEST")
+
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
-	assert.Equal(t, 200, model.Code)
+	assert.Equal(t, http.StatusOK, model.Code)
 	assert.Equal(t, "OK", model.Text)
 
-	data, ok := model.Data.(map[string]any)
-
-	require.True(t, ok)
-	list, ok := data["list"].([]any)
-	require.True(t, ok)
-	assert.NotEmpty(t, list)
-
-	for _, routeId := range list {
-		routeIdStr, ok := routeId.(string)
-		require.True(t, ok)
-		assert.True(t, strings.HasPrefix(routeIdStr, agencyId+"_"),
-			"Route ID should start with agency ID prefix: %s", routeIdStr)
+	expected := make([]string, 0, len(testdata.RabaRoutes))
+	for _, r := range testdata.RabaRoutes {
+		expected = append(expected, r.ID)
 	}
-
-	refs, ok := data["references"].(map[string]any)
-	require.True(t, ok)
-	agencyRefs, ok := refs["agencies"].([]any)
-	require.True(t, ok)
-	assert.Len(t, agencyRefs, 0)
+	assert.ElementsMatch(t, expected, model.Data.List)
+	assert.Empty(t, model.Data.References.Agencies)
 }
 
 func TestInvalidAgencyIdForRouteIds(t *testing.T) {
-	_, resp, model := serveAndRetrieveEndpoint(t, "/api/where/route-ids-for-agency/invalid.json?key=TEST")
+	api := createTestApi(t)
+	defer api.Shutdown()
+
+	resp, model := callAPIHandler[RouteIDsForAgencyResponse](t, api, "/api/where/route-ids-for-agency/invalid.json?key=TEST")
+
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, "", model.Text)
 }

--- a/internal/restapi/stop_ids_for_agency_handler_test.go
+++ b/internal/restapi/stop_ids_for_agency_handler_test.go
@@ -6,11 +6,15 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+	"maglev.onebusaway.org/internal/restapi/testdata"
 )
 
 func TestStopIdsForAgencyRequiresValidApiKey(t *testing.T) {
-	_, resp, model := serveAndRetrieveEndpoint(t, "/api/where/stop-ids-for-agency/test.json?key=invalid")
+	api := createTestApi(t)
+	defer api.Shutdown()
+
+	resp, model := callAPIHandler[StopIDsForAgencyResponse](t, api, "/api/where/stop-ids-for-agency/test.json?key=invalid")
+
 	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
 	assert.Equal(t, http.StatusUnauthorized, model.Code)
 	assert.Equal(t, "permission denied", model.Text)
@@ -19,41 +23,27 @@ func TestStopIdsForAgencyRequiresValidApiKey(t *testing.T) {
 func TestStopIdsForAgencyEndToEnd(t *testing.T) {
 	api := createTestApi(t)
 	defer api.Shutdown()
-	agencies := mustGetAgencies(t, api)
-	require.NotEmpty(t, agencies)
-	agencyId := agencies[0].ID
 
-	resp, model := serveApiAndRetrieveEndpoint(t, api, "/api/where/stop-ids-for-agency/"+agencyId+".json?key=TEST")
+	resp, model := callAPIHandler[StopIDsForAgencyResponse](t, api, "/api/where/stop-ids-for-agency/"+testdata.Raba.ID+".json?key=TEST")
 
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
-
-	assert.Equal(t, 200, model.Code)
+	assert.Equal(t, http.StatusOK, model.Code)
 	assert.Equal(t, "OK", model.Text)
 
-	data, ok := model.Data.(map[string]any)
-	require.True(t, ok)
-
-	list, ok := data["list"].([]any)
-	require.True(t, ok)
-	assert.NotEmpty(t, list)
-
-	for _, stopId := range list {
-		stopIdStr, ok := stopId.(string)
-		require.True(t, ok)
-		assert.True(t, strings.HasPrefix(stopIdStr, agencyId+"_"),
-			"Stop ID should start with agency ID prefix: %s", stopIdStr)
+	assert.NotEmpty(t, model.Data.List)
+	for _, stopID := range model.Data.List {
+		assert.True(t, strings.HasPrefix(stopID, testdata.Raba.ID+"_"),
+			"Stop ID should start with agency ID prefix: %s", stopID)
 	}
-
-	refs, ok := data["references"].(map[string]any)
-	require.True(t, ok)
-
-	agencyRefs, ok := refs["agencies"].([]any)
-	require.True(t, ok)
-	assert.Len(t, agencyRefs, 0)
+	assert.Empty(t, model.Data.References.Agencies)
 }
 
 func TestInvalidAgencyId(t *testing.T) {
-	_, resp, model := serveAndRetrieveEndpoint(t, "/api/where/stop-ids-for-agency/invalid.json?key=TEST")
+	api := createTestApi(t)
+	defer api.Shutdown()
+
+	resp, model := callAPIHandler[StopIDsForAgencyResponse](t, api, "/api/where/stop-ids-for-agency/invalid.json?key=TEST")
+
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, "", model.Text)
 }

--- a/internal/restapi/stop_ids_for_agency_handler_test.go
+++ b/internal/restapi/stop_ids_for_agency_handler_test.go
@@ -47,3 +47,13 @@ func TestInvalidAgencyId(t *testing.T) {
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, "", model.Text)
 }
+
+func TestMalformedAgencyIdForStopIds(t *testing.T) {
+	api := createTestApi(t)
+	defer api.Shutdown()
+
+	resp, model := callAPIHandler[StopIDsForAgencyResponse](t, api, "/api/where/stop-ids-for-agency/bad@agency.json?key=TEST")
+
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	assert.Equal(t, http.StatusBadRequest, model.Code)
+}


### PR DESCRIPTION
Fixes: #901 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * API now provides explicit list response types for route and stop ID lists for an agency, improving consistency of those endpoints.
* **Tests**
  * Enhanced test infrastructure for API handlers with stronger typing, deterministic fixtures, and new cases validating malformed agency IDs (400 responses).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->