### PR TITLE
chore: remove path filter from Go CI push trigger

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -3,10 +3,6 @@ name: Go CI
 on:
   push:
     branches: [main]
-    paths:
-      - '**.go'
-      - 'go.mod'
-      - 'go.sum'
   pull_request:
 
 jobs:


### PR DESCRIPTION
## Summary

Path filters on the `push` trigger silently skip CI when non-Go files change (workflow configs, `sonar-project.properties`, etc.), causing hard-to-diagnose gaps. For a single Go application the cost of running CI on every push to main is negligible compared to the reliability gain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)