### PR TITLE
fix: stops-for-agency response gaps — 404, code fallback, parent stations

### DIFF
--- a/internal/restapi/reference_utils.go
+++ b/internal/restapi/reference_utils.go
@@ -347,7 +347,7 @@ func groupRoutesByStop(agencyID string, allRoutes []gtfsdb.GetRoutesForStopsRow)
 func (api *RestAPI) combinedRouteIDsForStop(agencyID string, routesForStop []gtfsdb.Route) []string {
 	// Sort naturally by ShortName (falling back to LongName, then AgencyID, then ID) so the
 	// route IDs are returned in a stable, human-friendly order.
-	utils.SortRoutesByName(routesForStop, utils.DBRouteSortKey)
+	utils.SortRoutesByName(routesForStop)
 	combinedRouteIDs := make([]string, len(routesForStop))
 	for i, rt := range routesForStop {
 		combinedRouteIDs[i] = utils.FormCombinedID(agencyID, rt.ID)

--- a/internal/restapi/reference_utils.go
+++ b/internal/restapi/reference_utils.go
@@ -347,7 +347,7 @@ func groupRoutesByStop(agencyID string, allRoutes []gtfsdb.GetRoutesForStopsRow)
 func (api *RestAPI) combinedRouteIDsForStop(agencyID string, routesForStop []gtfsdb.Route) []string {
 	// Sort naturally by ShortName (falling back to LongName, then AgencyID, then ID) so the
 	// route IDs are returned in a stable, human-friendly order.
-	utils.SortDBRoutesByName(routesForStop)
+	utils.SortRoutesByName(routesForStop, utils.DBRouteSortKey)
 	combinedRouteIDs := make([]string, len(routesForStop))
 	for i, rt := range routesForStop {
 		combinedRouteIDs[i] = utils.FormCombinedID(agencyID, rt.ID)

--- a/internal/restapi/reference_utils.go
+++ b/internal/restapi/reference_utils.go
@@ -1,10 +1,8 @@
 package restapi
 
 import (
-	"cmp"
 	"context"
 	"net/http"
-	"slices"
 	"strconv"
 	"time"
 
@@ -277,20 +275,13 @@ func BuildStopReferencesAndRouteIDsForStops(api *RestAPI, ctx context.Context, a
 		return []models.Stop{}, map[string]gtfsdb.GetRoutesForStopsRow{}, nil
 	}
 
-	stopIDSet := make(map[string]struct{})
-	uniqueStopIDs := make([]string, 0, len(stopIDs))
-	for _, id := range stopIDs {
-		if _, exists := stopIDSet[id]; !exists {
-			stopIDSet[id] = struct{}{}
-			uniqueStopIDs = append(uniqueStopIDs, id)
-		}
-	}
+	uniqueStopIDs := dedupeStrings(stopIDs)
 
 	stopsDB, err := api.GtfsManager.GtfsDB.Queries.GetStopsByIDs(ctx, uniqueStopIDs)
 	if err != nil {
 		return nil, nil, err
 	}
-	stopMap := make(map[string]gtfsdb.Stop)
+	stopMap := make(map[string]gtfsdb.Stop, len(stopsDB))
 	for _, stop := range stopsDB {
 		stopMap[stop.ID] = stop
 	}
@@ -299,7 +290,37 @@ func BuildStopReferencesAndRouteIDsForStops(api *RestAPI, ctx context.Context, a
 	if err != nil {
 		return nil, nil, err
 	}
+	routesByStop, uniqueRouteMap := groupRoutesByStop(agencyID, allRoutes)
 
+	modelStops := make([]models.Stop, 0, len(uniqueStopIDs))
+	for _, stopID := range uniqueStopIDs {
+		stop, exists := stopMap[stopID]
+		if !exists {
+			continue
+		}
+		combinedRouteIDs := api.combinedRouteIDsForStop(agencyID, routesByStop[stopID])
+		modelStops = append(modelStops, api.buildStopModel(ctx, agencyID, stop, combinedRouteIDs))
+	}
+
+	return modelStops, uniqueRouteMap, nil
+}
+
+// dedupeStrings returns the input slice with duplicates removed, preserving order.
+func dedupeStrings(values []string) []string {
+	seen := make(map[string]struct{}, len(values))
+	unique := make([]string, 0, len(values))
+	for _, v := range values {
+		if _, exists := seen[v]; !exists {
+			seen[v] = struct{}{}
+			unique = append(unique, v)
+		}
+	}
+	return unique
+}
+
+// groupRoutesByStop groups the routes returned by GetRoutesForStops by their stop ID and
+// builds a map of unique routes keyed by their agency-combined ID.
+func groupRoutesByStop(agencyID string, allRoutes []gtfsdb.GetRoutesForStopsRow) (map[string][]gtfsdb.Route, map[string]gtfsdb.GetRoutesForStopsRow) {
 	routesByStop := make(map[string][]gtfsdb.Route)
 	uniqueRouteMap := make(map[string]gtfsdb.GetRoutesForStopsRow)
 	for _, routeRow := range allRoutes {
@@ -318,48 +339,34 @@ func BuildStopReferencesAndRouteIDsForStops(api *RestAPI, ctx context.Context, a
 		combinedID := utils.FormCombinedID(agencyID, routeRow.ID)
 		uniqueRouteMap[combinedID] = routeRow
 	}
+	return routesByStop, uniqueRouteMap
+}
 
-	modelStops := make([]models.Stop, 0, len(uniqueStopIDs))
-	for _, stopID := range uniqueStopIDs {
-		stop, exists := stopMap[stopID]
-		if !exists {
-			continue
-		}
-		routesForStop := routesByStop[stopID]
-		// Sort naturally by ShortName (falling back to LongName, then ID) so the
-		// route IDs are returned in a stable, human-friendly order.
-		slices.SortFunc(routesForStop, func(a, b gtfsdb.Route) int {
-			nameA := a.ShortName.String
-			if nameA == "" {
-				nameA = a.LongName.String
-			}
-			nameB := b.ShortName.String
-			if nameB == "" {
-				nameB = b.LongName.String
-			}
-			if res := utils.NaturalCompare(nameA, nameB); res != 0 {
-				return res
-			}
-			return cmp.Compare(a.ID, b.ID)
-		})
-		combinedRouteIDs := make([]string, len(routesForStop))
-		for i, rt := range routesForStop {
-			combinedRouteIDs[i] = utils.FormCombinedID(agencyID, rt.ID)
-		}
-		stopModel := models.Stop{
-			ID:                 utils.FormCombinedID(agencyID, stop.ID),
-			Name:               stop.Name.String,
-			Lat:                stop.Lat,
-			Lon:                stop.Lon,
-			Code:               stop.Code.String,
-			Direction:          api.DirectionCalculator.CalculateStopDirection(ctx, stop.ID, stop.Direction),
-			LocationType:       int(stop.LocationType.Int64),
-			WheelchairBoarding: utils.MapWheelchairBoarding(nulls.WheelchairBoardingOrUnknown(stop.WheelchairBoarding)),
-			RouteIDs:           combinedRouteIDs,
-			StaticRouteIDs:     combinedRouteIDs,
-		}
-		modelStops = append(modelStops, stopModel)
+// combinedRouteIDsForStop sorts the routes serving a stop into a stable, human-friendly
+// order and returns their agency-combined IDs.
+func (api *RestAPI) combinedRouteIDsForStop(agencyID string, routesForStop []gtfsdb.Route) []string {
+	// Sort naturally by ShortName (falling back to LongName, then AgencyID, then ID) so the
+	// route IDs are returned in a stable, human-friendly order.
+	utils.SortDBRoutesByName(routesForStop)
+	combinedRouteIDs := make([]string, len(routesForStop))
+	for i, rt := range routesForStop {
+		combinedRouteIDs[i] = utils.FormCombinedID(agencyID, rt.ID)
 	}
+	return combinedRouteIDs
+}
 
-	return modelStops, uniqueRouteMap, nil
+// buildStopModel converts a database stop into a models.Stop with the given combined route IDs.
+func (api *RestAPI) buildStopModel(ctx context.Context, agencyID string, stop gtfsdb.Stop, combinedRouteIDs []string) models.Stop {
+	return models.Stop{
+		ID:                 utils.FormCombinedID(agencyID, stop.ID),
+		Name:               stop.Name.String,
+		Lat:                stop.Lat,
+		Lon:                stop.Lon,
+		Code:               stop.Code.String,
+		Direction:          api.DirectionCalculator.CalculateStopDirection(ctx, stop.ID, stop.Direction),
+		LocationType:       int(stop.LocationType.Int64),
+		WheelchairBoarding: utils.MapWheelchairBoarding(nulls.WheelchairBoardingOrUnknown(stop.WheelchairBoarding)),
+		RouteIDs:           combinedRouteIDs,
+		StaticRouteIDs:     combinedRouteIDs,
+	}
 }

--- a/internal/restapi/reference_utils.go
+++ b/internal/restapi/reference_utils.go
@@ -362,7 +362,7 @@ func (api *RestAPI) buildStopModel(ctx context.Context, agencyID string, stop gt
 		Name:               stop.Name.String,
 		Lat:                stop.Lat,
 		Lon:                stop.Lon,
-		Code:               stop.Code.String,
+		Code:               nulls.StringOrDefault(stop.Code, stop.ID),
 		Direction:          api.DirectionCalculator.CalculateStopDirection(ctx, stop.ID, stop.Direction),
 		LocationType:       int(stop.LocationType.Int64),
 		WheelchairBoarding: utils.MapWheelchairBoarding(nulls.WheelchairBoardingOrUnknown(stop.WheelchairBoarding)),

--- a/internal/restapi/reference_utils.go
+++ b/internal/restapi/reference_utils.go
@@ -1,14 +1,17 @@
 package restapi
 
 import (
+	"cmp"
 	"context"
 	"net/http"
+	"slices"
 	"strconv"
 	"time"
 
 	"github.com/OneBusAway/go-gtfs"
 	"maglev.onebusaway.org/gtfsdb"
 	"maglev.onebusaway.org/internal/models"
+	"maglev.onebusaway.org/internal/nulls"
 	"maglev.onebusaway.org/internal/utils"
 )
 
@@ -266,4 +269,97 @@ func ShouldIncludeReferences(r *http.Request) bool {
 	}
 
 	return parsed
+}
+
+// BuildStopReferencesAndRouteIDsForStops builds full stop references and collects unique routes for the given stop IDs.
+func BuildStopReferencesAndRouteIDsForStops(api *RestAPI, ctx context.Context, agencyID string, stopIDs []string) ([]models.Stop, map[string]gtfsdb.GetRoutesForStopsRow, error) {
+	if len(stopIDs) == 0 {
+		return []models.Stop{}, map[string]gtfsdb.GetRoutesForStopsRow{}, nil
+	}
+
+	stopIDSet := make(map[string]struct{})
+	uniqueStopIDs := make([]string, 0, len(stopIDs))
+	for _, id := range stopIDs {
+		if _, exists := stopIDSet[id]; !exists {
+			stopIDSet[id] = struct{}{}
+			uniqueStopIDs = append(uniqueStopIDs, id)
+		}
+	}
+
+	stopsDB, err := api.GtfsManager.GtfsDB.Queries.GetStopsByIDs(ctx, uniqueStopIDs)
+	if err != nil {
+		return nil, nil, err
+	}
+	stopMap := make(map[string]gtfsdb.Stop)
+	for _, stop := range stopsDB {
+		stopMap[stop.ID] = stop
+	}
+
+	allRoutes, err := api.GtfsManager.GtfsDB.Queries.GetRoutesForStops(ctx, uniqueStopIDs)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	routesByStop := make(map[string][]gtfsdb.Route)
+	uniqueRouteMap := make(map[string]gtfsdb.GetRoutesForStopsRow)
+	for _, routeRow := range allRoutes {
+		route := gtfsdb.Route{
+			ID:        routeRow.ID,
+			AgencyID:  routeRow.AgencyID,
+			ShortName: routeRow.ShortName,
+			LongName:  routeRow.LongName,
+			Desc:      routeRow.Desc,
+			Type:      routeRow.Type,
+			Url:       routeRow.Url,
+			Color:     routeRow.Color,
+			TextColor: routeRow.TextColor,
+		}
+		routesByStop[routeRow.StopID] = append(routesByStop[routeRow.StopID], route)
+		combinedID := utils.FormCombinedID(agencyID, routeRow.ID)
+		uniqueRouteMap[combinedID] = routeRow
+	}
+
+	modelStops := make([]models.Stop, 0, len(uniqueStopIDs))
+	for _, stopID := range uniqueStopIDs {
+		stop, exists := stopMap[stopID]
+		if !exists {
+			continue
+		}
+		routesForStop := routesByStop[stopID]
+		// Sort naturally by ShortName (falling back to LongName, then ID) so the
+		// route IDs are returned in a stable, human-friendly order.
+		slices.SortFunc(routesForStop, func(a, b gtfsdb.Route) int {
+			nameA := a.ShortName.String
+			if nameA == "" {
+				nameA = a.LongName.String
+			}
+			nameB := b.ShortName.String
+			if nameB == "" {
+				nameB = b.LongName.String
+			}
+			if res := utils.NaturalCompare(nameA, nameB); res != 0 {
+				return res
+			}
+			return cmp.Compare(a.ID, b.ID)
+		})
+		combinedRouteIDs := make([]string, len(routesForStop))
+		for i, rt := range routesForStop {
+			combinedRouteIDs[i] = utils.FormCombinedID(agencyID, rt.ID)
+		}
+		stopModel := models.Stop{
+			ID:                 utils.FormCombinedID(agencyID, stop.ID),
+			Name:               stop.Name.String,
+			Lat:                stop.Lat,
+			Lon:                stop.Lon,
+			Code:               stop.Code.String,
+			Direction:          api.DirectionCalculator.CalculateStopDirection(ctx, stop.ID, stop.Direction),
+			LocationType:       int(stop.LocationType.Int64),
+			WheelchairBoarding: utils.MapWheelchairBoarding(nulls.WheelchairBoardingOrUnknown(stop.WheelchairBoarding)),
+			RouteIDs:           combinedRouteIDs,
+			StaticRouteIDs:     combinedRouteIDs,
+		}
+		modelStops = append(modelStops, stopModel)
+	}
+
+	return modelStops, uniqueRouteMap, nil
 }

--- a/internal/restapi/reference_utils_test.go
+++ b/internal/restapi/reference_utils_test.go
@@ -1,12 +1,17 @@
 package restapi
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
+	"slices"
+	"strings"
 	"testing"
 
 	"github.com/OneBusAway/go-gtfs"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"maglev.onebusaway.org/internal/utils"
 )
 
 func TestDeduplicateAlerts(t *testing.T) {
@@ -67,4 +72,102 @@ func TestShouldIncludeReferences(t *testing.T) {
 			assert.Equal(t, tt.expected, actual)
 		})
 	}
+}
+
+func TestDedupeStrings(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []string
+		expected []string
+	}{
+		{"empty", []string{}, []string{}},
+		{"no duplicates", []string{"a", "b", "c"}, []string{"a", "b", "c"}},
+		{"duplicates removed preserving order", []string{"b", "a", "b", "c", "a"}, []string{"b", "a", "c"}},
+		{"all duplicates", []string{"x", "x", "x"}, []string{"x"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, dedupeStrings(tt.input))
+		})
+	}
+}
+
+// firstRabaStopIDs returns raw (un-combined) stop IDs from the RABA test data.
+func firstRabaStopIDs(t *testing.T, api *RestAPI, limit int) []string {
+	t.Helper()
+	rows, err := api.GtfsManager.GtfsDB.DB.QueryContext(context.Background(),
+		`SELECT id FROM stops WHERE location_type = 0 OR location_type IS NULL LIMIT ?`, limit)
+	require.NoError(t, err)
+	defer rows.Close()
+
+	var ids []string
+	for rows.Next() {
+		var id string
+		require.NoError(t, rows.Scan(&id))
+		ids = append(ids, id)
+	}
+	require.NoError(t, rows.Err())
+	require.NotEmpty(t, ids, "RABA test data should contain stops")
+	return ids
+}
+
+func TestBuildStopReferencesAndRouteIDsForStops_Empty(t *testing.T) {
+	api := createTestApi(t)
+	agency := mustGetAgencies(t, api)[0]
+
+	stops, routeMap, err := BuildStopReferencesAndRouteIDsForStops(api, context.Background(), agency.ID, []string{})
+	require.NoError(t, err)
+	assert.Empty(t, stops)
+	assert.Empty(t, routeMap)
+	assert.NotNil(t, stops, "should return a non-nil empty slice")
+	assert.NotNil(t, routeMap, "should return a non-nil empty map")
+}
+
+func TestBuildStopReferencesAndRouteIDsForStops(t *testing.T) {
+	api := createTestApi(t)
+	agency := mustGetAgencies(t, api)[0]
+	stopIDs := firstRabaStopIDs(t, api, 3)
+
+	stops, routeMap, err := BuildStopReferencesAndRouteIDsForStops(api, context.Background(), agency.ID, stopIDs)
+	require.NoError(t, err)
+	require.Len(t, stops, len(stopIDs), "should return one model per unique stop ID")
+
+	for _, stop := range stops {
+		// IDs are agency-combined.
+		assert.True(t, strings.HasPrefix(stop.ID, agency.ID+"_"), "stop ID %q should be agency-combined", stop.ID)
+
+		// RouteIDs and StaticRouteIDs mirror each other and are agency-combined.
+		assert.Equal(t, stop.RouteIDs, stop.StaticRouteIDs)
+		for _, rid := range stop.RouteIDs {
+			assert.True(t, strings.HasPrefix(rid, agency.ID+"_"), "route ID %q should be agency-combined", rid)
+		}
+
+		// Route IDs are sorted in natural order (no duplicates, stable ordering).
+		assert.True(t, slices.IsSortedFunc(stop.RouteIDs, func(a, b string) int {
+			return utils.NaturalCompare(a, b)
+		}), "route IDs for stop %q should be naturally sorted: %v", stop.ID, stop.RouteIDs)
+	}
+
+	// Every combined route ID referenced by a stop appears in the returned route map.
+	for _, stop := range stops {
+		for _, rid := range stop.RouteIDs {
+			_, ok := routeMap[rid]
+			assert.True(t, ok, "route %q referenced by stop should be present in routeMap", rid)
+		}
+	}
+}
+
+func TestBuildStopReferencesAndRouteIDsForStops_DeduplicatesStopIDs(t *testing.T) {
+	api := createTestApi(t)
+	agency := mustGetAgencies(t, api)[0]
+	stopIDs := firstRabaStopIDs(t, api, 2)
+
+	// Pass duplicates; the result should contain each stop only once.
+	withDupes := append([]string{}, stopIDs...)
+	withDupes = append(withDupes, stopIDs...)
+
+	stops, _, err := BuildStopReferencesAndRouteIDsForStops(api, context.Background(), agency.ID, withDupes)
+	require.NoError(t, err)
+	assert.Len(t, stops, len(stopIDs), "duplicate stop IDs should be collapsed")
 }

--- a/internal/restapi/stop_handler.go
+++ b/internal/restapi/stop_handler.go
@@ -33,7 +33,7 @@ func (api *RestAPI) stopHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Sort routes naturally by ShortName
-	utils.SortRoutesByName(routes, utils.RouteRowSortKey)
+	utils.SortRoutesForStopRowsByName(routes)
 
 	combinedRouteIDs := make([]string, len(routes))
 	for i, route := range routes {

--- a/internal/restapi/stop_handler.go
+++ b/internal/restapi/stop_handler.go
@@ -111,30 +111,12 @@ func (api *RestAPI) stopHandler(w http.ResponseWriter, r *http.Request) {
 		}
 
 		if nulls.StringOrEmpty(stop.ParentStation) != "" {
-			parentStop, err := api.GtfsManager.GtfsDB.Queries.GetStop(ctx, stop.ParentStation.String)
-			if err == nil {
-				parentRoutes, _ := api.GtfsManager.GtfsDB.Queries.GetRoutesForStop(ctx, parentStop.ID)
-
-				// Sort parent routes naturally by ShortName
-				utils.SortRoutesByName(parentRoutes)
-
-				parentRouteIDs := make([]string, len(parentRoutes))
-				for i, r := range parentRoutes {
-					parentRouteIDs[i] = utils.FormCombinedID(r.AgencyID, r.ID)
-				}
-				references.Stops = append(references.Stops, models.Stop{
-					ID:                 utils.FormCombinedID(agencyID, parentStop.ID),
-					Name:               nulls.StringOrEmpty(parentStop.Name),
-					Lat:                parentStop.Lat,
-					Lon:                parentStop.Lon,
-					Code:               nulls.StringOrDefault(parentStop.Code, parentStop.ID),
-					Direction:          nulls.StringOrEmpty(parentStop.Direction),
-					LocationType:       int(nulls.Int64OrDefault(parentStop.LocationType, 0)),
-					WheelchairBoarding: utils.MapWheelchairBoarding(nulls.WheelchairBoardingOrUnknown(parentStop.WheelchairBoarding)),
-					RouteIDs:           parentRouteIDs,
-					StaticRouteIDs:     parentRouteIDs,
-				})
+			parentRefs, _, err := BuildStopReferencesAndRouteIDsForStops(api, ctx, agencyID, []string{stop.ParentStation.String})
+			if err != nil {
+				api.serverErrorResponse(w, r, err)
+				return
 			}
+			references.Stops = append(references.Stops, parentRefs...)
 		}
 	}
 

--- a/internal/restapi/stop_handler.go
+++ b/internal/restapi/stop_handler.go
@@ -33,7 +33,7 @@ func (api *RestAPI) stopHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Sort routes naturally by ShortName
-	utils.SortRoutesByName(routes)
+	utils.SortRoutesByName(routes, utils.RouteRowSortKey)
 
 	combinedRouteIDs := make([]string, len(routes))
 	for i, route := range routes {

--- a/internal/restapi/stops_for_agency_handler.go
+++ b/internal/restapi/stops_for_agency_handler.go
@@ -74,7 +74,7 @@ func (api *RestAPI) stopsForAgencyHandler(w http.ResponseWriter, r *http.Request
 }
 
 // buildParentStationReferences resolves the unique parent stations referenced by
-// stopsList into minimal Stop records for the references block.
+// stopsList into full Stop records for the references block.
 func (api *RestAPI) buildParentStationReferences(ctx context.Context, agencyID string, stopsList []models.Stop) ([]models.Stop, error) {
 	seen := make(map[string]struct{})
 	var parentRawIDs []string
@@ -93,29 +93,9 @@ func (api *RestAPI) buildParentStationReferences(ctx context.Context, agencyID s
 		parentRawIDs = append(parentRawIDs, rawID)
 	}
 
-	if len(parentRawIDs) == 0 {
-		return []models.Stop{}, nil
-	}
-
-	parentStops, err := api.GtfsManager.GtfsDB.Queries.GetStopsByIDs(ctx, parentRawIDs)
+	parentRefs, _, err := BuildStopReferencesAndRouteIDsForStops(api, ctx, agencyID, parentRawIDs)
 	if err != nil {
 		return nil, err
-	}
-
-	parentRefs := make([]models.Stop, 0, len(parentStops))
-	for _, ps := range parentStops {
-		parentRefs = append(parentRefs, models.Stop{
-			Code:               nulls.StringOrDefault(ps.Code, ps.ID),
-			Direction:          nulls.StringOrEmpty(ps.Direction),
-			ID:                 utils.FormCombinedID(agencyID, ps.ID),
-			Lat:                ps.Lat,
-			LocationType:       int(ps.LocationType.Int64),
-			Lon:                ps.Lon,
-			Name:               ps.Name.String,
-			RouteIDs:           []string{},
-			StaticRouteIDs:     []string{},
-			WheelchairBoarding: utils.MapWheelchairBoarding(nulls.WheelchairBoardingOrUnknown(ps.WheelchairBoarding)),
-		})
 	}
 
 	return parentRefs, nil

--- a/internal/restapi/stops_for_agency_handler.go
+++ b/internal/restapi/stops_for_agency_handler.go
@@ -31,7 +31,7 @@ func (api *RestAPI) stopsForAgencyHandler(w http.ResponseWriter, r *http.Request
 		return
 	}
 	if agency == nil {
-		api.sendNull(w, r)
+		api.sendNotFound(w, r)
 		return
 	}
 
@@ -61,8 +61,64 @@ func (api *RestAPI) stopsForAgencyHandler(w http.ResponseWriter, r *http.Request
 	references.Agencies = []models.AgencyReference{models.AgencyReferenceFromDatabase(agency)}
 	references.Routes = routeRefs
 
+	// Resolve parent stations referenced by any stop into references.stops.
+	parentRefs, err := api.buildParentStationReferences(ctx, id, stopsList)
+	if err != nil {
+		api.serverErrorResponse(w, r, err)
+		return
+	}
+	references.Stops = parentRefs
+
 	response := models.NewListResponse(stopsList, *references, false, api.Clock)
 	api.sendResponse(w, r, response)
+}
+
+// buildParentStationReferences resolves the unique parent stations referenced by
+// stopsList into minimal Stop records for the references block.
+func (api *RestAPI) buildParentStationReferences(ctx context.Context, agencyID string, stopsList []models.Stop) ([]models.Stop, error) {
+	seen := make(map[string]struct{})
+	var parentRawIDs []string
+	for _, s := range stopsList {
+		if s.Parent == "" {
+			continue
+		}
+		rawID, err := utils.ExtractCodeID(s.Parent)
+		if err != nil {
+			continue
+		}
+		if _, ok := seen[rawID]; ok {
+			continue
+		}
+		seen[rawID] = struct{}{}
+		parentRawIDs = append(parentRawIDs, rawID)
+	}
+
+	if len(parentRawIDs) == 0 {
+		return []models.Stop{}, nil
+	}
+
+	parentStops, err := api.GtfsManager.GtfsDB.Queries.GetStopsByIDs(ctx, parentRawIDs)
+	if err != nil {
+		return nil, err
+	}
+
+	parentRefs := make([]models.Stop, 0, len(parentStops))
+	for _, ps := range parentStops {
+		parentRefs = append(parentRefs, models.Stop{
+			Code:               nulls.StringOrDefault(ps.Code, ps.ID),
+			Direction:          nulls.StringOrEmpty(ps.Direction),
+			ID:                 utils.FormCombinedID(agencyID, ps.ID),
+			Lat:                ps.Lat,
+			LocationType:       int(ps.LocationType.Int64),
+			Lon:                ps.Lon,
+			Name:               ps.Name.String,
+			RouteIDs:           []string{},
+			StaticRouteIDs:     []string{},
+			WheelchairBoarding: utils.MapWheelchairBoarding(nulls.WheelchairBoardingOrUnknown(ps.WheelchairBoarding)),
+		})
+	}
+
+	return parentRefs, nil
 }
 
 func (api *RestAPI) buildStopsListForAgency(ctx context.Context, agencyID string, stopIDs []string) ([]models.Stop, error) {
@@ -103,14 +159,20 @@ func (api *RestAPI) buildStopsListForAgency(ctx context.Context, agencyID string
 			routeIdsString = []string{}
 		}
 
+		parentID := ""
+		if nulls.StringOrEmpty(stop.ParentStation) != "" {
+			parentID = utils.FormCombinedID(agencyID, stop.ParentStation.String)
+		}
+
 		stopsList = append(stopsList, models.Stop{
-			Code:               stop.Code.String,
+			Code:               nulls.StringOrDefault(stop.Code, stop.ID),
 			Direction:          nulls.StringOrEmpty(stop.Direction),
 			ID:                 utils.FormCombinedID(agencyID, stop.ID),
 			Lat:                stop.Lat,
 			LocationType:       int(stop.LocationType.Int64),
 			Lon:                stop.Lon,
 			Name:               stop.Name.String,
+			Parent:             parentID,
 			RouteIDs:           routeIdsString,
 			StaticRouteIDs:     routeIdsString,
 			WheelchairBoarding: utils.MapWheelchairBoarding(nulls.WheelchairBoardingOrUnknown(stop.WheelchairBoarding)),

--- a/internal/restapi/stops_for_agency_handler_test.go
+++ b/internal/restapi/stops_for_agency_handler_test.go
@@ -92,6 +92,9 @@ func TestStopsForAgencyInvalidAgency(t *testing.T) {
 
 	resp, model := callAPIHandler[StopsResponse](t, api, stopsForAgencyURL("invalid"))
 
-	assert.Equal(t, http.StatusOK, resp.StatusCode)
-	assert.Equal(t, "", model.Text)
+	// Maglev intentionally corrects the legacy 200+null behavior: an unknown
+	// agency returns 404, consistent with stop-ids-for-agency and other endpoints.
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+	assert.Equal(t, http.StatusNotFound, model.Code)
+	assert.Equal(t, "resource not found", model.Text)
 }

--- a/internal/restapi/trip_details_handler.go
+++ b/internal/restapi/trip_details_handler.go
@@ -10,7 +10,6 @@ import (
 	gtfs "github.com/OneBusAway/go-gtfs"
 	"maglev.onebusaway.org/gtfsdb"
 	"maglev.onebusaway.org/internal/models"
-	"maglev.onebusaway.org/internal/nulls"
 	"maglev.onebusaway.org/internal/utils"
 )
 
@@ -303,7 +302,16 @@ func (api *RestAPI) tripDetailsHandler(w http.ResponseWriter, r *http.Request) {
 		}
 
 		if params.IncludeSchedule && schedule != nil {
-			stops, err := api.buildStopReferences(ctx, agencyID, schedule.StopTimes)
+			stopIDs := make([]string, 0, len(schedule.StopTimes))
+			for _, st := range schedule.StopTimes {
+				_, rawStopID, err := utils.ExtractAgencyIDAndCodeID(st.StopID)
+				if err != nil {
+					continue
+				}
+				stopIDs = append(stopIDs, rawStopID)
+			}
+
+			stops, _, err := BuildStopReferencesAndRouteIDsForStops(api, ctx, agencyID, stopIDs)
 			if err != nil {
 				api.serverErrorResponse(w, r, err)
 				return
@@ -419,106 +427,4 @@ func (api *RestAPI) buildReferencedTrips(ctx context.Context, agencyID string, t
 	}
 
 	return referencedTrips, nil
-}
-
-func (api *RestAPI) buildStopReferences(ctx context.Context, agencyID string, stopTimes []models.StopTime) ([]models.Stop, error) {
-	stopIDSet := make(map[string]bool)
-	originalStopIDs := make([]string, 0, len(stopTimes))
-
-	for _, st := range stopTimes {
-		_, originalStopID, err := utils.ExtractAgencyIDAndCodeID(st.StopID)
-		if err != nil {
-			continue
-		}
-
-		if !stopIDSet[originalStopID] {
-			stopIDSet[originalStopID] = true
-			originalStopIDs = append(originalStopIDs, originalStopID)
-		}
-	}
-
-	if len(originalStopIDs) == 0 {
-		return []models.Stop{}, nil
-	}
-
-	stops, err := api.GtfsManager.GtfsDB.Queries.GetStopsByIDs(ctx, originalStopIDs)
-	if err != nil {
-		return nil, err
-	}
-
-	stopMap := make(map[string]gtfsdb.Stop)
-	for _, stop := range stops {
-		stopMap[stop.ID] = stop
-	}
-
-	allRoutes, err := api.GtfsManager.GtfsDB.Queries.GetRoutesForStops(ctx, originalStopIDs)
-	if err != nil {
-		return nil, err
-	}
-
-	routesByStop := make(map[string][]gtfsdb.Route)
-	for _, routeRow := range allRoutes {
-		if ctx.Err() != nil {
-			return nil, ctx.Err()
-		}
-
-		route := gtfsdb.Route{
-			ID:        routeRow.ID,
-			AgencyID:  routeRow.AgencyID,
-			ShortName: routeRow.ShortName,
-			LongName:  routeRow.LongName,
-			Desc:      routeRow.Desc,
-			Type:      routeRow.Type,
-			Url:       routeRow.Url,
-			Color:     routeRow.Color,
-			TextColor: routeRow.TextColor,
-		}
-		routesByStop[routeRow.StopID] = append(routesByStop[routeRow.StopID], route)
-	}
-
-	modelStops := make([]models.Stop, 0, len(stopTimes))
-	processedStops := make(map[string]bool)
-
-	for _, st := range stopTimes {
-		if ctx.Err() != nil {
-			return nil, ctx.Err()
-		}
-
-		_, originalStopID, err := utils.ExtractAgencyIDAndCodeID(st.StopID)
-		if err != nil {
-			continue
-		}
-
-		if processedStops[originalStopID] {
-			continue
-		}
-		processedStops[originalStopID] = true
-
-		stop, exists := stopMap[originalStopID]
-		if !exists {
-			continue
-		}
-
-		routesForStop := routesByStop[originalStopID]
-		combinedRouteIDs := make([]string, len(routesForStop))
-		for i, rt := range routesForStop {
-			combinedRouteIDs[i] = utils.FormCombinedID(agencyID, rt.ID)
-		}
-
-		stopModel := models.Stop{
-			ID:                 utils.FormCombinedID(agencyID, stop.ID),
-			Name:               stop.Name.String,
-			Lat:                stop.Lat,
-			Lon:                stop.Lon,
-			Code:               stop.Code.String,
-			Direction:          api.DirectionCalculator.CalculateStopDirection(ctx, stop.ID, stop.Direction),
-			LocationType:       int(stop.LocationType.Int64),
-			WheelchairBoarding: utils.MapWheelchairBoarding(nulls.WheelchairBoardingOrUnknown(stop.WheelchairBoarding)),
-			RouteIDs:           combinedRouteIDs,
-			StaticRouteIDs:     combinedRouteIDs,
-		}
-		modelStops = append(modelStops, stopModel)
-	}
-
-	return modelStops, nil
 }

--- a/internal/restapi/trip_for_vehicle_handler.go
+++ b/internal/restapi/trip_for_vehicle_handler.go
@@ -1,16 +1,13 @@
 package restapi
 
 import (
-	"context"
 	"database/sql"
 	"errors"
 	"net/http"
 	"strconv"
 	"time"
 
-	"maglev.onebusaway.org/gtfsdb"
 	"maglev.onebusaway.org/internal/models"
-	"maglev.onebusaway.org/internal/nulls"
 	"maglev.onebusaway.org/internal/utils"
 )
 
@@ -205,81 +202,4 @@ func (api *RestAPI) tripForVehicleHandler(w http.ResponseWriter, r *http.Request
 
 	response := models.NewEntryResponse(entry, *references, api.Clock)
 	api.sendResponse(w, r, response)
-}
-
-// BuildStopReferencesAndRouteIDsForStops builds stop references and collects unique routes for the given stop IDs.
-func BuildStopReferencesAndRouteIDsForStops(api *RestAPI, ctx context.Context, agencyID string, stopIDs []string) ([]models.Stop, map[string]gtfsdb.GetRoutesForStopsRow, error) {
-	if len(stopIDs) == 0 {
-		return []models.Stop{}, map[string]gtfsdb.GetRoutesForStopsRow{}, nil
-	}
-
-	stopIDSet := make(map[string]struct{})
-	uniqueStopIDs := make([]string, 0, len(stopIDs))
-	for _, id := range stopIDs {
-		if _, exists := stopIDSet[id]; !exists {
-			stopIDSet[id] = struct{}{}
-			uniqueStopIDs = append(uniqueStopIDs, id)
-		}
-	}
-
-	stopsDB, err := api.GtfsManager.GtfsDB.Queries.GetStopsByIDs(ctx, uniqueStopIDs)
-	if err != nil {
-		return nil, nil, err
-	}
-	stopMap := make(map[string]gtfsdb.Stop)
-	for _, stop := range stopsDB {
-		stopMap[stop.ID] = stop
-	}
-
-	allRoutes, err := api.GtfsManager.GtfsDB.Queries.GetRoutesForStops(ctx, uniqueStopIDs)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	routesByStop := make(map[string][]gtfsdb.Route)
-	uniqueRouteMap := make(map[string]gtfsdb.GetRoutesForStopsRow)
-	for _, routeRow := range allRoutes {
-		route := gtfsdb.Route{
-			ID:        routeRow.ID,
-			AgencyID:  routeRow.AgencyID,
-			ShortName: routeRow.ShortName,
-			LongName:  routeRow.LongName,
-			Desc:      routeRow.Desc,
-			Type:      routeRow.Type,
-			Url:       routeRow.Url,
-			Color:     routeRow.Color,
-			TextColor: routeRow.TextColor,
-		}
-		routesByStop[routeRow.StopID] = append(routesByStop[routeRow.StopID], route)
-		combinedID := utils.FormCombinedID(agencyID, routeRow.ID)
-		uniqueRouteMap[combinedID] = routeRow
-	}
-
-	modelStops := make([]models.Stop, 0, len(uniqueStopIDs))
-	for _, stopID := range uniqueStopIDs {
-		stop, exists := stopMap[stopID]
-		if !exists {
-			continue
-		}
-		routesForStop := routesByStop[stopID]
-		combinedRouteIDs := make([]string, len(routesForStop))
-		for i, rt := range routesForStop {
-			combinedRouteIDs[i] = utils.FormCombinedID(agencyID, rt.ID)
-		}
-		stopModel := models.Stop{
-			ID:                 utils.FormCombinedID(agencyID, stop.ID),
-			Name:               stop.Name.String,
-			Lat:                stop.Lat,
-			Lon:                stop.Lon,
-			Code:               stop.Code.String,
-			Direction:          api.DirectionCalculator.CalculateStopDirection(ctx, stop.ID, stop.Direction),
-			LocationType:       int(stop.LocationType.Int64),
-			WheelchairBoarding: utils.MapWheelchairBoarding(nulls.WheelchairBoardingOrUnknown(stop.WheelchairBoarding)),
-			RouteIDs:           combinedRouteIDs,
-			StaticRouteIDs:     combinedRouteIDs,
-		}
-		modelStops = append(modelStops, stopModel)
-	}
-
-	return modelStops, uniqueRouteMap, nil
 }

--- a/internal/utils/sort.go
+++ b/internal/utils/sort.go
@@ -7,26 +7,45 @@ import (
 	"maglev.onebusaway.org/gtfsdb"
 )
 
+// compareRoutesByName compares two routes naturally by their sort name (ShortName,
+// falling back to LongName), then by AgencyID, then by ID. It is the single source
+// of truth for the ordering rules shared by the SortRoutesByName* helpers.
+func compareRoutesByName(shortNameA, longNameA, agencyIDA, idA, shortNameB, longNameB, agencyIDB, idB string) int {
+	nameA := shortNameA
+	if nameA == "" {
+		nameA = longNameA
+	}
+
+	nameB := shortNameB
+	if nameB == "" {
+		nameB = longNameB
+	}
+
+	if res := NaturalCompare(nameA, nameB); res != 0 {
+		return res
+	}
+	if agencyIDA != agencyIDB {
+		return cmp.Compare(agencyIDA, agencyIDB)
+	}
+	return cmp.Compare(idA, idB)
+}
+
 // SortRoutesByName sorts routes naturally by ShortName, falling back to LongName, then by AgencyID and ID.
 func SortRoutesByName(routes []gtfsdb.GetRoutesForStopRow) {
 	slices.SortFunc(routes, func(a, b gtfsdb.GetRoutesForStopRow) int {
-		nameA := a.ShortName.String
-		if nameA == "" {
-			nameA = a.LongName.String
-		}
+		return compareRoutesByName(
+			a.ShortName.String, a.LongName.String, a.AgencyID, a.ID,
+			b.ShortName.String, b.LongName.String, b.AgencyID, b.ID,
+		)
+	})
+}
 
-		nameB := b.ShortName.String
-		if nameB == "" {
-			nameB = b.LongName.String
-		}
-
-		res := NaturalCompare(nameA, nameB)
-		if res != 0 {
-			return res
-		}
-		if a.AgencyID != b.AgencyID {
-			return cmp.Compare(a.AgencyID, b.AgencyID)
-		}
-		return cmp.Compare(a.ID, b.ID)
+// SortDBRoutesByName sorts gtfsdb.Route values using the same ordering rules as SortRoutesByName.
+func SortDBRoutesByName(routes []gtfsdb.Route) {
+	slices.SortFunc(routes, func(a, b gtfsdb.Route) int {
+		return compareRoutesByName(
+			a.ShortName.String, a.LongName.String, a.AgencyID, a.ID,
+			b.ShortName.String, b.LongName.String, b.AgencyID, b.ID,
+		)
 	})
 }

--- a/internal/utils/sort.go
+++ b/internal/utils/sort.go
@@ -5,6 +5,7 @@ import (
 	"slices"
 
 	"maglev.onebusaway.org/gtfsdb"
+	"maglev.onebusaway.org/internal/nulls"
 )
 
 // RouteSortKey holds the fields used to order routes, decoupling the comparison
@@ -50,10 +51,10 @@ func SortRoutesByName[T any](routes []T, keyFn func(T) RouteSortKey) {
 
 // RouteRowSortKey adapts a GetRoutesForStopRow for SortRoutesByName.
 func RouteRowSortKey(r gtfsdb.GetRoutesForStopRow) RouteSortKey {
-	return RouteSortKey{r.ShortName.String, r.LongName.String, r.AgencyID, r.ID}
+	return RouteSortKey{nulls.StringOrEmpty(r.ShortName), nulls.StringOrEmpty(r.LongName), r.AgencyID, r.ID}
 }
 
 // DBRouteSortKey adapts a gtfsdb.Route for SortRoutesByName.
 func DBRouteSortKey(r gtfsdb.Route) RouteSortKey {
-	return RouteSortKey{r.ShortName.String, r.LongName.String, r.AgencyID, r.ID}
+	return RouteSortKey{nulls.StringOrEmpty(r.ShortName), nulls.StringOrEmpty(r.LongName), r.AgencyID, r.ID}
 }

--- a/internal/utils/sort.go
+++ b/internal/utils/sort.go
@@ -7,54 +7,53 @@ import (
 	"maglev.onebusaway.org/gtfsdb"
 )
 
-// routeSortKey holds the fields used to order routes, decoupling the comparison
+// RouteSortKey holds the fields used to order routes, decoupling the comparison
 // logic from any particular gtfsdb row type.
-type routeSortKey struct {
-	shortName string
-	longName  string
-	agencyID  string
-	id        string
+type RouteSortKey struct {
+	ShortName string
+	LongName  string
+	AgencyID  string
+	ID        string
 }
 
 // compareRouteSortKeys compares two routes naturally by their sort name (ShortName,
 // falling back to LongName), then by AgencyID, then by ID. It is the single source
-// of truth for the ordering rules shared by the SortRoutesByName* helpers.
-func compareRouteSortKeys(a, b routeSortKey) int {
-	nameA := a.shortName
+// of truth for the route ordering rules.
+func compareRouteSortKeys(a, b RouteSortKey) int {
+	nameA := a.ShortName
 	if nameA == "" {
-		nameA = a.longName
+		nameA = a.LongName
 	}
 
-	nameB := b.shortName
+	nameB := b.ShortName
 	if nameB == "" {
-		nameB = b.longName
+		nameB = b.LongName
 	}
 
 	if res := NaturalCompare(nameA, nameB); res != 0 {
 		return res
 	}
-	if a.agencyID != b.agencyID {
-		return cmp.Compare(a.agencyID, b.agencyID)
+	if a.AgencyID != b.AgencyID {
+		return cmp.Compare(a.AgencyID, b.AgencyID)
 	}
-	return cmp.Compare(a.id, b.id)
+	return cmp.Compare(a.ID, b.ID)
 }
 
-// SortRoutesByName sorts routes naturally by ShortName, falling back to LongName, then by AgencyID and ID.
-func SortRoutesByName(routes []gtfsdb.GetRoutesForStopRow) {
-	slices.SortFunc(routes, func(a, b gtfsdb.GetRoutesForStopRow) int {
-		return compareRouteSortKeys(
-			routeSortKey{a.ShortName.String, a.LongName.String, a.AgencyID, a.ID},
-			routeSortKey{b.ShortName.String, b.LongName.String, b.AgencyID, b.ID},
-		)
+// SortRoutesByName sorts any slice of route-like values naturally by ShortName
+// (falling back to LongName), then by AgencyID, then by ID. keyFn adapts each
+// element to the fields used for comparison.
+func SortRoutesByName[T any](routes []T, keyFn func(T) RouteSortKey) {
+	slices.SortFunc(routes, func(a, b T) int {
+		return compareRouteSortKeys(keyFn(a), keyFn(b))
 	})
 }
 
-// SortDBRoutesByName sorts gtfsdb.Route values using the same ordering rules as SortRoutesByName.
-func SortDBRoutesByName(routes []gtfsdb.Route) {
-	slices.SortFunc(routes, func(a, b gtfsdb.Route) int {
-		return compareRouteSortKeys(
-			routeSortKey{a.ShortName.String, a.LongName.String, a.AgencyID, a.ID},
-			routeSortKey{b.ShortName.String, b.LongName.String, b.AgencyID, b.ID},
-		)
-	})
+// RouteRowSortKey adapts a GetRoutesForStopRow for SortRoutesByName.
+func RouteRowSortKey(r gtfsdb.GetRoutesForStopRow) RouteSortKey {
+	return RouteSortKey{r.ShortName.String, r.LongName.String, r.AgencyID, r.ID}
+}
+
+// DBRouteSortKey adapts a gtfsdb.Route for SortRoutesByName.
+func DBRouteSortKey(r gtfsdb.Route) RouteSortKey {
+	return RouteSortKey{r.ShortName.String, r.LongName.String, r.AgencyID, r.ID}
 }

--- a/internal/utils/sort.go
+++ b/internal/utils/sort.go
@@ -40,21 +40,26 @@ func compareRouteSortKeys(a, b RouteSortKey) int {
 	return cmp.Compare(a.ID, b.ID)
 }
 
-// SortRoutesByName sorts any slice of route-like values naturally by ShortName
-// (falling back to LongName), then by AgencyID, then by ID. keyFn adapts each
-// element to the fields used for comparison.
-func SortRoutesByName[T any](routes []T, keyFn func(T) RouteSortKey) {
-	slices.SortFunc(routes, func(a, b T) int {
-		return compareRouteSortKeys(keyFn(a), keyFn(b))
+// SortRoutesForStopRowsByName sorts gtfsdb.GetRoutesForStopRow values naturally by
+// ShortName (falling back to LongName), then by AgencyID, then by ID.
+func SortRoutesForStopRowsByName(routes []gtfsdb.GetRoutesForStopRow) {
+	slices.SortFunc(routes, func(a, b gtfsdb.GetRoutesForStopRow) int {
+		return compareRouteSortKeys(routesForStopRowSortKey(a), routesForStopRowSortKey(b))
 	})
 }
 
-// RouteRowSortKey adapts a GetRoutesForStopRow for SortRoutesByName.
-func RouteRowSortKey(r gtfsdb.GetRoutesForStopRow) RouteSortKey {
+// SortRoutesByName sorts gtfsdb.Route values naturally by ShortName
+// (falling back to LongName), then by AgencyID, then by ID.
+func SortRoutesByName(routes []gtfsdb.Route) {
+	slices.SortFunc(routes, func(a, b gtfsdb.Route) int {
+		return compareRouteSortKeys(routeSortKey(a), routeSortKey(b))
+	})
+}
+
+func routesForStopRowSortKey(r gtfsdb.GetRoutesForStopRow) RouteSortKey {
 	return RouteSortKey{nulls.StringOrEmpty(r.ShortName), nulls.StringOrEmpty(r.LongName), r.AgencyID, r.ID}
 }
 
-// DBRouteSortKey adapts a gtfsdb.Route for SortRoutesByName.
-func DBRouteSortKey(r gtfsdb.Route) RouteSortKey {
+func routeSortKey(r gtfsdb.Route) RouteSortKey {
 	return RouteSortKey{nulls.StringOrEmpty(r.ShortName), nulls.StringOrEmpty(r.LongName), r.AgencyID, r.ID}
 }

--- a/internal/utils/sort.go
+++ b/internal/utils/sort.go
@@ -7,35 +7,44 @@ import (
 	"maglev.onebusaway.org/gtfsdb"
 )
 
-// compareRoutesByName compares two routes naturally by their sort name (ShortName,
+// routeSortKey holds the fields used to order routes, decoupling the comparison
+// logic from any particular gtfsdb row type.
+type routeSortKey struct {
+	shortName string
+	longName  string
+	agencyID  string
+	id        string
+}
+
+// compareRouteSortKeys compares two routes naturally by their sort name (ShortName,
 // falling back to LongName), then by AgencyID, then by ID. It is the single source
 // of truth for the ordering rules shared by the SortRoutesByName* helpers.
-func compareRoutesByName(shortNameA, longNameA, agencyIDA, idA, shortNameB, longNameB, agencyIDB, idB string) int {
-	nameA := shortNameA
+func compareRouteSortKeys(a, b routeSortKey) int {
+	nameA := a.shortName
 	if nameA == "" {
-		nameA = longNameA
+		nameA = a.longName
 	}
 
-	nameB := shortNameB
+	nameB := b.shortName
 	if nameB == "" {
-		nameB = longNameB
+		nameB = b.longName
 	}
 
 	if res := NaturalCompare(nameA, nameB); res != 0 {
 		return res
 	}
-	if agencyIDA != agencyIDB {
-		return cmp.Compare(agencyIDA, agencyIDB)
+	if a.agencyID != b.agencyID {
+		return cmp.Compare(a.agencyID, b.agencyID)
 	}
-	return cmp.Compare(idA, idB)
+	return cmp.Compare(a.id, b.id)
 }
 
 // SortRoutesByName sorts routes naturally by ShortName, falling back to LongName, then by AgencyID and ID.
 func SortRoutesByName(routes []gtfsdb.GetRoutesForStopRow) {
 	slices.SortFunc(routes, func(a, b gtfsdb.GetRoutesForStopRow) int {
-		return compareRoutesByName(
-			a.ShortName.String, a.LongName.String, a.AgencyID, a.ID,
-			b.ShortName.String, b.LongName.String, b.AgencyID, b.ID,
+		return compareRouteSortKeys(
+			routeSortKey{a.ShortName.String, a.LongName.String, a.AgencyID, a.ID},
+			routeSortKey{b.ShortName.String, b.LongName.String, b.AgencyID, b.ID},
 		)
 	})
 }
@@ -43,9 +52,9 @@ func SortRoutesByName(routes []gtfsdb.GetRoutesForStopRow) {
 // SortDBRoutesByName sorts gtfsdb.Route values using the same ordering rules as SortRoutesByName.
 func SortDBRoutesByName(routes []gtfsdb.Route) {
 	slices.SortFunc(routes, func(a, b gtfsdb.Route) int {
-		return compareRoutesByName(
-			a.ShortName.String, a.LongName.String, a.AgencyID, a.ID,
-			b.ShortName.String, b.LongName.String, b.AgencyID, b.ID,
+		return compareRouteSortKeys(
+			routeSortKey{a.ShortName.String, a.LongName.String, a.AgencyID, a.ID},
+			routeSortKey{b.ShortName.String, b.LongName.String, b.AgencyID, b.ID},
 		)
 	})
 }

--- a/internal/utils/sort_test.go
+++ b/internal/utils/sort_test.go
@@ -52,3 +52,62 @@ func TestSortRoutesByName(t *testing.T) {
 	assert.Equal(t, "5", routes[4].ID, "Expected ID 5: C, agency1, ID 5")
 	assert.Equal(t, "6", routes[5].ID, "Expected ID 6: C, agency1, ID 6")
 }
+
+func TestSortDBRoutesByName(t *testing.T) {
+	routes := []gtfsdb.Route{
+		{
+			ID:        "3",
+			AgencyID:  "agency2",
+			ShortName: sql.NullString{String: "A", Valid: true},
+		},
+		{
+			ID:        "1",
+			AgencyID:  "agency1",
+			ShortName: sql.NullString{String: "A", Valid: true},
+		},
+		{
+			ID:       "2",
+			AgencyID: "agency1",
+			LongName: sql.NullString{String: "B", Valid: true},
+		},
+		{
+			ID:        "4",
+			AgencyID:  "agency2",
+			ShortName: sql.NullString{String: "B", Valid: true},
+		},
+		{
+			ID:        "6",
+			AgencyID:  "agency1",
+			ShortName: sql.NullString{String: "C", Valid: true},
+		},
+		{
+			ID:        "5",
+			AgencyID:  "agency1",
+			ShortName: sql.NullString{String: "C", Valid: true},
+		},
+	}
+
+	utils.SortDBRoutesByName(routes)
+
+	assert.Equal(t, "1", routes[0].ID, "Expected ID 1: A, agency1")
+	assert.Equal(t, "3", routes[1].ID, "Expected ID 3: A, agency2")
+	assert.Equal(t, "2", routes[2].ID, "Expected ID 2: B (LongName fallback), agency1")
+	assert.Equal(t, "4", routes[3].ID, "Expected ID 4: B, agency2")
+	assert.Equal(t, "5", routes[4].ID, "Expected ID 5: C, agency1, ID 5")
+	assert.Equal(t, "6", routes[5].ID, "Expected ID 6: C, agency1, ID 6")
+}
+
+func TestSortDBRoutesByNaturalOrder(t *testing.T) {
+	// NaturalCompare should order numeric route names numerically, not lexically.
+	routes := []gtfsdb.Route{
+		{ID: "c", ShortName: sql.NullString{String: "10", Valid: true}},
+		{ID: "a", ShortName: sql.NullString{String: "2", Valid: true}},
+		{ID: "b", ShortName: sql.NullString{String: "9", Valid: true}},
+	}
+
+	utils.SortDBRoutesByName(routes)
+
+	assert.Equal(t, "a", routes[0].ID, "Expected 2 first")
+	assert.Equal(t, "b", routes[1].ID, "Expected 9 second")
+	assert.Equal(t, "c", routes[2].ID, "Expected 10 last")
+}

--- a/internal/utils/sort_test.go
+++ b/internal/utils/sort_test.go
@@ -43,7 +43,7 @@ func TestSortRoutesByName(t *testing.T) {
 		},
 	}
 
-	utils.SortRoutesByName(routes)
+	utils.SortRoutesByName(routes, utils.RouteRowSortKey)
 
 	assert.Equal(t, "1", routes[0].ID, "Expected ID 1: A, agency1")
 	assert.Equal(t, "3", routes[1].ID, "Expected ID 3: A, agency2")
@@ -87,7 +87,7 @@ func TestSortDBRoutesByName(t *testing.T) {
 		},
 	}
 
-	utils.SortDBRoutesByName(routes)
+	utils.SortRoutesByName(routes, utils.DBRouteSortKey)
 
 	assert.Equal(t, "1", routes[0].ID, "Expected ID 1: A, agency1")
 	assert.Equal(t, "3", routes[1].ID, "Expected ID 3: A, agency2")
@@ -105,7 +105,7 @@ func TestSortDBRoutesByNaturalOrder(t *testing.T) {
 		{ID: "b", ShortName: sql.NullString{String: "9", Valid: true}},
 	}
 
-	utils.SortDBRoutesByName(routes)
+	utils.SortRoutesByName(routes, utils.DBRouteSortKey)
 
 	assert.Equal(t, "a", routes[0].ID, "Expected 2 first")
 	assert.Equal(t, "b", routes[1].ID, "Expected 9 second")

--- a/internal/utils/sort_test.go
+++ b/internal/utils/sort_test.go
@@ -9,7 +9,7 @@ import (
 	"maglev.onebusaway.org/internal/utils"
 )
 
-func TestSortRoutesByName(t *testing.T) {
+func TestSortRoutesForStopRowsByName(t *testing.T) {
 	routes := []gtfsdb.GetRoutesForStopRow{
 		{
 			ID:        "3",
@@ -43,7 +43,7 @@ func TestSortRoutesByName(t *testing.T) {
 		},
 	}
 
-	utils.SortRoutesByName(routes, utils.RouteRowSortKey)
+	utils.SortRoutesForStopRowsByName(routes)
 
 	assert.Equal(t, "1", routes[0].ID, "Expected ID 1: A, agency1")
 	assert.Equal(t, "3", routes[1].ID, "Expected ID 3: A, agency2")
@@ -53,7 +53,7 @@ func TestSortRoutesByName(t *testing.T) {
 	assert.Equal(t, "6", routes[5].ID, "Expected ID 6: C, agency1, ID 6")
 }
 
-func TestSortDBRoutesByName(t *testing.T) {
+func TestSortRoutesByName(t *testing.T) {
 	routes := []gtfsdb.Route{
 		{
 			ID:        "3",
@@ -87,7 +87,7 @@ func TestSortDBRoutesByName(t *testing.T) {
 		},
 	}
 
-	utils.SortRoutesByName(routes, utils.DBRouteSortKey)
+	utils.SortRoutesByName(routes)
 
 	assert.Equal(t, "1", routes[0].ID, "Expected ID 1: A, agency1")
 	assert.Equal(t, "3", routes[1].ID, "Expected ID 3: A, agency2")
@@ -97,7 +97,7 @@ func TestSortDBRoutesByName(t *testing.T) {
 	assert.Equal(t, "6", routes[5].ID, "Expected ID 6: C, agency1, ID 6")
 }
 
-func TestSortDBRoutesByNaturalOrder(t *testing.T) {
+func TestSortRoutesByNaturalOrder(t *testing.T) {
 	// NaturalCompare should order numeric route names numerically, not lexically.
 	routes := []gtfsdb.Route{
 		{ID: "c", ShortName: sql.NullString{String: "10", Valid: true}},
@@ -105,7 +105,7 @@ func TestSortDBRoutesByNaturalOrder(t *testing.T) {
 		{ID: "b", ShortName: sql.NullString{String: "9", Valid: true}},
 	}
 
-	utils.SortRoutesByName(routes, utils.DBRouteSortKey)
+	utils.SortRoutesByName(routes)
 
 	assert.Equal(t, "a", routes[0].ID, "Expected 2 first")
 	assert.Equal(t, "b", routes[1].ID, "Expected 9 second")


### PR DESCRIPTION
Fixes: #1090

## Summary
- Unknown agency → 404 (was 200 + null), matching stop-ids-for-agency and the spec
- code falls back to the entity ID when the feed defines none
- parent populated + parent stations resolved into references.stops (Extension 3a)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Stop and trip responses now include richer parent-station references, including wheelchair boarding.
  * Route and static route IDs are populated per stop with deterministic ordering and de-duplicated references.

* **Bug Fixes**
  * Unknown agencies now return a proper “not found” response (404).
  * Empty stop inputs return clean, empty results.
  * Duplicate stop IDs are collapsed to avoid repeated stop entries.
  * Parent-station reference lookup failures now fail the request instead of being silently ignored.

* **Refactor**
  * Route name sorting is now more natural and consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->