### PR TITLE
test: Add coverage for empty references 

### DIFF
--- a/internal/restapi/stop_handler_test.go
+++ b/internal/restapi/stop_handler_test.go
@@ -50,6 +50,8 @@ func TestStopHandlerEndToEnd(t *testing.T) {
 	require.Len(t, model.Data.References.Routes, len(testdata.Stop4062.RouteIDs),
 		"references.routes count should match entry.routeIds count")
 	assert.Equal(t, []models.AgencyReference{testdata.Raba}, model.Data.References.Agencies)
+	assert.Empty(t, model.Data.References.Trips, "trips should always be empty for this endpoint")
+	assert.Empty(t, model.Data.References.StopTimes, "stopTimes should always be empty for this endpoint")
 	assert.Empty(t, model.Data.References.Situations, "situations should always be empty for this endpoint")
 }
 


### PR DESCRIPTION
### Description
Resolves #1048 by adding missing defensive test coverage to the `/stop` endpoint.

### Changes Made
* Added explicit `assert.Empty` checks for `references.Trips` and `references.StopTimes` to the standard end-to-end test to enforce the wiki spec guarantees.

### Testing
* Verified the new test assertions pass successfully using `make test`.
