### PR TITLE
refactor: add helpers for creating null strings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -342,13 +342,11 @@ When a single feed refreshes, only its per-feed sub-map is overwritten; other fe
 
 ### Working with sqlc Models
 
-Database models use `sql.NullString` for optional fields:
+Database models use `sql.NullString` for optional fields. Use helpers in the
+nulls package for working with nullable SQL types.
 
 ```go
-// Always check .Valid before accessing .String
-if route.ShortName.Valid {
-    shortName = route.ShortName.String
-}
+shortName := nulls.StringOrEmpty(route.ShortName)
 ```
 
 Common nullable fields: `ShortName`, `LongName`, `Desc`, `Url`, `Color`, `TextColor`

--- a/gtfsdb/bulk_insert_frequency_test.go
+++ b/gtfsdb/bulk_insert_frequency_test.go
@@ -2,7 +2,6 @@ package gtfsdb
 
 import (
 	"context"
-	"database/sql"
 	"testing"
 	"time"
 
@@ -10,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"maglev.onebusaway.org/internal/appconf"
+	"maglev.onebusaway.org/internal/nulls"
 )
 
 // hoursAfterMidnight returns the int64 nanoseconds-since-midnight value
@@ -43,7 +43,7 @@ func createFrequencyTestClient(t *testing.T) *Client {
 	_, err = client.Queries.CreateRoute(ctx, CreateRouteParams{
 		ID:        "test_route",
 		AgencyID:  "test_agency",
-		ShortName: sql.NullString{String: "TEST", Valid: true},
+		ShortName: nulls.String("TEST"),
 		Type:      3,
 	})
 	require.NoError(t, err)
@@ -64,7 +64,7 @@ func createFrequencyTestClient(t *testing.T) *Client {
 
 	_, err = client.Queries.CreateStop(ctx, CreateStopParams{
 		ID:   "stop_1",
-		Name: sql.NullString{String: "Test Stop", Valid: true},
+		Name: nulls.String("Test Stop"),
 		Lat:  40.0,
 		Lon:  -74.0,
 	})
@@ -76,7 +76,7 @@ func createFrequencyTestClient(t *testing.T) *Client {
 			ID:           tripID,
 			RouteID:      "test_route",
 			ServiceID:    "test_service",
-			TripHeadsign: sql.NullString{String: "Test", Valid: true},
+			TripHeadsign: nulls.String("Test"),
 		})
 		require.NoError(t, err)
 	}

