### PR TITLE
ci: trigger Docker build on go.mod changes

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -7,6 +7,7 @@ on:
     paths:
       - 'Dockerfile'
       - '.github/workflows/docker-publish.yml'
+      - 'go.mod'
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

- Adds `go.mod` to the `pull_request` path filter in the Docker workflow

## Problem

The Docker PR check only fired when `Dockerfile` or the workflow file itself changed. A dependency update that bumps the minimum Go version in `go.mod` (like #934 did) also breaks the Docker build — but wasn't caught until after merge because `go.mod` wasn't in the path filter.

## Test plan

- [ ] Confirm this PR itself triggers the Docker build check

🤖 Generated with [Claude Code](https://claude.com/claude-code)