### PR TITLE
feat: support yyyy-MM-dd format for serviceDate in trip parameters

### DIFF
--- a/internal/restapi/trip_details_handler.go
+++ b/internal/restapi/trip_details_handler.go
@@ -35,13 +35,22 @@ func (api *RestAPI) parseTripParams(r *http.Request, includeScheduleDefault bool
 
 	fieldErrors := make(map[string][]string)
 
-	// Validate serviceDate
+	// Validate serviceDate — accepts either a Unix timestamp in milliseconds
+	// (e.g. "1718409600000") or a calendar date in yyyy-MM-dd format (e.g. "2024-06-15").
 	if serviceDateStr := r.URL.Query().Get("serviceDate"); serviceDateStr != "" {
 		if serviceDateMs, err := strconv.ParseInt(serviceDateStr, 10, 64); err == nil {
 			serviceDate := time.Unix(serviceDateMs/1000, 0)
 			params.ServiceDate = &serviceDate
 		} else {
-			fieldErrors["serviceDate"] = []string{"must be a valid Unix timestamp in milliseconds"}
+			dateLoc := time.UTC
+			if len(loc) > 0 && loc[0] != nil {
+				dateLoc = loc[0]
+			}
+			if serviceDate, err := time.ParseInLocation("2006-01-02", serviceDateStr, dateLoc); err == nil {
+				params.ServiceDate = &serviceDate
+			} else {
+				fieldErrors["serviceDate"] = []string{"must be a valid Unix timestamp in milliseconds or a date in yyyy-MM-dd format"}
+			}
 		}
 	}
 

--- a/internal/restapi/trip_details_handler.go
+++ b/internal/restapi/trip_details_handler.go
@@ -96,7 +96,8 @@ func (api *RestAPI) parseTripParams(r *http.Request, includeScheduleDefault bool
 	// callers receive times in the agency's timezone by default. This prevents the
 	// bug where time.Unix(ms/1000, 0) creates a UTC time and downstream
 	// Year()/Month()/Day()/Format() calls extract the wrong calendar date for
-	// agencies in positive UTC offsets.
+	// agencies in positive UTC offsets. For yyyy-MM-dd dates, this is a no-op since
+	// they are already parsed in the correct timezone at line 49
 	if len(loc) > 0 && loc[0] != nil {
 		if params.ServiceDate != nil {
 			localized := params.ServiceDate.In(loc[0])

--- a/internal/restapi/trip_details_handler_test.go
+++ b/internal/restapi/trip_details_handler_test.go
@@ -115,6 +115,26 @@ func TestTripDetailsHandlerWithServiceDate(t *testing.T) {
 	assert.Equal(t, expectedMidnight.UnixMilli(), model.Data.Entry.ServiceDate.UnixMilli())
 }
 
+func TestTripDetailsHandlerWithServiceDateString(t *testing.T) {
+	api := createTestApi(t)
+	defer api.Shutdown()
+
+	agency := mustGetAgencies(t, api)[0]
+	trip := mustGetTrip(t, api)
+	tripID := utils.FormCombinedID(agency.ID, trip.ID)
+
+	agencyLoc, err := time.LoadLocation(agency.Timezone)
+	require.NoError(t, err)
+	expectedMidnight := time.Date(2025, 7, 20, 0, 0, 0, 0, agencyLoc)
+
+	resp, model := callAPIHandler[TripDetailsResponse](t, api,
+		"/api/where/trip-details/"+tripID+".json?key=TEST&serviceDate=2025-07-20")
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, http.StatusOK, model.Code)
+	assert.Equal(t, expectedMidnight.UnixMilli(), model.Data.Entry.ServiceDate.UnixMilli())
+}
+
 func TestTripDetailsHandlerWithIncludeTrip(t *testing.T) {
 	api := createTestApi(t)
 	defer api.Shutdown()
@@ -246,6 +266,18 @@ func TestParseTripIdDetailsParams_Unit(t *testing.T) {
 		assert.False(t, params.IncludeTrip)
 		assert.False(t, params.IncludeSchedule)
 		assert.NotNil(t, params.ServiceDate)
+	})
+
+	t.Run("serviceDate yyyy-MM-dd format", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/?serviceDate=2024-06-15", nil)
+
+		params, errs := api.parseTripParams(req, true)
+
+		assert.Nil(t, errs)
+		require.NotNil(t, params.ServiceDate)
+		assert.Equal(t, 2024, params.ServiceDate.Year())
+		assert.Equal(t, time.June, params.ServiceDate.Month())
+		assert.Equal(t, 15, params.ServiceDate.Day())
 	})
 
 	t.Run("defaults", func(t *testing.T) {

--- a/internal/restapi/trip_for_vehicle_handler_test.go
+++ b/internal/restapi/trip_for_vehicle_handler_test.go
@@ -289,6 +289,6 @@ func TestParseTripForVehicleParams_Unit(t *testing.T) {
 		require.NotNil(t, errs)
 		assert.Contains(t, errs, "serviceDate")
 		assert.Contains(t, errs, "time")
-		assert.Equal(t, "must be a valid Unix timestamp in milliseconds", errs["serviceDate"][0])
+		assert.Equal(t, "must be a valid Unix timestamp in milliseconds or a date in yyyy-MM-dd format", errs["serviceDate"][0])
 	})
 }


### PR DESCRIPTION
### Description

This PR addresses by enhancing the shared `parseTripParams` function to natively support calendar dates (`yyyy-MM-dd`) for the `serviceDate` parameter, conforming to the wiki spec.

### Changes Included:

* **Native Parsing Logic:** Upgraded `parseTripParams` to first attempt parsing the `serviceDate` as Unix milliseconds. If that fails, it falls back to parsing the string as a `yyyy-MM-dd` calendar date.
* **Timezone Safety:** Crucially, calendar dates are parsed using `time.ParseInLocation` with the provided agency timezone (`loc`). This ensures "midnight" is calculated correctly relative to the agency's local time, preventing UTC-offset date-shift bugs. Defaults to UTC safely if no location is provided.
* **Refined Error Messaging:** Updated the validation error to explicitly state: `"must be a valid Unix timestamp in milliseconds or a date in yyyy-MM-dd format"`.
* **Testing:** 
   * Added `TestParseTripIdDetailsParams_Unit/serviceDate yyyy-MM-dd format` to verify accurate year/month/day extraction.
  * Added `TestTripDetailsHandlerWithServiceDateString` to integration test a full handler call with the calendar string format.

Fixes: #1054 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Service dates can now be provided in user-friendly `yyyy-MM-dd` format, in addition to Unix timestamps in milliseconds. Calendar dates are interpreted using the agency’s local timezone.
  * Added coverage to confirm `TripDetailsHandler` correctly accepts `serviceDate=YYYY-MM-DD` and returns the expected service date value.
* **Bug Fixes**
  * Updated validation/error messaging to reflect the expanded accepted `serviceDate` formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->