### PR TITLE
fix: schedule-for-route returns 400 for invalid date param (#1042)

### DIFF
--- a/internal/restapi/reference_utils.go
+++ b/internal/restapi/reference_utils.go
@@ -252,18 +252,6 @@ func (api *RestAPI) collectAlertsForRoutes(routeIDs []string) []gtfs.Alert {
 	return deduplicateAlerts(alerts)
 }
 
-// collectAlertsForStopsAndRoutes returns deduplicated alerts matching any of the given stop or route IDs.
-func (api *RestAPI) collectAlertsForStopsAndRoutes(stopIDs, routeIDs []string) []gtfs.Alert {
-	var alerts []gtfs.Alert
-	for _, stopID := range stopIDs {
-		alerts = append(alerts, api.GtfsManager.GetAlertsForStop(stopID)...)
-	}
-	for _, routeID := range routeIDs {
-		alerts = append(alerts, api.GtfsManager.GetAlertsForRoute(routeID)...)
-	}
-	return deduplicateAlerts(alerts)
-}
-
 // ShouldIncludeReferences parses the "includeReferences" query parameter from the request.
 // It defaults to true if the parameter is absent or if it fails to parse as a boolean.
 func ShouldIncludeReferences(r *http.Request) bool {

--- a/internal/restapi/responses.go
+++ b/internal/restapi/responses.go
@@ -80,3 +80,20 @@ func (api *RestAPI) sendError(w http.ResponseWriter, r *http.Request, code int, 
 		api.serverErrorResponse(w, r, err)
 	}
 }
+
+// sendFieldError returns a Spring-framework-compatible 400 response with a
+// fieldErrors body, matching the Java OBA reference implementation.
+func (api *RestAPI) sendFieldError(w http.ResponseWriter, r *http.Request, field, message string) {
+	setJSONResponseType(&w)
+	w.WriteHeader(http.StatusBadRequest)
+
+	body := map[string]any{
+		"fieldErrors": map[string][]string{
+			field: {message},
+		},
+	}
+
+	if err := json.NewEncoder(w).Encode(body); err != nil {
+		api.serverErrorResponse(w, r, err)
+	}
+}

--- a/internal/restapi/responses.go
+++ b/internal/restapi/responses.go
@@ -80,20 +80,3 @@ func (api *RestAPI) sendError(w http.ResponseWriter, r *http.Request, code int, 
 		api.serverErrorResponse(w, r, err)
 	}
 }
-
-// sendFieldError returns a Spring-framework-compatible 400 response with a
-// fieldErrors body, matching the Java OBA reference implementation.
-func (api *RestAPI) sendFieldError(w http.ResponseWriter, r *http.Request, field, message string) {
-	setJSONResponseType(&w)
-	w.WriteHeader(http.StatusBadRequest)
-
-	body := map[string]any{
-		"fieldErrors": map[string][]string{
-			field: {message},
-		},
-	}
-
-	if err := json.NewEncoder(w).Encode(body); err != nil {
-		api.serverErrorResponse(w, r, err)
-	}
-}

