### PR TITLE
fix: implement vehicleId query parameter in trip-details

### DIFF
--- a/internal/restapi/trip_details_handler.go
+++ b/internal/restapi/trip_details_handler.go
@@ -159,8 +159,12 @@ func (api *RestAPI) tripDetailsHandler(w http.ResponseWriter, r *http.Request) {
 
 	var requestedVehicle *gtfs.Vehicle
 	if params.VehicleID != "" {
-		_, rawVehicleID, vErr := utils.ExtractAgencyIDAndCodeID(params.VehicleID)
+		vehicleAgencyID, rawVehicleID, vErr := utils.ExtractAgencyIDAndCodeID(params.VehicleID)
 		if vErr != nil {
+			api.sendNotFound(w, r)
+			return
+		}
+		if vehicleAgencyID != agencyID {
 			api.sendNotFound(w, r)
 			return
 		}

--- a/internal/restapi/trip_details_handler.go
+++ b/internal/restapi/trip_details_handler.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"time"
 
+	gtfs "github.com/OneBusAway/go-gtfs"
 	"maglev.onebusaway.org/gtfsdb"
 	"maglev.onebusaway.org/internal/models"
 	"maglev.onebusaway.org/internal/nulls"
@@ -21,6 +22,7 @@ type TripParams struct {
 	IncludeSchedule bool
 	IncludeStatus   bool
 	Time            *time.Time
+	VehicleID       string
 }
 
 // parseTripParams parses and validates the common trip query params
@@ -78,6 +80,8 @@ func (api *RestAPI) parseTripParams(r *http.Request, includeScheduleDefault bool
 			fieldErrors["time"] = []string{"must be a valid Unix timestamp in milliseconds"}
 		}
 	}
+
+	params.VehicleID = r.URL.Query().Get("vehicleId")
 
 	if len(fieldErrors) > 0 {
 		return params, fieldErrors
@@ -153,12 +157,27 @@ func (api *RestAPI) tripDetailsHandler(w http.ResponseWriter, r *http.Request) {
 
 	serviceDate, midnight := utils.ServiceDateMidnight(params.ServiceDate, currentTime)
 
+	var requestedVehicle *gtfs.Vehicle
+	if params.VehicleID != "" {
+		_, rawVehicleID, vErr := utils.ExtractAgencyIDAndCodeID(params.VehicleID)
+		if vErr != nil {
+			api.sendNotFound(w, r)
+			return
+		}
+		v, vErr := api.GtfsManager.GetVehicleByID(rawVehicleID)
+		if vErr != nil || v == nil {
+			api.sendNotFound(w, r)
+			return
+		}
+		requestedVehicle = v
+	}
+
 	var schedule *models.Schedule
 	var status *models.TripStatus
 
 	if params.IncludeStatus {
 		var statusErr error
-		status, statusErr = api.BuildTripStatus(ctx, agencyID, trip.ID, nil, serviceDate, currentTime)
+		status, statusErr = api.BuildTripStatus(ctx, agencyID, trip.ID, requestedVehicle, serviceDate, currentTime)
 		if statusErr != nil {
 			api.Logger.Warn("BuildTripStatus failed",
 				"trip_id", trip.ID,

--- a/internal/restapi/trip_details_handler_test.go
+++ b/internal/restapi/trip_details_handler_test.go
@@ -269,4 +269,58 @@ func TestParseTripIdDetailsParams_Unit(t *testing.T) {
 		assert.Contains(t, errs, "serviceDate")
 		assert.Equal(t, "must be a valid Unix timestamp in milliseconds", errs["time"][0])
 	})
+
+	t.Run("vehicleId is parsed", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/?vehicleId=40_v123", nil)
+
+		params, errs := api.parseTripParams(req, true)
+
+		assert.Nil(t, errs)
+		assert.Equal(t, "40_v123", params.VehicleID)
+	})
+
+	t.Run("vehicleId defaults to empty", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/", nil)
+
+		params, errs := api.parseTripParams(req, true)
+
+		assert.Nil(t, errs)
+		assert.Equal(t, "", params.VehicleID)
+	})
+}
+
+func TestTripDetailsHandlerWithVehicleId(t *testing.T) {
+	api := createTestApi(t)
+	defer api.Shutdown()
+
+	agency := mustGetAgencies(t, api)[0]
+	trip := mustGetTrip(t, api)
+	tripID := utils.FormCombinedID(agency.ID, trip.ID)
+
+	t.Run("unknown vehicleId returns 404", func(t *testing.T) {
+		resp, model := callAPIHandler[TripDetailsResponse](t, api,
+			"/api/where/trip-details/"+tripID+".json?key=TEST&vehicleId="+agency.ID+"_nonexistent")
+
+		assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+		assert.Equal(t, http.StatusNotFound, model.Code)
+	})
+
+	t.Run("malformed vehicleId returns 404", func(t *testing.T) {
+		resp, model := callAPIHandler[TripDetailsResponse](t, api,
+			"/api/where/trip-details/"+tripID+".json?key=TEST&vehicleId=malformed")
+
+		assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+		assert.Equal(t, http.StatusNotFound, model.Code)
+	})
+
+	t.Run("valid vehicleId returns 200", func(t *testing.T) {
+		api.GtfsManager.MockAddVehicle("test-vehicle", trip.ID, trip.RouteID)
+
+		resp, model := callAPIHandler[TripDetailsResponse](t, api,
+			"/api/where/trip-details/"+tripID+".json?key=TEST&vehicleId="+agency.ID+"_test-vehicle")
+
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		assert.Equal(t, http.StatusOK, model.Code)
+		assert.Equal(t, tripID, model.Data.Entry.TripID)
+	})
 }


### PR DESCRIPTION
### Description

This PR addresses (spec gap) by implementing support for the `vehicleId` query parameter in the `trip-details` endpoint. 

Previously, the endpoint ignored this parameter entirely. Per the wiki spec, when `vehicleId` is provided, the endpoint must filter the results to only consider the block instance currently assigned to that specific vehicle.

### Changes Included:

* **Parameter Parsing:** Updated `TripParams` and `parseTripParams` to explicitly extract the `vehicleId` from the URL query.
* **Vehicle Validation:** Added logic in `tripDetailsHandler` to extract the raw entity ID and verify the vehicle's existence via `GtfsManager.GetVehicleByID()`.
* **404 Not Found Handling:** If the provided vehicle ID is malformed, or if no block location currently exists for that vehicle, the handler immediately short-circuits and returns an HTTP 404.
* **Status Building:** Injected the resolved `*gtfs.Vehicle` into `BuildTripStatus` instead of passing `nil`.
* **Unit Tests:** Added comprehensive test coverage in `trip_details_handler_test.go` verifying valid, unknown, and malformed `vehicleId` inputs.

fixes: #1052 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Trip details API accepts an optional vehicleId query parameter to produce vehicle-aware trip status.

* **Bug Fixes**
  * Returns 404 for unknown, malformed, or cross-agency vehicle IDs; returns 200 when a valid matching vehicle is provided.

* **Tests**
  * Added unit and end-to-end tests covering vehicleId parsing and trip-details handler behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->