### PR TITLE
fix: sort schedule-for-stop times by departure time

### DIFF
--- a/gtfsdb/query.sql
+++ b/gtfsdb/query.sql
@@ -502,7 +502,7 @@ FROM
 WHERE
     st.stop_id = ?
 ORDER BY
-    r.id, st.arrival_time;
+    r.id, st.departure_time;
 
 -- name: GetScheduleForStopOnDate :many
 SELECT
@@ -553,7 +553,7 @@ WHERE
     )
     AND r.id IN (sqlc.slice('route_ids'))
 ORDER BY
-    r.id, st.arrival_time;
+    r.id, st.departure_time;
 
 
 -- name: GetImportMetadata :one

--- a/gtfsdb/query.sql.go
+++ b/gtfsdb/query.sql.go
@@ -2885,7 +2885,7 @@ FROM
 WHERE
     st.stop_id = ?
 ORDER BY
-    r.id, st.arrival_time
+    r.id, st.departure_time
 `
 
 type GetScheduleForStopRow struct {
@@ -2982,7 +2982,7 @@ WHERE
     )
     AND r.id IN (/*SLICE:route_ids*/?)
 ORDER BY
-    r.id, st.arrival_time
+    r.id, st.departure_time
 `
 
 type GetScheduleForStopOnDateParams struct {

--- a/internal/restapi/schedule_for_stop_handler_test.go
+++ b/internal/restapi/schedule_for_stop_handler_test.go
@@ -422,6 +422,16 @@ func TestScheduleForStopQueryValidation(t *testing.T) {
 					require.True(ok, "ServiceID should be a string")
 					require.NotEmpty(serviceID, "ServiceID should not be empty")
 					require.Contains(serviceID, "_", "serviceId should have agency prefix")
+
+					// Verify that stop times are strictly sorted by departureTime
+					for i := 0; i < len(stopTimes)-1; i++ {
+						curr := stopTimes[i].(map[string]any)
+						next := stopTimes[i+1].(map[string]any)
+						currDep, okCurr := curr["departureTime"].(float64)
+						nextDep, okNext := next["departureTime"].(float64)
+						require.True(okCurr && okNext, "departureTime should be a number")
+						require.LessOrEqual(currDep, nextDep, "Stop times must be sorted by departureTime ascending")
+					}
 				}
 			}
 		}


### PR DESCRIPTION

### Description
This PR corrects the sorting behavior of the `schedule-for-stop` API endpoint. Previously, fixed-schedule stop times within direction groups were being sorted sequentially by `arrival_time`. This has been updated to align with the specification, ensuring they are strictly sorted by `departure_time`.

### Changes Made
- **SQL Queries:** Updated `GetScheduleForStop` and `GetScheduleForStopOnDate` in `gtfsdb/query.sql` to use `ORDER BY r.id, st.departure_time`.
- **Generated Code:** Ran `make models` to regenerate `query.sql.go` and align it with the updated SQL.
- **Unit Tests:** Enhanced `TestScheduleForStopQueryValidation` in `internal/restapi/schedule_for_stop_handler_test.go` with an explicit assertion loop to verify that stop times are strictly returned in ascending order of `departureTime`. 

### Acceptance Criteria Verified
- [x] Stop times within a `StopRouteDirectionSchedule` are sorted strictly by `departure_time` ascending.
- [x] Unit tests verify this sorting behavior explicitly.

Closes #1033

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated schedule query results to order by departure time instead of arrival time.

* **Tests**
  * Added validation that schedule results are correctly sorted by departure time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->