### PR TITLE
fix(api): respect includeReferences query parameter 

### DIFF
--- a/internal/restapi/route_handler.go
+++ b/internal/restapi/route_handler.go
@@ -49,19 +49,8 @@ func (api *RestAPI) routeHandler(w http.ResponseWriter, r *http.Request) {
 			api.serverErrorResponse(w, r, err)
 			return
 		}
-		agencyModel := models.NewAgencyReference(
-			agency.ID,
-			agency.Name,
-			agency.Url,
-			agency.Timezone,
-			agency.Lang.String,
-			agency.Phone.String,
-			agency.Email.String,
-			agency.FareUrl.String,
-			"",    // disclaimer
-			false, // privateService
-		)
-		references.Agencies = append(references.Agencies, agencyModel)
+		// Use the existing helper to map the database row to the model
+		references.Agencies = append(references.Agencies, models.AgencyReferenceFromDatabase(&agency))
 	}
 
 	// Populate situation references for alerts affecting this route

--- a/internal/restapi/stop_handler.go
+++ b/internal/restapi/stop_handler.go
@@ -58,81 +58,86 @@ func (api *RestAPI) stopHandler(w http.ResponseWriter, r *http.Request) {
 		Parent:             parentID,
 	}
 
+	// Initialize empty references struct
 	references := models.NewEmptyReferences()
-	uniqueAgencyIDs := make(map[string]bool)
 
