### PR TITLE
fix: remove undocumented fields from trip-details stopTimes schema

### DIFF
--- a/internal/models/block.go
+++ b/internal/models/block.go
@@ -19,8 +19,14 @@ type TripBlock struct {
 }
 
 type BlockStopTime struct {
-	AccumulatedSlackTime ModelDuration `json:"accumulatedSlackTime"`
-	BlockSequence        int           `json:"blockSequence"`
-	DistanceAlongBlock   float64       `json:"distanceAlongBlock"`
-	StopTime             StopTime      `json:"stopTime"`
+	AccumulatedSlackTime ModelDuration     `json:"accumulatedSlackTime"`
+	BlockSequence        int               `json:"blockSequence"`
+	DistanceAlongBlock   float64           `json:"distanceAlongBlock"`
+	StopTime             BlockStopTimeData `json:"stopTime"`
+}
+
+type BlockStopTimeData struct {
+	StopTime
+	DropOffType int `json:"dropOffType"`
+	PickupType  int `json:"pickupType"`
 }

--- a/internal/models/stop_times.go
+++ b/internal/models/stop_times.go
@@ -9,8 +9,6 @@ type StopTimes struct {
 type StopTime struct {
 	ArrivalTime         ModelDuration `json:"arrivalTime"`
 	DepartureTime       ModelDuration `json:"departureTime"`
-	DropOffType         int           `json:"dropOffType"`
-	PickupType          int           `json:"pickupType"`
 	StopID              string        `json:"stopId"`
 	StopHeadsign        string        `json:"stopHeadsign"`
 	DistanceAlongTrip   float64       `json:"distanceAlongTrip"`

--- a/internal/models/stop_times_test.go
+++ b/internal/models/stop_times_test.go
@@ -30,8 +30,6 @@ func TestStopTimeJSON(t *testing.T) {
 	stopTime := StopTime{
 		ArrivalTime:         NewModelDuration(8 * time.Hour),
 		DepartureTime:       NewModelDuration(8*time.Hour + (100 * time.Second)),
-		DropOffType:         0,
-		PickupType:          0,
 		StopID:              "unitrans_22005",
 		StopHeadsign:        "Downtown",
 		DistanceAlongTrip:   1234.56,

--- a/internal/restapi/block_handler.go
+++ b/internal/restapi/block_handler.go
@@ -124,12 +124,14 @@ func transformBlockToEntry(block []gtfsdb.GetBlockDetailsRow, blockID, agencyID 
 				blockStopTime := models.BlockStopTime{
 					BlockSequence:      int(stop.StopSequence - 1),
 					DistanceAlongBlock: blockDistance,
-					StopTime: models.StopTime{
-						ArrivalTime:   models.NewModelDuration(time.Duration(stop.ArrivalTime)),
-						DepartureTime: models.NewModelDuration(time.Duration(stop.DepartureTime)),
-						DropOffType:   int(stop.DropOffType.Int64),
-						PickupType:    int(stop.PickupType.Int64),
-						StopID:        utils.FormCombinedID(agencyID, stop.StopID),
+					StopTime: models.BlockStopTimeData{
+						StopTime: models.StopTime{
+							ArrivalTime:   models.NewModelDuration(time.Duration(stop.ArrivalTime)),
+							DepartureTime: models.NewModelDuration(time.Duration(stop.DepartureTime)),
+							StopID:        utils.FormCombinedID(agencyID, stop.StopID),
+						},
+						DropOffType: int(stop.DropOffType.Int64),
+						PickupType:  int(stop.PickupType.Int64),
 					},
 				}
 				blockStopTimes = append(blockStopTimes, blockStopTime)


### PR DESCRIPTION
### Description

This PR addresses by removing extra fields from the `trip-details` response that were not defined in the wiki spec, reducing payload noise and strictly adhering to the API contract.

### Changes Included:

* **Cleaned StopTime Model:** Removed `DropOffType` and `PickupType` from the base `StopTime` struct in `internal/models/stop_times.go` to match the `trip-details` spec.
* **Preserved Block Endpoint Contract:** Since the `block` endpoint *does* require these fields in its spec, I introduced a new `BlockStopTimeData` struct in `internal/models/block.go`. This wrapper embeds the clean `StopTime` and appends the necessary drop-off/pickup types.
* **Handler Updates:** Updated `block_handler.go` to construct the response using the new `BlockStopTimeData` wrapper, isolating the schemas without duplicating core logic.
* **Test Updates:** Cleaned up `stop_times_test.go` to reflect the removed fields.

Fixes: #1057 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Reorganized internal data model for block stop timing information to improve code structure and better separate scheduling attributes related to pickup and drop-off operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->