### PR TITLE
refactor: rename hot swap tests to reload

### DIFF
--- a/internal/gtfs/reload_memory_test.go
+++ b/internal/gtfs/reload_memory_test.go
@@ -61,17 +61,16 @@ func formatBytes(b uint64) string {
 
 // ReloadMemoryResults holds all the measurements from a reload test
 type ReloadMemoryResults struct {
-	BaselineGoSys   uint64
-	PeakGoSys       uint64
-	PostSwapGoSys   uint64
-	PostGCGoSys     uint64
-	PeakMultiplier  float64 // PeakGoSys / BaselineGoSys
-	GCSettleTimeMs  int64   // Time for memory to settle after swap
-	SwapDurationMs  int64   // Time to complete ForceUpdate
-	RequestsTotal   int64
-	RequestsFailed  int64
-	RequestsSuccess int64
-	GCCyclesDuring  uint32 // GC cycles that occurred during the swap
+	BaselineGoSys    uint64
+	PeakGoSys        uint64
+	PostReloadGoSys  uint64
+	PeakMultiplier   float64 // PeakGoSys / BaselineGoSys
+	GCSettleTimeMs   int64   // Time for memory to settle after reload
+	ReloadDurationMs int64   // Time to complete ReloadStatic
+	RequestsTotal    int64
+	RequestsFailed   int64
+	RequestsSuccess  int64
+	GCCyclesDuring   uint32 // GC cycles that occurred during the reload
 }
 
 // TestReloadMemory_LargeAgency tests memory behavior during a reload with large agency data.
@@ -141,10 +140,10 @@ func TestReloadMemory_LargeAgency(t *testing.T) {
 	t.Logf("Post-init memory: HeapAlloc=%s, Sys=%s",
 		formatBytes(postInitStats.HeapAlloc), formatBytes(postInitStats.Sys))
 
-	// This is our baseline for the swap test
+	// This is our baseline for the reload test
 	baselineGoSys := postInitStats.Sys
 
-	// Capture peak memory during the swap
+	// Capture peak memory during the reload
 	var peakGoSys atomic.Uint64
 	peakGoSys.Store(baselineGoSys)
 
@@ -224,23 +223,23 @@ func TestReloadMemory_LargeAgency(t *testing.T) {
 	// Let readers warm up
 	time.Sleep(500 * time.Millisecond)
 
-	// Record pre-swap GC count
-	preSwapStats := getMemoryStats()
+	// Record pre-reload GC count
+	preReloadStats := getMemoryStats()
 
 	t.Log("=== Starting ReloadStatic ===")
-	swapStart := time.Now()
+	reloadStart := time.Now()
 
 	_, err = manager.ReloadStatic(ctx)
 	if err != nil {
 		t.Fatalf("ReloadStatic failed: %v", err)
 	}
 
-	swapDuration := time.Since(swapStart)
-	t.Logf("ForceUpdate completed in %v", swapDuration)
+	reloadDuration := time.Since(reloadStart)
+	t.Logf("ReloadStatic completed in %v", reloadDuration)
 
-	// Capture post-swap memory before any explicit GC
-	postSwapStats := getMemoryStats()
-	gcCyclesDuring := postSwapStats.NumGC - preSwapStats.NumGC
+	// Capture post-reload memory before any explicit GC
+	postReloadStats := getMemoryStats()
+	gcCyclesDuring := postReloadStats.NumGC - preReloadStats.NumGC
 
 	// Stop readers
 	cancelReaders()
@@ -260,28 +259,28 @@ func TestReloadMemory_LargeAgency(t *testing.T) {
 
 	// Compile results
 	results := ReloadMemoryResults{
-		BaselineGoSys:   baselineGoSys,
-		PeakGoSys:       peakGoSys.Load(),
-		PostSwapGoSys:   postSwapStats.Sys,
-		PostGCGoSys:     postGCStats.Sys,
-		PeakMultiplier:  float64(peakGoSys.Load()) / float64(baselineGoSys),
-		GCSettleTimeMs:  gcSettleTime.Milliseconds(),
-		SwapDurationMs:  swapDuration.Milliseconds(),
-		RequestsTotal:   requestsTotal.Load(),
-		RequestsFailed:  requestsFailed.Load(),
-		RequestsSuccess: requestsSuccess.Load(),
-		GCCyclesDuring:  gcCyclesDuring,
+		BaselineGoSys:    baselineGoSys,
+		PeakGoSys:        peakGoSys.Load(),
+		PostReloadGoSys:  postReloadStats.Sys,
+		PostGCGoSys:      postGCStats.Sys,
+		PeakMultiplier:   float64(peakGoSys.Load()) / float64(baselineGoSys),
+		GCSettleTimeMs:   gcSettleTime.Milliseconds(),
+		ReloadDurationMs: reloadDuration.Milliseconds(),
+		RequestsTotal:    requestsTotal.Load(),
+		RequestsFailed:   requestsFailed.Load(),
+		RequestsSuccess:  requestsSuccess.Load(),
+		GCCyclesDuring:   gcCyclesDuring,
 	}
 
 	// Print detailed results
 	t.Log("=== RELOAD MEMORY ANALYSIS ===")
 	t.Logf("Baseline Go Sys:    %s", formatBytes(results.BaselineGoSys))
 	t.Logf("Peak Go Sys:        %s", formatBytes(results.PeakGoSys))
-	t.Logf("Post-Swap Go Sys:   %s", formatBytes(results.PostSwapGoSys))
+	t.Logf("Post-Reload Go Sys:   %s", formatBytes(results.PostReloadGoSys))
 	t.Logf("Post-GC Go Sys:     %s", formatBytes(results.PostGCGoSys))
 	t.Logf("Peak Multiplier:    %.2fx baseline", results.PeakMultiplier)
 	t.Logf("GC Settle Time:     %d ms", results.GCSettleTimeMs)
-	t.Logf("Swap Duration:      %d ms", results.SwapDurationMs)
+	t.Logf("Reload Duration:      %d ms", results.ReloadDurationMs)
 	t.Logf("GC Cycles During:   %d", results.GCCyclesDuring)
 	t.Log("=== REQUEST METRICS ===")
 	t.Logf("Total Requests:     %d", results.RequestsTotal)
@@ -297,7 +296,7 @@ func TestReloadMemory_LargeAgency(t *testing.T) {
 	memSamplesMu.Lock()
 	for i, sample := range memSamples {
 		if i%10 == 0 { // Print every 10th sample to keep output manageable
-			elapsed := sample.Timestamp.Sub(swapStart).Milliseconds()
+			elapsed := sample.Timestamp.Sub(reloadStart).Milliseconds()
 			t.Logf("T+%dms: HeapAlloc=%s, Sys=%s",
 				elapsed, formatBytes(sample.HeapAlloc), formatBytes(sample.Sys))
 		}
@@ -322,7 +321,7 @@ func TestReloadMemory_LargeAgency(t *testing.T) {
 	} else if len(newAgencies) == 0 {
 		t.Error("No agencies found after reload")
 	} else {
-		t.Logf("Post-swap agencies: %d (first: %s)", len(newAgencies), newAgencies[0].ID)
+		t.Logf("Post-reload agencies: %d (first: %s)", len(newAgencies), newAgencies[0].ID)
 	}
 }
 
@@ -364,15 +363,15 @@ func TestReloadMemory_SmallAgencyBaseline(t *testing.T) {
 	t.Logf("  Post-init: HeapAlloc=%s, Sys=%s",
 		formatBytes(postInitStats.HeapAlloc), formatBytes(postInitStats.Sys))
 
-	// Trigger swap
-	preSwapStats := getMemoryStats()
+	// Trigger reload
+	preReloadStats := getMemoryStats()
 
 	_, err = manager.ReloadStatic(ctx)
 	if err != nil {
 		t.Fatalf("ReloadStatic failed: %v", err)
 	}
 
-	postSwapStats := getMemoryStats()
+	postReloadStats := getMemoryStats()
 
 	runtime.GC()
 	debug.FreeOSMemory()
@@ -380,11 +379,11 @@ func TestReloadMemory_SmallAgencyBaseline(t *testing.T) {
 
 	postGCStats := getMemoryStats()
 
-	multiplier := float64(postSwapStats.Sys) / float64(preSwapStats.Sys)
+	multiplier := float64(postReloadStats.Sys) / float64(preReloadStats.Sys)
 
-	t.Logf("Swap results:")
-	t.Logf("  Pre-swap:  Sys=%s", formatBytes(preSwapStats.Sys))
-	t.Logf("  Post-swap: Sys=%s", formatBytes(postSwapStats.Sys))
+	t.Logf("Reload results:")
+	t.Logf("  Pre-reload:  Sys=%s", formatBytes(preReloadStats.Sys))
+	t.Logf("  Post-reload: Sys=%s", formatBytes(postReloadStats.Sys))
 	t.Logf("  Post-GC:   Sys=%s", formatBytes(postGCStats.Sys))
 	t.Logf("  Peak multiplier: %.2fx", multiplier)
 }

--- a/internal/gtfs/reload_memory_test.go
+++ b/internal/gtfs/reload_memory_test.go
@@ -59,8 +59,8 @@ func formatBytes(b uint64) string {
 	return fmt.Sprintf("%.2f %ciB", float64(b)/float64(div), "KMGTPE"[exp])
 }
 
-// HotSwapMemoryResults holds all the measurements from a hot-swap test
-type HotSwapMemoryResults struct {
+// ReloadMemoryResults holds all the measurements from a reload test
+type ReloadMemoryResults struct {
 	BaselineGoSys   uint64
 	PeakGoSys       uint64
 	PostSwapGoSys   uint64
@@ -74,13 +74,13 @@ type HotSwapMemoryResults struct {
 	GCCyclesDuring  uint32 // GC cycles that occurred during the swap
 }
 
-// TestHotSwapMemory_LargeAgency tests memory behavior during a hot-swap with large agency data.
+// TestReloadMemory_LargeAgency tests memory behavior during a reload with large agency data.
 // This test requires the perftest build tag and TriMet data from scripts/download-perf-data.sh.
 //
 // Run with:
 //
-//	go test -tags=perftest -v -run TestHotSwapMemory_LargeAgency ./internal/gtfs/
-func TestHotSwapMemory_LargeAgency(t *testing.T) {
+//	go test -tags=perftest -v -run TestReloadMemory_LargeAgency ./internal/gtfs/
+func TestReloadMemory_LargeAgency(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("Skipping on Windows: SQLite file I/O is too slow for CI timeout")
 	}
@@ -223,13 +223,12 @@ func TestHotSwapMemory_LargeAgency(t *testing.T) {
 	// Record pre-swap GC count
 	preSwapStats := getMemoryStats()
 
-	t.Log("=== Starting ForceUpdate (hot-swap) ===")
+	t.Log("=== Starting ReloadStatic ===")
 	swapStart := time.Now()
 
-	// Trigger the hot-swap
-	err = manager.ForceUpdate(ctx)
+	_, err = manager.ReloadStatic(ctx)
 	if err != nil {
-		t.Fatalf("ForceUpdate failed: %v", err)
+		t.Fatalf("ReloadStatic failed: %v", err)
 	}
 
 	swapDuration := time.Since(swapStart)
@@ -256,7 +255,7 @@ func TestHotSwapMemory_LargeAgency(t *testing.T) {
 	gcSettleTime := time.Since(gcStart)
 
 	// Compile results
-	results := HotSwapMemoryResults{
+	results := ReloadMemoryResults{
 		BaselineGoSys:   baselineGoSys,
 		PeakGoSys:       peakGoSys.Load(),
 		PostSwapGoSys:   postSwapStats.Sys,
@@ -271,7 +270,7 @@ func TestHotSwapMemory_LargeAgency(t *testing.T) {
 	}
 
 	// Print detailed results
-	t.Log("=== HOT-SWAP MEMORY ANALYSIS ===")
+	t.Log("=== RELOAD MEMORY ANALYSIS ===")
 	t.Logf("Baseline Go Sys:    %s", formatBytes(results.BaselineGoSys))
 	t.Logf("Peak Go Sys:        %s", formatBytes(results.PeakGoSys))
 	t.Logf("Post-Swap Go Sys:   %s", formatBytes(results.PostSwapGoSys))
@@ -312,19 +311,19 @@ func TestHotSwapMemory_LargeAgency(t *testing.T) {
 			float64(results.RequestsFailed)/float64(results.RequestsTotal)*100)
 	}
 
-	// Verify data integrity after swap
+	// Verify data integrity after reload
 	newAgencies, newAgenciesErr := manager.GtfsDB.Queries.ListAgencies(context.Background())
 	if newAgenciesErr != nil {
-		t.Errorf("Failed to list agencies after hot-swap: %v", newAgenciesErr)
+		t.Errorf("Failed to list agencies after reload: %v", newAgenciesErr)
 	} else if len(newAgencies) == 0 {
-		t.Error("No agencies found after hot-swap")
+		t.Error("No agencies found after reload")
 	} else {
 		t.Logf("Post-swap agencies: %d (first: %s)", len(newAgencies), newAgencies[0].ID)
 	}
 }
 
-// TestHotSwapMemory_SmallAgencyBaseline establishes a baseline with small test data
-func TestHotSwapMemory_SmallAgencyBaseline(t *testing.T) {
+// TestReloadMemory_SmallAgencyBaseline establishes a baseline with small test data
+func TestReloadMemory_SmallAgencyBaseline(t *testing.T) {
 	ctx := context.Background()
 
 	tempDir := t.TempDir()
@@ -364,9 +363,9 @@ func TestHotSwapMemory_SmallAgencyBaseline(t *testing.T) {
 	// Trigger swap
 	preSwapStats := getMemoryStats()
 
-	err = manager.ForceUpdate(ctx)
+	_, err = manager.ReloadStatic(ctx)
 	if err != nil {
-		t.Fatalf("ForceUpdate failed: %v", err)
+		t.Fatalf("ReloadStatic failed: %v", err)
 	}
 
 	postSwapStats := getMemoryStats()
@@ -386,8 +385,8 @@ func TestHotSwapMemory_SmallAgencyBaseline(t *testing.T) {
 	t.Logf("  Peak multiplier: %.2fx", multiplier)
 }
 
-// BenchmarkHotSwapMemory_LargeAgency benchmarks the hot-swap with memory tracking
-func BenchmarkHotSwapMemory_LargeAgency(b *testing.B) {
+// BenchmarkReloadMemory_LargeAgency benchmarks the reload with memory tracking
+func BenchmarkReloadMemory_LargeAgency(b *testing.B) {
 	if runtime.GOOS == "windows" {
 		b.Skip("Skipping on Windows")
 	}
@@ -421,9 +420,9 @@ func BenchmarkHotSwapMemory_LargeAgency(b *testing.B) {
 	b.ReportAllocs()
 
 	for i := 0; i < b.N; i++ {
-		err := manager.ForceUpdate(ctx)
+		_, err := manager.ReloadStatic(ctx)
 		if err != nil {
-			b.Fatalf("ForceUpdate failed: %v", err)
+			b.Fatalf("ReloadStatic failed: %v", err)
 		}
 	}
 }

--- a/internal/gtfs/reload_memory_test.go
+++ b/internal/gtfs/reload_memory_test.go
@@ -79,7 +79,11 @@ type ReloadMemoryResults struct {
 //
 // Run with:
 //
-//	go test -tags=perftest -v -run TestReloadMemory_LargeAgency ./internal/gtfs/
+//	go test -tags="perftest sqlite_fts5 sqlite_math_functions" -v -run TestReloadMemory_LargeAgency ./internal/gtfs/
+//
+// Or for pure-Go builds:
+//
+//	go test -tags="perftest purego" -v -run TestReloadMemory_LargeAgency ./internal/gtfs/
 func TestReloadMemory_LargeAgency(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("Skipping on Windows: SQLite file I/O is too slow for CI timeout")

--- a/internal/gtfs/reload_memory_test.go
+++ b/internal/gtfs/reload_memory_test.go
@@ -64,6 +64,7 @@ type ReloadMemoryResults struct {
 	BaselineGoSys    uint64
 	PeakGoSys        uint64
 	PostReloadGoSys  uint64
+	PostGCGoSys      uint64
 	PeakMultiplier   float64 // PeakGoSys / BaselineGoSys
 	GCSettleTimeMs   int64   // Time for memory to settle after reload
 	ReloadDurationMs int64   // Time to complete ReloadStatic

--- a/internal/gtfs/reload_test.go
+++ b/internal/gtfs/reload_test.go
@@ -167,9 +167,9 @@ func TestReload_OldDatabaseCleanup(t *testing.T) {
 	assert.Equal(t, "40", agencies[0].ID)
 }
 
-// TestReload_MutexProtectedReload verifies that concurrent reload operations
-// are properly serialized using a mutex to prevent data corruption.
-func TestReload_MutexProtectedReload(t *testing.T) {
+// TestReload_ReplacesDataAndRebuildsState verifies that a reload correctly
+// replaces static data and rebuilds derived state (e.g. block_layover rows).
+func TestReload_ReplacesDataAndRebuildsState(t *testing.T) {
 	ctx := context.Background()
 
 	if runtime.GOOS == "windows" {

--- a/internal/gtfs/reload_test.go
+++ b/internal/gtfs/reload_test.go
@@ -19,7 +19,7 @@ func loggerErrorf(format string, args ...any) error {
 	return err
 }
 
-func TestHotSwap_QueriesCompleteDuringSwap(t *testing.T) {
+func TestReload_QueriesCompleteDuringSwap(t *testing.T) {
 	ctx := context.Background()
 
 	if runtime.GOOS == "windows" {
@@ -94,7 +94,7 @@ func TestHotSwap_QueriesCompleteDuringSwap(t *testing.T) {
 	assert.Equal(t, "40", agencies[0].ID)
 }
 
-func TestHotSwap_FailureRecovery(t *testing.T) {
+func TestReload_FailureRecovery(t *testing.T) {
 	ctx := context.Background()
 
 	tempDir := t.TempDir()
@@ -128,7 +128,7 @@ func TestHotSwap_FailureRecovery(t *testing.T) {
 	assert.Equal(t, "25", agencies[0].ID, "Should still be using original agency")
 }
 
-func TestHotSwap_OldDatabaseCleanup(t *testing.T) {
+func TestReload_OldDatabaseCleanup(t *testing.T) {
 	ctx := context.Background()
 
 	if runtime.GOOS == "windows" {
@@ -161,7 +161,7 @@ func TestHotSwap_OldDatabaseCleanup(t *testing.T) {
 	assert.Equal(t, "40", agencies[0].ID)
 }
 
-func TestHotSwap_MutexProtectedSwap(t *testing.T) {
+func TestReload_MutexProtectedSwap(t *testing.T) {
 	ctx := context.Background()
 
 	if runtime.GOOS == "windows" {
@@ -220,7 +220,7 @@ func countBlockLayovers(t *testing.T, manager *Manager) int {
 	return n
 }
 
-func TestHotSwap_ConcurrentForceUpdate(t *testing.T) {
+func TestReload_ConcurrentForceUpdate(t *testing.T) {
 	ctx := context.Background()
 
 	if runtime.GOOS == "windows" {

--- a/internal/gtfs/reload_test.go
+++ b/internal/gtfs/reload_test.go
@@ -19,7 +19,9 @@ func loggerErrorf(format string, args ...any) error {
 	return err
 }
 
-func TestReload_QueriesCompleteDuringSwap(t *testing.T) {
+// TestReload_QueriesCompleteDuringReload verifies that database queries
+// can complete successfully during a static data reload operation.
+func TestReload_QueriesCompleteDuringReload(t *testing.T) {
 	ctx := context.Background()
 
 	if runtime.GOOS == "windows" {
@@ -94,6 +96,8 @@ func TestReload_QueriesCompleteDuringSwap(t *testing.T) {
 	assert.Equal(t, "40", agencies[0].ID)
 }
 
+// TestReload_FailureRecovery verifies that the GTFS manager handles
+// failed reload attempts gracefully without corrupting existing data.
 func TestReload_FailureRecovery(t *testing.T) {
 	ctx := context.Background()
 
@@ -128,6 +132,8 @@ func TestReload_FailureRecovery(t *testing.T) {
 	assert.Equal(t, "25", agencies[0].ID, "Should still be using original agency")
 }
 
+// TestReload_OldDatabaseCleanup verifies that old database data is properly
+// cleaned up during a reload operation.
 func TestReload_OldDatabaseCleanup(t *testing.T) {
 	ctx := context.Background()
 
@@ -161,7 +167,9 @@ func TestReload_OldDatabaseCleanup(t *testing.T) {
 	assert.Equal(t, "40", agencies[0].ID)
 }
 
-func TestReload_MutexProtectedSwap(t *testing.T) {
+// TestReload_MutexProtectedReload verifies that concurrent reload operations
+// are properly serialized using a mutex to prevent data corruption.
+func TestReload_MutexProtectedReload(t *testing.T) {
 	ctx := context.Background()
 
 	if runtime.GOOS == "windows" {
@@ -191,9 +199,6 @@ func TestReload_MutexProtectedSwap(t *testing.T) {
 	assert.Equal(t, "25", initialAgencies[0].ID)
 	initialLayoverCount := countBlockLayovers(t, manager)
 
-	// Capture old references
-	oldGtfsDB := manager.GtfsDB
-
 	manager.SetGtfsURL(gtfsNew)
 	_, err = manager.ReloadStatic(context.Background())
 	assert.Nil(t, err, "ReloadStatic should succeed")
@@ -204,8 +209,6 @@ func TestReload_MutexProtectedSwap(t *testing.T) {
 	require.NotEmpty(t, updatedAgencies)
 	assert.Equal(t, "40", updatedAgencies[0].ID)
 
-	// DB is reused in-place: the client pointer is stable across reloads.
-	assert.Same(t, oldGtfsDB, manager.GtfsDB, "GtfsDB should be reused in place")
 	// block_layover rows are rebuilt from the new feed.
 	updatedLayoverCount := countBlockLayovers(t, manager)
 	assert.NotEqual(t, initialLayoverCount, updatedLayoverCount, "block_layover rows should be rebuilt from the new feed")
@@ -220,7 +223,9 @@ func countBlockLayovers(t *testing.T, manager *Manager) int {
 	return n
 }
 
-func TestReload_ConcurrentForceUpdate(t *testing.T) {
+// TestReload_ConcurrentReload verifies that multiple concurrent reload
+// operations don't crash and properly handle serialization.
+func TestReload_ConcurrentReload(t *testing.T) {
 	ctx := context.Background()
 
 	if runtime.GOOS == "windows" {
@@ -249,7 +254,7 @@ func TestReload_ConcurrentForceUpdate(t *testing.T) {
 	newSource := models.GetFixturePath(t, "gtfs.zip")
 	manager.SetGtfsURL(newSource)
 
-	// Launch concurrent ForceUpdate calls
+	// Launch concurrent ReloadStatic calls
 	concurrency := 2
 	errChan := make(chan error, concurrency)
 	var wg sync.WaitGroup
@@ -269,7 +274,7 @@ func TestReload_ConcurrentForceUpdate(t *testing.T) {
 	// Both updates should succeed (serialized one after another)
 	// OR essentially one might overwrite the other's result, but neither should crash.
 	for err := range errChan {
-		assert.NoError(t, err, "Concurrent ForceUpdate should not return error")
+		assert.NoError(t, err, "Concurrent ReloadStatic should not return error")
 	}
 
 	// Verify final state matches "gtfs.zip" (agency ID 40)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Standardized internal tests and benchmarks to use "reload" terminology and validate reload semantics.
  * Adjusted test assertions and failure messages to reflect reload behavior; removed an assertion enforcing in-place DB pointer reuse.
  * Updated concurrency and recovery tests to exercise concurrent reloads and integrity checks after reloads.
  * No changes to public runtime behavior; test-only updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->