### PR TITLE
fix(ci): only run openapi check on PRs, not on main

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -58,6 +58,7 @@ jobs:
         run: go mod verify
 
       - name: Check OpenAPI spec is up to date with upstream
+        if: github.event_name == 'pull_request'
         run: bash scripts/check-openapi.sh
         shell: bash
 

--- a/testdata/openapi.yml
+++ b/testdata/openapi.yml
@@ -1,5 +1,5 @@
 # Source: https://github.com/OneBusAway/sdk-config/blob/main/openapi.yml
-# Fetched: 2026-03-31
+# Fetched: 2026-05-22
 openapi: 3.0.0
 info:
   title: OneBusAway
@@ -1859,7 +1859,6 @@ components:
           description: The ID of the trip for the arriving vehicle.
         tripStatus:
           $ref: '#/components/schemas/TripStatus'
-          description: Trip-specific status for the arriving transit vehicle.
         vehicleId:
           type: string
           description: ID of the transit vehicle serving this trip.
@@ -2165,6 +2164,7 @@ components:
 
     TripStatus:
       type: object
+      description: Trip-specific status for the arriving transit vehicle.
       properties:
         activeTripId:
           type: string


### PR DESCRIPTION
## What

The `check-openapi` CI step fetches the upstream OpenAPI spec at runtime and fails if it differs from our committed `testdata/openapi.yml`. It was running on both PRs and pushes to `main`.

## Why this is a problem on main

The check passing on a PR does not guarantee it will pass on `main` after merge. The upstream spec can be changed independently at any time, so if it changes between when a PR merges and when CI runs on the merge commit, the main build fails for a reason unrelated to the merged code.

This is a time-of-check to time-of-use problem: the condition checked on the PR branch is not necessarily the same condition being checked on main after merge.

## Fix

Scoped the step to `pull_request` events only. PRs still cannot merge a stale spec, which is the point of the check. Main builds are no longer affected by changes to the upstream spec.

Also updates `testdata/openapi.yml` to the current upstream version to clear the broken build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration workflow configuration to conditionally execute OpenAPI specification validation when pull requests are initiated, streamlining the CI pipeline.

* **Documentation**
  * Updated API schema documentation by refreshing metadata timestamps and reorganizing schema component descriptions to enhance documentation consistency and clarity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OneBusAway/maglev/pull/965?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->