### PR TITLE
Add govulncheck to CI for vulnerability scanning

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -142,3 +142,23 @@ jobs:
       - name: Run race detector on concurrent packages
         run: go test -race -v -tags='sqlite_fts5 sqlite_math_functions' -timeout 20m ./internal/gtfs/...
         shell: bash
+
+  vuln_check:
+    name: Vulnerability Check
+    runs-on: ubuntu-latest
+    continue-on-error: true 
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.24'
+          cache: true
+          check-latest: true
+
+      - name: Check for vulnerabilities
+        run: go run golang.org/x/vuln/cmd/govulncheck@latest ./...


### PR DESCRIPTION
- This PR adds a standalone `vuln_check` job to the CI workflow that runs `govulncheck ./...` against the codebase on every push request to catch known CVEs in Go dependencies before they ship.

### Why `continue-on-error` flag:
- Setting `continue-on-error: true` adds visibility into vulnerabilities without blocking merges while the project remains on Go 1.24. Once the project bumps to Go 1.25, `continue-on-error` can be removed and the job becomes a hard gate.

FIX: #884  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced automated security scanning to verify dependencies for known vulnerabilities during the development process.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OneBusAway/maglev/pull/921)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->