### PR TITLE
fix: schedule-for-route headsign fallback to last stop name (#1041)

### DIFF
--- a/internal/restapi/schedule_for_route_handler.go
+++ b/internal/restapi/schedule_for_route_handler.go
@@ -181,16 +181,6 @@ func (api *RestAPI) scheduleForRouteHandler(w http.ResponseWriter, r *http.Reque
 			globalStopIDSet[stopID] = struct{}{}
 		}
 
-		seenHeadsigns := make(map[string]bool)
-		var headsigns []string
-		for _, trip := range tripsInGroup {
-			hs := trip.TripHeadsign.String
-			if hs != "" && !seenHeadsigns[hs] {
-				seenHeadsigns[hs] = true
-				headsigns = append(headsigns, hs)
-			}
-		}
-
 		rawTripIDs := make([]string, 0, len(tripsInGroup))
 		for _, trip := range tripsInGroup {
 			rawTripIDs = append(rawTripIDs, trip.ID)
@@ -205,6 +195,42 @@ func (api *RestAPI) scheduleForRouteHandler(w http.ResponseWriter, r *http.Reque
 		stopTimesByTrip := make(map[string][]gtfsdb.StopTime, len(tripsInGroup))
 		for _, st := range allStopTimes {
 			stopTimesByTrip[st.TripID] = append(stopTimesByTrip[st.TripID], st)
+		}
+
+		// Collect headsigns; fall back to the last stop's name when a trip has no
+		// recorded headsign, matching the Java reference behavior.
+		seenHeadsigns := make(map[string]bool)
+		var headsigns []string
+		var fallbackStopIDs []string
+		seenFallbackStops := make(map[string]bool)
+		for _, trip := range tripsInGroup {
+			hs := trip.TripHeadsign.String
+			if hs != "" {
+				if !seenHeadsigns[hs] {
+					seenHeadsigns[hs] = true
+					headsigns = append(headsigns, hs)
+				}
+			} else if sts := stopTimesByTrip[trip.ID]; len(sts) > 0 {
+				lastStopID := sts[len(sts)-1].StopID
+				if !seenFallbackStops[lastStopID] {
+					seenFallbackStops[lastStopID] = true
+					fallbackStopIDs = append(fallbackStopIDs, lastStopID)
+				}
+			}
+		}
+		if len(fallbackStopIDs) > 0 {
+			lastStops, err := api.GtfsManager.GtfsDB.Queries.GetStopsByIDs(ctx, fallbackStopIDs)
+			if err != nil {
+				api.serverErrorResponse(w, r, err)
+				return
+			}
+			for _, s := range lastStops {
+				name := s.Name.String
+				if name != "" && !seenHeadsigns[name] {
+					seenHeadsigns[name] = true
+					headsigns = append(headsigns, name)
+				}
+			}
 		}
 
 		var tripIDs []string

--- a/internal/restapi/schedule_for_route_handler_test.go
+++ b/internal/restapi/schedule_for_route_handler_test.go
@@ -1,13 +1,16 @@
 package restapi
 
 import (
+	"context"
 	"net/http"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"maglev.onebusaway.org/gtfsdb"
 	"maglev.onebusaway.org/internal/clock"
+	"maglev.onebusaway.org/internal/nulls"
 	"maglev.onebusaway.org/internal/restapi/testdata"
 	"maglev.onebusaway.org/internal/utils"
 )
@@ -282,4 +285,80 @@ func TestScheduleForRouteHandlerWithMalformedID(t *testing.T) {
 
 	assert.Equal(t, http.StatusBadRequest, resp.StatusCode, "Status code should be 400 Bad Request")
 	assert.Equal(t, http.StatusBadRequest, model.Code)
+}
+
+func setupHeadsignlessTrip(t *testing.T, api *RestAPI) (combinedRouteID, expectedHeadsign string) {
+	t.Helper()
+	ctx := context.Background()
+	q := api.GtfsManager.GtfsDB.Queries
+
+	const (
+		agencyID     = "hsagency"
+		routeID      = "hsroute"
+		serviceID    = "hssvc"
+		tripID       = "hstrip"
+		lastStopName = "Final Destination"
+	)
+
+	_, err := q.CreateAgency(ctx, gtfsdb.CreateAgencyParams{
+		ID: agencyID, Name: "Headsign Test Agency", Url: "http://hs.test", Timezone: "America/Los_Angeles",
+	})
+	require.NoError(t, err)
+
+	_, err = q.CreateRoute(ctx, gtfsdb.CreateRouteParams{
+		ID: routeID, AgencyID: agencyID, Type: 3, ShortName: nulls.String("HS"),
+	})
+	require.NoError(t, err)
+
+	// Active on Thursdays; the tests query 2025-06-12, which is a Thursday.
+	_, err = q.CreateCalendar(ctx, gtfsdb.CreateCalendarParams{
+		ID: serviceID, Thursday: 1, StartDate: "20250101", EndDate: "20251231",
+	})
+	require.NoError(t, err)
+
+	_, err = q.CreateStop(ctx, gtfsdb.CreateStopParams{
+		ID: "hsstopone", Name: nulls.String("First Stop"), Lat: 40.0, Lon: -120.0,
+	})
+	require.NoError(t, err)
+	_, err = q.CreateStop(ctx, gtfsdb.CreateStopParams{
+		ID: "hsstoptwo", Name: nulls.String(lastStopName), Lat: 40.1, Lon: -120.1,
+	})
+	require.NoError(t, err)
+
+	// Trip with NO headsign: TripHeadsign is left as a zero-value (invalid) NullString.
+	_, err = q.CreateTrip(ctx, gtfsdb.CreateTripParams{
+		ID: tripID, RouteID: routeID, ServiceID: serviceID,
+		DirectionID: nulls.Int64(0),
+	})
+	require.NoError(t, err)
+
+	createStopTime(t, ctx, q, tripID, "hsstopone", 1, 8*3600)
+	createStopTime(t, ctx, q, tripID, "hsstoptwo", 2, 9*3600)
+
+	return utils.FormCombinedID(agencyID, routeID), lastStopName
+}
+
+func createStopTime(t *testing.T, ctx context.Context, q *gtfsdb.Queries, tripID, stopID string, seq, secs int64) {
+	t.Helper()
+	ns := secs * int64(time.Second)
+	_, err := q.CreateStopTime(ctx, gtfsdb.CreateStopTimeParams{
+		TripID: tripID, StopID: stopID, StopSequence: seq,
+		ArrivalTime: ns, DepartureTime: ns,
+	})
+	require.NoError(t, err)
+}
+
+func TestScheduleForRouteHandler_HeadsignFallbackToLastStop(t *testing.T) {
+	api := newScheduleForRouteAPI(t)
+	defer api.Shutdown()
+
+	combinedRouteID, expectedHeadsign := setupHeadsignlessTrip(t, api)
+
+	resp, model := callAPIHandler[ScheduleForRouteResponse](t, api, scheduleForRouteURL(combinedRouteID, "2025-06-12"))
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NotEmpty(t, model.Data.Entry.StopTripGroupings)
+
+	g := model.Data.Entry.StopTripGroupings[0]
+	assert.Contains(t, g.TripHeadsigns, expectedHeadsign,
+		"trip with no headsign should fall back to the last stop's name")
 }


### PR DESCRIPTION
Fixes #1041

When a trip has no `trip_headsign`, the name of its last stop is now used as the
headsign (matching the Java reference). Previously headsign-less trips were
silently skipped, leaving `tripHeadsigns` incomplete.

Note: RABA/unitrans fixtures populate all headsigns, so this fallback path isn't
covered by existing test data.
