### PR TITLE
fix (route): preserve and deprecate nullSafeShortName, fix ID fallback

### DIFF
--- a/internal/models/routes.go
+++ b/internal/models/routes.go
@@ -3,11 +3,14 @@ package models
 type RouteType int
 
 type Route struct {
-	AgencyID          string    `json:"agencyId"`
-	Color             string    `json:"color"`
-	Description       string    `json:"description"`
-	ID                string    `json:"id"`
-	LongName          string    `json:"longName"`
+	AgencyID    string `json:"agencyId"`
+	Color       string `json:"color"`
+	Description string `json:"description"`
+	ID          string `json:"id"`
+	LongName    string `json:"longName"`
+	// Deprecated: NullSafeShortName is an accidental leak from the legacy Java
+	// OBA server. It is preserved only for backward compatibility with the
+	// Wayfinder web client. Do not use in new code; prefer ShortName and ID.
 	NullSafeShortName string    `json:"nullSafeShortName"`
 	ShortName         string    `json:"shortName"`
 	TextColor         string    `json:"textColor"`
@@ -18,7 +21,7 @@ type Route struct {
 func NewRoute(id, agencyID, shortName, longName, description string, routeType RouteType, url, color, textColor string) Route {
 	nullSafeShortName := shortName
 	if nullSafeShortName == "" {
-		nullSafeShortName = longName
+		nullSafeShortName = id
 	}
 
 	return Route{

--- a/internal/models/routes_test.go
+++ b/internal/models/routes_test.go
@@ -171,12 +171,10 @@ func TestRouteResponseJSON(t *testing.T) {
 }
 
 func TestRouteNullSafeShortNameFallback(t *testing.T) {
-	// When shortName is empty, NullSafeShortName should fall back to longName
-	route := NewRoute("1", "agency-1", "", "Downtown Express", "", 3, "", "", "")
-	assert.Equal(t, "Downtown Express", route.NullSafeShortName)
-	assert.Equal(t, "", route.ShortName) // ShortName itself stays empty
+	route := NewRoute("25_100", "agency-1", "", "Downtown Express", "", 3, "", "", "")
+	assert.Equal(t, "25_100", route.NullSafeShortName)
+	assert.Equal(t, "", route.ShortName)
 
-	// When shortName is present, NullSafeShortName should use it
-	route2 := NewRoute("2", "agency-1", "DX", "Downtown Express", "", 3, "", "", "")
+	route2 := NewRoute("25_200", "agency-1", "DX", "Downtown Express", "", 3, "", "", "")
 	assert.Equal(t, "DX", route2.NullSafeShortName)
 }

--- a/internal/restapi/reference_utils.go
+++ b/internal/restapi/reference_utils.go
@@ -55,8 +55,14 @@ func (api *RestAPI) BuildRouteReferences(ctx context.Context, agencyID string, s
 			return nil, ctx.Err()
 		}
 
+		combinedID := utils.FormCombinedID(agencyID, route.ID)
+		nullSafeShortName := route.ShortName.String
+		if nullSafeShortName == "" {
+			nullSafeShortName = combinedID
+		}
+
 		routeModel := models.Route{
-			ID:                utils.FormCombinedID(agencyID, route.ID),
+			ID:                combinedID,
 			AgencyID:          agencyID,
 			ShortName:         route.ShortName.String,
 			LongName:          route.LongName.String,
@@ -65,7 +71,7 @@ func (api *RestAPI) BuildRouteReferences(ctx context.Context, agencyID string, s
 			URL:               route.Url.String,
 			Color:             route.Color.String,
 			TextColor:         route.TextColor.String,
-			NullSafeShortName: route.ShortName.String,
+			NullSafeShortName: nullSafeShortName,
 		}
 		modelRoutes = append(modelRoutes, routeModel)
 	}

--- a/internal/restapi/reference_utils.go
+++ b/internal/restapi/reference_utils.go
@@ -49,6 +49,13 @@ func (api *RestAPI) BuildRouteReferences(ctx context.Context, agencyID string, s
 		return nil, err
 	}
 
+	return buildRouteModels(ctx, agencyID, routes)
+}
+
+// buildRouteModels converts a slice of database routes into model routes.
+// It is the single source of truth for mapping gtfsdb.Route → models.Route,
+// used by both BuildRouteReferences and BuildRouteReference.
+func buildRouteModels(ctx context.Context, agencyID string, routes []gtfsdb.Route) ([]models.Route, error) {
 	modelRoutes := make([]models.Route, 0, len(routes))
 	for _, route := range routes {
 		if ctx.Err() != nil {
@@ -56,23 +63,18 @@ func (api *RestAPI) BuildRouteReferences(ctx context.Context, agencyID string, s
 		}
 
 		combinedID := utils.FormCombinedID(agencyID, route.ID)
-		nullSafeShortName := route.ShortName.String
-		if nullSafeShortName == "" {
-			nullSafeShortName = combinedID
-		}
 
-		routeModel := models.Route{
-			ID:                combinedID,
-			AgencyID:          agencyID,
-			ShortName:         route.ShortName.String,
-			LongName:          route.LongName.String,
-			Description:       route.Desc.String,
-			Type:              models.RouteType(route.Type),
-			URL:               route.Url.String,
-			Color:             route.Color.String,
-			TextColor:         route.TextColor.String,
-			NullSafeShortName: nullSafeShortName,
-		}
+		routeModel := models.NewRoute(
+			combinedID,
+			agencyID,
+			route.ShortName.String,
+			route.LongName.String,
+			route.Desc.String,
+			models.RouteType(route.Type),
+			route.Url.String,
+			route.Color.String,
+			route.TextColor.String,
+		)
 		modelRoutes = append(modelRoutes, routeModel)
 	}
 

--- a/internal/restapi/reference_utils.go
+++ b/internal/restapi/reference_utils.go
@@ -53,8 +53,7 @@ func (api *RestAPI) BuildRouteReferences(ctx context.Context, agencyID string, s
 }
 
 // buildRouteModels converts a slice of database routes into model routes.
-// It is the single source of truth for mapping gtfsdb.Route → models.Route,
-// used by both BuildRouteReferences and BuildRouteReference.
+// It is the single source of truth for mapping gtfsdb.Route → models.Route.
 func buildRouteModels(ctx context.Context, agencyID string, routes []gtfsdb.Route) ([]models.Route, error) {
 	modelRoutes := make([]models.Route, 0, len(routes))
 	for _, route := range routes {

--- a/internal/restapi/trip_details_handler.go
+++ b/internal/restapi/trip_details_handler.go
@@ -275,7 +275,7 @@ func (api *RestAPI) tripDetailsHandler(w http.ResponseWriter, r *http.Request) {
 		}
 		references.Stops = stops
 
-		routes, err := api.BuildRouteReference(ctx, agencyID, stops)
+		routes, err := api.BuildRouteReferences(ctx, agencyID, stops)
 		if err != nil {
 			api.serverErrorResponse(w, r, err)
 			return
@@ -485,39 +485,4 @@ func (api *RestAPI) buildStopReferences(ctx context.Context, agencyID string, st
 	}
 
 	return modelStops, nil
-}
-
-func (api *RestAPI) BuildRouteReference(ctx context.Context, agencyID string, stops []models.Stop) ([]models.Route, error) {
-
-	routeIDSet := make(map[string]bool)
-	originalRouteIDs := make([]string, 0)
-
-	for _, stop := range stops {
-		if ctx.Err() != nil {
-			return nil, ctx.Err()
-		}
-
-		for _, routeID := range stop.StaticRouteIDs {
-			_, originalRouteID, err := utils.ExtractAgencyIDAndCodeID(routeID)
-			if err != nil {
-				continue
-			}
-
-			if !routeIDSet[originalRouteID] {
-				routeIDSet[originalRouteID] = true
-				originalRouteIDs = append(originalRouteIDs, originalRouteID)
-			}
-		}
-	}
-
-	if len(originalRouteIDs) == 0 {
-		return []models.Route{}, nil
-	}
-
-	routes, err := api.GtfsManager.GtfsDB.Queries.GetRoutesByIDs(ctx, originalRouteIDs)
-	if err != nil {
-		return nil, err
-	}
-
-	return buildRouteModels(ctx, agencyID, routes)
 }

--- a/internal/restapi/trip_details_handler.go
+++ b/internal/restapi/trip_details_handler.go
@@ -519,32 +519,5 @@ func (api *RestAPI) BuildRouteReference(ctx context.Context, agencyID string, st
 		return nil, err
 	}
 
-	modelRoutes := make([]models.Route, 0, len(routes))
-	for _, route := range routes {
-		if ctx.Err() != nil {
-			return nil, ctx.Err()
-		}
-
-		combinedID := utils.FormCombinedID(agencyID, route.ID)
-		nullSafeShortName := route.ShortName.String
-		if nullSafeShortName == "" {
-			nullSafeShortName = combinedID
-		}
-
-		routeModel := models.Route{
-			ID:                combinedID,
-			AgencyID:          agencyID,
-			ShortName:         route.ShortName.String,
-			LongName:          route.LongName.String,
-			Description:       route.Desc.String,
-			Type:              models.RouteType(route.Type),
-			URL:               route.Url.String,
-			Color:             route.Color.String,
-			TextColor:         route.TextColor.String,
-			NullSafeShortName: nullSafeShortName,
-		}
-		modelRoutes = append(modelRoutes, routeModel)
-	}
-
-	return modelRoutes, nil
+	return buildRouteModels(ctx, agencyID, routes)
 }

--- a/internal/restapi/trip_details_handler.go
+++ b/internal/restapi/trip_details_handler.go
@@ -525,8 +525,14 @@ func (api *RestAPI) BuildRouteReference(ctx context.Context, agencyID string, st
 			return nil, ctx.Err()
 		}
 
+		combinedID := utils.FormCombinedID(agencyID, route.ID)
+		nullSafeShortName := route.ShortName.String
+		if nullSafeShortName == "" {
+			nullSafeShortName = combinedID
+		}
+
 		routeModel := models.Route{
-			ID:                utils.FormCombinedID(agencyID, route.ID),
+			ID:                combinedID,
 			AgencyID:          agencyID,
 			ShortName:         route.ShortName.String,
 			LongName:          route.LongName.String,
@@ -535,7 +541,7 @@ func (api *RestAPI) BuildRouteReference(ctx context.Context, agencyID string, st
 			URL:               route.Url.String,
 			Color:             route.Color.String,
 			TextColor:         route.TextColor.String,
-			NullSafeShortName: route.ShortName.String,
+			NullSafeShortName: nullSafeShortName,
 		}
 		modelRoutes = append(modelRoutes, routeModel)
 	}


### PR DESCRIPTION
**Changes Made:**
* **Preserved & Deprecated:** Retained `NullSafeShortName` in the `Route` model and added a standard `// Deprecated:` comment in `models/routes.go` to formally warn developers to migrate to `ShortName` and `ID`.
* **Fixed Fallback Logic:** Updated the fallback logic so that if a route lacks a `shortName`, `nullSafeShortName` correctly falls back to the combined route `id` (e.g., `AgencyID_RouteID`) instead of `longName`.
* **Updated Route Builders:** Applied this fix across all relevant files to ensure the fallback works even when the standard constructor is bypassed:
  * `models/routes.go` (`NewRoute`)
  * `restapi/reference_utils.go` (`BuildRouteReferences`)
  * `restapi/trip_details_handler.go` (`BuildRouteReference`)

**Tests:**
* Modified `TestRouteNullSafeShortNameFallback` in `routes_test.go` to assert the correct fallback behavior to the ID.

fixes: #1008 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added deprecation guidance for a legacy route identification field and recommended using current identifiers.

* **Bug Fixes**
  * Fixed fallback behavior so routes consistently use the route ID when short names are missing.

* **Refactor**
  * Centralized route model construction to a single helper for clearer, more maintainable mapping logic.

* **Tests**
  * Updated tests to cover the revised route identification fallback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->