--- a/gtfsdb/bulk_insert_test.go
+++ b/gtfsdb/bulk_insert_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"maglev.onebusaway.org/internal/appconf"
+	"maglev.onebusaway.org/internal/nulls"
 )
 
 func TestBulkInsertStopTimes(t *testing.T) {
@@ -35,7 +36,7 @@ func TestBulkInsertStopTimes(t *testing.T) {
 	_, err = client.Queries.CreateRoute(ctx, CreateRouteParams{
 		ID:        "test_route",
 		AgencyID:  "test_agency",
-		ShortName: sql.NullString{String: "TEST", Valid: true},
+		ShortName: nulls.String("TEST"),
 		Type:      3,
 	})
 	require.NoError(t, err)
@@ -57,7 +58,7 @@ func TestBulkInsertStopTimes(t *testing.T) {
 	// Create a test stop
 	_, err = client.Queries.CreateStop(ctx, CreateStopParams{
 		ID:   "stop_1",
-		Name: sql.NullString{String: "Test Stop", Valid: true},
+		Name: nulls.String("Test Stop"),
 		Lat:  40.0,
 		Lon:  -74.0,
 	})
@@ -68,7 +69,7 @@ func TestBulkInsertStopTimes(t *testing.T) {
 		ID:           "test_trip",
 		RouteID:      "test_route",
 		ServiceID:    "test_service",
-		TripHeadsign: sql.NullString{String: "Test", Valid: true},
+		TripHeadsign: nulls.String("Test"),
 	})
 	require.NoError(t, err)
 
@@ -279,7 +280,7 @@ func TestBulkInsertPerformance(t *testing.T) {
 	_, err = client.Queries.CreateRoute(ctx, CreateRouteParams{
 		ID:        "perf_route",
 		AgencyID:  "perf_agency",
-		ShortName: sql.NullString{String: "PERF", Valid: true},
+		ShortName: nulls.String("PERF"),
 		Type:      3,
 	})
 	require.NoError(t, err)
@@ -301,7 +302,7 @@ func TestBulkInsertPerformance(t *testing.T) {
 	// Create a test stop
 	_, err = client.Queries.CreateStop(ctx, CreateStopParams{
 		ID:   "stop_1",
-		Name: sql.NullString{String: "Performance Test Stop", Valid: true},
+		Name: nulls.String("Performance Test Stop"),
 		Lat:  40.0,
 		Lon:  -74.0,
 	})
@@ -312,7 +313,7 @@ func TestBulkInsertPerformance(t *testing.T) {
 		ID:           "perf_trip",
 		RouteID:      "perf_route",
 		ServiceID:    "perf_service",
-		TripHeadsign: sql.NullString{String: "Performance", Valid: true},
+		TripHeadsign: nulls.String("Performance"),
 	})
 	require.NoError(t, err)
 

--- a/gtfsdb/fts_queries_test.go
+++ b/gtfsdb/fts_queries_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"maglev.onebusaway.org/internal/appconf"
+	"maglev.onebusaway.org/internal/nulls"
 )
 
 func createFTSTestClient(t *testing.T) *Client {
@@ -42,27 +43,27 @@ func TestSearchRoutesByFullText(t *testing.T) {
 	routes := []CreateRouteParams{
 		{
 			ID: "r1", AgencyID: "agency1",
-			ShortName: toNullString("10"), LongName: toNullString("Downtown Express"),
-			Desc: toNullString("Express service through downtown"),
-			Type: 3, Url: toNullString("http://test.com/r1"),
-			Color: toNullString("FF0000"), TextColor: toNullString("FFFFFF"),
+			ShortName: nulls.String("10"), LongName: nulls.String("Downtown Express"),
+			Desc: nulls.String("Express service through downtown"),
+			Type: 3, Url: nulls.String("http://test.com/r1"),
+			Color: nulls.String("FF0000"), TextColor: nulls.String("FFFFFF"),
 			ContinuousPickup:  sql.NullInt64{Int64: 1, Valid: true},
 			ContinuousDropOff: sql.NullInt64{Int64: 2, Valid: true},
 		},
 		{
 			ID: "r2", AgencyID: "agency1",
-			ShortName: toNullString("20"), LongName: toNullString("Airport Shuttle"),
+			ShortName: nulls.String("20"), LongName: nulls.String("Airport Shuttle"),
 			Type: 3,
 		},
 		{
 			ID: "r3", AgencyID: "agency1",
-			ShortName: toNullString("30"), LongName: toNullString("Downtown Local"),
+			ShortName: nulls.String("30"), LongName: nulls.String("Downtown Local"),
 			Type: 3,
 		},
 		// Route with NULL short_name to verify FTS trigger coalesce + nullable scan
 		{
 			ID: "r4", AgencyID: "agency1",
-			LongName: toNullString("Riverfront Circulator"),
+			LongName: nulls.String("Riverfront Circulator"),
 			Type:     3,
 		},
 	}
@@ -211,23 +212,23 @@ func TestSearchStopsByName(t *testing.T) {
 	// Insert test stops with varied fields to verify correct column scanning
 	stops := []CreateStopParams{
 		{
-			ID: "s1", Name: toNullString("Main Street Station"),
-			Code: toNullString("MS01"),
+			ID: "s1", Name: nulls.String("Main Street Station"),
+			Code: nulls.String("MS01"),
 			Lat:  40.0, Lon: -74.0,
 			LocationType:       sql.NullInt64{Int64: 1, Valid: true},
 			WheelchairBoarding: sql.NullInt64{Int64: 1, Valid: true},
-			Direction:          toNullString("N"),
+			Direction:          nulls.String("N"),
 		},
 		{
-			ID: "s2", Name: toNullString("Airport Terminal"),
+			ID: "s2", Name: nulls.String("Airport Terminal"),
 			Lat: 40.1, Lon: -74.1,
 		},
 		{
-			ID: "s3", Name: toNullString("Main Street Mall"),
+			ID: "s3", Name: nulls.String("Main Street Mall"),
 			Lat: 40.2, Lon: -74.2,
 		},
 		{
-			ID: "hub1", Name: toNullString("Main Street Hub"),
+			ID: "hub1", Name: nulls.String("Main Street Hub"),
 			Lat: 40.0, Lon: -74.0,
 		},
 	}

--- a/gtfsdb/helpers.go
+++ b/gtfsdb/helpers.go
@@ -19,6 +19,7 @@ import (
 	"github.com/OneBusAway/go-gtfs"
 	"maglev.onebusaway.org/internal/appconf"
 	"maglev.onebusaway.org/internal/logging"
+	"maglev.onebusaway.org/internal/nulls"
 )
 
 //go:embed schema.sql
@@ -267,10 +268,10 @@ func (c *Client) StoreGtfsData(ctx context.Context, data *GtfsData) (bool, error
 			Name:     a.Name,
 			Url:      a.Url,
 			Timezone: a.Timezone,
-			Lang:     toNullString(a.Language),
-			Phone:    toNullString(a.Phone),
-			FareUrl:  toNullString(a.FareUrl),
-			Email:    toNullString(a.Email),
+			Lang:     nulls.String(a.Language),
+			Phone:    nulls.String(a.Phone),
+			FareUrl:  nulls.String(a.FareUrl),
+			Email:    nulls.String(a.Email),
 		}
 
 		_, err := qtx.CreateAgency(ctx, params)
@@ -288,13 +289,13 @@ func (c *Client) StoreGtfsData(ctx context.Context, data *GtfsData) (bool, error
 		route := CreateRouteParams{
 			ID:                r.Id,
 			AgencyID:          pickFirstAvailable(r.Agency.Id, singleAgencyID),
-			ShortName:         toNullString(r.ShortName),
-			LongName:          toNullString(r.LongName),
-			Desc:              toNullString(r.Description),
+			ShortName:         nulls.String(r.ShortName),
+			LongName:          nulls.String(r.LongName),
+			Desc:              nulls.String(r.Description),
 			Type:              int64(r.Type),
-			Url:               toNullString(r.Url),
-			Color:             toNullString(r.Color),
-			TextColor:         toNullString(r.TextColor),
+			Url:               nulls.String(r.Url),
+			Color:             nulls.NonEmptyString(r.Color),
+			TextColor:         nulls.NonEmptyString(r.TextColor),
 			ContinuousPickup:  toNullInt64(int64(r.ContinuousPickup)),
 			ContinuousDropOff: toNullInt64(int64(r.ContinuousDropOff)),
 		}
@@ -327,19 +328,19 @@ func (c *Client) StoreGtfsData(ctx context.Context, data *GtfsData) (bool, error
 		}
 		params := CreateStopParams{
 			ID:                 s.Id,
-			Code:               toNullString(s.Code),
-			Name:               toNullString(s.Name),
-			Desc:               toNullString(s.Description),
+			Code:               nulls.String(s.Code),
+			Name:               nulls.String(s.Name),
+			Desc:               nulls.String(s.Description),
 			Lat:                *s.Latitude,
 			Lon:                *s.Longitude,
-			ZoneID:             toNullString(s.ZoneId),
-			Url:                toNullString(s.Url),
+			ZoneID:             nulls.String(s.ZoneId),
+			Url:                nulls.String(s.Url),
 			LocationType:       toNullInt64(int64(s.Type)),
-			Timezone:           toNullString(s.Timezone),
+			Timezone:           nulls.String(s.Timezone),
 			WheelchairBoarding: toNullInt64(int64(s.WheelchairBoarding)),
-			PlatformCode:       toNullString(s.PlatformCode),
+			PlatformCode:       nulls.String(s.PlatformCode),
 			Direction:          sql.NullString{}, // Will be computed later
-			ParentStation:      toNullString(parentStation),
+			ParentStation:      nulls.NonEmptyString(parentStation),
 		}
 
 		allStopParams = append(allStopParams, params)
@@ -389,11 +390,11 @@ func (c *Client) StoreGtfsData(ctx context.Context, data *GtfsData) (bool, error
 			ID:                   t.ID,
 			RouteID:              t.Route.Id,
 			ServiceID:            t.Service.Id,
-			TripHeadsign:         toNullString(t.Headsign),
-			TripShortName:        toNullString(t.ShortName),
+			TripHeadsign:         nulls.String(t.Headsign),
+			TripShortName:        nulls.String(t.ShortName),
 			DirectionID:          gtfsDirectionIDToDB(t.DirectionId),
-			BlockID:              toNullString(t.BlockID),
-			ShapeID:              toNullString(shapeID),
+			BlockID:              nulls.String(t.BlockID),
+			ShapeID:              nulls.NonEmptyString(shapeID),
 			WheelchairAccessible: toNullInt64(int64(t.WheelchairAccessible)),
 			BikesAllowed:         toNullInt64(int64(t.BikesAllowed)),
 		}
@@ -417,7 +418,7 @@ func (c *Client) StoreGtfsData(ctx context.Context, data *GtfsData) (bool, error
 				DepartureTime:     int64(st.DepartureTime),
 				StopID:            st.Stop.Id,
 				StopSequence:      int64(st.StopSequence),
-				StopHeadsign:      toNullString(st.Headsign),
+				StopHeadsign:      nulls.String(st.Headsign),
 				PickupType:        toNullInt64(int64(st.PickupType)),
 				DropOffType:       toNullInt64(int64(st.DropOffType)),
 				ShapeDistTraveled: toNullFloat64(shapeDistTraveled),
@@ -698,19 +699,6 @@ func toNullFloat64(f float64) sql.NullFloat64 {
 		}
 	}
 	return sql.NullFloat64{}
-}
-
-// toNullString converts a string to sql.NullString (unexported, for internal use)
-func toNullString(s string) sql.NullString {
-	return sql.NullString{
-		String: s,
-		Valid:  s != "",
-	}
-}
-
-// ToNullString converts a string to sql.NullString, with empty strings becoming NULL (exported).
-func ToNullString(s string) sql.NullString {
-	return toNullString(s)
 }
 
 // ParseNullFloat parses a string to sql.NullFloat64, with empty or invalid values becoming NULL.
@@ -1352,7 +1340,7 @@ func (c *Client) buildBlockTripIndex(ctx context.Context, staticData *gtfs.Stati
 				err = qtx.CreateBlockTripEntry(ctx, CreateBlockTripEntryParams{
 					BlockTripIndexID:  indexID,
 					TripID:            trip.tripID,
-					BlockID:           toNullString(trip.blockID),
+					BlockID:           nulls.String(trip.blockID),
 					ServiceID:         trip.serviceID,
 					BlockTripSequence: int64(sequence),
 				})

--- a/gtfsdb/helpers_coverage_test.go
+++ b/gtfsdb/helpers_coverage_test.go
@@ -7,9 +7,6 @@ import (
 )
 
 func TestNullHelpersCoverage(t *testing.T) {
-	assert.True(t, ToNullString("val").Valid)
-	assert.False(t, ToNullString("").Valid)
-
 	f := ParseNullFloat("1.23")
 	assert.True(t, f.Valid)
 	assert.Equal(t, 1.23, f.Float64)

--- a/gtfsdb/sqlite_performance_test.go
+++ b/gtfsdb/sqlite_performance_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"maglev.onebusaway.org/internal/appconf"
+	"maglev.onebusaway.org/internal/nulls"
 )
 
 func TestSQLitePerformancePragmasApplied(t *testing.T) {
@@ -277,7 +278,7 @@ func TestSQLitePerformanceWithBulkOperations(t *testing.T) {
 	_, err = client.Queries.CreateRoute(ctx, CreateRouteParams{
 		ID:        "perf_route",
 		AgencyID:  "perf_agency",
-		ShortName: sql.NullString{String: "PERF", Valid: true},
+		ShortName: nulls.String("PERF"),
 		Type:      3,
 	})
 	require.NoError(t, err)
@@ -299,7 +300,7 @@ func TestSQLitePerformanceWithBulkOperations(t *testing.T) {
 	// Create a test stop
 	_, err = client.Queries.CreateStop(ctx, CreateStopParams{
 		ID:   "stop_1",
-		Name: sql.NullString{String: "Performance Test Stop", Valid: true},
+		Name: nulls.String("Performance Test Stop"),
 		Lat:  40.0,
 		Lon:  -74.0,
 	})

--- a/internal/gtfs/advanced_direction_calculator_test.go
+++ b/internal/gtfs/advanced_direction_calculator_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"maglev.onebusaway.org/gtfsdb"
 	"maglev.onebusaway.org/internal/models"
+	"maglev.onebusaway.org/internal/nulls"
 )
 
 // This uses a Singleton pattern to load the DB and Warm the Cache exactly ONCE
@@ -109,12 +110,12 @@ func TestCalculateStopDirectionResultCache(t *testing.T) {
 	_, calc := getSharedTestComponents(t)
 
 	// First call: precomputed direction "NE" from DB should be recognized
-	result := calc.CalculateStopDirection(context.Background(), "stop-1", sql.NullString{String: "NE", Valid: true})
+	result := calc.CalculateStopDirection(context.Background(), "stop-1", nulls.String("NE"))
 	assert.Equal(t, "NE", result, "should recognize compass abbreviation NE from precomputed direction")
 
 	// Verify that a stop with no GTFS direction falls through to computeFromShapes,
 	// gets an empty result (no data in cache for nonexistent stop), and caches the empty result.
-	result = calc.CalculateStopDirection(context.Background(), "nonexistent-stop", sql.NullString{Valid: false})
+	result = calc.CalculateStopDirection(context.Background(), "nonexistent-stop", sql.NullString{})
 	assert.Equal(t, "", result, "should return empty for stop with no direction data")
 
 	// The empty result should be cached (negative cache) — verify via sync.Map
@@ -123,7 +124,7 @@ func TestCalculateStopDirectionResultCache(t *testing.T) {
 	assert.Equal(t, "", cached.(string), "cached value should be empty string")
 
 	// Second call for same stop should return from cache without recomputation
-	result = calc.CalculateStopDirection(context.Background(), "nonexistent-stop", sql.NullString{Valid: false})
+	result = calc.CalculateStopDirection(context.Background(), "nonexistent-stop", sql.NullString{})
 	assert.Equal(t, "", result, "second call should return cached empty result")
 }
 
@@ -166,7 +167,7 @@ func TestCalculateStopDirectionPrecomputedAbbreviations(t *testing.T) {
 			result := calc.CalculateStopDirection(
 				context.Background(),
 				"stop-"+abbr,
-				sql.NullString{String: abbr, Valid: true},
+				nulls.String(abbr),
 			)
 			assert.Equal(t, expected, result)
 		})
@@ -211,22 +212,22 @@ func TestCalculateStopDirectionWithGtfsDirection(t *testing.T) {
 	}{
 		{
 			name:          "Valid text direction",
-			gtfsDirection: sql.NullString{String: "North", Valid: true},
+			gtfsDirection: nulls.String("North"),
 			expected:      "N",
 		},
 		{
 			name:          "Valid numeric direction",
-			gtfsDirection: sql.NullString{String: "90", Valid: true},
+			gtfsDirection: nulls.String("90"),
 			expected:      "E", // 90° in GTFS = East
 		},
 		{
 			name:          "Invalid direction falls through",
-			gtfsDirection: sql.NullString{String: "invalid", Valid: true},
+			gtfsDirection: nulls.String("invalid"),
 			expected:      "", // Would need shape data to compute
 		},
 		{
 			name:          "Null direction falls through",
-			gtfsDirection: sql.NullString{Valid: false},
+			gtfsDirection: sql.NullString{},
 			expected:      "", // Would need shape data to compute
 		},
 	}
@@ -280,7 +281,7 @@ func TestCalculateStopDirection_WithShapeData(t *testing.T) {
 	_, calc := getSharedTestComponents(t)
 
 	// Test with a real stop from RABA data
-	direction := calc.CalculateStopDirection(ctx, "7000", sql.NullString{Valid: false})
+	direction := calc.CalculateStopDirection(ctx, "7000", sql.NullString{})
 	// Should return a valid direction or empty string
 	assert.True(t, direction == "" || len(direction) <= 2)
 }
@@ -448,7 +449,7 @@ func TestCalculateStopDirection_VariadicSignature(t *testing.T) {
 
 	// Case 1: Caller provides the optimized direction (should be used instantly)
 	// We pass "North", expect "N"
-	dirProvided := calc.CalculateStopDirection(ctx, "any_stop", sql.NullString{String: "North", Valid: true})
+	dirProvided := calc.CalculateStopDirection(ctx, "any_stop", nulls.String("North"))
 	assert.Equal(t, "N", dirProvided, "Should use provided direction argument")
 
 	// Case 2: Caller omits the argument (should fall back to DB)

--- a/internal/gtfs/gtfs_manager_mock.go
+++ b/internal/gtfs/gtfs_manager_mock.go
@@ -2,11 +2,11 @@ package gtfs
 
 import (
 	"context"
-	"database/sql"
 	"time"
 
 	"github.com/OneBusAway/go-gtfs"
 	"maglev.onebusaway.org/gtfsdb"
+	"maglev.onebusaway.org/internal/nulls"
 )
 
 func (m *Manager) MockAddAgency(id, name string) {
@@ -32,7 +32,7 @@ func (m *Manager) MockAddRoute(id, agencyID, name string) {
 	_, _ = m.GtfsDB.Queries.CreateRoute(ctx, gtfsdb.CreateRouteParams{
 		ID:        id,
 		AgencyID:  agencyID,
-		ShortName: sql.NullString{String: name, Valid: true},
+		ShortName: nulls.String(name),
 	})
 }
 func (m *Manager) MockAddVehicle(vehicleID, tripID, routeID string) {

--- a/internal/models/problem_report_test.go
+++ b/internal/models/problem_report_test.go
@@ -6,17 +6,18 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"maglev.onebusaway.org/gtfsdb"
+	"maglev.onebusaway.org/internal/nulls"
 )
 
 func TestNewProblemReportTrip(t *testing.T) {
 	dbReport := gtfsdb.ProblemReportsTrip{
 		ID:            1,
 		TripID:        "trip-1",
-		ServiceDate:   sql.NullString{String: "20230101", Valid: true},
-		VehicleID:     sql.NullString{String: "veh-1", Valid: true},
-		StopID:        sql.NullString{String: "stop-1", Valid: true},
-		Code:          sql.NullString{String: "code-1", Valid: true},
-		UserComment:   sql.NullString{String: "late", Valid: true},
+		ServiceDate:   nulls.String("20230101"),
+		VehicleID:     nulls.String("veh-1"),
+		StopID:        nulls.String("stop-1"),
+		Code:          nulls.String("code-1"),
+		UserComment:   nulls.String("late"),
 		UserOnVehicle: sql.NullInt64{Int64: 1, Valid: true},
 	}
 	apiReport := NewProblemReportTrip(dbReport)
@@ -32,7 +33,7 @@ func TestNewProblemReportStop(t *testing.T) {
 	dbReport := gtfsdb.ProblemReportsStop{
 		ID:          2,
 		StopID:      "stop-2",
-		UserComment: sql.NullString{String: "dirty", Valid: true},
+		UserComment: nulls.String("dirty"),
 	}
 	apiReport := NewProblemReportStop(dbReport)
 

--- a/internal/nulls/database.go
+++ b/internal/nulls/database.go
@@ -40,3 +40,18 @@ func WheelchairBoardingOrUnknown(ni sql.NullInt64) gtfs.WheelchairBoarding {
 	}
 	return gtfs.WheelchairBoarding_NotSpecified
 }
+
+func String(value string) sql.NullString {
+	return sql.NullString{
+		String: value,
+		Valid:  true,
+	}
+}
+
+// NonEmptyString creates a sql.NullString from the given string, converting empty values to null.
+func NonEmptyString(value string) sql.NullString {
+	return sql.NullString{
+		String: value,
+		Valid:  value != "",
+	}
+}

--- a/internal/nulls/database_test.go
+++ b/internal/nulls/database_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestNullStringOrEmpty(t *testing.T) {
-	assert.Equal(t, "test", StringOrEmpty(sql.NullString{String: "test", Valid: true}))
+	assert.Equal(t, "test", StringOrEmpty(String("test")))
 	assert.Equal(t, "", StringOrEmpty(sql.NullString{String: "test", Valid: false}))
 }
 
@@ -22,6 +22,11 @@ func TestNullStringOrDefault(t *testing.T) {
 func TestNullInt64OrDefault(t *testing.T) {
 	assert.Equal(t, int64(42), Int64OrDefault(sql.NullInt64{Int64: 42, Valid: true}, 10))
 	assert.Equal(t, int64(10), Int64OrDefault(sql.NullInt64{Int64: 42, Valid: false}, 10))
+}
+
+func TestNonEmptyString(t *testing.T) {
+	assert.Equal(t, sql.NullString{String: "test", Valid: true}, NonEmptyString("test"))
+	assert.Equal(t, sql.NullString{String: "", Valid: false}, NonEmptyString(""))
 }
 
 func TestNullWheelchairBoardingOrUnknown(t *testing.T) {

--- a/internal/restapi/arrival_and_departure_for_stop_handler_test.go
+++ b/internal/restapi/arrival_and_departure_for_stop_handler_test.go
@@ -2,7 +2,6 @@ package restapi
 
 import (
 	"context"
-	"database/sql"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -16,6 +15,7 @@ import (
 	"maglev.onebusaway.org/gtfsdb"
 	internalgtfs "maglev.onebusaway.org/internal/gtfs"
 	"maglev.onebusaway.org/internal/models"
+	"maglev.onebusaway.org/internal/nulls"
 	"maglev.onebusaway.org/internal/restapi/testdata"
 	"maglev.onebusaway.org/internal/utils"
 )
@@ -497,7 +497,7 @@ func TestArrivalAndDepartureForStopHandler_MultiAgency_Regression(t *testing.T) 
 
 	_, err = queries.CreateStop(ctx, gtfsdb.CreateStopParams{
 		ID:   stopID,
-		Name: sql.NullString{String: "Shared Transit Center", Valid: true},
+		Name: nulls.String("Shared Transit Center"),
 		Lat:  47.6062,
 		Lon:  -122.3321,
 	})
@@ -517,8 +517,8 @@ func TestArrivalAndDepartureForStopHandler_MultiAgency_Regression(t *testing.T) 
 	_, err = queries.CreateRoute(ctx, gtfsdb.CreateRouteParams{
 		ID:        routeB_ID,
 		AgencyID:  agencyB,
-		ShortName: sql.NullString{String: "B-Line", Valid: true},
-		LongName:  sql.NullString{String: "Agency B Express", Valid: true},
+		ShortName: nulls.String("B-Line"),
+		LongName:  nulls.String("Agency B Express"),
 		Type:      3,
 	})
 	require.NoError(t, err)
@@ -542,7 +542,7 @@ func TestArrivalAndDepartureForStopHandler_MultiAgency_Regression(t *testing.T) 
 		ID:           tripB_ID,
 		RouteID:      routeB_ID,
 		ServiceID:    "service1",
-		TripHeadsign: sql.NullString{String: "Downtown", Valid: true},
+		TripHeadsign: nulls.String("Downtown"),
 	})
 	require.NoError(t, err)
 
@@ -746,13 +746,10 @@ func TestArrivalAndDepartureForStopHandler_LoopRouteStopSequence(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = queries.CreateStop(ctx, gtfsdb.CreateStopParams{
-		ID: stopID,
-		Name: sql.NullString{
-			String: "Loop Stop",
-			Valid:  true,
-		},
-		Lat: 47.0,
-		Lon: -122.0,
+		ID:   stopID,
+		Name: nulls.String("Loop Stop"),
+		Lat:  47.0,
+		Lon:  -122.0,
 	})
 	require.NoError(t, err)
 

--- a/internal/restapi/arrivals_and_departures_for_stop_handler_test.go
+++ b/internal/restapi/arrivals_and_departures_for_stop_handler_test.go
@@ -2,7 +2,6 @@ package restapi
 
 import (
 	"context"
-	"database/sql"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
@@ -15,6 +14,7 @@ import (
 	"maglev.onebusaway.org/gtfsdb"
 	"maglev.onebusaway.org/internal/clock"
 	internalgtfs "maglev.onebusaway.org/internal/gtfs"
+	"maglev.onebusaway.org/internal/nulls"
 	"maglev.onebusaway.org/internal/utils"
 )
 
@@ -478,7 +478,7 @@ func TestArrivalsAndDeparturesForStopHandler_MultiAgency_Regression(t *testing.T
 
 	_, err = queries.CreateStop(ctx, gtfsdb.CreateStopParams{
 		ID:   stopID,
-		Name: sql.NullString{String: "Shared Transit Center", Valid: true},
+		Name: nulls.String("Shared Transit Center"),
 		Lat:  47.6062,
 		Lon:  -122.3321,
 	})
@@ -497,8 +497,8 @@ func TestArrivalsAndDeparturesForStopHandler_MultiAgency_Regression(t *testing.T
 	_, err = queries.CreateRoute(ctx, gtfsdb.CreateRouteParams{
 		ID:        routeB_ID,
 		AgencyID:  agencyB,
-		ShortName: sql.NullString{String: "B-Line", Valid: true},
-		LongName:  sql.NullString{String: "Agency B Express", Valid: true},
+		ShortName: nulls.String("B-Line"),
+		LongName:  nulls.String("Agency B Express"),
 		Type:      3,
 	})
 	require.NoError(t, err)
@@ -522,7 +522,7 @@ func TestArrivalsAndDeparturesForStopHandler_MultiAgency_Regression(t *testing.T
 		ID:           tripB_ID,
 		RouteID:      routeB_ID,
 		ServiceID:    "service1",
-		TripHeadsign: sql.NullString{String: "Downtown", Valid: true},
+		TripHeadsign: nulls.String("Downtown"),
 	})
 	require.NoError(t, err)
 
@@ -657,7 +657,7 @@ func setupDelayPropTestData(t *testing.T, api *RestAPI, stopSeq int64) (stopCode
 
 	_, err = q.CreateStop(ctx, gtfsdb.CreateStopParams{
 		ID:   stopCode,
-		Name: sql.NullString{String: "Delay Test Stop", Valid: true},
+		Name: nulls.String("Delay Test Stop"),
 		Lat:  47.0,
 		Lon:  -122.0,
 	})
@@ -666,8 +666,8 @@ func setupDelayPropTestData(t *testing.T, api *RestAPI, stopSeq int64) (stopCode
 	_, err = q.CreateRoute(ctx, gtfsdb.CreateRouteParams{
 		ID:        routeID,
 		AgencyID:  agencyID,
-		ShortName: sql.NullString{String: "DT", Valid: true},
-		LongName:  sql.NullString{String: "Delay Test Route", Valid: true},
+		ShortName: nulls.String("DT"),
+		LongName:  nulls.String("Delay Test Route"),
 		Type:      3,
 	})
 	require.NoError(t, err)
@@ -691,7 +691,7 @@ func setupDelayPropTestData(t *testing.T, api *RestAPI, stopSeq int64) (stopCode
 		ID:        tripID,
 		RouteID:   routeID,
 		ServiceID: serviceID,
-		BlockID:   sql.NullString{String: "dp-block", Valid: true},
+		BlockID:   nulls.String("dp-block"),
 	})
 	require.NoError(t, err)
 
@@ -1109,7 +1109,7 @@ func TestPluralArrivals_TripUpdateWithoutVehicle(t *testing.T) {
 
 	_, err = queries.CreateStop(ctx, gtfsdb.CreateStopParams{
 		ID:   stopID,
-		Name: sql.NullString{String: "Trip Update Test Stop", Valid: true},
+		Name: nulls.String("Trip Update Test Stop"),
 		Lat:  40.5865,
 		Lon:  -122.3917,
 	})
@@ -1118,8 +1118,8 @@ func TestPluralArrivals_TripUpdateWithoutVehicle(t *testing.T) {
 	_, err = queries.CreateRoute(ctx, gtfsdb.CreateRouteParams{
 		ID:        routeID,
 		AgencyID:  agencyID,
-		ShortName: sql.NullString{String: "TU", Valid: true},
-		LongName:  sql.NullString{String: "Trip Update Line", Valid: true},
+		ShortName: nulls.String("TU"),
+		LongName:  nulls.String("Trip Update Line"),
 		Type:      3,
 	})
 	require.NoError(t, err)
@@ -1142,7 +1142,7 @@ func TestPluralArrivals_TripUpdateWithoutVehicle(t *testing.T) {
 		ID:           tripID,
 		RouteID:      routeID,
 		ServiceID:    "tu_service",
-		TripHeadsign: sql.NullString{String: "Test Destination", Valid: true},
+		TripHeadsign: nulls.String("Test Destination"),
 	})
 	require.NoError(t, err)
 
@@ -1235,7 +1235,7 @@ func TestArrivalsAndDeparturesForStop_VehicleWithNilID(t *testing.T) {
 
 	_, err = queries.CreateStop(ctx, gtfsdb.CreateStopParams{
 		ID:   stopID,
-		Name: sql.NullString{String: "Nil ID Test Stop", Valid: true},
+		Name: nulls.String("Nil ID Test Stop"),
 		Lat:  40.5865,
 		Lon:  -122.3917,
 	})

--- a/internal/restapi/block_handler.go
+++ b/internal/restapi/block_handler.go
@@ -3,7 +3,6 @@ package restapi
 import (
 	"cmp"
 	"context"
-	"database/sql"
 	"net/http"
 	"slices"
 	"strconv"
@@ -11,6 +10,7 @@ import (
 
 	"maglev.onebusaway.org/gtfsdb"
 	"maglev.onebusaway.org/internal/models"
+	"maglev.onebusaway.org/internal/nulls"
 	"maglev.onebusaway.org/internal/utils"
 )
 
@@ -35,7 +35,7 @@ func (api *RestAPI) blockHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	block, err := api.GtfsManager.GtfsDB.Queries.GetBlockDetails(ctx, sql.NullString{String: blockID, Valid: true})
+	block, err := api.GtfsManager.GtfsDB.Queries.GetBlockDetails(ctx, nulls.String(blockID))
 	if err != nil {
 		if ctx.Err() != nil {
 			api.clientCanceledResponse(w, r, ctx.Err())

--- a/internal/restapi/calculate_block_trip_sequence_test.go
+++ b/internal/restapi/calculate_block_trip_sequence_test.go
@@ -3,7 +3,6 @@ package restapi
 import (
 	"cmp"
 	"context"
-	"database/sql"
 	"math"
 	"slices"
 	"testing"
@@ -11,6 +10,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"maglev.onebusaway.org/internal/nulls"
 )
 
 func TestCalculateBlockTripSequence(t *testing.T) {
@@ -42,7 +42,7 @@ func TestCalculateBlockTripSequence(t *testing.T) {
 		}
 		seenBlocks[bid] = true
 
-		blockTrips, err := api.GtfsManager.GtfsDB.Queries.GetTripsByBlockID(ctx, sql.NullString{String: bid, Valid: true})
+		blockTrips, err := api.GtfsManager.GtfsDB.Queries.GetTripsByBlockID(ctx, nulls.String(bid))
 		if err != nil {
 			continue
 		}

--- a/internal/restapi/report_problem_with_stop_handler.go
+++ b/internal/restapi/report_problem_with_stop_handler.go
@@ -7,6 +7,7 @@ import (
 	"maglev.onebusaway.org/gtfsdb"
 	"maglev.onebusaway.org/internal/logging"
 	"maglev.onebusaway.org/internal/models"
+	"maglev.onebusaway.org/internal/nulls"
 	"maglev.onebusaway.org/internal/utils"
 )
 
@@ -50,8 +51,8 @@ func (api *RestAPI) reportProblemWithStopHandler(w http.ResponseWriter, r *http.
 	now := api.Clock.Now().UnixMilli()
 	params := gtfsdb.CreateProblemReportStopParams{
 		StopID:               stopID,
-		Code:                 gtfsdb.ToNullString(code),
-		UserComment:          gtfsdb.ToNullString(userComment),
+		Code:                 nulls.String(code),
+		UserComment:          nulls.String(userComment),
 		UserLat:              gtfsdb.ParseNullFloat(userLatStr),
 		UserLon:              gtfsdb.ParseNullFloat(userLonStr),
 		UserLocationAccuracy: gtfsdb.ParseNullFloat(userLocationAccuracy),

--- a/internal/restapi/report_problem_with_trip_handler.go
+++ b/internal/restapi/report_problem_with_trip_handler.go
@@ -7,6 +7,7 @@ import (
 	"maglev.onebusaway.org/gtfsdb"
 	"maglev.onebusaway.org/internal/logging"
 	"maglev.onebusaway.org/internal/models"
+	"maglev.onebusaway.org/internal/nulls"
 	"maglev.onebusaway.org/internal/utils"
 )
 
@@ -59,16 +60,16 @@ func (api *RestAPI) reportProblemWithTripHandler(w http.ResponseWriter, r *http.
 	now := api.Clock.Now().UnixMilli()
 	params := gtfsdb.CreateProblemReportTripParams{
 		TripID:               tripID,
-		ServiceDate:          gtfsdb.ToNullString(serviceDate),
-		VehicleID:            gtfsdb.ToNullString(vehicleID),
-		StopID:               gtfsdb.ToNullString(stopID),
-		Code:                 gtfsdb.ToNullString(code),
-		UserComment:          gtfsdb.ToNullString(userComment),
+		ServiceDate:          nulls.String(serviceDate),
+		VehicleID:            nulls.String(vehicleID),
+		StopID:               nulls.String(stopID),
+		Code:                 nulls.String(code),
+		UserComment:          nulls.String(userComment),
 		UserLat:              gtfsdb.ParseNullFloat(userLatStr),
 		UserLon:              gtfsdb.ParseNullFloat(userLonStr),
 		UserLocationAccuracy: gtfsdb.ParseNullFloat(userLocationAccuracy),
 		UserOnVehicle:        gtfsdb.ParseNullBool(userOnVehicle),
-		UserVehicleNumber:    gtfsdb.ToNullString(userVehicleNumber),
+		UserVehicleNumber:    nulls.String(userVehicleNumber),
 		CreatedAt:            now,
 		SubmittedAt:          now,
 	}

--- a/internal/restapi/servicedate_timezone_regression_test.go
+++ b/internal/restapi/servicedate_timezone_regression_test.go
@@ -2,7 +2,6 @@ package restapi
 
 import (
 	"context"
-	"database/sql"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -15,6 +14,7 @@ import (
 	"maglev.onebusaway.org/gtfsdb"
 	"maglev.onebusaway.org/internal/clock"
 	"maglev.onebusaway.org/internal/models"
+	"maglev.onebusaway.org/internal/nulls"
 	"maglev.onebusaway.org/internal/utils"
 )
 
@@ -44,14 +44,14 @@ func setupTzTestGTFS(t *testing.T, queries *gtfsdb.Queries, td tzTestData, activ
 
 	_, err = queries.CreateRoute(ctx, gtfsdb.CreateRouteParams{
 		ID: td.RouteID, AgencyID: td.AgencyID,
-		ShortName: sql.NullString{String: "TZ", Valid: true},
-		LongName:  sql.NullString{String: "TZ Route", Valid: true},
+		ShortName: nulls.String("TZ"),
+		LongName:  nulls.String("TZ Route"),
 		Type:      3,
 	})
 	require.NoError(t, err)
 
 	_, err = queries.CreateStop(ctx, gtfsdb.CreateStopParams{
-		ID: td.StopID, Name: sql.NullString{String: "TZ Stop", Valid: true},
+		ID: td.StopID, Name: nulls.String("TZ Stop"),
 		Lat: -36.8485, Lon: 174.7633,
 	})
 	require.NoError(t, err)
@@ -73,8 +73,8 @@ func setupTzTestGTFS(t *testing.T, queries *gtfsdb.Queries, td tzTestData, activ
 	// Trip 1: departs 06:00 (earlier in block)
 	_, err = queries.CreateTrip(ctx, gtfsdb.CreateTripParams{
 		ID: td.TripID1, RouteID: td.RouteID, ServiceID: td.ServiceID,
-		TripHeadsign: sql.NullString{String: "Early", Valid: true},
-		BlockID:      sql.NullString{String: td.BlockID, Valid: true},
+		TripHeadsign: nulls.String("Early"),
+		BlockID:      nulls.String(td.BlockID),
 	})
 	require.NoError(t, err)
 
@@ -87,8 +87,8 @@ func setupTzTestGTFS(t *testing.T, queries *gtfsdb.Queries, td tzTestData, activ
 	// Trip 2: departs 09:00 (later in block, our target)
 	_, err = queries.CreateTrip(ctx, gtfsdb.CreateTripParams{
 		ID: td.TripID2, RouteID: td.RouteID, ServiceID: td.ServiceID,
-		TripHeadsign: sql.NullString{String: "Late", Valid: true},
-		BlockID:      sql.NullString{String: td.BlockID, Valid: true},
+		TripHeadsign: nulls.String("Late"),
+		BlockID:      nulls.String(td.BlockID),
 	})
 	require.NoError(t, err)
 

--- a/internal/restapi/stop_handler_test.go
+++ b/internal/restapi/stop_handler_test.go
@@ -2,7 +2,6 @@ package restapi
 
 import (
 	"context"
-	"database/sql"
 	"net/http"
 	"testing"
 
@@ -11,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"maglev.onebusaway.org/gtfsdb"
 	"maglev.onebusaway.org/internal/models"
+	"maglev.onebusaway.org/internal/nulls"
 	"maglev.onebusaway.org/internal/utils"
 )
 
@@ -171,7 +171,7 @@ func TestStopHandlerMultiAgencyScenario(t *testing.T) {
 
 	_, err = queries.CreateStop(ctx, gtfsdb.CreateStopParams{
 		ID:   stopID,
-		Name: sql.NullString{String: "Shared Transit Center", Valid: true},
+		Name: nulls.String("Shared Transit Center"),
 		Lat:  47.6062,
 		Lon:  -122.3321,
 	})
@@ -191,7 +191,7 @@ func TestStopHandlerMultiAgencyScenario(t *testing.T) {
 	_, err = queries.CreateRoute(ctx, gtfsdb.CreateRouteParams{
 		ID:        routeB_ID,
 		AgencyID:  agencyB,
-		ShortName: sql.NullString{String: "B-Line", Valid: true},
+		ShortName: nulls.String("B-Line"),
 		Type:      3, // Bus
 	})
 	require.NoError(t, err)
@@ -201,7 +201,7 @@ func TestStopHandlerMultiAgencyScenario(t *testing.T) {
 	_, err = queries.CreateRoute(ctx, gtfsdb.CreateRouteParams{
 		ID:        routeA_ID,
 		AgencyID:  agencyA,
-		ShortName: sql.NullString{String: "A-Line", Valid: true},
+		ShortName: nulls.String("A-Line"),
 		Type:      3,
 	})
 	require.NoError(t, err)

--- a/internal/restapi/trips_for_location_handler.go
+++ b/internal/restapi/trips_for_location_handler.go
@@ -277,7 +277,7 @@ func (api *RestAPI) buildTripsForLocationEntries(
 
 			blockIDsNull := make([]sql.NullString, len(blockIDs))
 			for i, id := range blockIDs {
-				blockIDsNull[i] = sql.NullString{String: id, Valid: true}
+				blockIDsNull[i] = nulls.String(id)
 			}
 
 			params := gtfsdb.GetTripsByBlockIDsParams{

--- a/internal/restapi/trips_for_route_handler.go
+++ b/internal/restapi/trips_for_route_handler.go
@@ -210,7 +210,7 @@ func (api *RestAPI) tripsForRouteHandler(w http.ResponseWriter, r *http.Request)
 			return
 		}
 
-		blockIDNullStr := sql.NullString{String: blockID, Valid: true}
+		blockIDNullStr := nulls.String(blockID)
 
 		for _, sd := range serviceDays {
 			tripsInBlock, err := api.GtfsManager.GtfsDB.Queries.GetTripsInBlock(ctx, gtfsdb.GetTripsInBlockParams{

--- a/internal/restapi/trips_helper_test.go
+++ b/internal/restapi/trips_helper_test.go
@@ -14,6 +14,7 @@ import (
 	"maglev.onebusaway.org/gtfsdb"
 	internalgtfs "maglev.onebusaway.org/internal/gtfs"
 	"maglev.onebusaway.org/internal/models"
+	"maglev.onebusaway.org/internal/nulls"
 	"maglev.onebusaway.org/internal/utils"
 )
 
@@ -2069,7 +2070,7 @@ func TestGetNextAndPreviousTripIDs_SingleTripBlock(t *testing.T) {
 		ID:        tripID,
 		RouteID:   "1",
 		ServiceID: "1",
-		BlockID:   sql.NullString{String: "single_trip_block", Valid: true},
+		BlockID:   nulls.String("single_trip_block"),
 	})
 	require.NoError(t, err)
 
@@ -2087,7 +2088,7 @@ func TestGetNextAndPreviousTripIDs_SingleTripBlock(t *testing.T) {
 	err = queries.CreateBlockTripEntry(ctx, gtfsdb.CreateBlockTripEntryParams{
 		BlockTripIndexID:  indexID,
 		TripID:            tripID,
-		BlockID:           sql.NullString{String: "single_trip_block", Valid: true},
+		BlockID:           nulls.String("single_trip_block"),
 		ServiceID:         "1",
 		BlockTripSequence: 0,
 	})
@@ -2117,7 +2118,7 @@ func TestGetNextAndPreviousTripIDs_TripNotInBlockOnDate(t *testing.T) {
 		ID:        tripID,
 		RouteID:   "1",
 		ServiceID: "1",
-		BlockID:   sql.NullString{String: "missing_block", Valid: true},
+		BlockID:   nulls.String("missing_block"),
 	})
 	require.NoError(t, err)
 

--- a/internal/utils/filters_test.go
+++ b/internal/utils/filters_test.go
@@ -2,7 +2,6 @@ package utils
 
 import (
 	"context"
-	"database/sql"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -10,14 +9,8 @@ import (
 	"maglev.onebusaway.org/gtfsdb"
 	"maglev.onebusaway.org/internal/appconf"
 	"maglev.onebusaway.org/internal/models"
+	"maglev.onebusaway.org/internal/nulls"
 )
-
-func nullString(s string) sql.NullString {
-	if s == "" {
-		return sql.NullString{}
-	}
-	return sql.NullString{String: s, Valid: true}
-}
 
 func TestFilterAgencies(t *testing.T) {
 	tests := []struct {
@@ -74,10 +67,10 @@ func TestFilterAgencies(t *testing.T) {
 					Name:     "Agency One",
 					Url:      "http://one.com",
 					Timezone: "America/Los_Angeles",
-					Lang:     nullString("en"),
-					Phone:    nullString("555-1234"),
-					Email:    nullString("info@one.com"),
-					FareUrl:  nullString("http://one.com/fares"),
+					Lang:     nulls.String("en"),
+					Phone:    nulls.String("555-1234"),
+					Email:    nulls.String("info@one.com"),
+					FareUrl:  nulls.String("http://one.com/fares"),
 				},
 			},
 			present:  map[string]bool{"agency1": true},
@@ -105,10 +98,10 @@ func TestFilterAgencies_VerifyFields(t *testing.T) {
 			Name:     "Test Agency",
 			Url:      "http://test.com",
 			Timezone: "America/Los_Angeles",
-			Lang:     nullString("en"),
-			Phone:    nullString("555-0000"),
-			Email:    nullString("test@test.com"),
-			FareUrl:  nullString("http://test.com/fares"),
+			Lang:     nulls.String("en"),
+			Phone:    nulls.String("555-0000"),
+			Email:    nulls.String("test@test.com"),
+			FareUrl:  nulls.String("http://test.com/fares"),
 		},
 	}
 	present := map[string]bool{"test_agency": true}


### PR DESCRIPTION
Add helpers to nulls for creating null strings: one that allows empty values and one that maps them to null.

Migrate all usages of existing helpers or manual non-null NullString construction to these helpers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated guidance for managing nullable database fields with recommended helper patterns and best practices.

* **Refactor**
  * Improved and standardized internal handling of nullable field operations across the codebase to enhance consistency and maintainability.

* **Tests**
  * Updated test coverage and fixtures throughout multiple modules to reflect refined implementation patterns.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OneBusAway/maglev/pull/922)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->