### PR TITLE
Add Dependabot docker ecosystem to track Dockerfile base images

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,11 @@ updates:
     schedule:
       interval: weekly
 
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly
+
   - package-ecosystem: github-actions
     directory: /
     schedule:


### PR DESCRIPTION
This should help keep docker images used for building in sync with changes to the go version.