### PR TITLE
Remove path filter from the go workflow so it always runs

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -8,10 +8,6 @@ on:
       - 'go.mod'
       - 'go.sum'
   pull_request:
-    paths:
-      - '**.go'
-      - 'go.mod'
-      - 'go.sum'
 
 jobs:
   fmt:


### PR DESCRIPTION
Dependabot raised a PR on go.yml, bumping the linter version. This could break the build but we would never know since the go linter is not executed because the workflow only runs when .go files are modified. Run the go CI workflow on all PRs because we can't always predict what kind of file might break the build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD pipeline configuration to run checks on all pull requests without file-based filtering restrictions, while maintaining existing filters for push events.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OneBusAway/maglev/pull/938)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->