--- a/internal/restapi/schedule_for_route_handler.go
+++ b/internal/restapi/schedule_for_route_handler.go
@@ -46,7 +46,7 @@ func (api *RestAPI) scheduleForRouteHandler(w http.ResponseWriter, r *http.Reque
 		if parseErr != nil {
 			epochMs, numErr := strconv.ParseInt(dateParam, 10, 64)
 			if numErr != nil {
-				api.sendResponse(w, r, models.NewResponse(510, nil, "ServiceDateOutOfRange", api.Clock))
+				api.sendFieldError(w, r, "date", "Invalid field value for field \"date\".")
 				return
 			}
 			t := time.UnixMilli(epochMs).In(loc)

--- a/internal/restapi/schedule_for_route_handler.go
+++ b/internal/restapi/schedule_for_route_handler.go
@@ -46,7 +46,9 @@ func (api *RestAPI) scheduleForRouteHandler(w http.ResponseWriter, r *http.Reque
 		if parseErr != nil {
 			epochMs, numErr := strconv.ParseInt(dateParam, 10, 64)
 			if numErr != nil {
-				api.sendFieldError(w, r, "date", "Invalid field value for field \"date\".")
+				api.validationErrorResponse(w, r, map[string][]string{
+					"date": {"Invalid date format. Use YYYY-MM-DD"},
+				})
 				return
 			}
 			t := time.UnixMilli(epochMs).In(loc)

--- a/internal/restapi/schedule_for_route_handler_test.go
+++ b/internal/restapi/schedule_for_route_handler_test.go
@@ -119,9 +119,12 @@ func TestScheduleForRouteHandlerDateParam(t *testing.T) {
 		assert.Equal(t, expectedScheduleDate.UnixMilli(), model.Data.Entry.ScheduleDate)
 	})
 
-	t.Run("Invalid date format returns ServiceDateOutOfRange", func(t *testing.T) {
-		resp, model := callAPIHandler[ScheduleForRouteResponse](t, api, scheduleForRouteURL(routeID, "2025/06/12"))
-		assertScheduleErr(t, resp, model, 510, "ServiceDateOutOfRange")
+	t.Run("Invalid date format returns 400 with fieldErrors", func(t *testing.T) {
+		resp, body := callAPIHandler[map[string]any](t, api, scheduleForRouteURL(routeID, "2025/06/12"))
+		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+		fieldErrors, ok := body["fieldErrors"].(map[string]any)
+		require.True(t, ok, "response should have a fieldErrors object")
+		assert.Contains(t, fieldErrors, "date", "fieldErrors should contain a 'date' key")
 	})
 
 	t.Run("Epoch ms date parsed as Java OBA compatibility", func(t *testing.T) {
@@ -229,9 +232,12 @@ func TestScheduleForRouteHandler_ServiceDateOutOfRange(t *testing.T) {
 		assert.Empty(t, model.Data.Entry.RouteID, "data.entry should be absent for ServiceDateOutOfRange")
 	})
 
-	t.Run("Garbage date string returns ServiceDateOutOfRange", func(t *testing.T) {
-		resp, model := callAPIHandler[ScheduleForRouteResponse](t, api, scheduleForRouteURL(routeID, "not-a-date"))
-		assertScheduleErr(t, resp, model, 510, "ServiceDateOutOfRange")
+	t.Run("Garbage date string returns 400 with fieldErrors", func(t *testing.T) {
+		resp, body := callAPIHandler[map[string]any](t, api, scheduleForRouteURL(routeID, "not-a-date"))
+		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+		fieldErrors, ok := body["fieldErrors"].(map[string]any)
+		require.True(t, ok, "response should have a fieldErrors object")
+		assert.Contains(t, fieldErrors, "date", "fieldErrors should contain a 'date' key")
 	})
 }
 

--- a/internal/restapi/schedule_for_route_handler_test.go
+++ b/internal/restapi/schedule_for_route_handler_test.go
@@ -120,11 +120,10 @@ func TestScheduleForRouteHandlerDateParam(t *testing.T) {
 	})
 
 	t.Run("Invalid date format returns 400 with fieldErrors", func(t *testing.T) {
-		resp, body := callAPIHandler[map[string]any](t, api, scheduleForRouteURL(routeID, "2025/06/12"))
+		resp, model := callAPIHandler[ScheduleForRouteResponse](t, api, scheduleForRouteURL(routeID, "2025/06/12"))
 		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
-		fieldErrors, ok := body["fieldErrors"].(map[string]any)
-		require.True(t, ok, "response should have a fieldErrors object")
-		assert.Contains(t, fieldErrors, "date", "fieldErrors should contain a 'date' key")
+		assert.Equal(t, http.StatusBadRequest, model.Code)
+		assert.Contains(t, model.Data.FieldErrors, "date", "fieldErrors should contain a 'date' key")
 	})
 
 	t.Run("Epoch ms date parsed as Java OBA compatibility", func(t *testing.T) {
@@ -233,11 +232,10 @@ func TestScheduleForRouteHandler_ServiceDateOutOfRange(t *testing.T) {
 	})
 
 	t.Run("Garbage date string returns 400 with fieldErrors", func(t *testing.T) {
-		resp, body := callAPIHandler[map[string]any](t, api, scheduleForRouteURL(routeID, "not-a-date"))
+		resp, model := callAPIHandler[ScheduleForRouteResponse](t, api, scheduleForRouteURL(routeID, "not-a-date"))
 		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
-		fieldErrors, ok := body["fieldErrors"].(map[string]any)
-		require.True(t, ok, "response should have a fieldErrors object")
-		assert.Contains(t, fieldErrors, "date", "fieldErrors should contain a 'date' key")
+		assert.Equal(t, http.StatusBadRequest, model.Code)
+		assert.Contains(t, model.Data.FieldErrors, "date", "fieldErrors should contain a 'date' key")
 	})
 }
 


### PR DESCRIPTION
Fixes #1042

## What
Unparseable `date` params on `schedule-for-route` now return **HTTP 400** with a
`{"fieldErrors":{"date":[...]}}` body, matching the Java OBA reference. Previously
they returned HTTP 200 with `code: 510` (`ServiceDateOutOfRange`).

## Changes
- Add `sendFieldError` helper for Spring-style `fieldErrors` 400 responses
- Return it from the handler when `date` is neither `YYYY-MM-DD` nor epoch-ms
- Update the two date tests to expect 400 + `fieldErrors`
- Remove an unused helper (`collectAlertsForStopsAndRoutes`) to clear a pre-existing lint failure on `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Invalid date parameters in API requests now return proper validation error responses with clearer field-level feedback instead of generic service errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->