### PR TITLE
refactor: unify middleware application for API routes and tests

### DIFF
--- a/cmd/api/app.go
+++ b/cmd/api/app.go
@@ -174,7 +174,7 @@ func CreateServer(coreApp *app.Application, cfg appconf.Config) (*http.Server, *
 	apiHandler = restapi.GtfsExpiryMiddleware(api.GtfsManager)(apiHandler)
 	apiHandler = api.VersionValidationMiddleware(apiHandler)
 
-	// Apply global compression around the entire mux
+	// Apply compression around apiHandler (the mux plus API-specific middleware)
 	compressedMux := restapi.CompressionMiddleware(apiHandler)
 
 	// Add freshness middleware

--- a/cmd/api/app.go
+++ b/cmd/api/app.go
@@ -166,8 +166,16 @@ func CreateServer(coreApp *app.Application, cfg appconf.Config) (*http.Server, *
 		ErrorLog: slog.NewLogLogger(coreApp.Logger.Handler(), slog.LevelError),
 	}))
 
+	// Apply API-specific middleware closest to the routes. Both middlewares
+	// guard on the "/api/" path prefix internally, so wrapping the whole mux
+	// leaves web UI and other endpoints untouched.
+	// Order (innermost to outermost): expiry -> version.
+	var apiHandler http.Handler = mux
+	apiHandler = restapi.GtfsExpiryMiddleware(api.GtfsManager)(apiHandler)
+	apiHandler = api.VersionValidationMiddleware(apiHandler)
+
 	// Apply global compression around the entire mux
-	compressedMux := restapi.CompressionMiddleware(mux)
+	compressedMux := restapi.CompressionMiddleware(apiHandler)
 
 	// Add freshness middleware
 	freshnessHandler := api.FreshnessMiddleware(compressedMux)

--- a/internal/restapi/routes.go
+++ b/internal/restapi/routes.go
@@ -118,21 +118,3 @@ func (api *RestAPI) SetRoutes(mux *http.ServeMux) {
 	mux.Handle("GET /api/where/trips-for-route/{id}", CacheControlMiddleware(models.CacheDurationShort, rateLimitAndValidateAPIKey(api, api.tripsForRouteHandler)))
 	mux.Handle("GET /api/where/arrivals-and-departures-for-stop/{id}", CacheControlMiddleware(models.CacheDurationShort, rateLimitAndValidateAPIKey(api, api.arrivalsAndDeparturesForStopHandler)))
 }
-
-// SetupAPIRoutes creates and configures the API router with all middleware applied globally
-func (api *RestAPI) SetupAPIRoutes() http.Handler {
-	// Create the base router
-	mux := http.NewServeMux()
-
-	// Register all API routes
-	api.SetRoutes(mux)
-
-	// Apply global middleware chain: compression -> freshness -> version -> expiry -> base routes
-	var handler http.Handler = mux
-	handler = GtfsExpiryMiddleware(api.GtfsManager)(handler)
-	handler = api.VersionValidationMiddleware(handler)
-	handler = api.FreshnessMiddleware(handler)
-	handler = CompressionMiddleware(handler)
-
-	return handler
-}

--- a/internal/restapi/routes_test.go
+++ b/internal/restapi/routes_test.go
@@ -12,12 +12,12 @@ func (api *RestAPI) SetupAPIRoutes() http.Handler {
 	// Register all API routes
 	api.SetRoutes(mux)
 
-	// Apply global middleware chain: compression -> freshness -> version -> expiry -> base routes
+	// Apply global middleware chain: freshness -> compression -> version -> expiry -> base routes
 	var handler http.Handler = mux
 	handler = GtfsExpiryMiddleware(api.GtfsManager)(handler)
 	handler = api.VersionValidationMiddleware(handler)
-	handler = api.FreshnessMiddleware(handler)
 	handler = CompressionMiddleware(handler)
+	handler = api.FreshnessMiddleware(handler)
 
 	return handler
 }

--- a/internal/restapi/routes_test.go
+++ b/internal/restapi/routes_test.go
@@ -1,0 +1,23 @@
+package restapi
+
+import "net/http"
+
+// SetupAPIRoutes creates and configures the API router with all middleware applied globally.
+// It is a test-only helper that mirrors the middleware chain assembled in production by
+// cmd/api.CreateServer, so handler tests exercise the same global middleware as production.
+func (api *RestAPI) SetupAPIRoutes() http.Handler {
+	// Create the base router
+	mux := http.NewServeMux()
+
+	// Register all API routes
+	api.SetRoutes(mux)
+
+	// Apply global middleware chain: compression -> freshness -> version -> expiry -> base routes
+	var handler http.Handler = mux
+	handler = GtfsExpiryMiddleware(api.GtfsManager)(handler)
+	handler = api.VersionValidationMiddleware(handler)
+	handler = api.FreshnessMiddleware(handler)
+	handler = CompressionMiddleware(handler)
+
+	return handler
+}


### PR DESCRIPTION
Fixes: #1045 

## Summary

Production and test middleware stacks had drifted apart. `SetupAPIRoutes` was only used in tests, which led to `VersionValidationMiddleware` being tested but never running in production (#1004).

### Changes
- Added `GtfsExpiryMiddleware` and `VersionValidationMiddleware` to `cmd/api.CreateServer`.
- Moved `SetupAPIRoutes` to `routes_test.go` since it's only used by tests.
- Ensured production and test behavior are aligned for API middleware.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured middleware application to improve request handling efficiency. API-specific validation and compression are now applied more selectively based on request routes, reducing overhead on non-API endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->