### PR TITLE
fix: omit schedule field from trip-details response when nil

### DIFF
--- a/internal/models/trip_details.go
+++ b/internal/models/trip_details.go
@@ -4,7 +4,7 @@ import "time"
 
 type TripDetails struct {
 	Frequency    *Frequency  `json:"frequency,omitempty"` // omitempty intentional: trip-details callers expect the field absent when the trip is not frequency-based
-	Schedule     *Schedule   `json:"schedule"`
+	Schedule     *Schedule   `json:"schedule,omitempty"`
 	ServiceDate  ModelTime   `json:"serviceDate"`
 	SituationIDs []string    `json:"situationIds"`
 	Status       *TripStatus `json:"status,omitempty"`


### PR DESCRIPTION
### Description

This PR addresses to ensure strict compliance with the wiki spec regarding the `schedule` field in the `trip-details` endpoint.

The spec explicitly states: *"The schedule key is absent from the entry entirely"* when `includeSchedule=false`. Previously, the field lacked the `omitempty` tag, causing the JSON encoder to emit `"schedule": null` when the schedule pointer was `nil`. 

### Changes Included:

* **JSON Tag Update:** Added the `omitempty` tag to the `Schedule` field within the `TripDetails` model (`internal/models/trip_details.go`). This ensures the key is completely dropped from the JSON payload when the schedule is not requested, matching the expected contract behavior.

Fixes: #1058 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized trip details data format to exclude empty schedule entries from API responses, resulting in cleaner and more efficient data transmission to clients.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->