### PR TITLE
Fix broken source code link in welcome page , fixes the #977

### DIFF
--- a/index.html
+++ b/index.html
@@ -71,7 +71,7 @@
         </p>
 
         <div class="links">
-            <a href="https://github.com/OneBusAway/onebusaway-maglev">View the Source Code</a>
+            <a href="https://github.com/OneBusAway/maglev">View the Source Code</a>
             <a href="https://developer.onebusaway.org/api/where/methods">API Documentation</a>
         </div>
     </div>


### PR DESCRIPTION
Fixes #977

## Changes
- Updated the "View the Source Code" link in `index.html` from 
  `https://github.com/OneBusAway/onebusaway-maglev` to 
  `https://github.com/OneBusAway/maglev`

## Testing
1. Run the server locally
2. Open http://localhost:4000
3. Click "View the Source Code" now redirects to the correct repository

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the footer "View the Source Code" link to point to the correct repository, ensuring users are directed to the proper project source for browsing and contributions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OneBusAway/maglev/pull/978?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->