### PR TITLE
chore: Add `.golangci.yml` config and pin golangci-lint version in workflow

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Run linter
         uses: golangci/golangci-lint-action@v3
         with:
-          version: latest
+          version: v2.12.2
           args: --timeout=5m --build-tags='sqlite_fts5 sqlite_math_functions'
 
   test:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -56,7 +56,7 @@ jobs:
         run: go mod download
 
       - name: Run linter
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.12.2
           args: --timeout=5m --build-tags='sqlite_fts5 sqlite_math_functions'

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,7 +4,6 @@ run:
   build-tags:
     - sqlite_fts5
     - sqlite_math_functions
-    - integration
   allow-parallel-runners: true
 linters:
   default: none

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,23 @@
+version: "2"
+run:
+  timeout: 5m
+  build-tags:
+    - sqlite_fts5
+    - sqlite_math_functions
+    - integration
+  allow-parallel-runners: true
+linters:
+  default: none
+  enable:
+    - errcheck
+    - misspell
+  settings:
+    errcheck:
+      exclude-functions:
+        - (*database/sql.Rows).Close
+    misspell:
+      locale: US
+issues:
+  exclude-use-default: false
+  max-issues-per-linter: 0
+  max-same-issues: 0

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -17,6 +17,5 @@ linters:
     misspell:
       locale: US
 issues:
-  exclude-use-default: false
   max-issues-per-linter: 0
   max-same-issues: 0

