### PR TITLE
fix: trip endpoint spec gaps — routeShortName source and includeReferences

### DIFF
--- a/internal/restapi/trip_handler.go
+++ b/internal/restapi/trip_handler.go
@@ -74,14 +74,7 @@ func (api *RestAPI) tripHandler(w http.ResponseWriter, r *http.Request) {
 
 	// includeReferences defaults to true; when explicitly false the references
 	// block is returned with all sub-arrays empty (matches the Java reference).
-	includeReferences := true
-	if v := r.URL.Query().Get("includeReferences"); v != "" {
-		if parsed, err := strconv.ParseBool(v); err == nil {
-			includeReferences = parsed
-		}
-	}
-
-	if includeReferences {
+	if ShouldIncludeReferences(r) {
 		references.Routes = append(references.Routes, models.NewRoute(
 			utils.FormCombinedID(route.AgencyID, trip.RouteID),
 			route.AgencyID,

--- a/internal/restapi/trip_handler.go
+++ b/internal/restapi/trip_handler.go
@@ -49,15 +49,20 @@ func (api *RestAPI) tripHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	tripModel := &models.Trip{
-		ID:             utils.FormCombinedID(agencyID, trip.ID),
-		RouteID:        utils.FormCombinedID(agencyID, trip.RouteID),
-		ServiceID:      utils.FormCombinedID(agencyID, trip.ServiceID),
-		DirectionID:    strconv.FormatInt(trip.DirectionID.Int64, 10),
-		BlockID:        blockID,
-		ShapeID:        shapeID,
-		TripHeadsign:   trip.TripHeadsign.String,
-		TripShortName:  trip.TripShortName.String,
-		RouteShortName: route.ShortName.String,
+		ID:            utils.FormCombinedID(agencyID, trip.ID),
+		RouteID:       utils.FormCombinedID(agencyID, trip.RouteID),
+		ServiceID:     utils.FormCombinedID(agencyID, trip.ServiceID),
+		DirectionID:   strconv.FormatInt(trip.DirectionID.Int64, 10),
+		BlockID:       blockID,
+		ShapeID:       shapeID,
+		TripHeadsign:  trip.TripHeadsign.String,
+		TripShortName: trip.TripShortName.String,
+		// RouteShortName is the trip's own per-trip route short name (the GTFS
+		// trips.txt route_short_name extension), not the route's short name.
+		// Maglev does not store that column, so it is always empty — matching the
+		// Java reference (BeanFactoryV2.getTrip reads trip.getRouteShortName()).
+		// Clients fall back to the route's shortName in the references block.
+		RouteShortName: "",
 	}
 	tripResponse := models.NewTripResponse(
 		tripModel,
@@ -67,29 +72,40 @@ func (api *RestAPI) tripHandler(w http.ResponseWriter, r *http.Request) {
 
 	references := models.NewEmptyReferences()
 
-	references.Routes = append(references.Routes, models.NewRoute(
-		utils.FormCombinedID(route.AgencyID, trip.RouteID),
-		route.AgencyID,
-		route.ShortName.String,
-		route.LongName.String,
-		route.Desc.String,
-		models.RouteType(route.Type),
-		route.Url.String,
-		route.Color.String,
-		route.TextColor.String))
+	// includeReferences defaults to true; when explicitly false the references
+	// block is returned with all sub-arrays empty (matches the Java reference).
+	includeReferences := true
+	if v := r.URL.Query().Get("includeReferences"); v != "" {
+		if parsed, err := strconv.ParseBool(v); err == nil {
+			includeReferences = parsed
+		}
+	}
 
-	references.Agencies = append(references.Agencies, models.NewAgencyReference(
-		agency.ID,
-		agency.Name,
-		agency.Url,
-		agency.Timezone,
-		agency.Lang.String,
-		agency.Phone.String,
-		agency.Email.String,
-		agency.FareUrl.String,
-		"",
-		false,
-	))
+	if includeReferences {
+		references.Routes = append(references.Routes, models.NewRoute(
+			utils.FormCombinedID(route.AgencyID, trip.RouteID),
+			route.AgencyID,
+			route.ShortName.String,
+			route.LongName.String,
+			route.Desc.String,
+			models.RouteType(route.Type),
+			route.Url.String,
+			route.Color.String,
+			route.TextColor.String))
+
+		references.Agencies = append(references.Agencies, models.NewAgencyReference(
+			agency.ID,
+			agency.Name,
+			agency.Url,
+			agency.Timezone,
+			agency.Lang.String,
+			agency.Phone.String,
+			agency.Email.String,
+			agency.FareUrl.String,
+			"",
+			false,
+		))
+	}
 
 	api.sendResponse(w, r, models.NewEntryResponse(tripResponse, *references, api.Clock))
 }

--- a/internal/restapi/trip_handler_test.go
+++ b/internal/restapi/trip_handler_test.go
@@ -56,7 +56,10 @@ func TestTripHandlerEndToEnd(t *testing.T) {
 	assert.Equal(t, utils.FormCombinedID(testdata.Raba.ID, nulls.StringOrEmpty(trip.ShapeID)), entry.ShapeID)
 	assert.Equal(t, nulls.StringOrEmpty(trip.TripHeadsign), entry.TripHeadsign)
 	assert.Equal(t, nulls.StringOrEmpty(trip.TripShortName), entry.TripShortName)
-	assert.Equal(t, nulls.StringOrEmpty(route.ShortName), entry.RouteShortName)
+	// entry.routeShortName is the trip's own per-trip route short name, not the
+	// route's. Maglev does not store that column, so it is always empty (parity
+	// with the Java reference). Clients fall back to the route reference's shortName.
+	assert.Equal(t, "", entry.RouteShortName)
 
 	// Route reference: id is combined, agencyId matches, shortName echoes the DB.
 	require.NotEmpty(t, model.Data.References.Routes)
@@ -67,6 +70,49 @@ func TestTripHandlerEndToEnd(t *testing.T) {
 
 	// Agency reference: the RABA fixture should be exactly one entry.
 	assert.Contains(t, model.Data.References.Agencies, testdata.Raba)
+}
+
+func TestTripHandler_IncludeReferences(t *testing.T) {
+	api := createTestApi(t)
+	defer api.Shutdown()
+
+	trip := mustGetTrip(t, api)
+	combinedTripID := utils.FormCombinedID(testdata.Raba.ID, trip.ID)
+
+	t.Run("includeReferences=false returns empty references", func(t *testing.T) {
+		resp, model := callAPIHandler[TripEntryResponse](t, api,
+			tripURL(combinedTripID)+"&includeReferences=false")
+
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		assert.Equal(t, http.StatusOK, model.Code)
+
+		// Entry is still fully populated.
+		assert.Equal(t, combinedTripID, model.Data.Entry.ID)
+
+		// All references sub-arrays are empty.
+		assert.Empty(t, model.Data.References.Agencies)
+		assert.Empty(t, model.Data.References.Routes)
+		assert.Empty(t, model.Data.References.Stops)
+		assert.Empty(t, model.Data.References.Trips)
+		assert.Empty(t, model.Data.References.Situations)
+	})
+
+	t.Run("includeReferences=true populates references", func(t *testing.T) {
+		resp, model := callAPIHandler[TripEntryResponse](t, api,
+			tripURL(combinedTripID)+"&includeReferences=true")
+
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		assert.NotEmpty(t, model.Data.References.Routes)
+		assert.NotEmpty(t, model.Data.References.Agencies)
+	})
+
+	t.Run("absent includeReferences defaults to true", func(t *testing.T) {
+		resp, model := callAPIHandler[TripEntryResponse](t, api, tripURL(combinedTripID))
+
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		assert.NotEmpty(t, model.Data.References.Routes)
+		assert.NotEmpty(t, model.Data.References.Agencies)
+	})
 }
 
 func TestTripHandler_NotFoundAndMalformed(t *testing.T) {


### PR DESCRIPTION
Fixes: #987, #1062

Fixes two spec gaps in `/api/where/trip/{id}`, both verified byte-for-byte against the Java reference server.

**1. `entry.routeShortName` sourced from the wrong table**
It read the route's short name; the spec/Java define it as the trip's own per-trip route short name (GTFS `trips.txt route_short_name`). Maglev doesn't store that column, so the parity-correct value is `""`. Clients fall back to `references.routes[].shortName` as the spec instructs.

**2. `includeReferences=false` ignored**
The handler never read the parameter and always populated references. Now parses it (default `true`) and returns empty reference arrays when `false`.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `includeReferences` query parameter to the trip endpoint. When set to `false`, reference data (routes, agencies, stops, trips, situations) are excluded from responses. References are included by default.

* **Bug Fixes**
  * Updated route short name field to reflect correct stored values.

* **Tests**
  * Added test coverage for the new `includeReferences` parameter functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->