### PR TITLE
fix: align schedule-for-route with spec (510 responses, combined IDs, arrivalEnabled)

### DIFF
--- a/internal/restapi/schedule_for_route_handler.go
+++ b/internal/restapi/schedule_for_route_handler.go
@@ -223,9 +223,9 @@ func (api *RestAPI) scheduleForRouteHandler(w http.ResponseWriter, r *http.Reque
 				arrivalDur := time.Duration(st.ArrivalTime)
 				departureDur := time.Duration(st.DepartureTime)
 				stopTimesList = append(stopTimesList, models.RouteStopTime{
-					ArrivalEnabled:   arrivalDur > 0,
+					ArrivalEnabled:   arrivalDur >= 0,
 					ArrivalTime:      models.NewModelDuration(arrivalDur),
-					DepartureEnabled: departureDur > 0,
+					DepartureEnabled: departureDur >= 0,
 					DepartureTime:    models.NewModelDuration(departureDur),
 					ServiceID:        utils.FormCombinedID(agencyID, trip.ServiceID),
 					StopHeadsign:     st.StopHeadsign.String,

--- a/internal/restapi/schedule_for_route_handler.go
+++ b/internal/restapi/schedule_for_route_handler.go
@@ -223,9 +223,9 @@ func (api *RestAPI) scheduleForRouteHandler(w http.ResponseWriter, r *http.Reque
 				arrivalDur := time.Duration(st.ArrivalTime)
 				departureDur := time.Duration(st.DepartureTime)
 				stopTimesList = append(stopTimesList, models.RouteStopTime{
-					ArrivalEnabled:   arrivalDur >= 0,
+					ArrivalEnabled:   arrivalDur > 0,
 					ArrivalTime:      models.NewModelDuration(arrivalDur),
-					DepartureEnabled: departureDur >= 0,
+					DepartureEnabled: departureDur > 0,
 					DepartureTime:    models.NewModelDuration(departureDur),
 					ServiceID:        utils.FormCombinedID(agencyID, trip.ServiceID),
 					StopHeadsign:     st.StopHeadsign.String,

--- a/internal/restapi/schedule_for_route_handler.go
+++ b/internal/restapi/schedule_for_route_handler.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"maglev.onebusaway.org/gtfsdb"
+	"maglev.onebusaway.org/internal/clock"
 	"maglev.onebusaway.org/internal/models"
 	"maglev.onebusaway.org/internal/utils"
 )
@@ -19,13 +20,6 @@ func (api *RestAPI) scheduleForRouteHandler(w http.ResponseWriter, r *http.Reque
 	}
 
 	dateParam := r.URL.Query().Get("date")
-	if err := utils.ValidateDate(dateParam); err != nil {
-		fieldErrors := map[string][]string{
-			"date": {err.Error()},
-		}
-		api.validationErrorResponse(w, r, fieldErrors)
-		return
-	}
 	ctx := r.Context()
 
 	route, err := api.GtfsManager.GtfsDB.Queries.GetRoute(ctx, routeID)
@@ -48,16 +42,21 @@ func (api *RestAPI) scheduleForRouteHandler(w http.ResponseWriter, r *http.Reque
 	var targetDate string
 	var scheduleDate int64
 	if dateParam != "" {
-		parsedDate, err := time.ParseInLocation("2006-01-02", dateParam, loc)
-		if err != nil {
-			fieldErrors := map[string][]string{
-				"date": {"Invalid date format. Use YYYY-MM-DD"},
+		parsedDate, parseErr := time.ParseInLocation("2006-01-02", dateParam, loc)
+		if parseErr != nil {
+			epochMs, numErr := strconv.ParseInt(dateParam, 10, 64)
+			if numErr != nil {
+				api.sendResponse(w, r, models.NewResponse(510, nil, "ServiceDateOutOfRange", api.Clock))
+				return
 			}
-			api.validationErrorResponse(w, r, fieldErrors)
-			return
+			t := time.UnixMilli(epochMs).In(loc)
+			y, m, d := t.Date()
+			parsedDate = time.Date(y, m, d, 0, 0, 0, 0, loc)
 		}
-		targetDate = parsedDate.Format("20060102")
-		scheduleDate = parsedDate.UnixMilli()
+		y, m, d := parsedDate.Date()
+		startOfDay := time.Date(y, m, d, 0, 0, 0, 0, loc)
+		targetDate = startOfDay.Format("20060102")
+		scheduleDate = startOfDay.UnixMilli()
 	} else {
 		now := api.Clock.Now().In(loc)
 		y, m, d := now.Date()
@@ -66,22 +65,48 @@ func (api *RestAPI) scheduleForRouteHandler(w http.ResponseWriter, r *http.Reque
 		scheduleDate = startOfDay.UnixMilli()
 	}
 
+	// Check if date exceeds the feed's max calendar end date -> ServiceDateOutOfRange
+	feedEndDateRaw, err := api.GtfsManager.GtfsDB.Queries.GetFeedEndDate(ctx)
+	if err != nil {
+		api.serverErrorResponse(w, r, err)
+		return
+	}
+	if feedEndDate, ok := feedEndDateRaw.(string); ok && feedEndDate != "" && targetDate > feedEndDate {
+		api.sendResponse(w, r, models.NewResponse(510, nil, "ServiceDateOutOfRange", api.Clock))
+		return
+	}
+
+	agencyModel := models.NewAgencyReference(
+		agency.ID,
+		agency.Name,
+		agency.Url,
+		agency.Timezone,
+		agency.Lang.String,
+		agency.Phone.String,
+		agency.Email.String,
+		agency.FareUrl.String,
+		"",
+		false,
+	)
+	routeModel := models.NewRoute(
+		utils.FormCombinedID(agencyID, route.ID),
+		route.AgencyID,
+		route.ShortName.String,
+		route.LongName.String,
+		route.Desc.String,
+		models.RouteType(route.Type),
+		route.Url.String,
+		route.Color.String,
+		route.TextColor.String)
+
 	serviceIDs, err := api.GtfsManager.GtfsDB.Queries.GetActiveServiceIDsForDate(ctx, targetDate)
 	if err != nil {
 		api.serverErrorResponse(w, r, err)
 		return
 	}
 
-	// Behavior Change (Jan 2026): Previously, this returned a 500 Server Error.
-	// We now return 200 OK with an empty schedule because "no service found" is a valid state, not a server failure.
 	if len(serviceIDs) == 0 {
-		entry := models.ScheduleForRouteEntry{
-			RouteID:           utils.FormCombinedID(agencyID, routeID),
-			ScheduleDate:      scheduleDate,
-			ServiceIDs:        []string{},
-			StopTripGroupings: []models.StopTripGrouping{},
-		}
-		api.sendResponse(w, r, models.NewEntryResponse(entry, *models.NewEmptyReferences(), api.Clock))
+		api.sendResponse(w, r, buildNoServiceThatDayResponse(agencyID, routeID, scheduleDate, agencyModel, routeModel, api.Clock))
 		return
 	}
 
@@ -94,6 +119,11 @@ func (api *RestAPI) scheduleForRouteHandler(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
+	if len(trips) == 0 {
+		api.sendResponse(w, r, buildNoServiceThatDayResponse(agencyID, routeID, scheduleDate, agencyModel, routeModel, api.Clock))
+		return
+	}
+
 	routeSvcIDs := make(map[string]bool)
 	combinedServiceIDs := make([]string, 0, len(trips))
 	for _, trip := range trips {
@@ -103,32 +133,8 @@ func (api *RestAPI) scheduleForRouteHandler(w http.ResponseWriter, r *http.Reque
 		}
 	}
 
-	// Handle case where service exists but this route has no trips today.
-	// Return 200 OK with empty data.
-	if len(trips) == 0 {
-		entry := models.ScheduleForRouteEntry{
-			RouteID:           utils.FormCombinedID(agencyID, routeID),
-			ScheduleDate:      scheduleDate,
-			ServiceIDs:        combinedServiceIDs,
-			StopTripGroupings: []models.StopTripGrouping{},
-		}
-		api.sendResponse(w, r, models.NewEntryResponse(entry, *models.NewEmptyReferences(), api.Clock))
-		return
-	}
-
 	routeRefs := make(map[string]models.Route)
 	tripIDsSet := make(map[string]bool)
-
-	routeModel := models.NewRoute(
-		utils.FormCombinedID(agencyID, route.ID),
-		route.AgencyID,
-		route.ShortName.String,
-		route.LongName.String,
-		route.Desc.String,
-		models.RouteType(route.Type),
-		route.Url.String,
-		route.Color.String,
-		route.TextColor.String)
 
 	routeRefs[utils.FormCombinedID(agencyID, route.ID)] = routeModel
 
@@ -214,11 +220,13 @@ func (api *RestAPI) scheduleForRouteHandler(w http.ResponseWriter, r *http.Reque
 
 			stopTimesList := make([]models.RouteStopTime, 0, len(stopTimes))
 			for _, st := range stopTimes {
+				arrivalDur := time.Duration(st.ArrivalTime)
+				departureDur := time.Duration(st.DepartureTime)
 				stopTimesList = append(stopTimesList, models.RouteStopTime{
-					ArrivalEnabled:   true,
-					ArrivalTime:      models.NewModelDuration(time.Duration(st.ArrivalTime)),
-					DepartureEnabled: true,
-					DepartureTime:    models.NewModelDuration(time.Duration(st.DepartureTime)),
+					ArrivalEnabled:   arrivalDur > 0,
+					ArrivalTime:      models.NewModelDuration(arrivalDur),
+					DepartureEnabled: departureDur > 0,
+					DepartureTime:    models.NewModelDuration(departureDur),
 					ServiceID:        utils.FormCombinedID(agencyID, trip.ServiceID),
 					StopHeadsign:     st.StopHeadsign.String,
 					StopID:           utils.FormCombinedID(agencyID, st.StopID),
@@ -247,20 +255,7 @@ func (api *RestAPI) scheduleForRouteHandler(w http.ResponseWriter, r *http.Reque
 	}
 
 	references := models.NewEmptyReferences()
-	agencyModel := models.NewAgencyReference(
-		agency.ID,
-		agency.Name,
-		agency.Url,
-		agency.Timezone,
-		agency.Lang.String,
-		agency.Phone.String,
-		agency.Email.String,
-		agency.FareUrl.String,
-		"",
-		false,
-	)
 	references.Agencies = append(references.Agencies, agencyModel)
-
 	references.Routes = utils.MapValues(routeRefs)
 
 	tripIDs := make([]string, 0, len(tripIDsSet))
@@ -279,8 +274,8 @@ func (api *RestAPI) scheduleForRouteHandler(w http.ResponseWriter, r *http.Reque
 			combinedTripID := utils.FormCombinedID(agencyID, t.ID)
 			tripRef := models.NewTripReference(
 				combinedTripID,
-				t.RouteID,
-				t.ServiceID,
+				utils.FormCombinedID(agencyID, t.RouteID),
+				utils.FormCombinedID(agencyID, t.ServiceID),
 				t.TripHeadsign.String,
 				t.TripShortName.String,
 				strconv.FormatInt(t.DirectionID.Int64, 10),
@@ -316,4 +311,23 @@ func (api *RestAPI) scheduleForRouteHandler(w http.ResponseWriter, r *http.Reque
 		StopTripGroupings: stopTripGroupings,
 	}
 	api.sendResponse(w, r, models.NewEntryResponse(entry, *references, api.Clock))
+}
+
+// buildNoServiceThatDayResponse constructs the spec-compliant 510 NoServiceThatDay response,
+// which includes the entry stub and agency+route references required by the spec.
+func buildNoServiceThatDayResponse(agencyID, routeID string, scheduleDate int64, agencyModel models.AgencyReference, routeModel models.Route, clk clock.Clock) models.ResponseModel {
+	refs := models.NewEmptyReferences()
+	refs.Agencies = append(refs.Agencies, agencyModel)
+	refs.Routes = append(refs.Routes, routeModel)
+	entry := models.ScheduleForRouteEntry{
+		RouteID:           utils.FormCombinedID(agencyID, routeID),
+		ScheduleDate:      scheduleDate,
+		ServiceIDs:        []string{},
+		StopTripGroupings: []models.StopTripGrouping{},
+	}
+	data := map[string]any{
+		"entry":      entry,
+		"references": *refs,
+	}
+	return models.NewResponse(510, data, "NoServiceThatDay", clk)
 }

--- a/internal/restapi/schedule_for_route_handler_test.go
+++ b/internal/restapi/schedule_for_route_handler_test.go
@@ -90,12 +90,23 @@ func TestScheduleForRouteHandlerDateParam(t *testing.T) {
 		assert.Equal(t, expectedScheduleDate.UnixMilli(), model.Data.Entry.ScheduleDate)
 	})
 
-	t.Run("Invalid date format", func(t *testing.T) {
+	t.Run("Invalid date format returns ServiceDateOutOfRange", func(t *testing.T) {
 		endpoint := "/api/where/schedule-for-route/" + routeID + ".json?key=TEST&date=2025/06/12"
 		resp, model := callAPIHandler[ScheduleForRouteResponse](t, api, endpoint)
 
-		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
-		assert.Equal(t, http.StatusBadRequest, model.Code)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		assert.Equal(t, 510, model.Code)
+		assert.Equal(t, "ServiceDateOutOfRange", model.Text)
+	})
+
+	t.Run("Epoch ms date parsed as Java OBA compatibility", func(t *testing.T) {
+		// date=0 → epoch start (1970-01-01 00:00:00 UTC) → before any RABA service → NoServiceThatDay
+		endpoint := "/api/where/schedule-for-route/" + routeID + ".json?key=TEST&date=0"
+		resp, model := callAPIHandler[ScheduleForRouteResponse](t, api, endpoint)
+
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		assert.Equal(t, 510, model.Code)
+		assert.Equal(t, "NoServiceThatDay", model.Text)
 	})
 }
 
@@ -183,18 +194,74 @@ func TestScheduleForRouteHandler_TripIDsSorted(t *testing.T) {
 	}
 }
 
-func TestScheduleForRouteHandler_NoServiceOrOutOfRange(t *testing.T) {
+func TestScheduleForRouteHandler_ServiceDateOutOfRange(t *testing.T) {
 	api := createTestApi(t)
 	defer api.Shutdown()
 
 	routeID := testdata.Route1.ID
-	futureDate := "2099-01-01"
-	endpoint := "/api/where/schedule-for-route/" + routeID + ".json?key=TEST&date=" + futureDate
+
+	t.Run("Future date beyond feed returns ServiceDateOutOfRange", func(t *testing.T) {
+		endpoint := "/api/where/schedule-for-route/" + routeID + ".json?key=TEST&date=2099-01-01"
+		resp, model := callAPIHandler[ScheduleForRouteResponse](t, api, endpoint)
+
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		assert.Equal(t, 510, model.Code)
+		assert.Equal(t, "ServiceDateOutOfRange", model.Text)
+		assert.Empty(t, model.Data.Entry.RouteID, "data.entry should be absent for ServiceDateOutOfRange")
+	})
+
+	t.Run("Garbage date string returns ServiceDateOutOfRange", func(t *testing.T) {
+		endpoint := "/api/where/schedule-for-route/" + routeID + ".json?key=TEST&date=not-a-date"
+		resp, model := callAPIHandler[ScheduleForRouteResponse](t, api, endpoint)
+
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		assert.Equal(t, 510, model.Code)
+		assert.Equal(t, "ServiceDateOutOfRange", model.Text)
+	})
+}
+
+func TestScheduleForRouteHandler_NoServiceThatDay(t *testing.T) {
+	api := createTestApi(t)
+	defer api.Shutdown()
+
+	routeID := testdata.Route1.ID
+
+	t.Run("Early date before feed returns NoServiceThatDay with references", func(t *testing.T) {
+		// 1970-01-01 is before any RABA calendar data but not after the feed end date.
+		endpoint := "/api/where/schedule-for-route/" + routeID + ".json?key=TEST&date=1970-01-01"
+		resp, model := callAPIHandler[ScheduleForRouteResponse](t, api, endpoint)
+
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		assert.Equal(t, 510, model.Code)
+		assert.Equal(t, "NoServiceThatDay", model.Text)
+
+		entry := model.Data.Entry
+		assert.NotEmpty(t, entry.RouteID, "routeId should be present in NoServiceThatDay")
+		assert.Empty(t, entry.ServiceIDs)
+		assert.Empty(t, entry.StopTripGroupings)
+
+		refs := model.Data.References
+		assert.NotEmpty(t, refs.Agencies, "references.agencies should be populated for NoServiceThatDay")
+		assert.NotEmpty(t, refs.Routes, "references.routes should be populated for NoServiceThatDay")
+	})
+}
+
+func TestScheduleForRouteHandler_TripReferenceCombinedIDs(t *testing.T) {
+	clk := clock.NewMockClock(time.Date(2025, 6, 12, 12, 0, 0, 0, time.UTC))
+	api := createTestApiWithClock(t, clk)
+	defer api.Shutdown()
+
+	routeID := testdata.Route1.ID
+	endpoint := "/api/where/schedule-for-route/" + routeID + ".json?key=TEST&date=2025-06-12"
 	resp, model := callAPIHandler[ScheduleForRouteResponse](t, api, endpoint)
 
-	assert.Equal(t, http.StatusOK, resp.StatusCode)
-	assert.Equal(t, http.StatusOK, model.Code)
-	assert.Equal(t, "OK", model.Text)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NotEmpty(t, model.Data.References.Trips)
+
+	for _, tr := range model.Data.References.Trips {
+		assert.Contains(t, tr.RouteID, "_", "trip reference routeId must be a combined ID")
+		assert.Contains(t, tr.ServiceID, "_", "trip reference serviceId must be a combined ID")
+	}
 }
 
 func TestScheduleForRouteHandlerWithMalformedID(t *testing.T) {

--- a/internal/restapi/schedule_for_route_handler_test.go
+++ b/internal/restapi/schedule_for_route_handler_test.go
@@ -43,9 +43,9 @@ func assertScheduleErr(t *testing.T, resp *http.Response, model ScheduleForRoute
 	assert.Equal(t, wantText, model.Text)
 }
 
-func laDate(t *testing.T, ymd string) time.Time {
+func agencyDate(t *testing.T, ymd string) time.Time {
 	t.Helper()
-	loc, err := time.LoadLocation("America/Los_Angeles")
+	loc, err := time.LoadLocation(testdata.Raba.Timezone)
 	require.NoError(t, err)
 	d, err := time.ParseInLocation("2006-01-02", ymd, loc)
 	require.NoError(t, err)
@@ -63,7 +63,7 @@ func TestScheduleForRouteHandler(t *testing.T) {
 
 		assertScheduleOK(t, resp, model)
 
-		expectedScheduleDate := laDate(t, "2025-06-12")
+		expectedScheduleDate := agencyDate(t, "2025-06-12")
 
 		entry := model.Data.Entry
 		assert.Equal(t, routeID, entry.RouteID)
@@ -115,7 +115,7 @@ func TestScheduleForRouteHandlerDateParam(t *testing.T) {
 		assertScheduleOK(t, resp, model)
 
 		// Clock is 2025-06-12 12:00 UTC = 2025-06-12 05:00 PDT, so start of day in LA is 2025-06-12.
-		expectedScheduleDate := laDate(t, "2025-06-12")
+		expectedScheduleDate := agencyDate(t, "2025-06-12")
 		assert.Equal(t, expectedScheduleDate.UnixMilli(), model.Data.Entry.ScheduleDate)
 	})
 

--- a/internal/restapi/schedule_for_route_handler_test.go
+++ b/internal/restapi/schedule_for_route_handler_test.go
@@ -12,15 +12,31 @@ import (
 	"maglev.onebusaway.org/internal/utils"
 )
 
+// scheduleForRouteFixedClock is the mock-clock instant used across schedule-for-route
+// tests; 2025-06-12 12:00 UTC corresponds to a known service date in the RABA test data.
+var scheduleForRouteFixedClock = time.Date(2025, 6, 12, 12, 0, 0, 0, time.UTC)
+
+func newScheduleForRouteAPI(t *testing.T) *RestAPI {
+	t.Helper()
+	return createTestApiWithClock(t, clock.NewMockClock(scheduleForRouteFixedClock))
+}
+
+func scheduleForRouteURL(routeID, date string) string {
+	u := "/api/where/schedule-for-route/" + routeID + ".json?key=TEST"
+	if date != "" {
+		u += "&date=" + date
+	}
+	return u
+}
+
 func TestScheduleForRouteHandler(t *testing.T) {
-	clk := clock.NewMockClock(time.Date(2025, 6, 12, 12, 0, 0, 0, time.UTC))
-	api := createTestApiWithClock(t, clk)
+	api := newScheduleForRouteAPI(t)
 	defer api.Shutdown()
 
 	routeID := testdata.Route1.ID
 
 	t.Run("Valid route", func(t *testing.T) {
-		resp, model := callAPIHandler[ScheduleForRouteResponse](t, api, "/api/where/schedule-for-route/"+routeID+".json?key=TEST&date=2025-06-12")
+		resp, model := callAPIHandler[ScheduleForRouteResponse](t, api, scheduleForRouteURL(routeID, "2025-06-12"))
 
 		assert.Equal(t, http.StatusOK, resp.StatusCode)
 		assert.Equal(t, http.StatusOK, model.Code)
@@ -62,22 +78,20 @@ func TestScheduleForRouteHandler(t *testing.T) {
 	})
 
 	t.Run("Invalid route", func(t *testing.T) {
-		resp, model := callAPIHandler[ScheduleForRouteResponse](t, api, "/api/where/schedule-for-route/"+routeID+"notexist.json?key=TEST")
+		resp, model := callAPIHandler[ScheduleForRouteResponse](t, api, scheduleForRouteURL(routeID+"notexist", ""))
 		assert.Equal(t, http.StatusNotFound, resp.StatusCode)
 		assert.Equal(t, http.StatusNotFound, model.Code)
 	})
 }
 
 func TestScheduleForRouteHandlerDateParam(t *testing.T) {
-	clk := clock.NewMockClock(time.Date(2025, 6, 12, 12, 0, 0, 0, time.UTC))
-	api := createTestApiWithClock(t, clk)
+	api := newScheduleForRouteAPI(t)
 	defer api.Shutdown()
 
 	routeID := testdata.Route1.ID
 
 	t.Run("No date param uses current date", func(t *testing.T) {
-		endpoint := "/api/where/schedule-for-route/" + routeID + ".json?key=TEST"
-		resp, model := callAPIHandler[ScheduleForRouteResponse](t, api, endpoint)
+		resp, model := callAPIHandler[ScheduleForRouteResponse](t, api, scheduleForRouteURL(routeID, ""))
 
 		assert.Equal(t, http.StatusOK, resp.StatusCode)
 		assert.Equal(t, http.StatusOK, model.Code)
@@ -91,8 +105,7 @@ func TestScheduleForRouteHandlerDateParam(t *testing.T) {
 	})
 
 	t.Run("Invalid date format returns ServiceDateOutOfRange", func(t *testing.T) {
-		endpoint := "/api/where/schedule-for-route/" + routeID + ".json?key=TEST&date=2025/06/12"
-		resp, model := callAPIHandler[ScheduleForRouteResponse](t, api, endpoint)
+		resp, model := callAPIHandler[ScheduleForRouteResponse](t, api, scheduleForRouteURL(routeID, "2025/06/12"))
 
 		assert.Equal(t, http.StatusOK, resp.StatusCode)
 		assert.Equal(t, 510, model.Code)
@@ -101,8 +114,7 @@ func TestScheduleForRouteHandlerDateParam(t *testing.T) {
 
 	t.Run("Epoch ms date parsed as Java OBA compatibility", func(t *testing.T) {
 		// date=0 → epoch start (1970-01-01 00:00:00 UTC) → before any RABA service → NoServiceThatDay
-		endpoint := "/api/where/schedule-for-route/" + routeID + ".json?key=TEST&date=0"
-		resp, model := callAPIHandler[ScheduleForRouteResponse](t, api, endpoint)
+		resp, model := callAPIHandler[ScheduleForRouteResponse](t, api, scheduleForRouteURL(routeID, "0"))
 
 		assert.Equal(t, http.StatusOK, resp.StatusCode)
 		assert.Equal(t, 510, model.Code)
@@ -111,8 +123,7 @@ func TestScheduleForRouteHandlerDateParam(t *testing.T) {
 
 	t.Run("Epoch ms for valid service date returns schedule", func(t *testing.T) {
 		// 1749711600000 = 2025-06-12 00:00:00 PDT (America/Los_Angeles), which has RABA service.
-		endpoint := "/api/where/schedule-for-route/" + routeID + ".json?key=TEST&date=1749711600000"
-		resp, model := callAPIHandler[ScheduleForRouteResponse](t, api, endpoint)
+		resp, model := callAPIHandler[ScheduleForRouteResponse](t, api, scheduleForRouteURL(routeID, "1749711600000"))
 
 		assert.Equal(t, http.StatusOK, resp.StatusCode)
 		assert.Equal(t, http.StatusOK, model.Code)
@@ -126,15 +137,13 @@ func TestScheduleForRouteHandlerDateParam(t *testing.T) {
 // uses only c_868_b_79978_d_31, while several other services are active on
 // the same weekday — the response must include only the route-scoped set.
 func TestScheduleForRouteHandler_ServiceIDsScopedToRoute(t *testing.T) {
-	clk := clock.NewMockClock(time.Date(2025, 6, 12, 12, 0, 0, 0, time.UTC))
-	api := createTestApiWithClock(t, clk)
+	api := newScheduleForRouteAPI(t)
 	defer api.Shutdown()
 
 	routeID := utils.FormCombinedID("25", "1885")
 	expectedServiceID := utils.FormCombinedID("25", "c_868_b_79978_d_31")
 
-	endpoint := "/api/where/schedule-for-route/" + routeID + ".json?key=TEST&date=2025-06-12"
-	resp, model := callAPIHandler[ScheduleForRouteResponse](t, api, endpoint)
+	resp, model := callAPIHandler[ScheduleForRouteResponse](t, api, scheduleForRouteURL(routeID, "2025-06-12"))
 
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 
@@ -143,13 +152,11 @@ func TestScheduleForRouteHandler_ServiceIDsScopedToRoute(t *testing.T) {
 }
 
 func TestScheduleForRouteHandler_DirectionIDMatchesCSV(t *testing.T) {
-	clk := clock.NewMockClock(time.Date(2025, 6, 12, 12, 0, 0, 0, time.UTC))
-	api := createTestApiWithClock(t, clk)
+	api := newScheduleForRouteAPI(t)
 	defer api.Shutdown()
 
 	routeID := utils.FormCombinedID("25", "1885")
-	endpoint := "/api/where/schedule-for-route/" + routeID + ".json?key=TEST&date=2025-06-12"
-	resp, model := callAPIHandler[ScheduleForRouteResponse](t, api, endpoint)
+	resp, model := callAPIHandler[ScheduleForRouteResponse](t, api, scheduleForRouteURL(routeID, "2025-06-12"))
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 
 	groupings := model.Data.Entry.StopTripGroupings
@@ -173,13 +180,11 @@ func TestScheduleForRouteHandler_DirectionIDMatchesCSV(t *testing.T) {
 }
 
 func TestScheduleForRouteHandler_WithReferences(t *testing.T) {
-	clk := clock.NewMockClock(time.Date(2025, 6, 12, 12, 0, 0, 0, time.UTC))
-	api := createTestApiWithClock(t, clk)
+	api := newScheduleForRouteAPI(t)
 	defer api.Shutdown()
 
 	routeID := testdata.Route1.ID
-	endpoint := "/api/where/schedule-for-route/" + routeID + ".json?key=TEST&date=2025-06-12"
-	resp, model := callAPIHandler[ScheduleForRouteResponse](t, api, endpoint)
+	resp, model := callAPIHandler[ScheduleForRouteResponse](t, api, scheduleForRouteURL(routeID, "2025-06-12"))
 
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NotEmpty(t, model.Data.References.Agencies)
@@ -190,13 +195,11 @@ func TestScheduleForRouteHandler_WithReferences(t *testing.T) {
 }
 
 func TestScheduleForRouteHandler_TripIDsSorted(t *testing.T) {
-	clk := clock.NewMockClock(time.Date(2025, 6, 12, 12, 0, 0, 0, time.UTC))
-	api := createTestApiWithClock(t, clk)
+	api := newScheduleForRouteAPI(t)
 	defer api.Shutdown()
 
 	routeID := testdata.Route1.ID
-	endpoint := "/api/where/schedule-for-route/" + routeID + ".json?key=TEST&date=2025-06-12"
-	resp, model := callAPIHandler[ScheduleForRouteResponse](t, api, endpoint)
+	resp, model := callAPIHandler[ScheduleForRouteResponse](t, api, scheduleForRouteURL(routeID, "2025-06-12"))
 
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 
@@ -212,8 +215,7 @@ func TestScheduleForRouteHandler_ServiceDateOutOfRange(t *testing.T) {
 	routeID := testdata.Route1.ID
 
 	t.Run("Future date beyond feed returns ServiceDateOutOfRange", func(t *testing.T) {
-		endpoint := "/api/where/schedule-for-route/" + routeID + ".json?key=TEST&date=2099-01-01"
-		resp, model := callAPIHandler[ScheduleForRouteResponse](t, api, endpoint)
+		resp, model := callAPIHandler[ScheduleForRouteResponse](t, api, scheduleForRouteURL(routeID, "2099-01-01"))
 
 		assert.Equal(t, http.StatusOK, resp.StatusCode)
 		assert.Equal(t, 510, model.Code)
@@ -222,8 +224,7 @@ func TestScheduleForRouteHandler_ServiceDateOutOfRange(t *testing.T) {
 	})
 
 	t.Run("Garbage date string returns ServiceDateOutOfRange", func(t *testing.T) {
-		endpoint := "/api/where/schedule-for-route/" + routeID + ".json?key=TEST&date=not-a-date"
-		resp, model := callAPIHandler[ScheduleForRouteResponse](t, api, endpoint)
+		resp, model := callAPIHandler[ScheduleForRouteResponse](t, api, scheduleForRouteURL(routeID, "not-a-date"))
 
 		assert.Equal(t, http.StatusOK, resp.StatusCode)
 		assert.Equal(t, 510, model.Code)
@@ -239,8 +240,7 @@ func TestScheduleForRouteHandler_NoServiceThatDay(t *testing.T) {
 
 	t.Run("Early date before feed returns NoServiceThatDay with references", func(t *testing.T) {
 		// 1970-01-01 is before any RABA calendar data but not after the feed end date.
-		endpoint := "/api/where/schedule-for-route/" + routeID + ".json?key=TEST&date=1970-01-01"
-		resp, model := callAPIHandler[ScheduleForRouteResponse](t, api, endpoint)
+		resp, model := callAPIHandler[ScheduleForRouteResponse](t, api, scheduleForRouteURL(routeID, "1970-01-01"))
 
 		assert.Equal(t, http.StatusOK, resp.StatusCode)
 		assert.Equal(t, 510, model.Code)
@@ -258,13 +258,11 @@ func TestScheduleForRouteHandler_NoServiceThatDay(t *testing.T) {
 }
 
 func TestScheduleForRouteHandler_TripReferenceCombinedIDs(t *testing.T) {
-	clk := clock.NewMockClock(time.Date(2025, 6, 12, 12, 0, 0, 0, time.UTC))
-	api := createTestApiWithClock(t, clk)
+	api := newScheduleForRouteAPI(t)
 	defer api.Shutdown()
 
 	routeID := testdata.Route1.ID
-	endpoint := "/api/where/schedule-for-route/" + routeID + ".json?key=TEST&date=2025-06-12"
-	resp, model := callAPIHandler[ScheduleForRouteResponse](t, api, endpoint)
+	resp, model := callAPIHandler[ScheduleForRouteResponse](t, api, scheduleForRouteURL(routeID, "2025-06-12"))
 
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NotEmpty(t, model.Data.References.Trips)
@@ -279,10 +277,7 @@ func TestScheduleForRouteHandlerWithMalformedID(t *testing.T) {
 	api := createTestApi(t)
 	defer api.Shutdown()
 
-	malformedID := "1110"
-	endpoint := "/api/where/schedule-for-route/" + malformedID + ".json?key=TEST"
-
-	resp, model := callAPIHandler[ScheduleForRouteResponse](t, api, endpoint)
+	resp, model := callAPIHandler[ScheduleForRouteResponse](t, api, scheduleForRouteURL("1110", ""))
 
 	assert.Equal(t, http.StatusBadRequest, resp.StatusCode, "Status code should be 400 Bad Request")
 	assert.Equal(t, http.StatusBadRequest, model.Code)

--- a/internal/restapi/schedule_for_route_handler_test.go
+++ b/internal/restapi/schedule_for_route_handler_test.go
@@ -108,6 +108,17 @@ func TestScheduleForRouteHandlerDateParam(t *testing.T) {
 		assert.Equal(t, 510, model.Code)
 		assert.Equal(t, "NoServiceThatDay", model.Text)
 	})
+
+	t.Run("Epoch ms for valid service date returns schedule", func(t *testing.T) {
+		// 1749711600000 = 2025-06-12 00:00:00 PDT (America/Los_Angeles), which has RABA service.
+		endpoint := "/api/where/schedule-for-route/" + routeID + ".json?key=TEST&date=1749711600000"
+		resp, model := callAPIHandler[ScheduleForRouteResponse](t, api, endpoint)
+
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		assert.Equal(t, http.StatusOK, model.Code)
+		assert.NotEqual(t, "NoServiceThatDay", model.Text)
+		assert.NotEmpty(t, model.Data.Entry.StopTripGroupings)
+	})
 }
 
 // Regression for #790: serviceIds must be derived from the route's actual

--- a/internal/restapi/schedule_for_route_handler_test.go
+++ b/internal/restapi/schedule_for_route_handler_test.go
@@ -29,6 +29,29 @@ func scheduleForRouteURL(routeID, date string) string {
 	return u
 }
 
+func assertScheduleOK(t *testing.T, resp *http.Response, model ScheduleForRouteResponse) {
+	t.Helper()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, http.StatusOK, model.Code)
+	assert.Equal(t, "OK", model.Text)
+}
+
+func assertScheduleErr(t *testing.T, resp *http.Response, model ScheduleForRouteResponse, wantCode int, wantText string) {
+	t.Helper()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, wantCode, model.Code)
+	assert.Equal(t, wantText, model.Text)
+}
+
+func laDate(t *testing.T, ymd string) time.Time {
+	t.Helper()
+	loc, err := time.LoadLocation("America/Los_Angeles")
+	require.NoError(t, err)
+	d, err := time.ParseInLocation("2006-01-02", ymd, loc)
+	require.NoError(t, err)
+	return d
+}
+
 func TestScheduleForRouteHandler(t *testing.T) {
 	api := newScheduleForRouteAPI(t)
 	defer api.Shutdown()
@@ -38,13 +61,9 @@ func TestScheduleForRouteHandler(t *testing.T) {
 	t.Run("Valid route", func(t *testing.T) {
 		resp, model := callAPIHandler[ScheduleForRouteResponse](t, api, scheduleForRouteURL(routeID, "2025-06-12"))
 
-		assert.Equal(t, http.StatusOK, resp.StatusCode)
-		assert.Equal(t, http.StatusOK, model.Code)
-		assert.Equal(t, "OK", model.Text)
+		assertScheduleOK(t, resp, model)
 
-		loc, err := time.LoadLocation("America/Los_Angeles")
-		require.NoError(t, err)
-		expectedScheduleDate, _ := time.ParseInLocation("2006-01-02", "2025-06-12", loc)
+		expectedScheduleDate := laDate(t, "2025-06-12")
 
 		entry := model.Data.Entry
 		assert.Equal(t, routeID, entry.RouteID)
@@ -93,32 +112,22 @@ func TestScheduleForRouteHandlerDateParam(t *testing.T) {
 	t.Run("No date param uses current date", func(t *testing.T) {
 		resp, model := callAPIHandler[ScheduleForRouteResponse](t, api, scheduleForRouteURL(routeID, ""))
 
-		assert.Equal(t, http.StatusOK, resp.StatusCode)
-		assert.Equal(t, http.StatusOK, model.Code)
-		assert.Equal(t, "OK", model.Text)
+		assertScheduleOK(t, resp, model)
 
 		// Clock is 2025-06-12 12:00 UTC = 2025-06-12 05:00 PDT, so start of day in LA is 2025-06-12.
-		loc, err := time.LoadLocation("America/Los_Angeles")
-		require.NoError(t, err)
-		expectedScheduleDate, _ := time.ParseInLocation("2006-01-02", "2025-06-12", loc)
+		expectedScheduleDate := laDate(t, "2025-06-12")
 		assert.Equal(t, expectedScheduleDate.UnixMilli(), model.Data.Entry.ScheduleDate)
 	})
 
 	t.Run("Invalid date format returns ServiceDateOutOfRange", func(t *testing.T) {
 		resp, model := callAPIHandler[ScheduleForRouteResponse](t, api, scheduleForRouteURL(routeID, "2025/06/12"))
-
-		assert.Equal(t, http.StatusOK, resp.StatusCode)
-		assert.Equal(t, 510, model.Code)
-		assert.Equal(t, "ServiceDateOutOfRange", model.Text)
+		assertScheduleErr(t, resp, model, 510, "ServiceDateOutOfRange")
 	})
 
 	t.Run("Epoch ms date parsed as Java OBA compatibility", func(t *testing.T) {
 		// date=0 → epoch start (1970-01-01 00:00:00 UTC) → before any RABA service → NoServiceThatDay
 		resp, model := callAPIHandler[ScheduleForRouteResponse](t, api, scheduleForRouteURL(routeID, "0"))
-
-		assert.Equal(t, http.StatusOK, resp.StatusCode)
-		assert.Equal(t, 510, model.Code)
-		assert.Equal(t, "NoServiceThatDay", model.Text)
+		assertScheduleErr(t, resp, model, 510, "NoServiceThatDay")
 	})
 
 	t.Run("Epoch ms for valid service date returns schedule", func(t *testing.T) {
@@ -216,19 +225,13 @@ func TestScheduleForRouteHandler_ServiceDateOutOfRange(t *testing.T) {
 
 	t.Run("Future date beyond feed returns ServiceDateOutOfRange", func(t *testing.T) {
 		resp, model := callAPIHandler[ScheduleForRouteResponse](t, api, scheduleForRouteURL(routeID, "2099-01-01"))
-
-		assert.Equal(t, http.StatusOK, resp.StatusCode)
-		assert.Equal(t, 510, model.Code)
-		assert.Equal(t, "ServiceDateOutOfRange", model.Text)
+		assertScheduleErr(t, resp, model, 510, "ServiceDateOutOfRange")
 		assert.Empty(t, model.Data.Entry.RouteID, "data.entry should be absent for ServiceDateOutOfRange")
 	})
 
 	t.Run("Garbage date string returns ServiceDateOutOfRange", func(t *testing.T) {
 		resp, model := callAPIHandler[ScheduleForRouteResponse](t, api, scheduleForRouteURL(routeID, "not-a-date"))
-
-		assert.Equal(t, http.StatusOK, resp.StatusCode)
-		assert.Equal(t, 510, model.Code)
-		assert.Equal(t, "ServiceDateOutOfRange", model.Text)
+		assertScheduleErr(t, resp, model, 510, "ServiceDateOutOfRange")
 	})
 }
 
@@ -242,9 +245,7 @@ func TestScheduleForRouteHandler_NoServiceThatDay(t *testing.T) {
 		// 1970-01-01 is before any RABA calendar data but not after the feed end date.
 		resp, model := callAPIHandler[ScheduleForRouteResponse](t, api, scheduleForRouteURL(routeID, "1970-01-01"))
 
-		assert.Equal(t, http.StatusOK, resp.StatusCode)
-		assert.Equal(t, 510, model.Code)
-		assert.Equal(t, "NoServiceThatDay", model.Text)
+		assertScheduleErr(t, resp, model, 510, "NoServiceThatDay")
 
 		entry := model.Data.Entry
 		assert.NotEmpty(t, entry.RouteID, "routeId should be present in NoServiceThatDay")


### PR DESCRIPTION
## Summary
- Return 510 `ServiceDateOutOfRange` (no data) when date exceeds feed calendar end or is unparseable
- Return 510 `NoServiceThatDay` (with entry + agency/route references) when date is in range but no trips run
- Accept numeric epoch-ms timestamps as `date` param (Java OBA compatibility)
- Fix `references.trips[].routeId` and `serviceId` to use combined `{agencyId}_{id}` format
- Fix `arrivalEnabled`/`departureEnabled` to be `true` only when time > 0




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Date parsing accepts YYYY-MM-DD (in agency timezone) and epoch-milliseconds; malformed/future dates now return a clear "ServiceDateOutOfRange" response instead of HTTP 400.
  * Arrival/departure availability flags set only when times are positive.

* **New Features**
  * Schedule API returns a distinct "NoServiceThatDay" response (with required agency/route references) when no service exists for the date.

* **Tests**
  * Expanded tests for date formats, separate out-of-range vs no-service flows, and combined route+service trip references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->