--- a/cmd/api/lock_safety_test.go
+++ b/cmd/api/lock_safety_test.go
@@ -122,7 +122,7 @@ func TestHandlerLockSafety(t *testing.T) {
 			for {
 				select {
 				case <-readerCtx.Done():
-					t.Log("cancelled reader context for reader", id)
+					t.Log("canceled reader context for reader", id)
 					return
 				default:
 					req, err := http.NewRequestWithContext(readerCtx, "GET", url, nil)

--- a/internal/gtfs/parallel_realtime_test.go
+++ b/internal/gtfs/parallel_realtime_test.go
@@ -162,7 +162,7 @@ func TestParallelRealtimeUpdatesWithContextCancellation(t *testing.T) {
 	elapsed := time.Since(start)
 
 	// Should return quickly due to context cancellation
-	assert.Less(t, elapsed, 150*time.Millisecond, "Should return quickly when context is cancelled")
+	assert.Less(t, elapsed, 150*time.Millisecond, "Should return quickly when context is canceled")
 }
 
 func TestRealTimeDataConsistency(t *testing.T) {

--- a/internal/gtfs/realtime.go
+++ b/internal/gtfs/realtime.go
@@ -678,7 +678,7 @@ func (manager *Manager) rebuildMergedRealtimeLocked() {
 				}
 				// Only match route-level entities that have no stop or trip restriction.
 				// Entities with {routeId + stopId} are stop-specific alerts and are filed
-				// in byStop only (matching Java's inverted index bucket behaviour).
+				// in byStop only (matching Java's inverted index bucket behavior).
 				if entity.RouteID != nil && entity.StopID == nil && entity.TripID == nil && !seenRoute[*entity.RouteID] {
 					seenRoute[*entity.RouteID] = true
 					idx.byRoute[*entity.RouteID] = append(idx.byRoute[*entity.RouteID], alert)

--- a/internal/restapi/agencies_with_coverage_handler.go
+++ b/internal/restapi/agencies_with_coverage_handler.go
@@ -11,7 +11,7 @@ import (
 func (api *RestAPI) agenciesWithCoverageHandler(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
-	// Check if context is already cancelled
+	// Check if context is already canceled
 	if ctx.Err() != nil {
 		api.clientCanceledResponse(w, r, ctx.Err())
 		return

--- a/internal/restapi/block_handler_test.go
+++ b/internal/restapi/block_handler_test.go
@@ -510,7 +510,7 @@ func TestBlockHandlerContextCancellation(t *testing.T) {
 	api := createTestApi(t)
 	defer api.Shutdown()
 
-	t.Run("cancelled context should be handled gracefully", func(t *testing.T) {
+	t.Run("canceled context should be handled gracefully", func(t *testing.T) {
 		req, err := http.NewRequest("GET", "/api/where/block/25_1.json?key=TEST", nil)
 		require.NoError(t, err)
 

--- a/internal/restapi/context_cancellation_test.go
+++ b/internal/restapi/context_cancellation_test.go
@@ -72,8 +72,8 @@ func TestContextCancellationHandling(t *testing.T) {
 			// Execute the request
 			mux.ServeHTTP(w, req)
 
-			// The request should either complete normally or be cancelled
-			// If cancelled, we expect a timeout or cancellation error response
+			// The request should either complete normally or be canceled
+			// If canceled, we expect a timeout or cancellation error response
 			statusCode := w.Code
 
 			// Valid responses: 200 (completed), 401 (API validation), 500 (error), or timeout-related
@@ -136,12 +136,12 @@ func TestContextCancellationDuringDatabaseQueries(t *testing.T) {
 	api := createTestApi(t)
 	defer api.Shutdown()
 
-	t.Run("cancelled context in database query should be handled", func(t *testing.T) {
-		// Create a context that's already cancelled
+	t.Run("canceled context in database query should be handled", func(t *testing.T) {
+		// Create a context that's already canceled
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()
 
-		// Try to execute a database query with cancelled context
+		// Try to execute a database query with canceled context
 		_, err := api.GtfsManager.GtfsDB.Queries.ListAgencies(ctx)
 
 		// The query should either succeed (if fast enough) or return a context error

--- a/internal/restapi/stop_ids_for_agency_handler.go
+++ b/internal/restapi/stop_ids_for_agency_handler.go
@@ -26,7 +26,7 @@ func (api *RestAPI) stopIDsForAgencyHandler(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	// Check if context is already cancelled
+	// Check if context is already canceled
 	if ctx.Err() != nil {
 		api.clientCanceledResponse(w, r, ctx.Err())
 		return

--- a/internal/restapi/stops_for_agency_handler.go
+++ b/internal/restapi/stops_for_agency_handler.go
@@ -12,7 +12,7 @@ import (
 func (api *RestAPI) stopsForAgencyHandler(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
-	// Check if context is already cancelled
+	// Check if context is already canceled
 	if ctx.Err() != nil {
 		api.clientCanceledResponse(w, r, ctx.Err())
 		return

--- a/internal/restapi/stops_for_location_handler.go
+++ b/internal/restapi/stops_for_location_handler.go
@@ -87,7 +87,7 @@ func (api *RestAPI) stopsForLocationHandler(w http.ResponseWriter, r *http.Reque
 
 	ctx := r.Context()
 
-	// Check if context is already cancelled
+	// Check if context is already canceled
 	if ctx.Err() != nil {
 		api.clientCanceledResponse(w, r, ctx.Err())
 		return

--- a/internal/restapi/stops_for_route_handler.go
+++ b/internal/restapi/stops_for_route_handler.go
@@ -42,7 +42,7 @@ func (api *RestAPI) parseStopsForRouteParams(r *http.Request) stopsForRouteParam
 func (api *RestAPI) stopsForRouteHandler(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
-	// Check if context is already cancelled
+	// Check if context is already canceled
 	if ctx.Err() != nil {
 		api.clientCanceledResponse(w, r, ctx.Err())
 		return


### PR DESCRIPTION
Related : #886 

Added `.golangci.yml` config with basic linters and setting 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated golangci-lint action to pinned v2.12.2 and added configuration file to enforce consistent code quality standards and improve build reproducibility.
  * Standardized spelling conventions throughout the codebase to use American English (e.g., "canceled" vs "cancelled") in comments and test identifiers.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OneBusAway/maglev/pull/936)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->