### PR TITLE
fix: update Docker base image to Go 1.25

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM golang:1.24-alpine AS builder
+FROM golang:1.25-alpine AS builder
 
 # Install build dependencies for CGO (required by mattn/go-sqlite3)
 RUN apk add --no-cache gcc musl-dev

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,5 +1,5 @@
 # Development Dockerfile with live reload support
-FROM golang:1.24-alpine
+FROM golang:1.25-alpine
 
 # Add build arguments for UID and GID to support different host users
 # Note: UID 1000 matches the default first user on most Linux systems.


### PR DESCRIPTION
## Summary

- Bumps `Dockerfile` and `Dockerfile.dev` from `golang:1.24-alpine` to `golang:1.25-alpine`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Go runtime base image from version 1.24 to 1.25 in both production and development Docker configurations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OneBusAway/maglev/pull/942)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->