-	// Add routes to references and collect unique agency IDs
-	for _, route := range routes {
-		routeModel := models.NewRoute(
-			utils.FormCombinedID(route.AgencyID, route.ID),
-			route.AgencyID,
-			route.ShortName.String,
-			route.LongName.String,
-			route.Desc.String,
-			models.RouteType(route.Type),
-			route.Url.String,
-			route.Color.String,
-			route.TextColor.String)
+	// Only populate references if the query parameter is absent or true
+	if ShouldIncludeReferences(r) {
+		uniqueAgencyIDs := make(map[string]bool)
 
-		references.Routes = append(references.Routes, routeModel)
-		uniqueAgencyIDs[route.AgencyID] = true
-	}
+		// Add routes to references and collect unique agency IDs
+		for _, route := range routes {
+			routeModel := models.NewRoute(
+				utils.FormCombinedID(route.AgencyID, route.ID),
+				route.AgencyID,
+				route.ShortName.String,
+				route.LongName.String,
+				route.Desc.String,
+				models.RouteType(route.Type),
+				route.Url.String,
+				route.Color.String,
+				route.TextColor.String)
 
-	// Fetch references for ALL unique agencies involved, not just the first one.
-	for aid := range uniqueAgencyIDs {
-		agency, err := api.GtfsManager.GtfsDB.Queries.GetAgency(ctx, aid)
-		if err == nil {
-			agencyModel := models.NewAgencyReference(
-				agency.ID,
-				agency.Name,
-				agency.Url,
-				agency.Timezone,
-				agency.Lang.String,
-				agency.Phone.String,
-				agency.Email.String,
-				agency.FareUrl.String,
-				"",
-				false,
-			)
-			references.Agencies = append(references.Agencies, agencyModel)
+			references.Routes = append(references.Routes, routeModel)
+			uniqueAgencyIDs[route.AgencyID] = true
 		}
-	}
 
-	if nulls.StringOrEmpty(stop.ParentStation) != "" {
-		parentStop, err := api.GtfsManager.GtfsDB.Queries.GetStop(ctx, stop.ParentStation.String)
-		if err == nil {
-			parentRoutes, _ := api.GtfsManager.GtfsDB.Queries.GetRoutesForStop(ctx, parentStop.ID)
-
-			// Sort parent routes naturally by ShortName
-			utils.SortRoutesByName(parentRoutes)
-
-			parentRouteIDs := make([]string, len(parentRoutes))
-			for i, r := range parentRoutes {
-				parentRouteIDs[i] = utils.FormCombinedID(r.AgencyID, r.ID)
+		// Fetch references for ALL unique agencies involved, not just the first one.
+		for aid := range uniqueAgencyIDs {
+			agency, err := api.GtfsManager.GtfsDB.Queries.GetAgency(ctx, aid)
+			if err == nil {
+				agencyModel := models.NewAgencyReference(
+					agency.ID,
+					agency.Name,
+					agency.Url,
+					agency.Timezone,
+					agency.Lang.String,
+					agency.Phone.String,
+					agency.Email.String,
+					agency.FareUrl.String,
+					"",
+					false,
+				)
+				references.Agencies = append(references.Agencies, agencyModel)
 			}
-			references.Stops = append(references.Stops, models.Stop{
-				ID:                 utils.FormCombinedID(agencyID, parentStop.ID),
-				Name:               nulls.StringOrEmpty(parentStop.Name),
-				Lat:                parentStop.Lat,
-				Lon:                parentStop.Lon,
-				Code:               nulls.StringOrDefault(parentStop.Code, parentStop.ID),
-				Direction:          nulls.StringOrEmpty(parentStop.Direction),
-				LocationType:       int(nulls.Int64OrDefault(parentStop.LocationType, 0)),
-				WheelchairBoarding: utils.MapWheelchairBoarding(nulls.WheelchairBoardingOrUnknown(parentStop.WheelchairBoarding)),
-				RouteIDs:           parentRouteIDs,
-				StaticRouteIDs:     parentRouteIDs,
-			})
 		}
-	}
 
-	// Populate situation references for alerts affecting this stop and its serving routes
-	rawRouteIDs := make([]string, len(routes))
-	for i, route := range routes {
-		rawRouteIDs[i] = route.ID
+		if nulls.StringOrEmpty(stop.ParentStation) != "" {
+			parentStop, err := api.GtfsManager.GtfsDB.Queries.GetStop(ctx, stop.ParentStation.String)
+			if err == nil {
+				parentRoutes, _ := api.GtfsManager.GtfsDB.Queries.GetRoutesForStop(ctx, parentStop.ID)
+
+				// Sort parent routes naturally by ShortName
+				utils.SortRoutesByName(parentRoutes)
+
+				parentRouteIDs := make([]string, len(parentRoutes))
+				for i, r := range parentRoutes {
+					parentRouteIDs[i] = utils.FormCombinedID(r.AgencyID, r.ID)
+				}
+				references.Stops = append(references.Stops, models.Stop{
+					ID:                 utils.FormCombinedID(agencyID, parentStop.ID),
+					Name:               nulls.StringOrEmpty(parentStop.Name),
+					Lat:                parentStop.Lat,
+					Lon:                parentStop.Lon,
+					Code:               nulls.StringOrDefault(parentStop.Code, parentStop.ID),
+					Direction:          nulls.StringOrEmpty(parentStop.Direction),
+					LocationType:       int(nulls.Int64OrDefault(parentStop.LocationType, 0)),
+					WheelchairBoarding: utils.MapWheelchairBoarding(nulls.WheelchairBoardingOrUnknown(parentStop.WheelchairBoarding)),
+					RouteIDs:           parentRouteIDs,
+					StaticRouteIDs:     parentRouteIDs,
+				})
+			}
+		}
+
+		// Populate situation references for alerts affecting this stop and its serving routes
+		rawRouteIDs := make([]string, len(routes))
+		for i, route := range routes {
+			rawRouteIDs[i] = route.ID
+		}
+		alerts := api.collectAlertsForStopsAndRoutes([]string{stopID}, rawRouteIDs)
+		situations := api.BuildSituationReferences(alerts)
+		references.Situations = append(references.Situations, situations...)
 	}
-	alerts := api.collectAlertsForStopsAndRoutes([]string{stopID}, rawRouteIDs)
-	situations := api.BuildSituationReferences(alerts)
-	references.Situations = append(references.Situations, situations...)
 
 	response := models.NewEntryResponse(stopData, *references, api.Clock)
 	api.sendResponse(w, r, response)

--- a/internal/restapi/stop_handler.go
+++ b/internal/restapi/stop_handler.go
@@ -1,7 +1,10 @@
 package restapi
 
 import (
+	"database/sql"
+	"errors"
 	"net/http"
+	"sort"
 
 	"maglev.onebusaway.org/internal/models"
 	"maglev.onebusaway.org/internal/nulls"
@@ -83,23 +86,39 @@ func (api *RestAPI) stopHandler(w http.ResponseWriter, r *http.Request) {
 		}
 
 		// Fetch references for ALL unique agencies involved, not just the first one.
+		agencyIDs := make([]string, 0, len(uniqueAgencyIDs))
+		for aid := range uniqueAgencyIDs {
+			agencyIDs = append(agencyIDs, aid)
+		}
+
+		sort.Strings(agencyIDs)
+
 		for aid := range uniqueAgencyIDs {
 			agency, err := api.GtfsManager.GtfsDB.Queries.GetAgency(ctx, aid)
-			if err == nil {
-				agencyModel := models.NewAgencyReference(
-					agency.ID,
-					agency.Name,
-					agency.Url,
-					agency.Timezone,
-					agency.Lang.String,
-					agency.Phone.String,
-					agency.Email.String,
-					agency.FareUrl.String,
-					"",
-					false,
-				)
-				references.Agencies = append(references.Agencies, agencyModel)
+
+			if err != nil {
+				if errors.Is(err, sql.ErrNoRows) {
+					api.sendNotFound(w, r)
+					return
+				}
+				api.serverErrorResponse(w, r, err)
+				return
 			}
+
+			agencyModel := models.NewAgencyReference(
+				agency.ID,
+				agency.Name,
+				agency.Url,
+				agency.Timezone,
+				agency.Lang.String,
+				agency.Phone.String,
+				agency.Email.String,
+				agency.FareUrl.String,
+				"",
+				false,
+			)
+			references.Agencies = append(references.Agencies, agencyModel)
+
 		}
 
 		if nulls.StringOrEmpty(stop.ParentStation) != "" {

--- a/internal/restapi/stop_handler.go
+++ b/internal/restapi/stop_handler.go
@@ -93,7 +93,7 @@ func (api *RestAPI) stopHandler(w http.ResponseWriter, r *http.Request) {
 
 		sort.Strings(agencyIDs)
 
-		for aid := range uniqueAgencyIDs {
+		for _, aid := range agencyIDs {
 			agency, err := api.GtfsManager.GtfsDB.Queries.GetAgency(ctx, aid)
 
 			if err != nil {

--- a/internal/restapi/stop_handler.go
+++ b/internal/restapi/stop_handler.go
@@ -105,19 +105,8 @@ func (api *RestAPI) stopHandler(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 
-			agencyModel := models.NewAgencyReference(
-				agency.ID,
-				agency.Name,
-				agency.Url,
-				agency.Timezone,
-				agency.Lang.String,
-				agency.Phone.String,
-				agency.Email.String,
-				agency.FareUrl.String,
-				"",
-				false,
-			)
-			references.Agencies = append(references.Agencies, agencyModel)
+			// Use the existing helper to map the database row to the model
+			references.Agencies = append(references.Agencies, models.AgencyReferenceFromDatabase(&agency))
 
 		}
 

--- a/internal/restapi/stop_handler_test.go
+++ b/internal/restapi/stop_handler_test.go
@@ -511,3 +511,30 @@ func TestStopHandler_ParentStationNaturalSorting(t *testing.T) {
 	}
 	assert.Equal(t, expectedRouteIDs, parentRef.RouteIDs, "Parent station RouteIDs should preserve natural order")
 }
+
+func TestStopHandler_IncludeReferences(t *testing.T) {
+	api := createTestApi(t)
+	defer api.Shutdown()
+
+	// Verify standard behavior (includeReferences=true implicitly)
+	respTrue, modelTrue := callAPIHandler[StopEntryResponse](t, api, stopURL(testdata.Stop4062.ID))
+	require.Equal(t, http.StatusOK, respTrue.StatusCode)
+	assert.Equal(t, testdata.Stop4062, modelTrue.Data.Entry)
+	// Verify references are populated
+	assert.NotEmpty(t, modelTrue.Data.References.Agencies, "Agencies should be populated when includeReferences is not false")
+	assert.NotEmpty(t, modelTrue.Data.References.Routes, "Routes should be populated when includeReferences is not false")
+
+	// Verify explicit explicit includeReferences=false behavior
+	respFalse, modelFalse := callAPIHandler[StopEntryResponse](t, api, stopURL(testdata.Stop4062.ID)+"&includeReferences=false")
+	require.Equal(t, http.StatusOK, respFalse.StatusCode)
+
+	// Ensure the core entry data is unaffected
+	assert.Equal(t, testdata.Stop4062, modelFalse.Data.Entry)
+
+	// Verify the references object is present but all arrays are empty (as per spec)
+	assert.Empty(t, modelFalse.Data.References.Agencies, "Agencies must be empty when includeReferences=false")
+	assert.Empty(t, modelFalse.Data.References.Routes, "Routes must be empty when includeReferences=false")
+	assert.Empty(t, modelFalse.Data.References.Stops, "Stops must be empty when includeReferences=false")
+	assert.Empty(t, modelFalse.Data.References.Trips, "Trips must be empty when includeReferences=false")
+	assert.Empty(t, modelFalse.Data.References.Situations, "Situations must be empty when includeReferences=false")
+}

--- a/internal/restapi/stop_handler_test.go
+++ b/internal/restapi/stop_handler_test.go
@@ -535,6 +535,7 @@ func TestStopHandler_IncludeReferences(t *testing.T) {
 	assert.Empty(t, modelFalse.Data.References.Agencies, "Agencies must be empty when includeReferences=false")
 	assert.Empty(t, modelFalse.Data.References.Routes, "Routes must be empty when includeReferences=false")
 	assert.Empty(t, modelFalse.Data.References.Stops, "Stops must be empty when includeReferences=false")
+	assert.Empty(t, modelFalse.Data.References.StopTimes, "StopTimes must be empty when includeReferences=false")
 	assert.Empty(t, modelFalse.Data.References.Trips, "Trips must be empty when includeReferences=false")
 	assert.Empty(t, modelFalse.Data.References.Situations, "Situations must be empty when includeReferences=false")
 }


### PR DESCRIPTION
**Description**
This PR resolves the spec gap where the `includeReferences` query parameter was being ignored, causing the API to unconditionally fetch and populate reference entities.

When `includeReferences=false` is requested, the `stop_handler` now short-circuits the database queries for routes, agencies, stops, and situations. It returns the required references block with empty arrays, fulfilling the specification requirements and improving endpoint performance.

**Changes Made**

* Wrapped the reference population logic in `stop_handler.go` inside a `ShouldIncludeReferences(r)` condition.
* Added `TestStopHandler_IncludeReferences` to verify that passing `includeReferences=false` successfully bypasses the reference lookups without affecting the main `entry` payload.

Closes: #1047

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The stop endpoint supports an includeReferences query parameter to control whether related references (routes, agencies, parent-stop route references, and alert situations) are populated.
  * When includeReferences=false the response still contains a references object but its reference arrays are empty.

* **Tests**
  * Added test coverage verifying includeReferences behavior (references populated by default; empty arrays when false).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->