### PR TITLE
Fix: use version of go defined in go.mod when running stress tests

### DIFF
--- a/.github/workflows/loadtest-smoke.yml
+++ b/.github/workflows/loadtest-smoke.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24'
+          go-version-file: 'go.mod'
           cache: true
 
       - name: Download dependencies

--- a/.github/workflows/loadtest-stress.yml
+++ b/.github/workflows/loadtest-stress.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24'
+          go-version-file: 'go.mod'
           cache: true
 
       - name: Download dependencies

--- a/.github/workflows/loadtest-stress.yml
+++ b/.github/workflows/loadtest-stress.yml
@@ -3,6 +3,9 @@ name: Performance Stress Test (Nightly)
 on:
   push:
     branches: [main]
+  pull_request:
+    paths:
+      - '.github/workflows/loadtest-stress.yml'
   schedule:
     # Runs at 02:00 UTC every night
     - cron: '0 2 * * *'


### PR DESCRIPTION
Modify the stress test workflows to use the version of go defined in go.mod rather than hard-coding the go version in the workflow yml. This will make version bumps to go more reliable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflows to dynamically determine Go version from project configuration instead of using a fixed version, ensuring consistency across environments.
  * Enhanced load test workflow to trigger on workflow configuration changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OneBusAway/maglev/pull/951?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->