### PR TITLE
feat: support yyyy-MM-dd_HH-mm-ss format for time parameter

### DIFF
--- a/internal/restapi/trip_details_handler.go
+++ b/internal/restapi/trip_details_handler.go
@@ -69,13 +69,22 @@ func (api *RestAPI) parseTripParams(r *http.Request, includeScheduleDefault bool
 		}
 	}
 
-	// Validate time
+	// Validate time — accepts either a Unix timestamp in milliseconds
+	// (e.g. "1718459400000") or a datetime in yyyy-MM-dd_HH-mm-ss format (e.g. "2024-06-15_14-30-00").
 	if timeStr := r.URL.Query().Get("time"); timeStr != "" {
 		if timeMs, err := strconv.ParseInt(timeStr, 10, 64); err == nil {
 			timeParam := time.Unix(timeMs/1000, 0)
 			params.Time = &timeParam
 		} else {
-			fieldErrors["time"] = []string{"must be a valid Unix timestamp in milliseconds"}
+			timeLoc := time.UTC
+			if len(loc) > 0 && loc[0] != nil {
+				timeLoc = loc[0]
+			}
+			if timeParam, err := time.ParseInLocation("2006-01-02_15-04-05", timeStr, timeLoc); err == nil {
+				params.Time = &timeParam
+			} else {
+				fieldErrors["time"] = []string{"must be a valid Unix timestamp in milliseconds or a datetime in yyyy-MM-dd_HH-mm-ss format"}
+			}
 		}
 	}
 

--- a/internal/restapi/trip_details_handler_test.go
+++ b/internal/restapi/trip_details_handler_test.go
@@ -267,6 +267,37 @@ func TestParseTripIdDetailsParams_Unit(t *testing.T) {
 		assert.NotNil(t, errs)
 		assert.Contains(t, errs, "time")
 		assert.Contains(t, errs, "serviceDate")
-		assert.Equal(t, "must be a valid Unix timestamp in milliseconds", errs["time"][0])
+		assert.Equal(t, "must be a valid Unix timestamp in milliseconds or a datetime in yyyy-MM-dd_HH-mm-ss format", errs["time"][0])
 	})
+
+	t.Run("time yyyy-MM-dd_HH-mm-ss format", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/?time=2024-06-15_14-30-00", nil)
+
+		params, errs := api.parseTripParams(req, true)
+
+		assert.Nil(t, errs)
+		require.NotNil(t, params.Time)
+		assert.Equal(t, 2024, params.Time.Year())
+		assert.Equal(t, time.June, params.Time.Month())
+		assert.Equal(t, 15, params.Time.Day())
+		assert.Equal(t, 14, params.Time.Hour())
+		assert.Equal(t, 30, params.Time.Minute())
+		assert.Equal(t, 0, params.Time.Second())
+	})
+}
+
+func TestTripDetailsHandlerWithTimeParameterString(t *testing.T) {
+	api := createTestApi(t)
+	defer api.Shutdown()
+
+	agency := mustGetAgencies(t, api)[0]
+	trip := mustGetTrip(t, api)
+	tripID := utils.FormCombinedID(agency.ID, trip.ID)
+
+	resp, model := callAPIHandler[TripDetailsResponse](t, api,
+		"/api/where/trip-details/"+tripID+".json?key=TEST&time=2025-07-20_14-30-00")
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, http.StatusOK, model.Code)
+	assert.NotEmpty(t, model.Data.Entry.TripID)
 }


### PR DESCRIPTION
### Description

This PR addresses by updating the shared `parseTripParams` function to accept the `time` query parameter as a calendar datetime string (`yyyy-MM-dd_HH-mm-ss`), as specified in the wiki.

### Changes Included:

* **Dual-Format Parsing:** The `time` parameter now natively accepts both Unix millisecond timestamps (preserving backwards compatibility) and human-readable datetime strings.
* **Timezone Localization:** Datetime strings are parsed using `time.ParseInLocation` with the agency's configured timezone. This ensures that a time requested as "14:30:00" is accurately evaluated in the agency's local time, not UTC.
* **Validation Messaging:** Updated the `fieldErrors` map to return a precise error message when an invalid format is provided.
* **Test Coverage:** 
  * Added a unit test to verify exact extraction of year, month, day, hour, minute, and second.
  * Added an integration test (`TestTripDetailsHandlerWithTimeParameterString`) to verify the endpoint successfully returns HTTP 200 when using the new parameter format.

Fixes: #1055 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The `time` parameter now accepts datetime strings in `yyyy-MM-dd_HH-mm-ss` format in addition to Unix timestamps in milliseconds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->