### PR TITLE
fix: implement natural sorting for routeIds in /stop endpoint

### DIFF
--- a/internal/restapi/stop_handler.go
+++ b/internal/restapi/stop_handler.go
@@ -1,8 +1,11 @@
 package restapi
 
 import (
+	"cmp"
 	"net/http"
+	"slices"
 
+	"maglev.onebusaway.org/gtfsdb"
 	"maglev.onebusaway.org/internal/models"
 	"maglev.onebusaway.org/internal/nulls"
 	"maglev.onebusaway.org/internal/utils"
@@ -28,6 +31,28 @@ func (api *RestAPI) stopHandler(w http.ResponseWriter, r *http.Request) {
 		api.serverErrorResponse(w, r, err)
 		return
 	}
+
+	// Sort routes naturally by ShortName
+	slices.SortFunc(routes, func(a, b gtfsdb.GetRoutesForStopRow) int {
+		nameA := a.ShortName.String
+		if nameA == "" {
+			nameA = a.LongName.String
+		}
+
+		nameB := b.ShortName.String
+		if nameB == "" {
+			nameB = b.LongName.String
+		}
+
+		res := utils.NaturalCompare(nameA, nameB)
+		if res != 0 {
+			return res
+		}
+		if a.AgencyID != b.AgencyID {
+			return cmp.Compare(a.AgencyID, b.AgencyID)
+		}
+		return cmp.Compare(a.ID, b.ID)
+	})
 
 	combinedRouteIDs := make([]string, len(routes))
 	for i, route := range routes {

--- a/internal/restapi/stop_handler_test.go
+++ b/internal/restapi/stop_handler_test.go
@@ -203,3 +203,75 @@ func TestStopHandlerWithSituations(t *testing.T) {
 		"expected exactly one deduplicated situation despite matching multiple entities")
 	assert.Equal(t, alertID, model.Data.References.Situations[0].ID)
 }
+
+func TestStopHandler_NaturalSorting(t *testing.T) {
+	api := createTestApi(t)
+	defer api.Shutdown()
+
+	ctx := context.Background()
+	q := api.GtfsManager.GtfsDB.Queries
+
+	agencyID := "SortAgency"
+	stopID := "SortStop1"
+
+	// Create Agency and Stop
+	_, err := q.CreateAgency(ctx, gtfsdb.CreateAgencyParams{
+		ID: agencyID, Name: "Sort Transit", Url: "http://sort.com", Timezone: "America/Los_Angeles",
+	})
+	require.NoError(t, err)
+
+	_, err = q.CreateStop(ctx, gtfsdb.CreateStopParams{
+		ID: stopID, Name: nulls.String("Sorted Stop"), Lat: 47.6, Lon: -122.3,
+	})
+	require.NoError(t, err)
+
+	// Create Routes intentionally out of natural order
+	// We want to verify "2" < "14" < "101" < "B" < "Fallback"
+	routeNames := []string{"101", "B", "14", "2", "Fallback"}
+
+	_, err = q.CreateCalendar(ctx, gtfsdb.CreateCalendarParams{
+		ID: "serv1", Monday: 1, Tuesday: 1, Wednesday: 1, Thursday: 1, Friday: 1, Saturday: 1, Sunday: 1, StartDate: "20250101", EndDate: "20251231",
+	})
+	require.NoError(t, err)
+
+	for i, name := range routeNames {
+		routeID := "Route" + name
+		tripID := "Trip" + name
+
+		shortName := nulls.String(name)
+		longName := nulls.String("")
+		if name == "Fallback" {
+			shortName = nulls.String("")
+			longName = nulls.String(name)
+		}
+
+		_, err = q.CreateRoute(ctx, gtfsdb.CreateRouteParams{
+			ID: routeID, AgencyID: agencyID, ShortName: shortName, LongName: longName, Type: 3,
+		})
+		require.NoError(t, err)
+
+		_, err = q.CreateTrip(ctx, gtfsdb.CreateTripParams{
+			ID: tripID, RouteID: routeID, ServiceID: "serv1",
+		})
+		require.NoError(t, err)
+
+		_, err = q.CreateStopTime(ctx, gtfsdb.CreateStopTimeParams{
+			TripID: tripID, StopID: stopID, StopSequence: int64(i + 1), ArrivalTime: 30000, DepartureTime: 30000,
+		})
+		require.NoError(t, err)
+	}
+
+	// Call Endpoint
+	resp, model := callAPIHandler[StopEntryResponse](t, api, stopURL(utils.FormCombinedID(agencyID, stopID)))
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	// Also assert that model.Data.Entry.RouteIDs matches the same order exactly
+	expectedRouteIDs := []string{
+		utils.FormCombinedID(agencyID, "Route2"),
+		utils.FormCombinedID(agencyID, "Route14"),
+		utils.FormCombinedID(agencyID, "Route101"),
+		utils.FormCombinedID(agencyID, "RouteB"),
+		utils.FormCombinedID(agencyID, "RouteFallback"),
+	}
+	assert.Equal(t, expectedRouteIDs, model.Data.Entry.RouteIDs, "Entry.RouteIDs should preserve natural order")
+}

--- a/internal/utils/string_utils.go
+++ b/internal/utils/string_utils.go
@@ -1,0 +1,79 @@
+package utils
+
+import (
+	"cmp"
+	"math/big"
+	"strconv"
+)
+
+// isASCIIDigit checks if a rune is an ASCII digit (0-9)
+func isASCIIDigit(r int32) bool {
+	return r >= '0' && r <= '9'
+}
+
+// extractChunk grabs either a contiguous sequence of digits or non-digits.
+func extractChunk(s string, start int) (string, bool, int) {
+	if start >= len(s) {
+		return "", false, start
+	}
+
+	var isDigit bool
+	for idx, r := range s[start:] {
+		if idx == 0 {
+			isDigit = isASCIIDigit(r)
+			continue
+		}
+		if isASCIIDigit(r) != isDigit {
+			return s[start : start+idx], isDigit, start + idx
+		}
+	}
+	return s[start:], isDigit, len(s)
+}
+
+// compareNumericChunks compares two string chunks as numbers.
+// If they are numerically equal, it falls back to lexical comparison to handle leading zeros.
+func compareNumericChunks(chunkA, chunkB string) int {
+	numA, errA := strconv.ParseUint(chunkA, 10, 64)
+	numB, errB := strconv.ParseUint(chunkB, 10, 64)
+
+	if errA != nil || errB != nil {
+		bigA, okA := new(big.Int).SetString(chunkA, 10)
+		bigB, okB := new(big.Int).SetString(chunkB, 10)
+		if okA && okB {
+			if res := bigA.Cmp(bigB); res != 0 {
+				return res
+			}
+			return cmp.Compare(chunkA, chunkB)
+		}
+	}
+
+	if numA != numB {
+		return cmp.Compare(numA, numB)
+	}
+	return cmp.Compare(chunkA, chunkB)
+}
+
+// NaturalCompare compares two strings using natural sort order (e.g., "2" < "14" < "101" < "B").
+// Returns -1 if a < b, 0 if a == b, and 1 if a > b.
+func NaturalCompare(a, b string) int {
+	i, j := 0, 0
+	for i < len(a) && j < len(b) {
+		chunkA, isDigitA, nextI := extractChunk(a, i)
+		chunkB, isDigitB, nextJ := extractChunk(b, j)
+
+		var res int
+		if isDigitA && isDigitB {
+			res = compareNumericChunks(chunkA, chunkB)
+		} else {
+			res = cmp.Compare(chunkA, chunkB)
+		}
+
+		if res != 0 {
+			return res
+		}
+
+		i, j = nextI, nextJ
+	}
+
+	return cmp.Compare(len(a), len(b))
+}

--- a/internal/utils/string_utils_test.go
+++ b/internal/utils/string_utils_test.go
@@ -1,0 +1,98 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExtractChunk(t *testing.T) {
+	tests := []struct {
+		name      string
+		s         string
+		start     int
+		wantChunk string
+		wantIsNum bool
+		wantNext  int
+	}{
+		{"digits only", "123", 0, "123", true, 3},
+		{"letters only", "abc", 0, "abc", false, 3},
+		{"mixed starts with letter", "a123", 0, "a", false, 1},
+		{"mixed starts with digit", "123a", 0, "123", true, 3},
+		{"unicode letters", "世2", 0, "世", false, 3},
+		{"unicode digits", "123世", 0, "123", true, 3},
+		{"mixed long", "Route101", 0, "Route", false, 5},
+		{"mixed long digit", "Route101", 5, "101", true, 8},
+		{"out of bounds", "123", 5, "", false, 5},
+		{"unicode full-width digits", "１２３", 0, "１２３", false, 9},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			chunk, isNum, next := extractChunk(tt.s, tt.start)
+			assert.Equal(t, tt.wantChunk, chunk)
+			assert.Equal(t, tt.wantIsNum, isNum)
+			assert.Equal(t, tt.wantNext, next)
+		})
+	}
+}
+
+func TestCompareNumericChunks(t *testing.T) {
+	tests := []struct {
+		name string
+		a    string
+		b    string
+		want int
+	}{
+		{"equal", "123", "123", 0},
+		{"less", "12", "123", -1},
+		{"greater", "123", "12", 1},
+		{"leading zero equal val, lex less", "002", "2", -1},
+		{"leading zero equal val, lex greater", "2", "002", 1},
+		{"leading zero equal", "002", "002", 0},
+		{"overflow equal", "100000000000000000000", "100000000000000000000", 0},
+		{"overflow less", "100000000000000000000", "200000000000000000000", -1},
+		{"overflow greater", "200000000000000000000", "100000000000000000000", 1},
+		{"overflow mixed leading zero", "00100000000000000000000", "100000000000000000000", -1}, // value is 10^20, lex <
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := compareNumericChunks(tt.a, tt.b)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestNaturalCompare(t *testing.T) {
+	tests := []struct {
+		name string
+		a    string
+		b    string
+		want int
+	}{
+		{"equal", "A", "A", 0},
+		{"alpha less", "A", "B", -1},
+		{"alpha greater", "B", "A", 1},
+		{"numeric less", "2", "14", -1},
+		{"numeric greater", "14", "2", 1},
+		{"mixed less", "Route 2", "Route 14", -1},
+		{"mixed greater", "Route 14", "Route 2", 1},
+		{"prefix", "A", "AA", -1},
+		{"prefix inverse", "AA", "A", 1},
+		{"leading zeros", "001", "1", -1},
+		{"large num less", "Route 100000000000000000000", "Route 200000000000000000000", -1},
+		{"large num greater", "Route 200000000000000000000", "Route 100000000000000000000", 1},
+		{"empty a", "", "A", -1},
+		{"empty b", "A", "", 1},
+		{"both empty", "", "", 0},
+		{"unicode digits compare lexically", "１", "２", -1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := NaturalCompare(tt.a, tt.b)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
### Description

fixes #995 

This PR addresses a spec gap identified in the `/stop` endpoint. According to the [wiki spec](https://github.com/OneBusAway/maglev/wiki/stop), `routeIds` must be sorted in natural string order by `shortName` (falling back to `longName`), meaning `"14" < "101" < "B"`. Previously, the API returned routes in database fetch order. 

### Changes Made
- Added a `NaturalCompare` utility function to `internal/utils/` to handle string chunking and numeric comparisons.
- Updated `stopHandler` to use `slices.SortFunc` combined with `NaturalCompare` immediately after fetching the stop's routes from the DB.
- Added a targeted test `TestStopHandler_NaturalSorting` to explicitly verify the `"2" < "14" < "101" < "B"` ordering behavior.

### Testing
- [x] Added automated unit tests verifying natural sort.
- [x] Existing tests pass successfully.

<img width="940" height="418" alt="image" src="https://github.com/user-attachments/assets/edae7801-f496-4238-bf4e-bb20b89e4353" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Stop endpoint now returns routes in natural string order (numeric-aware), using short names when present and falling back to long names, improving route list readability.

* **Tests**
  * Added tests verifying natural sorting behavior, including numeric ordering, fallback name usage, and edge cases (leading zeros, large numbers).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->