### PR TITLE
Add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly


### PR DESCRIPTION
Addresses https://github.com/OneBusAway/maglev/issues/885 by adding a weekly Dependabot configuration for gomod and github-actions. Based on https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference\#package-ecosystem- there are no other valid ecosystems that could be considered here. Dependabot still needs to be enabled on the repository separately to scan for vulnerabilities but this file will allow for automated PRs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured automated dependency updates to check for new versions weekly across Go modules and GitHub Actions ecosystems.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OneBusAway/maglev/pull/923)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->