### PR TITLE
ci: Drop golangci-lint

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -34,29 +34,6 @@ jobs:
             exit 1
           fi
 
-  lint:
-    name: Lint
-    runs-on: ubuntu-latest
-    env:
-      CGO_ENABLED: 1
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Set up Go
-        uses: actions/setup-go@v6
-        with:
-          go-version-file: 'go.mod'
-          cache: true
-
-      - name: Download dependencies
-        run: go mod download
-
-      - name: Run linter
-        uses: golangci/golangci-lint-action@v3
-        with:
-          version: latest
-          args: --timeout=5m --build-tags='sqlite_fts5 sqlite_math_functions'
-
   test:
     name: Test
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Golangci-lint is causing issues when bumping other dependencies due to its reliance on specific minor versions of go. Linting is already done through go vet and sonar. Drop the dependency to make bumping other dependencies, and the version of go itself easier.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified the CI/CD pipeline by removing the lint job from automated workflow checks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OneBusAway/maglev/pull/940)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->