### PR TITLE
feat: implement includeReferences query parameter in trip-details

### DIFF
--- a/internal/restapi/trip_details_handler.go
+++ b/internal/restapi/trip_details_handler.go
@@ -218,70 +218,74 @@ func (api *RestAPI) tripDetailsHandler(w http.ResponseWriter, r *http.Request) {
 
 	references := models.NewEmptyReferences()
 
-	if params.IncludeTrip {
-		tripsToInclude := []string{utils.FormCombinedID(agencyID, trip.ID)}
+	includeReferences := ShouldIncludeReferences(r)
+
+	if includeReferences {
+		if params.IncludeTrip {
+			tripsToInclude := []string{utils.FormCombinedID(agencyID, trip.ID)}
+
+			if params.IncludeSchedule && schedule != nil {
+				if schedule.NextTripID != "" {
+					tripsToInclude = append(tripsToInclude, schedule.NextTripID)
+				}
+				if schedule.PreviousTripID != "" {
+					tripsToInclude = append(tripsToInclude, schedule.PreviousTripID)
+				}
+			}
+
+			if params.IncludeStatus && status != nil && status.ActiveTripID != "" {
+				tripsToInclude = append(tripsToInclude, status.ActiveTripID)
+			}
+
+			referencedTrips, err := api.buildReferencedTrips(ctx, agencyID, tripsToInclude, trip)
+			if err != nil {
+				api.serverErrorResponse(w, r, err)
+				return
+			}
+
+			for _, t := range referencedTrips {
+				references.Trips = append(references.Trips, *t)
+			}
+		}
+
+		agencyModel := models.NewAgencyReference(
+			agency.ID,
+			agency.Name,
+			agency.Url,
+			agency.Timezone,
+			agency.Lang.String,
+			agency.Phone.String,
+			agency.Email.String,
+			agency.FareUrl.String,
+			"",
+			false,
+		)
+		references.Agencies = append(references.Agencies, agencyModel)
+
+		if len(situationsIDs) > 0 {
+			alerts := api.GtfsManager.GetAlertsForTrip(r.Context(), tripID)
+			if len(alerts) > 0 {
+				situations := api.BuildSituationReferences(alerts)
+				references.Situations = append(references.Situations, situations...)
+			}
+		}
 
 		if params.IncludeSchedule && schedule != nil {
-			if schedule.NextTripID != "" {
-				tripsToInclude = append(tripsToInclude, schedule.NextTripID)
+			stops, err := api.buildStopReferences(ctx, agencyID, schedule.StopTimes)
+			if err != nil {
+				api.serverErrorResponse(w, r, err)
+				return
 			}
-			if schedule.PreviousTripID != "" {
-				tripsToInclude = append(tripsToInclude, schedule.PreviousTripID)
+			references.Stops = stops
+
+			routes, err := api.BuildRouteReferences(ctx, agencyID, stops)
+			if err != nil {
+				api.serverErrorResponse(w, r, err)
+				return
 			}
+
+			references.Routes = routes
 		}
-
-		if params.IncludeStatus && status != nil && status.ActiveTripID != "" {
-			tripsToInclude = append(tripsToInclude, status.ActiveTripID)
-		}
-
-		referencedTrips, err := api.buildReferencedTrips(ctx, agencyID, tripsToInclude, trip)
-		if err != nil {
-			api.serverErrorResponse(w, r, err)
-			return
-		}
-
-		for _, t := range referencedTrips {
-			references.Trips = append(references.Trips, *t)
-		}
-	}
-
-	agencyModel := models.NewAgencyReference(
-		agency.ID,
-		agency.Name,
-		agency.Url,
-		agency.Timezone,
-		agency.Lang.String,
-		agency.Phone.String,
-		agency.Email.String,
-		agency.FareUrl.String,
-		"",
-		false,
-	)
-	references.Agencies = append(references.Agencies, agencyModel)
-
-	if len(situationsIDs) > 0 {
-		alerts := api.GtfsManager.GetAlertsForTrip(r.Context(), tripID)
-		if len(alerts) > 0 {
-			situations := api.BuildSituationReferences(alerts)
-			references.Situations = append(references.Situations, situations...)
-		}
-	}
-
-	if params.IncludeSchedule && schedule != nil {
-		stops, err := api.buildStopReferences(ctx, agencyID, schedule.StopTimes)
-		if err != nil {
-			api.serverErrorResponse(w, r, err)
-			return
-		}
-		references.Stops = stops
-
-		routes, err := api.BuildRouteReferences(ctx, agencyID, stops)
-		if err != nil {
-			api.serverErrorResponse(w, r, err)
-			return
-		}
-
-		references.Routes = routes
 	}
 
 	response := models.NewEntryResponse(tripDetails, *references, api.Clock)

--- a/internal/restapi/trip_details_handler_test.go
+++ b/internal/restapi/trip_details_handler_test.go
@@ -270,3 +270,61 @@ func TestParseTripIdDetailsParams_Unit(t *testing.T) {
 		assert.Equal(t, "must be a valid Unix timestamp in milliseconds", errs["time"][0])
 	})
 }
+
+// TestTripDetailsHandlerWithIncludeReferencesFalse verifies that when includeReferences=false,
+// the response includes data.references with empty collections for agencies, routes, trips, stops,
+// and situations, while the entry data is still fully populated.
+func TestTripDetailsHandlerWithIncludeReferencesFalse(t *testing.T) {
+	api := createTestApi(t)
+	defer api.Shutdown()
+
+	agency := mustGetAgencies(t, api)[0]
+	trip := mustGetTrip(t, api)
+	tripID := utils.FormCombinedID(agency.ID, trip.ID)
+
+	resp, model := callAPIHandler[TripDetailsResponse](t, api,
+		"/api/where/trip-details/"+tripID+".json?key=TEST&includeReferences=false")
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, http.StatusOK, model.Code)
+
+	assert.Equal(t, tripID, model.Data.Entry.TripID)
+	assert.NotZero(t, model.Data.Entry.ServiceDate.UnixMilli())
+	require.NotNil(t, model.Data.Entry.Schedule)
+
+	refs := model.Data.References
+	assert.Empty(t, refs.Agencies, "agencies should be empty when includeReferences=false")
+	assert.Empty(t, refs.Trips, "trips should be empty when includeReferences=false")
+	assert.Empty(t, refs.Routes, "routes should be empty when includeReferences=false")
+	assert.Empty(t, refs.Stops, "stops should be empty when includeReferences=false")
+	assert.Empty(t, refs.Situations, "situations should be empty when includeReferences=false")
+}
+
+// TestTripDetailsHandlerWithIncludeReferencesDefault verifies that the default behaviour
+// (includeReferences absent or explicitly true) returns populated references.
+func TestTripDetailsHandlerWithIncludeReferencesDefault(t *testing.T) {
+	api := createTestApi(t)
+	defer api.Shutdown()
+
+	agency := mustGetAgencies(t, api)[0]
+	trip := mustGetTrip(t, api)
+	tripID := utils.FormCombinedID(agency.ID, trip.ID)
+
+	tests := []struct {
+		name string
+		url  string
+	}{
+		{"absent", "/api/where/trip-details/" + tripID + ".json?key=TEST"},
+		{"explicit true", "/api/where/trip-details/" + tripID + ".json?key=TEST&includeReferences=true"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp, model := callAPIHandler[TripDetailsResponse](t, api, tt.url)
+
+			assert.Equal(t, http.StatusOK, resp.StatusCode)
+			require.NotEmpty(t, model.Data.References.Agencies,
+				"agencies should be populated when includeReferences is true/absent")
+			assert.Equal(t, agency.ID, model.Data.References.Agencies[0].ID)
+		})
+	}
+}


### PR DESCRIPTION
### Description

This PR addresses by implementing the `includeReferences` query parameter for the `trip-details` endpoint.

Previously, the endpoint always built and serialized the full references object, ignoring caller intent. Now, when `includeReferences=false` is provided, the handler skips the reference-building logic entirely.

### Changes Included:

* **Performance Optimization:** Wrapped the reference-building block (agencies, trips, stops, routes, situations) in an `if includeReferences` condition. When false, we avoid unnecessary database queries, significantly speeding up the response.
* **Spec Compliance:** When false, the `references` object is still present in the JSON envelope, but all its internal collections are initialized as empty arrays `[]`, precisely matching the wiki specification.
* **Robust Testing:** 
  * Added `TestTripDetailsHandlerWithIncludeReferencesFalse` to assert all 5 reference collections are empty while entry data remains intact.
  * Added `TestTripDetailsHandlerWithIncludeReferencesDefault` (table-driven) to verify that both an absent parameter and an explicitly `true` parameter default to populating the references.

fixes: #1053 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Trip Details API now includes an optional parameter to control reference data inclusion in responses. Disabling this feature reduces payload size by excluding reference details for agencies, routes, trips, stops, and situations. When omitted or enabled, references are populated as before, maintaining backward compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->