### PR TITLE
fix: stops-for-agency spec: 404, stop direction parity, code fallback, parent station

### DIFF
--- a/internal/gtfs/advanced_direction_calculator.go
+++ b/internal/gtfs/advanced_direction_calculator.go
@@ -19,7 +19,6 @@ import (
 
 const (
 	defaultStandardDeviationThreshold = 0.7
-	shapePointWindow                  = 5
 )
 
 // AdvancedDirectionCalculator implements the OneBusAway Java algorithm for stop direction calculation
@@ -355,29 +354,65 @@ func (adc *AdvancedDirectionCalculator) calculateOrientationAtStop(ctx context.C
 		closestIdx = 0
 	}
 
-	// Define window around stop
-	indexFrom := closestIdx - shapePointWindow
-	if indexFrom < 0 {
-		indexFrom = 0
+	// Match the Java reference: the orientation is the bearing of the single shape
+	// segment the stop lies on. Java's DistanceTraveledShapePointIndex computes
+	// computeOrientation(index-1, index) over the segment bracketing the stop — NOT
+	// a wide multi-point chord. A wide chord rotates the bearing on curves and
+	// produces adjacent-bucket (±45°) divergences from the reference.
+	n := len(shapePoints)
+	var fromIdx, toIdx int
+	switch {
+	case closestIdx <= 0:
+		fromIdx, toIdx = 0, 1
+	case closestIdx >= n-1:
+		fromIdx, toIdx = n-2, n-1
+	default:
+		// Pick whichever adjacent segment (prev→closest or closest→next) the stop
+		// lies nearest to — i.e. the segment the stop is actually on.
+		prevD := distanceToSegment(stopLat, stopLon,
+			shapePoints[closestIdx-1].Lat, shapePoints[closestIdx-1].Lon,
+			shapePoints[closestIdx].Lat, shapePoints[closestIdx].Lon)
+		nextD := distanceToSegment(stopLat, stopLon,
+			shapePoints[closestIdx].Lat, shapePoints[closestIdx].Lon,
+			shapePoints[closestIdx+1].Lat, shapePoints[closestIdx+1].Lon)
+		if prevD <= nextD {
+			fromIdx, toIdx = closestIdx-1, closestIdx
+		} else {
+			fromIdx, toIdx = closestIdx, closestIdx+1
+		}
 	}
-	indexTo := closestIdx + shapePointWindow
-	if indexTo >= len(shapePoints) {
-		indexTo = len(shapePoints) - 1
+
+	fromPoint := shapePoints[fromIdx]
+	toPoint := shapePoints[toIdx]
+
+	// Use raw lon/lat deltas with NO cos(latitude) scaling, matching the Java
+	// reference (SphericalGeometryLibrary.getOrientation). A cos-lat correction
+	// would be more geographically accurate but diverges from the reference values
+	// clients expect, so we intentionally omit it.
+	dx := toPoint.Lon - fromPoint.Lon
+	dy := toPoint.Lat - fromPoint.Lat
+
+	return math.Atan2(dy, dx), nil
+}
+
+// distanceToSegment returns the (planar) distance from point (plat, plon) to the
+// segment (alat, alon)–(blat, blon). Used only to decide which adjacent shape
+// segment a stop lies on, so a flat lat/lon approximation is sufficient.
+func distanceToSegment(plat, plon, alat, alon, blat, blon float64) float64 {
+	dx := blon - alon
+	dy := blat - alat
+	if dx == 0 && dy == 0 {
+		return math.Hypot(plon-alon, plat-alat)
 	}
-
-	// Calculate orientation from the window using flat-earth approximation
-	if indexTo > indexFrom {
-		fromPoint := shapePoints[indexFrom]
-		toPoint := shapePoints[indexTo]
-
-		dx := (toPoint.Lon - fromPoint.Lon) * math.Cos(fromPoint.Lat*math.Pi/180.0)
-		dy := toPoint.Lat - fromPoint.Lat
-
-		orientation := math.Atan2(dy, dx)
-		return orientation, nil
+	t := ((plon-alon)*dx + (plat-alat)*dy) / (dx*dx + dy*dy)
+	if t < 0 {
+		t = 0
+	} else if t > 1 {
+		t = 1
 	}
-
-	return 0, sql.ErrNoRows
+	projLon := alon + t*dx
+	projLat := alat + t*dy
+	return math.Hypot(plon-projLon, plat-projLat)
 }
 
 // getAngleAsDirection converts a radian angle to compass direction

--- a/internal/restapi/stops_for_agency_handler.go
+++ b/internal/restapi/stops_for_agency_handler.go
@@ -31,7 +31,7 @@ func (api *RestAPI) stopsForAgencyHandler(w http.ResponseWriter, r *http.Request
 		return
 	}
 	if agency == nil {
-		api.sendNull(w, r)
+		api.sendNotFound(w, r)
 		return
 	}
 
@@ -61,8 +61,64 @@ func (api *RestAPI) stopsForAgencyHandler(w http.ResponseWriter, r *http.Request
 	references.Agencies = []models.AgencyReference{models.AgencyReferenceFromDatabase(agency)}
 	references.Routes = routeRefs
 
+	// Resolve parent stations referenced by any stop into references.stops.
+	parentRefs, err := api.buildParentStationReferences(ctx, id, stopsList)
+	if err != nil {
+		api.serverErrorResponse(w, r, err)
+		return
+	}
+	references.Stops = parentRefs
+
 	response := models.NewListResponse(stopsList, *references, false, api.Clock)
 	api.sendResponse(w, r, response)
+}
+
+// buildParentStationReferences resolves the unique parent stations referenced by
+// stopsList into minimal Stop records for the references block.
+func (api *RestAPI) buildParentStationReferences(ctx context.Context, agencyID string, stopsList []models.Stop) ([]models.Stop, error) {
+	seen := make(map[string]struct{})
+	var parentRawIDs []string
+	for _, s := range stopsList {
+		if s.Parent == "" {
+			continue
+		}
+		rawID, err := utils.ExtractCodeID(s.Parent)
+		if err != nil {
+			continue
+		}
+		if _, ok := seen[rawID]; ok {
+			continue
+		}
+		seen[rawID] = struct{}{}
+		parentRawIDs = append(parentRawIDs, rawID)
+	}
+
+	if len(parentRawIDs) == 0 {
+		return []models.Stop{}, nil
+	}
+
+	parentStops, err := api.GtfsManager.GtfsDB.Queries.GetStopsByIDs(ctx, parentRawIDs)
+	if err != nil {
+		return nil, err
+	}
+
+	parentRefs := make([]models.Stop, 0, len(parentStops))
+	for _, ps := range parentStops {
+		parentRefs = append(parentRefs, models.Stop{
+			Code:               nulls.StringOrDefault(ps.Code, ps.ID),
+			Direction:          nulls.StringOrEmpty(ps.Direction),
+			ID:                 utils.FormCombinedID(agencyID, ps.ID),
+			Lat:                ps.Lat,
+			LocationType:       int(ps.LocationType.Int64),
+			Lon:                ps.Lon,
+			Name:               ps.Name.String,
+			RouteIDs:           []string{},
+			StaticRouteIDs:     []string{},
+			WheelchairBoarding: utils.MapWheelchairBoarding(nulls.WheelchairBoardingOrUnknown(ps.WheelchairBoarding)),
+		})
+	}
+
+	return parentRefs, nil
 }
 
 func (api *RestAPI) buildStopsListForAgency(ctx context.Context, agencyID string, stopIDs []string) ([]models.Stop, error) {
@@ -103,14 +159,20 @@ func (api *RestAPI) buildStopsListForAgency(ctx context.Context, agencyID string
 			routeIdsString = []string{}
 		}
 
+		parentID := ""
+		if nulls.StringOrEmpty(stop.ParentStation) != "" {
+			parentID = utils.FormCombinedID(agencyID, stop.ParentStation.String)
+		}
+
 		stopsList = append(stopsList, models.Stop{
-			Code:               stop.Code.String,
+			Code:               nulls.StringOrDefault(stop.Code, stop.ID),
 			Direction:          nulls.StringOrEmpty(stop.Direction),
 			ID:                 utils.FormCombinedID(agencyID, stop.ID),
 			Lat:                stop.Lat,
 			LocationType:       int(stop.LocationType.Int64),
 			Lon:                stop.Lon,
 			Name:               stop.Name.String,
+			Parent:             parentID,
 			RouteIDs:           routeIdsString,
 			StaticRouteIDs:     routeIdsString,
 			WheelchairBoarding: utils.MapWheelchairBoarding(nulls.WheelchairBoardingOrUnknown(stop.WheelchairBoarding)),

--- a/internal/restapi/stops_for_agency_handler_test.go
+++ b/internal/restapi/stops_for_agency_handler_test.go
@@ -92,6 +92,9 @@ func TestStopsForAgencyInvalidAgency(t *testing.T) {
 
 	resp, model := callAPIHandler[StopsResponse](t, api, stopsForAgencyURL("invalid"))
 
-	assert.Equal(t, http.StatusOK, resp.StatusCode)
-	assert.Equal(t, "", model.Text)
+	// Maglev intentionally corrects the legacy 200+null behavior: an unknown
+	// agency returns 404, consistent with stop-ids-for-agency and other endpoints.
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+	assert.Equal(t, http.StatusNotFound, model.Code)
+	assert.Equal(t, "resource not found", model.Text)
 }


### PR DESCRIPTION
Fixes: #986, #1077

## Description
Fixes four spec gaps in `/api/where/stops-for-agency`, verified against the live Java reference server (unitrans). `stop-ids-for-agency` was already compliant.

**1. Unknown agency → 404**
Was returning HTTP 200 + `null`. The spec's Implementation Decisions mandate 404 (correcting the legacy Java defect), and `stop-ids-for-agency` already did this. Fixed + updated the test that asserted 200.

**2. Stop `direction` parity (112 → 3 mismatches)**
Direction is computed from shape geometry. maglev diverged from Java on 41% of stops because it measured the bearing over a **wide ±5-point chord**; Java uses the **single shape segment the stop lies on**. Also dropped a `cos(latitude)` longitude correction that Java doesn't apply. Now matches Java on 272/275 stops; the remaining 3 are threshold/compass-boundary edge cases (Java projects via synthesized `shape_dist_traveled`, which the feed lacks). This fix improves every stop-direction-bearing endpoint, not just this one.

**3. `code` fallback**
Now falls back to the entity ID when the feed defines no stop code (matching the single-stop handler and spec).

**4. `parent` + parent-station references**
`parent` is now populated, and parent stations are resolved into `references.stops` (spec Extension 3a).

All tests + lint pass.

_Note: directions are precomputed at GTFS load — rebuild the DB (delete `gtfs.db`) and restart to see the direction fix live._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * `/stops-for-agency` endpoint now returns proper 404 error for invalid agencies.

* **New Features**
  * `/stops-for-agency` endpoint now includes parent station information in responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->