### PR TITLE
Move TripStatus spec description to valid location

### DIFF
--- a/testdata/openapi.yml
+++ b/testdata/openapi.yml
@@ -1859,7 +1859,6 @@ components:
           description: The ID of the trip for the arriving vehicle.
         tripStatus:
           $ref: '#/components/schemas/TripStatus'
-          description: Trip-specific status for the arriving transit vehicle.
         vehicleId:
           type: string
           description: ID of the transit vehicle serving this trip.
@@ -2165,6 +2164,7 @@ components:
 
     TripStatus:
       type: object
+      description: Trip-specific status for the arriving transit vehicle.
       properties:
         activeTripId:
           type: string


### PR DESCRIPTION
All other properties in a $ref object are ignored so it is invalid to have both $ref and description for the tripStatus of ArrivalDepartureForStop. This diff moves the description to the referenced object so it can be reused by other objects that reference the TripStatus. Reviewers can confirm the warning exists by using https://editor.swagger.io/ or some other OpenAPI spec validator tool.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved API schema documentation structure for better clarity and consistency.

* **Refactor**
  * Reorganized field descriptions within API specifications.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OneBusAway/maglev/pull/963?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->