### PR TITLE
fix: return HTTP 404 for unknown agency ID in stop-ids-for-agency

### DIFF
--- a/internal/restapi/stop_ids_for_agency_handler.go
+++ b/internal/restapi/stop_ids_for_agency_handler.go
@@ -22,7 +22,7 @@ func (api *RestAPI) stopIDsForAgencyHandler(w http.ResponseWriter, r *http.Reque
 		return
 	}
 	if agency == nil {
-		api.sendNull(w, r)
+		api.sendNotFound(w, r)
 		return
 	}
 

--- a/internal/restapi/stop_ids_for_agency_handler_test.go
+++ b/internal/restapi/stop_ids_for_agency_handler_test.go
@@ -57,8 +57,9 @@ func TestStopIdsForAgencyInvalidAgency(t *testing.T) {
 
 	resp, model := callAPIHandler[StopIDsForAgencyResponse](t, api, stopIdsForAgencyURL("invalid"))
 
-	assert.Equal(t, http.StatusOK, resp.StatusCode)
-	assert.Equal(t, "", model.Text)
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+	assert.Equal(t, http.StatusNotFound, model.Code)
+	assert.Equal(t, "resource not found", model.Text)
 }
 
 func TestStopIdsForAgencyMalformedAgencyId(t *testing.T) {


### PR DESCRIPTION
## Summary
Fixed stop-ids-for-agency endpoint to return HTTP 404 
when an unknown agency ID is provided instead of 
HTTP 200 with a null body.

## Problem
When an unknown agency ID is provided, the endpoint 
was returning HTTP 200 with a null body instead of 
a proper HTTP 404 response.

## Changes
- Updated agency handler to call sendNotFound() when 
  agency ID is not found in the transit graph

## Testing
Before fix:
Request: GET /api/where/stop-ids-for-agency/999.json?key=test
HTTP Status: 200
Body: null

After fix:
Request: GET /api/where/stop-ids-for-agency/999.json?key=test
HTTP Status: 404
Body: {"code":404,"currentTime":1779991625902,"text":"resource not found","version":2}

## Spec Reference
https://github.com/OneBusAway/maglev/wiki/stop-ids-for-agency

## Proof

<img width="1797" height="439" alt="image" src="https://github.com/user-attachments/assets/b45d418b-0e8b-44a1-b124-c50c94e643a8" />


Closes #974 

