### PR TITLE
ci: bump setup-go to v6 and use go-version-file

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -18,9 +18,9 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
-          go-version: '1.24'
+          go-version-file: 'go.mod'
           cache: true
 
       - name: Check go fmt
@@ -43,9 +43,9 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
-          go-version: '1.24'
+          go-version-file: 'go.mod'
           cache: true
 
       - name: Download dependencies
@@ -69,9 +69,9 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Set up Go ${{ matrix.os }}
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
-          go-version: '1.24'
+          go-version-file: 'go.mod'
           cache: true
 
       - name: Download dependencies
@@ -127,9 +127,9 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
-          go-version: '1.24'
+          go-version-file: 'go.mod'
           cache: true
 
       - name: Download dependencies


### PR DESCRIPTION
setup-go v6 sets GOTOOLCHAIN=local by default, preventing Go from auto-downloading newer toolchains when a dependency declares a toolchain directive. This fixes lint failures caused by dependencies like golang.org/x/time v0.15.0 that declare a toolchain newer than the one installed in CI.

Also switches all jobs from a hardcoded go-version to go-version-file: go.mod so CI always uses the exact version declared in the module.