### PR TITLE
fix(api): group identical block itineraries and sort by active service id count

### DIFF
--- a/internal/models/block.go
+++ b/internal/models/block.go
@@ -8,7 +8,7 @@ type BlockEntry struct {
 type BlockConfiguration struct {
 	ActiveServiceIds   []string    `json:"activeServiceIds"`
 	InactiveServiceIds []string    `json:"inactiveServiceIds"`
-	TimeZone           string      `json:"timezone"`
+	TimeZone           string      `json:"timeZone"`
 	Trips              []TripBlock `json:"trips"`
 }
 

--- a/internal/models/block.go
+++ b/internal/models/block.go
@@ -8,6 +8,7 @@ type BlockEntry struct {
 type BlockConfiguration struct {
 	ActiveServiceIds   []string    `json:"activeServiceIds"`
 	InactiveServiceIds []string    `json:"inactiveServiceIds"`
+	TimeZone           string      `json:"timezone"`
 	Trips              []TripBlock `json:"trips"`
 }
 

--- a/internal/restapi/block_handler.go
+++ b/internal/restapi/block_handler.go
@@ -4,6 +4,7 @@ import (
 	"cmp"
 	"context"
 	"net/http"
+	"reflect"
 	"slices"
 	"strconv"
 	"time"
@@ -82,19 +83,11 @@ func transformBlockToEntry(block []gtfsdb.GetBlockDetailsRow, blockID, agencyID,
 	}
 	slices.Sort(serviceIDs)
 
-	configurations := make([]models.BlockConfiguration, 0, len(serviceGroups))
-
-	var blockDistance float64
+	// configurations will hold our grouped and distinct itineraries
+	var configurations []models.BlockConfiguration
 
 	for _, serviceID := range serviceIDs {
 		serviceStops := serviceGroups[serviceID]
-
-		config := &models.BlockConfiguration{
-			ActiveServiceIds:   []string{utils.FormCombinedID(agencyID, serviceID)},
-			InactiveServiceIds: []string{},
-			TimeZone:           timezone,
-			Trips:              make([]models.TripBlock, 0),
-		}
 
 		tripStops := make(map[string][]gtfsdb.GetBlockDetailsRow)
 		for _, stop := range serviceStops {
@@ -107,13 +100,48 @@ func transformBlockToEntry(block []gtfsdb.GetBlockDetailsRow, blockID, agencyID,
 		}
 		slices.Sort(tripIDs)
 
+		var currentTrips []models.TripBlock
+		var blockDistance float64 // Reset block distance for each service configuration
+
+		// Build the trips for the current serviceID
 		for _, tripID := range tripIDs {
 			trip := buildTripBlock(tripStops[tripID], tripID, agencyID, &blockDistance)
-			config.Trips = append(config.Trips, trip)
+			currentTrips = append(currentTrips, trip)
 		}
 
-		configurations = append(configurations, *config)
+		// Check if this identical itinerary already exists in our configurations
+		found := false
+		combinedServiceID := utils.FormCombinedID(agencyID, serviceID)
+
+		for i := range configurations {
+			// If the sequence of trips and stop times is identical, group them together
+			if reflect.DeepEqual(configurations[i].Trips, currentTrips) {
+				configurations[i].ActiveServiceIds = append(configurations[i].ActiveServiceIds, combinedServiceID)
+				found = true
+				break
+			}
+		}
+
+		// If no matching itinerary was found, create a new configuration variant
+		if !found {
+			configurations = append(configurations, models.BlockConfiguration{
+				ActiveServiceIds:   []string{combinedServiceID},
+				InactiveServiceIds: []string{},
+				TimeZone:           timezone,
+				Trips:              currentTrips,
+			})
+		}
 	}
+
+	// Sort configurations based on the wiki spec requirements
+	slices.SortFunc(configurations, func(a, b models.BlockConfiguration) int {
+		// Primary Sort: Descending by the number of active service IDs
+		if len(a.ActiveServiceIds) != len(b.ActiveServiceIds) {
+			return cmp.Compare(len(b.ActiveServiceIds), len(a.ActiveServiceIds))
+		}
+		// Secondary Sort: Alphabetically by the first service ID to break ties predictably
+		return cmp.Compare(a.ActiveServiceIds[0], b.ActiveServiceIds[0])
+	})
 
 	return models.BlockEntry{
 		Configurations: configurations,

--- a/internal/restapi/block_handler.go
+++ b/internal/restapi/block_handler.go
@@ -51,19 +51,25 @@ func (api *RestAPI) blockHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	blockEntry := transformBlockToEntry(block, utils.FormCombinedID(agencyID, blockID), agencyID)
-
 	references, err := api.getReferences(ctx, agencyID, block)
 	if err != nil {
 		api.serverErrorResponse(w, r, err)
 		return
 	}
 
+	// Extract TimeZone from the generated references to avoid a duplicate DB call
+	var timeZone string
+	if len(references.Agencies) > 0 {
+		timeZone = references.Agencies[0].Timezone
+	}
+
+	blockEntry := transformBlockToEntry(block, utils.FormCombinedID(agencyID, blockID), agencyID, timeZone)
+
 	response := models.NewEntryResponse(blockEntry, references, api.Clock)
 	api.sendResponse(w, r, response)
 }
 
-func transformBlockToEntry(block []gtfsdb.GetBlockDetailsRow, blockID, agencyID string) models.BlockEntry {
+func transformBlockToEntry(block []gtfsdb.GetBlockDetailsRow, blockID, agencyID, timezone string) models.BlockEntry {
 	serviceGroups := make(map[string][]gtfsdb.GetBlockDetailsRow)
 
 	for _, row := range block {
@@ -86,6 +92,7 @@ func transformBlockToEntry(block []gtfsdb.GetBlockDetailsRow, blockID, agencyID 
 		config := &models.BlockConfiguration{
 			ActiveServiceIds:   []string{utils.FormCombinedID(agencyID, serviceID)},
 			InactiveServiceIds: []string{},
+			TimeZone:           timezone,
 			Trips:              make([]models.TripBlock, 0),
 		}
 

--- a/internal/restapi/block_handler.go
+++ b/internal/restapi/block_handler.go
@@ -108,55 +108,7 @@ func transformBlockToEntry(block []gtfsdb.GetBlockDetailsRow, blockID, agencyID,
 		slices.Sort(tripIDs)
 
 		for _, tripID := range tripIDs {
-			stops := tripStops[tripID]
-
-			slices.SortFunc(stops, func(a, b gtfsdb.GetBlockDetailsRow) int {
-				return cmp.Compare(a.StopSequence, b.StopSequence)
-			})
-
-			var blockStopTimes []models.BlockStopTime
-			tripStartDistance := blockDistance
-
-			for i, stop := range stops {
-				var distanceFromPrevious float64
-				if i > 0 {
-					prevStop := stops[i-1]
-					distanceFromPrevious = utils.Distance(
-						prevStop.Lat, prevStop.Lon,
-						stop.Lat, stop.Lon,
-					)
-					blockDistance += distanceFromPrevious
-				}
-
-				blockStopTime := models.BlockStopTime{
-					BlockSequence:      int(stop.StopSequence - 1),
-					DistanceAlongBlock: blockDistance,
-					StopTime: models.StopTime{
-						ArrivalTime:   models.NewModelDuration(time.Duration(stop.ArrivalTime)),
-						DepartureTime: models.NewModelDuration(time.Duration(stop.DepartureTime)),
-						DropOffType:   int(stop.DropOffType.Int64),
-						PickupType:    int(stop.PickupType.Int64),
-						StopID:        utils.FormCombinedID(agencyID, stop.StopID),
-					},
-				}
-				blockStopTimes = append(blockStopTimes, blockStopTime)
-			}
-
-			blockStopTimes = calculateBlockSlackTimes(blockStopTimes)
-
-			var tripAccumulatedSlack time.Duration
-			if len(blockStopTimes) > 0 {
-				tripAccumulatedSlack = blockStopTimes[len(blockStopTimes)-1].AccumulatedSlackTime.Duration
-			}
-
-			tripDistance := blockDistance - tripStartDistance
-
-			trip := models.TripBlock{
-				AccumulatedSlackTime: models.NewModelDuration(tripAccumulatedSlack),
-				BlockStopTimes:       blockStopTimes,
-				DistanceAlongBlock:   tripDistance,
-				TripId:               utils.FormCombinedID(agencyID, tripID),
-			}
+			trip := buildTripBlock(tripStops[tripID], tripID, agencyID, &blockDistance)
 			config.Trips = append(config.Trips, trip)
 		}
 
@@ -166,6 +118,56 @@ func transformBlockToEntry(block []gtfsdb.GetBlockDetailsRow, blockID, agencyID,
 	return models.BlockEntry{
 		Configurations: configurations,
 		ID:             blockID,
+	}
+}
+
+func buildTripBlock(stops []gtfsdb.GetBlockDetailsRow, tripID, agencyID string, blockDistance *float64) models.TripBlock {
+	slices.SortFunc(stops, func(a, b gtfsdb.GetBlockDetailsRow) int {
+		return cmp.Compare(a.StopSequence, b.StopSequence)
+	})
+
+	var blockStopTimes []models.BlockStopTime
+	tripStartDistance := *blockDistance
+
+	for i, stop := range stops {
+		var distanceFromPrevious float64
+		if i > 0 {
+			prevStop := stops[i-1]
+			distanceFromPrevious = utils.Distance(
+				prevStop.Lat, prevStop.Lon,
+				stop.Lat, stop.Lon,
+			)
+			*blockDistance += distanceFromPrevious
+		}
+
+		blockStopTime := models.BlockStopTime{
+			BlockSequence:      int(stop.StopSequence - 1),
+			DistanceAlongBlock: *blockDistance,
+			StopTime: models.StopTime{
+				ArrivalTime:   models.NewModelDuration(time.Duration(stop.ArrivalTime)),
+				DepartureTime: models.NewModelDuration(time.Duration(stop.DepartureTime)),
+				DropOffType:   int(stop.DropOffType.Int64),
+				PickupType:    int(stop.PickupType.Int64),
+				StopID:        utils.FormCombinedID(agencyID, stop.StopID),
+			},
+		}
+		blockStopTimes = append(blockStopTimes, blockStopTime)
+	}
+
+	blockStopTimes = calculateBlockSlackTimes(blockStopTimes)
+
+	var tripAccumulatedSlack time.Duration
+	if len(blockStopTimes) > 0 {
+		tripAccumulatedSlack = blockStopTimes[len(blockStopTimes)-1].AccumulatedSlackTime.Duration
+	}
+
+	tripDistance := *blockDistance - tripStartDistance
+
+	return models.TripBlock{
+		AccumulatedSlackTime: models.NewModelDuration(tripAccumulatedSlack),
+		BlockStopTimes:       blockStopTimes,
+		DistanceAlongBlock:   tripDistance,
+		TripId:               utils.FormCombinedID(agencyID, tripID),
 	}
 }
 

--- a/internal/restapi/block_handler_test.go
+++ b/internal/restapi/block_handler_test.go
@@ -40,6 +40,10 @@ func TestBlockHandlerEndToEnd(t *testing.T) {
 	config := entry.Configurations[0]
 	require.NotEmpty(t, config.ActiveServiceIds)
 	assert.Contains(t, config.ActiveServiceIds[0], "_", "service IDs should be combined with agency prefix")
+
+	// Verify TimeZone is populated with the correct agency timezone
+	assert.Equal(t, testdata.Raba.Timezone, config.TimeZone, "timeZone should match the agency's timezone")
+
 	require.NotEmpty(t, config.Trips)
 
 	trip := config.Trips[0]
@@ -50,6 +54,7 @@ func TestBlockHandlerEndToEnd(t *testing.T) {
 	// Iterate every config/trip/stop-time — catches empty IDs in less-common configurations.
 	for _, c := range entry.Configurations {
 		assert.NotEmpty(t, c.ActiveServiceIds)
+		assert.NotEmpty(t, c.TimeZone, "timeZone should be populated for all configurations")
 		assert.NotEmpty(t, c.Trips)
 		for _, tr := range c.Trips {
 			assert.NotEmpty(t, tr.TripId)

--- a/internal/restapi/block_handler_test.go
+++ b/internal/restapi/block_handler_test.go
@@ -5,11 +5,13 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"slices"
+	"strconv"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"maglev.onebusaway.org/gtfsdb"
 	"maglev.onebusaway.org/internal/models"
 	"maglev.onebusaway.org/internal/restapi/testdata"
 )
@@ -233,4 +235,50 @@ func BenchmarkBlockHandler(b *testing.B) {
 	for b.Loop() {
 		_, _ = callAPIHandler[BlockEntryResponse](b, api, endpoint)
 	}
+}
+
+func TestTransformBlockToEntry_GroupingAndSorting(t *testing.T) {
+	agencyID := "TEST"
+	blockID := "B1"
+	timezone := "America/Los_Angeles"
+
+	// Helper to quickly mock DB rows
+	makeRow := func(serviceID, tripID string, stopSeq int64) gtfsdb.GetBlockDetailsRow {
+		return gtfsdb.GetBlockDetailsRow{
+			ServiceID:    serviceID,
+			TripID:       tripID,
+			StopSequence: stopSeq,
+			StopID:       "S" + strconv.Itoa(int(stopSeq)), // Dummy stop ID
+		}
+	}
+
+	mockDBRows := []gtfsdb.GetBlockDetailsRow{
+		// S_B has a unique itinerary. (Group of 1)
+		makeRow("S_B", "T2", 1),
+
+		// S_A, S_C, and S_D share the exact same itinerary (T1 with 2 stops). (Group of 3)
+		makeRow("S_C", "T1", 1), makeRow("S_C", "T1", 2),
+		makeRow("S_A", "T1", 1), makeRow("S_A", "T1", 2),
+		makeRow("S_D", "T1", 1), makeRow("S_D", "T1", 2),
+
+		// S_E and S_F share another identical itinerary. (Group of 2)
+		makeRow("S_E", "T3", 1),
+		makeRow("S_F", "T3", 1),
+	}
+
+	// Execute our new grouping and sorting logic
+	entry := transformBlockToEntry(mockDBRows, blockID, agencyID, timezone)
+
+	// ASSERTIONS
+	require.Len(t, entry.Configurations, 3, "Should compress 6 service calendars into 3 distinct configurations")
+
+	// 1st config: Largest group (3 items). Ties broken by natural alphabetical sort.
+	assert.Equal(t, []string{"TEST_S_A", "TEST_S_C", "TEST_S_D"}, entry.Configurations[0].ActiveServiceIds)
+	assert.Equal(t, timezone, entry.Configurations[0].TimeZone)
+
+	// 2nd config: Next largest group (2 items).
+	assert.Equal(t, []string{"TEST_S_E", "TEST_S_F"}, entry.Configurations[1].ActiveServiceIds)
+
+	// 3rd config: Smallest group (1 item).
+	assert.Equal(t, []string{"TEST_S_B"}, entry.Configurations[2].ActiveServiceIds)
 }


### PR DESCRIPTION
**Description**

This PR addresses a spec gap in the `block` endpoint. Previously, the endpoint created a 1:1 mapping between `serviceID` and `BlockConfiguration`, resulting in duplicated itineraries, and only sorted them alphabetically.

**Changes included:**

* **Group Itineraries:** Groups identical trip sequences across different calendars into a single `BlockConfiguration` containing multiple `ActiveServiceIds`.

* **Correct Sorting:** Sorts the configurations descending by the number of active service IDs. Ties are predictably broken alphabetically by `serviceID`, matching the wiki specification.

* **Testing:** Added `TestTransformBlockToEntry_GroupingAndSorting` to verify the grouping and sorting behavior.

**Note (Stacked PR):**

This PR is stacked on top of **PR #1020** (the `TimeZone` fix). The diff currently includes commits from that PR, but they will automatically drop off this diff once the base PR is merged into `main`.

Closes: #1015 