### PR TITLE
chore: disable CI-based SonarQube scan in favour of automatic analysis

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -38,6 +38,7 @@ jobs:
         os: [ubuntu-latest, windows-latest]
     env:
       CGO_ENABLED: 1
+      SONAR_CI_ANALYSIS_ENABLED: false
     steps:
       - uses: actions/checkout@v6
 
@@ -93,7 +94,7 @@ jobs:
         shell: bash
 
       - name: SonarQube Scan
-        if: matrix.os == 'ubuntu-latest' && github.repository == 'OneBusAway/maglev'
+        if: matrix.os == 'ubuntu-latest' && github.repository == 'OneBusAway/maglev' && env.SONAR_CI_ANALYSIS_ENABLED == 'true'
         uses: SonarSource/sonarqube-scan-action@7006c4492b2e0ee0f816d36501671557c97f5995 # v8.1.0
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
## Summary

CI analysis is the only way to get code coverage data into SonarCloud, but it requires a `SONAR_TOKEN` secret which GitHub does not expose to workflows triggered by PRs from external forks. Without the secret the scan fails and fails the build, blocking external contributors.

Switching to SonarCloud automatic analysis, which requires no secret and works for all PRs, at the cost of coverage data. The `SONAR_CI_ANALYSIS_ENABLED` switch is left in place so CI analysis can be re-enabled if a better solution for the fork secret problem is found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)