### PR TITLE
fix: add missing timeZone field to BlockConfiguration response

### DIFF
--- a/internal/models/block.go
+++ b/internal/models/block.go
@@ -8,7 +8,7 @@ type BlockEntry struct {
 type BlockConfiguration struct {
 	ActiveServiceIds   []string    `json:"activeServiceIds"`
 	InactiveServiceIds []string    `json:"inactiveServiceIds"`
-	TimeZone           string      `json:"timezone"`
+	TimeZone           string      `json:"timeZone"`
 	Trips              []TripBlock `json:"trips"`
 }
 

--- a/internal/models/block.go
+++ b/internal/models/block.go
@@ -8,6 +8,7 @@ type BlockEntry struct {
 type BlockConfiguration struct {
 	ActiveServiceIds   []string    `json:"activeServiceIds"`
 	InactiveServiceIds []string    `json:"inactiveServiceIds"`
+	TimeZone           string      `json:"timezone"`
 	Trips              []TripBlock `json:"trips"`
 }
 

--- a/internal/restapi/block_handler.go
+++ b/internal/restapi/block_handler.go
@@ -51,19 +51,25 @@ func (api *RestAPI) blockHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	blockEntry := transformBlockToEntry(block, utils.FormCombinedID(agencyID, blockID), agencyID)
-
 	references, err := api.getReferences(ctx, agencyID, block)
 	if err != nil {
 		api.serverErrorResponse(w, r, err)
 		return
 	}
 
+	// Extract TimeZone from the generated references to avoid a duplicate DB call
+	var timeZone string
+	if len(references.Agencies) > 0 {
+		timeZone = references.Agencies[0].Timezone
+	}
+
+	blockEntry := transformBlockToEntry(block, utils.FormCombinedID(agencyID, blockID), agencyID, timeZone)
+
 	response := models.NewEntryResponse(blockEntry, references, api.Clock)
 	api.sendResponse(w, r, response)
 }
 
-func transformBlockToEntry(block []gtfsdb.GetBlockDetailsRow, blockID, agencyID string) models.BlockEntry {
+func transformBlockToEntry(block []gtfsdb.GetBlockDetailsRow, blockID, agencyID, timezone string) models.BlockEntry {
 	serviceGroups := make(map[string][]gtfsdb.GetBlockDetailsRow)
 
 	for _, row := range block {
@@ -86,6 +92,7 @@ func transformBlockToEntry(block []gtfsdb.GetBlockDetailsRow, blockID, agencyID 
 		config := &models.BlockConfiguration{
 			ActiveServiceIds:   []string{utils.FormCombinedID(agencyID, serviceID)},
 			InactiveServiceIds: []string{},
+			TimeZone:           timezone,
 			Trips:              make([]models.TripBlock, 0),
 		}
 

--- a/internal/restapi/block_handler.go
+++ b/internal/restapi/block_handler.go
@@ -108,55 +108,7 @@ func transformBlockToEntry(block []gtfsdb.GetBlockDetailsRow, blockID, agencyID,
 		slices.Sort(tripIDs)
 
 		for _, tripID := range tripIDs {
-			stops := tripStops[tripID]
-
-			slices.SortFunc(stops, func(a, b gtfsdb.GetBlockDetailsRow) int {
-				return cmp.Compare(a.StopSequence, b.StopSequence)
-			})
-
-			var blockStopTimes []models.BlockStopTime
-			tripStartDistance := blockDistance
-
-			for i, stop := range stops {
-				var distanceFromPrevious float64
-				if i > 0 {
-					prevStop := stops[i-1]
-					distanceFromPrevious = utils.Distance(
-						prevStop.Lat, prevStop.Lon,
-						stop.Lat, stop.Lon,
-					)
-					blockDistance += distanceFromPrevious
-				}
-
-				blockStopTime := models.BlockStopTime{
-					BlockSequence:      int(stop.StopSequence - 1),
-					DistanceAlongBlock: blockDistance,
-					StopTime: models.StopTime{
-						ArrivalTime:   models.NewModelDuration(time.Duration(stop.ArrivalTime)),
-						DepartureTime: models.NewModelDuration(time.Duration(stop.DepartureTime)),
-						DropOffType:   int(stop.DropOffType.Int64),
-						PickupType:    int(stop.PickupType.Int64),
-						StopID:        utils.FormCombinedID(agencyID, stop.StopID),
-					},
-				}
-				blockStopTimes = append(blockStopTimes, blockStopTime)
-			}
-
-			blockStopTimes = calculateBlockSlackTimes(blockStopTimes)
-
-			var tripAccumulatedSlack time.Duration
-			if len(blockStopTimes) > 0 {
-				tripAccumulatedSlack = blockStopTimes[len(blockStopTimes)-1].AccumulatedSlackTime.Duration
-			}
-
-			tripDistance := blockDistance - tripStartDistance
-
-			trip := models.TripBlock{
-				AccumulatedSlackTime: models.NewModelDuration(tripAccumulatedSlack),
-				BlockStopTimes:       blockStopTimes,
-				DistanceAlongBlock:   tripDistance,
-				TripId:               utils.FormCombinedID(agencyID, tripID),
-			}
+			trip := buildTripBlock(tripStops[tripID], tripID, agencyID, &blockDistance)
 			config.Trips = append(config.Trips, trip)
 		}
 
@@ -166,6 +118,56 @@ func transformBlockToEntry(block []gtfsdb.GetBlockDetailsRow, blockID, agencyID,
 	return models.BlockEntry{
 		Configurations: configurations,
 		ID:             blockID,
+	}
+}
+
+func buildTripBlock(stops []gtfsdb.GetBlockDetailsRow, tripID, agencyID string, blockDistance *float64) models.TripBlock {
+	slices.SortFunc(stops, func(a, b gtfsdb.GetBlockDetailsRow) int {
+		return cmp.Compare(a.StopSequence, b.StopSequence)
+	})
+
+	var blockStopTimes []models.BlockStopTime
+	tripStartDistance := *blockDistance
+
+	for i, stop := range stops {
+		var distanceFromPrevious float64
+		if i > 0 {
+			prevStop := stops[i-1]
+			distanceFromPrevious = utils.Distance(
+				prevStop.Lat, prevStop.Lon,
+				stop.Lat, stop.Lon,
+			)
+			*blockDistance += distanceFromPrevious
+		}
+
+		blockStopTime := models.BlockStopTime{
+			BlockSequence:      int(stop.StopSequence - 1),
+			DistanceAlongBlock: *blockDistance,
+			StopTime: models.StopTime{
+				ArrivalTime:   models.NewModelDuration(time.Duration(stop.ArrivalTime)),
+				DepartureTime: models.NewModelDuration(time.Duration(stop.DepartureTime)),
+				DropOffType:   int(stop.DropOffType.Int64),
+				PickupType:    int(stop.PickupType.Int64),
+				StopID:        utils.FormCombinedID(agencyID, stop.StopID),
+			},
+		}
+		blockStopTimes = append(blockStopTimes, blockStopTime)
+	}
+
+	blockStopTimes = calculateBlockSlackTimes(blockStopTimes)
+
+	var tripAccumulatedSlack time.Duration
+	if len(blockStopTimes) > 0 {
+		tripAccumulatedSlack = blockStopTimes[len(blockStopTimes)-1].AccumulatedSlackTime.Duration
+	}
+
+	tripDistance := *blockDistance - tripStartDistance
+
+	return models.TripBlock{
+		AccumulatedSlackTime: models.NewModelDuration(tripAccumulatedSlack),
+		BlockStopTimes:       blockStopTimes,
+		DistanceAlongBlock:   tripDistance,
+		TripId:               utils.FormCombinedID(agencyID, tripID),
 	}
 }
 

--- a/internal/restapi/block_handler_test.go
+++ b/internal/restapi/block_handler_test.go
@@ -40,6 +40,10 @@ func TestBlockHandlerEndToEnd(t *testing.T) {
 	config := entry.Configurations[0]
 	require.NotEmpty(t, config.ActiveServiceIds)
 	assert.Contains(t, config.ActiveServiceIds[0], "_", "service IDs should be combined with agency prefix")
+
+	// Verify TimeZone is populated with the correct agency timezone
+	assert.Equal(t, testdata.Raba.Timezone, config.TimeZone, "timeZone should match the agency's timezone")
+
 	require.NotEmpty(t, config.Trips)
 
 	trip := config.Trips[0]
@@ -50,6 +54,7 @@ func TestBlockHandlerEndToEnd(t *testing.T) {
 	// Iterate every config/trip/stop-time — catches empty IDs in less-common configurations.
 	for _, c := range entry.Configurations {
 		assert.NotEmpty(t, c.ActiveServiceIds)
+		assert.NotEmpty(t, c.TimeZone, "timeZone should be populated for all configurations")
 		assert.NotEmpty(t, c.Trips)
 		for _, tr := range c.Trips {
 			assert.NotEmpty(t, tr.TripId)


### PR DESCRIPTION
### Description

Fixes a spec gap where the `timeZone` (IANA timezone ID) was missing from the `BlockConfiguration` response, which prevented clients from accurately converting block stop times into absolute timestamps.

### Changes

* **Models**: Added the `TimeZone` field to `models.BlockConfiguration`.
* **API**: Updated `blockHandler` to extract the agency's timezone from the references and inject it into the block configuration.
* **Tests**: Added assertions to `block_handler_test.go` to verify the `timeZone` field is populated correctly.

closes #1014 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Block configurations now include timezone information for clearer scheduling context.

* **Tests**
  * End-to-end tests updated to verify timezone is present on the first configuration and non-empty across all configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->