### PR TITLE
fix(route): support includeReferences query parameter

### DIFF
--- a/internal/restapi/reference_utils.go
+++ b/internal/restapi/reference_utils.go
@@ -2,6 +2,8 @@ package restapi
 
 import (
 	"context"
+	"net/http"
+	"strconv"
 	"time"
 
 	"github.com/OneBusAway/go-gtfs"
@@ -253,4 +255,20 @@ func (api *RestAPI) collectAlertsForStopsAndRoutes(stopIDs, routeIDs []string) [
 		alerts = append(alerts, api.GtfsManager.GetAlertsForRoute(routeID)...)
 	}
 	return deduplicateAlerts(alerts)
+}
+
+// ShouldIncludeReferences parses the "includeReferences" query parameter from the request.
+// It defaults to true if the parameter is absent or if it fails to parse as a boolean.
+func ShouldIncludeReferences(r *http.Request) bool {
+	val := r.URL.Query().Get("includeReferences")
+	if val == "" {
+		return true
+	}
+
+	parsed, err := strconv.ParseBool(val)
+	if err != nil {
+		return true
+	}
+
+	return parsed
 }

--- a/internal/restapi/reference_utils_test.go
+++ b/internal/restapi/reference_utils_test.go
@@ -1,6 +1,8 @@
 package restapi
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/OneBusAway/go-gtfs"
@@ -28,4 +30,41 @@ func TestDeduplicateAlerts(t *testing.T) {
 	assert.True(t, idMap["alert-1"], "Missing alert-1")
 	assert.True(t, idMap["alert-2"], "Missing alert-2")
 	assert.True(t, idMap["alert-3"], "Missing alert-3")
+}
+
+func TestShouldIncludeReferences(t *testing.T) {
+	tests := []struct {
+		name     string
+		url      string
+		expected bool
+	}{
+		{
+			name:     "empty string defaults to true",
+			url:      "/api/where/route/1.json?key=TEST",
+			expected: true,
+		},
+		{
+			name:     "explicit true returns true",
+			url:      "/api/where/route/1.json?key=TEST&includeReferences=true",
+			expected: true,
+		},
+		{
+			name:     "explicit false returns false",
+			url:      "/api/where/route/1.json?key=TEST&includeReferences=false",
+			expected: false,
+		},
+		{
+			name:     "garbage string defaults to true",
+			url:      "/api/where/route/1.json?key=TEST&includeReferences=banana",
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, tt.url, nil)
+			actual := ShouldIncludeReferences(req)
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
 }

--- a/internal/restapi/route_handler.go
+++ b/internal/restapi/route_handler.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"errors"
 	"net/http"
+	"strconv"
 
 	"maglev.onebusaway.org/internal/models"
 	"maglev.onebusaway.org/internal/utils"
@@ -37,15 +38,25 @@ func (api *RestAPI) routeHandler(w http.ResponseWriter, r *http.Request) {
 
 	references := models.NewEmptyReferences()
 
-	agency, err := api.GtfsManager.GtfsDB.Queries.GetAgency(ctx, agencyID)
-	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			api.sendNotFound(w, r)
+	// Parse includeReferences query parameter (default: true).
+	// When false, skip the agency lookup and return an empty agencies array.
+	includeReferences := true
+	if val := r.URL.Query().Get("includeReferences"); val != "" {
+		if parsed, parseErr := strconv.ParseBool(val); parseErr == nil {
+			includeReferences = parsed
+		}
+	}
+
+	if includeReferences {
+		agency, err := api.GtfsManager.GtfsDB.Queries.GetAgency(ctx, agencyID)
+		if err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				api.sendNotFound(w, r)
+				return
+			}
+			api.serverErrorResponse(w, r, err)
 			return
 		}
-		api.serverErrorResponse(w, r, err)
-		return
-	} else {
 		agencyModel := models.NewAgencyReference(
 			agency.ID,
 			agency.Name,

--- a/internal/restapi/route_handler.go
+++ b/internal/restapi/route_handler.go
@@ -4,7 +4,6 @@ import (
 	"database/sql"
 	"errors"
 	"net/http"
-	"strconv"
 
 	"maglev.onebusaway.org/internal/models"
 	"maglev.onebusaway.org/internal/utils"
@@ -38,14 +37,7 @@ func (api *RestAPI) routeHandler(w http.ResponseWriter, r *http.Request) {
 
 	references := models.NewEmptyReferences()
 
-	// Parse includeReferences query parameter (default: true).
-	// When false, skip the agency lookup and return an empty agencies array.
-	includeReferences := true
-	if val := r.URL.Query().Get("includeReferences"); val != "" {
-		if parsed, parseErr := strconv.ParseBool(val); parseErr == nil {
-			includeReferences = parsed
-		}
-	}
+	includeReferences := ShouldIncludeReferences(r)
 
 	if includeReferences {
 		agency, err := api.GtfsManager.GtfsDB.Queries.GetAgency(ctx, agencyID)

--- a/internal/restapi/route_handler_test.go
+++ b/internal/restapi/route_handler_test.go
@@ -107,3 +107,44 @@ func TestRouteHandlerWithSituations(t *testing.T) {
 		"expected exactly one situation matching the seeded alert")
 	assert.Equal(t, alertID, model.Data.References.Situations[0].ID)
 }
+
+// TestRouteHandler_IncludeReferencesFalse verifies that when includeReferences=false,
+// the response contains an empty agencies array and skips the agency database lookup.
+func TestRouteHandler_IncludeReferencesFalse(t *testing.T) {
+	api := createTestApi(t)
+	defer api.Shutdown()
+
+	url := "/api/where/route/" + testdata.Route1.ID + ".json?key=TEST&includeReferences=false"
+	resp, model := callAPIHandler[RouteEntryResponse](t, api, url)
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, http.StatusOK, model.Code)
+	assert.Equal(t, testdata.Route1, model.Data.Entry)
+	assert.Empty(t, model.Data.References.Agencies,
+		"agencies should be empty when includeReferences=false")
+}
+
+// TestRouteHandler_IncludeReferencesDefault verifies that the default behaviour
+// (includeReferences absent or explicitly true) returns the owning agency.
+func TestRouteHandler_IncludeReferencesDefault(t *testing.T) {
+	api := createTestApi(t)
+	defer api.Shutdown()
+
+	tests := []struct {
+		name string
+		url  string
+	}{
+		{"absent", routeURL(testdata.Route1.ID)},
+		{"explicit true", "/api/where/route/" + testdata.Route1.ID + ".json?key=TEST&includeReferences=true"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp, model := callAPIHandler[RouteEntryResponse](t, api, tt.url)
+
+			assert.Equal(t, http.StatusOK, resp.StatusCode)
+			require.Len(t, model.Data.References.Agencies, 1,
+				"agencies should contain the owning agency")
+			assert.Equal(t, testdata.Raba.ID, model.Data.References.Agencies[0].ID)
+		})
+	}
+}


### PR DESCRIPTION
### Description
This PR implements the `includeReferences` query parameter for the route endpoint, bringing the Maglev implementation into alignment with the OBA API specification. 

Previously, the route endpoint fetched and appended the agency reference unconditionally. Now, when a client passes `?includeReferences=false`, the server skips the agency database lookup entirely, saving a database call and returning an empty array for `data.references.agencies`.

### Changes Made
* **`route_handler.go`**: Added parsing for the `includeReferences` query parameter (defaulting to `true`). 
* **`route_handler_test.go`**: Added table-driven tests to verify both the explicit `false` behavior (empty agencies array) and the default/explicit `true` behavior (agency included).

fixes: #1007

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an includeReferences query parameter for route responses. When false, agency references are omitted; included by default.

* **Tests**
  * Added test coverage validating includeReferences behavior (default/included, explicit false, and invalid values handled as default).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->