### PR TITLE
ci: Run docker actions on pull request

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -3,17 +3,18 @@ on:
   push:
     branches:
       - main
-  release:
-    types: [ published ]
+  pull_request:
+    paths:
+      - 'Dockerfile'
+      - '.github/workflows/docker-publish.yml'
 
 permissions:
   contents: read
   packages: write
 
 jobs:
-  # Push to GHCR on every main branch commit
+  # Push to GHCR on every main branch commit; build-only on PRs
   buildx:
-    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
@@ -46,7 +47,7 @@ jobs:
           echo "Flags:     ${{ steps.buildx.outputs.flags }}"
           echo "Platforms: ${{ steps.buildx.outputs.platforms }}"
       - name: Login to GitHub Container Registry
-        if: steps.check.outputs.skip != 'true'
+        if: steps.check.outputs.skip != 'true' && github.event_name != 'pull_request'
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -58,53 +59,9 @@ jobs:
         with:
           context: .
           platforms: linux/amd64,linux/arm64
-          push: true
+          push: ${{ github.event_name != 'pull_request' }}
           tags: |
             ghcr.io/onebusaway/maglev:latest
             ghcr.io/onebusaway/maglev:${{ github.sha }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-
-  # Push to Docker Hub on published releases (non-prerelease only)
-  buildx-release:
-    if: ${{ github.event_name == 'release' && !github.event.release.prerelease }}
-    runs-on: ubuntu-latest
-    concurrency:
-      group: ${{ github.workflow }}-release
-      cancel-in-progress: false
-    steps:
-      - name: Compute image tag names
-        run: |
-          echo "IMAGE_TAG=$(echo $GITHUB_REF_NAME)" >> $GITHUB_ENV
-      - name: Checkout code
-        uses: actions/checkout@v6
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: linux/amd64,linux/arm64
-      - name: Set up Docker Buildx
-        id: buildx
-        uses: docker/setup-buildx-action@v3
-      - name: Inspect builder
-        run: |
-          echo "Name:      ${{ steps.buildx.outputs.name }}"
-          echo "Endpoint:  ${{ steps.buildx.outputs.endpoint }}"
-          echo "Status:    ${{ steps.buildx.outputs.status }}"
-          echo "Flags:     ${{ steps.buildx.outputs.flags }}"
-          echo "Platforms: ${{ steps.buildx.outputs.platforms }}"
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Build and push images
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: |
-            opentransitsoftwarefoundation/maglev:${{ env.IMAGE_TAG }}
-            opentransitsoftwarefoundation/maglev:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -23,6 +23,7 @@ jobs:
         uses: actions/checkout@v6
       - name: Check if build is needed
         id: check
+        if: github.event_name == 'push'
         run: |
           LATEST_SHA=$(git ls-remote origin refs/heads/main | awk '{print $1}')
           if [ "${{ github.sha }}" != "$LATEST_SHA" ]; then

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -1,0 +1,53 @@
+name: Docker Release
+on:
+  release:
+    types: [ published ]
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  # Push to Docker Hub on published releases (non-prerelease only)
+  buildx-release:
+    if: ${{ !github.event.release.prerelease }}
+    runs-on: ubuntu-latest
+    concurrency:
+      group: ${{ github.workflow }}-release
+      cancel-in-progress: false
+    steps:
+      - name: Compute image tag names
+        run: |
+          echo "IMAGE_TAG=$(echo $GITHUB_REF_NAME)" >> $GITHUB_ENV
+      - name: Checkout code
+        uses: actions/checkout@v6
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: linux/amd64,linux/arm64
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Inspect builder
+        run: |
+          echo "Name:      ${{ steps.buildx.outputs.name }}"
+          echo "Endpoint:  ${{ steps.buildx.outputs.endpoint }}"
+          echo "Status:    ${{ steps.buildx.outputs.status }}"
+          echo "Flags:     ${{ steps.buildx.outputs.flags }}"
+          echo "Platforms: ${{ steps.buildx.outputs.platforms }}"
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push images
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            opentransitsoftwarefoundation/maglev:${{ env.IMAGE_TAG }}
+            opentransitsoftwarefoundation/maglev:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
The docker workflow is not run on pull requests. This means that changes to the docker config (either via Dockerfile or the ci workflow) are only tested on main. Change the workflow to run the docker workflow (minus pushing the image) on pull requests. This will give us more confidence in changes to the docker config and workflow when changes are made to it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker image build and publishing workflows to support multi-architecture deployments and automate image publishing when releases are created.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OneBusAway/maglev/pull/937)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->