### PR TITLE
test: add missing spec coverage tests for stop-ids-for-agency

### DIFF
--- a/internal/restapi/stop_ids_for_agency_handler_test.go
+++ b/internal/restapi/stop_ids_for_agency_handler_test.go
@@ -119,6 +119,8 @@ func TestStopIdsForAgencyReferencesAlwaysPresentAndEmpty(t *testing.T) {
 	assert.Empty(t, model.Data.References.Trips)
 	assert.NotNil(t, model.Data.References.Situations)
 	assert.Empty(t, model.Data.References.Situations)
+	assert.NotNil(t, model.Data.References.StopTimes)
+	assert.Empty(t, model.Data.References.StopTimes)
 }
 
 func TestStopIdsForAgencyVersionIsTwo(t *testing.T) {

--- a/internal/restapi/stop_ids_for_agency_handler_test.go
+++ b/internal/restapi/stop_ids_for_agency_handler_test.go
@@ -109,10 +109,15 @@ func TestStopIdsForAgencyReferencesAlwaysPresentAndEmpty(t *testing.T) {
 	resp, model := callAPIHandler[StopIDsForAgencyResponse](t, api, stopIdsForAgencyURL(testdata.Raba.ID))
 
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.NotNil(t, model.Data.References.Agencies)
 	assert.Empty(t, model.Data.References.Agencies)
+	assert.NotNil(t, model.Data.References.Routes)
 	assert.Empty(t, model.Data.References.Routes)
+	assert.NotNil(t, model.Data.References.Stops)
 	assert.Empty(t, model.Data.References.Stops)
+	assert.NotNil(t, model.Data.References.Trips)
 	assert.Empty(t, model.Data.References.Trips)
+	assert.NotNil(t, model.Data.References.Situations)
 	assert.Empty(t, model.Data.References.Situations)
 }
 

--- a/internal/restapi/stop_ids_for_agency_handler_test.go
+++ b/internal/restapi/stop_ids_for_agency_handler_test.go
@@ -70,3 +70,58 @@ func TestStopIdsForAgencyMalformedAgencyId(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 	assert.Equal(t, http.StatusBadRequest, model.Code)
 }
+
+func TestStopIdsForAgencyMissingApiKey(t *testing.T) {
+	api := createTestApi(t)
+	defer api.Shutdown()
+
+	resp, model := callAPIHandler[StopIDsForAgencyResponse](t, api, "/api/where/stop-ids-for-agency/"+testdata.Raba.ID+".json")
+
+	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+	assert.Equal(t, http.StatusUnauthorized, model.Code)
+	assert.Equal(t, "permission denied", model.Text)
+}
+
+func TestStopIdsForAgencyEmptyAgencyId(t *testing.T) {
+	api := createTestApi(t)
+	defer api.Shutdown()
+
+	resp, model := callAPIHandler[StopIDsForAgencyResponse](t, api, stopIdsForAgencyURL(""))
+
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	assert.Equal(t, http.StatusBadRequest, model.Code)
+}
+
+func TestStopIdsForAgencyLimitExceededIsFalse(t *testing.T) {
+	api := createTestApi(t)
+	defer api.Shutdown()
+
+	resp, model := callAPIHandler[StopIDsForAgencyResponse](t, api, stopIdsForAgencyURL(testdata.Raba.ID))
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.False(t, model.Data.LimitExceeded)
+}
+
+func TestStopIdsForAgencyReferencesAlwaysPresentAndEmpty(t *testing.T) {
+	api := createTestApi(t)
+	defer api.Shutdown()
+
+	resp, model := callAPIHandler[StopIDsForAgencyResponse](t, api, stopIdsForAgencyURL(testdata.Raba.ID))
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Empty(t, model.Data.References.Agencies)
+	assert.Empty(t, model.Data.References.Routes)
+	assert.Empty(t, model.Data.References.Stops)
+	assert.Empty(t, model.Data.References.Trips)
+	assert.Empty(t, model.Data.References.Situations)
+}
+
+func TestStopIdsForAgencyVersionIsTwo(t *testing.T) {
+	api := createTestApi(t)
+	defer api.Shutdown()
+
+	resp, model := callAPIHandler[StopIDsForAgencyResponse](t, api, stopIdsForAgencyURL(testdata.Raba.ID))
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, 2, model.Version)
+}


### PR DESCRIPTION
## Summary
Added missing test coverage for the stop-ids-for-agency endpoint 
to align with the spec.

## Tests Added
- TestStopIdsForAgencyMissingApiKey — missing API key returns 401
- TestStopIdsForAgencyEmptyAgencyId — empty agency ID returns 400
- TestStopIdsForAgencyLimitExceededIsFalse — limitExceeded is always false
- TestStopIdsForAgencyReferencesAlwaysPresentAndEmpty — references block always present and empty
- TestStopIdsForAgencyVersionIsTwo — version is always 2

## Tests Already Existing
- TestStopIdsForAgencyRequiresValidApiKey
- TestStopIdsForAgencyEndToEnd
- TestStopIdsForAgencyInvalidAgency
- TestStopIdsForAgencyMalformedAgencyId

## Testing
All tests pass: make test

<img width="945" height="411" alt="image" src="https://github.com/user-attachments/assets/ca4864e1-3d82-4b4e-a06b-1315c5a826a7" />



## Spec Reference
https://github.com/OneBusAway/maglev/wiki/stop-ids-for-agency

Closes #979 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for the `/stop-ids-for-agency` API endpoint, including validation of authentication requirements, input validation, and response structure consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->