### PR TITLE
fix: remove full trips from schedule-for-stop references block

### DIFF
--- a/internal/restapi/schedule_for_stop_handler.go
+++ b/internal/restapi/schedule_for_stop_handler.go
@@ -128,7 +128,6 @@ func (api *RestAPI) scheduleForStopHandler(w http.ResponseWriter, r *http.Reques
 	)
 
 	routeRefs := make(map[string]models.Route)
-	tripIDsSet := make(map[string]bool)
 
 	// Pre-process to gather unique IDs for batch fetching
 	uniqueRouteIDsMap := make(map[string]bool)
@@ -207,8 +206,6 @@ func (api *RestAPI) scheduleForStopHandler(w http.ResponseWriter, r *http.Reques
 
 		combinedRouteID := utils.FormCombinedID(agencyID, row.RouteID)
 		combinedTripID := utils.FormCombinedID(agencyID, row.TripID)
-
-		tripIDsSet[row.TripID] = true
 
 		// Convert GTFS time (nanoseconds since midnight) to Unix timestamp in the agency's timezone in milliseconds
 		// GTFS times are stored as time.Duration values (nanoseconds), need to add to the target date

--- a/internal/restapi/schedule_for_stop_handler.go
+++ b/internal/restapi/schedule_for_stop_handler.go
@@ -2,7 +2,6 @@ package restapi
 
 import (
 	"net/http"
-	"strconv"
 	"strings"
 	"time"
 
@@ -237,20 +236,6 @@ func (api *RestAPI) scheduleForStopHandler(w http.ResponseWriter, r *http.Reques
 		}
 	}
 
-	tripIDs := make([]string, 0, len(tripIDsSet))
-	for tripID := range tripIDsSet {
-		tripIDs = append(tripIDs, tripID)
-	}
-
-	var trips []gtfsdb.Trip
-	if len(tripIDs) > 0 {
-		trips, err = api.GtfsManager.GtfsDB.Queries.GetTripsByIDs(ctx, tripIDs)
-		if err != nil {
-			api.serverErrorResponse(w, r, err)
-			return
-		}
-	}
-
 	// Build the route schedules
 	var routeSchedules []models.StopRouteSchedule
 	for routeID, stopTimes := range routeScheduleMap {
@@ -279,21 +264,6 @@ func (api *RestAPI) scheduleForStopHandler(w http.ResponseWriter, r *http.Reques
 	references := models.NewEmptyReferences()
 	references.Agencies = utils.MapValues(agencyRefs)
 	references.Routes = utils.MapValues(routeRefs)
-
-	for _, trip := range trips {
-		combinedTripID := utils.FormCombinedID(agencyID, trip.ID)
-		tripRef := models.NewTripReference(
-			combinedTripID,
-			utils.FormCombinedID(agencyID, trip.RouteID),
-			utils.FormCombinedID(agencyID, trip.ServiceID),
-			trip.TripHeadsign.String,
-			trip.TripShortName.String,
-			strconv.FormatInt(trip.DirectionID.Int64, 10),
-			utils.FormCombinedID(agencyID, trip.BlockID.String),
-			utils.FormCombinedID(agencyID, trip.ShapeID.String),
-		)
-		references.Trips = append(references.Trips, *tripRef)
-	}
 
 	routeIDsWithAgency := make([]string, 0, len(routeIDs))
 	for _, ri := range routeIDs {

--- a/internal/restapi/schedule_for_stop_handler_test.go
+++ b/internal/restapi/schedule_for_stop_handler_test.go
@@ -237,8 +237,6 @@ func TestScheduleForStopHandlerReferences(t *testing.T) {
 		assert.True(t, ok, "Stops should exist in references")
 		assert.Len(t, stopsRef, 1, "Should have exactly one stop")
 
-		_, ok = references["trips"].([]any)
-		assert.True(t, ok, "Trips should exist in references")
 		_, ok = references["routes"].([]any)
 		assert.True(t, ok, "Routes should exist in references")
 	})
@@ -366,9 +364,8 @@ func TestScheduleForStopQueryValidation(t *testing.T) {
 		// Check that all reference types exist (even if empty)
 		_, hasAgencies := references["agencies"]
 		_, hasRoutes := references["routes"]
-		_, hasTrips := references["trips"]
 
-		require.True(hasAgencies || hasRoutes || hasTrips, "At least one reference type should exist")
+		require.True(hasAgencies || hasRoutes, "At least one reference type should exist")
 
 		// Validate entry structure
 		entry, ok := data["entry"].(map[string]any)

--- a/internal/restapi/schedule_for_stop_handler_test.go
+++ b/internal/restapi/schedule_for_stop_handler_test.go
@@ -367,6 +367,13 @@ func TestScheduleForStopQueryValidation(t *testing.T) {
 
 		require.True(hasAgencies || hasRoutes, "At least one reference type should exist")
 
+		// trips must not contain full trip references for schedule-for-stop
+		if rawTrips, hasTrips := references["trips"]; hasTrips {
+			trips, ok := rawTrips.([]any)
+			require.True(ok, "references.trips should be an array when present")
+			require.Len(trips, 0, "references.trips must be empty for schedule-for-stop")
+		}
+
 		// Validate entry structure
 		entry, ok := data["entry"].(map[string]any)
 		require.True(ok, "Entry should exist")


### PR DESCRIPTION

### Description
The `schedule-for-stop` endpoint was fetching and returning full trip objects in the `data.references.Trips` array. This PR removes this behavior to comply with the specification, which explicitly prohibits returning full trip records in the references block to save bandwidth.

### Changes Made
- Removed the batch `GetTripsByIDs` query in `schedule_for_stop_handler.go`.
- Removed the loop that explicitly appended trip objects to `references.Trips`.
- Updated existing tests in `schedule_for_stop_handler_test.go` to remove assertions expecting `references["trips"]` to be present.

### Acceptance Criteria Verified
- [x] The handler no longer executes `GetTripsByIDs` to fetch trips for references.
- [x] `data.references.Trips` is omitted/empty in the JSON response.
- [x] Existing tests that checked for `references["trips"]` have been updated/removed.

Closes #1032

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Trip information has been removed from schedule API responses
  * Responses to schedule queries now include only agency, route, and stop references
  * This change impacts all endpoints related to schedule retrieval
  * Response validation and test expectations have been updated to reflect the modified response structure

<!-- end of auto-generated comment: release notes by coderabbit.ai -->