### PR TITLE
fix: validate agency namespace for stops 

### DIFF
--- a/internal/restapi/stop_handler.go
+++ b/internal/restapi/stop_handler.go
@@ -36,10 +36,35 @@ func (api *RestAPI) stopHandler(w http.ResponseWriter, r *http.Request) {
 	utils.SortRoutesByName(routes)
 
 	combinedRouteIDs := make([]string, len(routes))
+	uniqueAgencyIDs := make(map[string]bool)
+
 	for i, route := range routes {
 		// Use route.AgencyID, not the stop's agencyID.
 		// A stop can be served by routes from other agencies.
 		combinedRouteIDs[i] = utils.FormCombinedID(route.AgencyID, route.ID)
+		uniqueAgencyIDs[route.AgencyID] = true
+	}
+
+	// Validate the requested agency namespace
+	if len(routes) > 0 {
+		if !uniqueAgencyIDs[agencyID] {
+			// Stop exists, but is not served by the requested agency namespace.
+			api.sendNotFound(w, r)
+			return
+		}
+	} else {
+		// If the stop has no routes, we allow it to be retrieved under any valid agency namespace
+		// because Maglev stops do not have a dedicated agency_id column in the schema.
+		// Just ensure the requested agency actually exists.
+		agency, err := api.GtfsManager.FindAgency(ctx, agencyID)
+		if err != nil {
+			api.serverErrorResponse(w, r, err)
+			return
+		}
+		if agency == nil {
+			api.sendNotFound(w, r)
+			return
+		}
 	}
 
 	parentID := ""
@@ -66,7 +91,6 @@ func (api *RestAPI) stopHandler(w http.ResponseWriter, r *http.Request) {
 
 	// Only populate references if the query parameter is absent or true
 	if ShouldIncludeReferences(r) {
-		uniqueAgencyIDs := make(map[string]bool)
 
 		// Add routes to references and collect unique agency IDs
 		for _, route := range routes {

--- a/internal/restapi/stop_handler.go
+++ b/internal/restapi/stop_handler.go
@@ -90,7 +90,9 @@ func (api *RestAPI) stopHandler(w http.ResponseWriter, r *http.Request) {
 	references := models.NewEmptyReferences()
 
 	// Only populate references if the query parameter is absent or true
-	if ShouldIncludeReferences(r) {
+	includeReferences := ShouldIncludeReferences(r)
+
+	if includeReferences {
 
 		// Add routes to references and collect unique agency IDs
 		for _, route := range routes {
@@ -106,7 +108,6 @@ func (api *RestAPI) stopHandler(w http.ResponseWriter, r *http.Request) {
 				route.TextColor.String)
 
 			references.Routes = append(references.Routes, routeModel)
-			uniqueAgencyIDs[route.AgencyID] = true
 		}
 
 		// Fetch references for ALL unique agencies involved, not just the first one.

--- a/internal/restapi/stop_handler_test.go
+++ b/internal/restapi/stop_handler_test.go
@@ -512,3 +512,89 @@ func TestStopHandler_IncludeReferences(t *testing.T) {
 	assert.Empty(t, modelFalse.Data.References.Trips, "Trips must be empty when includeReferences=false")
 	assert.Empty(t, modelFalse.Data.References.Situations, "Situations must be empty when includeReferences=false")
 }
+
+// TestStopHandler_WrongAgency verifies that if a client requests a valid stop entity ID
+// but uses an incorrect agency namespace (one that does not serve the stop),
+// the API returns a 404 Not Found.
+func TestStopHandler_WrongAgency(t *testing.T) {
+	api := createTestApi(t)
+	defer api.Shutdown()
+
+	ctx := context.Background()
+	q := api.GtfsManager.GtfsDB.Queries
+
+	const (
+		validAgency   = "ValidAgency"
+		invalidAgency = "InvalidAgency"
+		stopID        = "Stop123"
+		orphanStopID  = "OrphanStop123"
+		routeID       = "RouteA"
+		tripID        = "TripA"
+		service       = "ServiceA"
+	)
+
+	// Create both agencies
+	_, err := q.CreateAgency(ctx, gtfsdb.CreateAgencyParams{
+		ID: validAgency, Name: "Valid Transit", Url: "http://valid.example.com", Timezone: "America/Los_Angeles",
+	})
+	require.NoError(t, err)
+	_, err = q.CreateAgency(ctx, gtfsdb.CreateAgencyParams{
+		ID: invalidAgency, Name: "Invalid Transit", Url: "http://invalid.example.com", Timezone: "America/Los_Angeles",
+	})
+	require.NoError(t, err)
+
+	// Create a stop with routes
+	_, err = q.CreateStop(ctx, gtfsdb.CreateStopParams{
+		ID: stopID, Name: nulls.String("Valid Stop"), Lat: 47.6, Lon: -122.3,
+	})
+	require.NoError(t, err)
+
+	// Create an orphan stop with no routes
+	_, err = q.CreateStop(ctx, gtfsdb.CreateStopParams{
+		ID: orphanStopID, Name: nulls.String("Orphan Stop"), Lat: 47.6, Lon: -122.3,
+	})
+	require.NoError(t, err)
+
+	// Create a route/trip/stop_time belonging to ValidAgency for the first stop
+	_, err = q.CreateRoute(ctx, gtfsdb.CreateRouteParams{
+		ID: routeID, AgencyID: validAgency, ShortName: nulls.String("Route A"), Type: 3,
+	})
+	require.NoError(t, err)
+	_, err = q.CreateCalendar(ctx, gtfsdb.CreateCalendarParams{
+		ID: service, Monday: 1, Tuesday: 1, Wednesday: 1, Thursday: 1, Friday: 1, Saturday: 1, Sunday: 1, StartDate: "20250101", EndDate: "20251231",
+	})
+	require.NoError(t, err)
+	_, err = q.CreateTrip(ctx, gtfsdb.CreateTripParams{
+		ID: tripID, RouteID: routeID, ServiceID: service,
+	})
+	require.NoError(t, err)
+	_, err = q.CreateStopTime(ctx, gtfsdb.CreateStopTimeParams{
+		TripID: tripID, StopID: stopID, StopSequence: 1, ArrivalTime: 36000, DepartureTime: 36000,
+	})
+	require.NoError(t, err)
+
+	// Test 1: Request with the valid agency namespace -> 200 OK
+	respValid, modelValid := callAPIHandler[StopEntryResponse](t, api, stopURL(utils.FormCombinedID(validAgency, stopID)))
+	require.Equal(t, http.StatusOK, respValid.StatusCode)
+	assert.Equal(t, http.StatusOK, modelValid.Code)
+
+	// Test 2: Request with the invalid agency namespace -> 404 Not Found
+	respInvalid, modelInvalid := callAPIHandler[StopEntryResponse](t, api, stopURL(utils.FormCombinedID(invalidAgency, stopID)))
+	require.Equal(t, http.StatusNotFound, respInvalid.StatusCode)
+	assert.Equal(t, http.StatusNotFound, modelInvalid.Code)
+
+	// Test 3: Request with an agency that doesn't even exist in the DB -> 404 Not Found
+	respGhost, modelGhost := callAPIHandler[StopEntryResponse](t, api, stopURL(utils.FormCombinedID("GhostAgency", stopID)))
+	require.Equal(t, http.StatusNotFound, respGhost.StatusCode)
+	assert.Equal(t, http.StatusNotFound, modelGhost.Code)
+
+	// Test 4: Request orphan stop with an existing agency namespace -> 200 OK
+	respOrphanValid, modelOrphanValid := callAPIHandler[StopEntryResponse](t, api, stopURL(utils.FormCombinedID(validAgency, orphanStopID)))
+	require.Equal(t, http.StatusOK, respOrphanValid.StatusCode)
+	assert.Equal(t, http.StatusOK, modelOrphanValid.Code)
+
+	// Test 5: Request orphan stop with a non-existent agency namespace -> 404 Not Found
+	respOrphanGhost, modelOrphanGhost := callAPIHandler[StopEntryResponse](t, api, stopURL(utils.FormCombinedID("GhostAgency", orphanStopID)))
+	require.Equal(t, http.StatusNotFound, respOrphanGhost.StatusCode)
+	assert.Equal(t, http.StatusNotFound, modelOrphanGhost.Code)
+}

--- a/internal/restapi/stop_handler_test.go
+++ b/internal/restapi/stop_handler_test.go
@@ -577,6 +577,7 @@ func TestStopHandler_WrongAgency(t *testing.T) {
 	respValid, modelValid := callAPIHandler[StopEntryResponse](t, api, stopURL(utils.FormCombinedID(validAgency, stopID)))
 	require.Equal(t, http.StatusOK, respValid.StatusCode)
 	assert.Equal(t, http.StatusOK, modelValid.Code)
+	assert.Equal(t, utils.FormCombinedID(validAgency, stopID), modelValid.Data.Entry.ID)
 
 	// Test 2: Request with the invalid agency namespace -> 404 Not Found
 	respInvalid, modelInvalid := callAPIHandler[StopEntryResponse](t, api, stopURL(utils.FormCombinedID(invalidAgency, stopID)))
@@ -597,4 +598,13 @@ func TestStopHandler_WrongAgency(t *testing.T) {
 	respOrphanGhost, modelOrphanGhost := callAPIHandler[StopEntryResponse](t, api, stopURL(utils.FormCombinedID("GhostAgency", orphanStopID)))
 	require.Equal(t, http.StatusNotFound, respOrphanGhost.StatusCode)
 	assert.Equal(t, http.StatusNotFound, modelOrphanGhost.Code)
+
+	// Create a fresh API instance to avoid rate limiting on the 6th request
+	api = createTestApi(t)
+	defer api.Shutdown()
+
+	// Test 6: Request invalid agency namespace with includeReferences=false -> 404 Not Found
+	respInvalid, modelInvalid = callAPIHandler[StopEntryResponse](t, api, stopURL(utils.FormCombinedID(invalidAgency, stopID))+"&includeReferences=false")
+	require.Equal(t, http.StatusNotFound, respInvalid.StatusCode)
+	assert.Equal(t, http.StatusNotFound, modelInvalid.Code)
 }


### PR DESCRIPTION
### Description
Resolves #1094 by ensuring the `/stop` endpoint strictly validates the requested agency namespace. 

### Changes Made
* **Validation Added:** The handler now verifies that the requested `agencyID` actually serves the retrieved stop. If the agency does not have any routes serving the stop, it returns a `404 Not Found` instead of falsely returning the stop.
* **Orphaned Stop Fallback:** Because Maglev's `stops` table lacks an explicit `agency_id` column, if a stop has *no routes at all*, the handler allows retrieval as long as the requested `agencyID` exists in the database.
* **Test Coverage:** Added `TestStopHandler_WrongAgency` to guarantee that requesting a valid stop under an incorrect or non-existent agency namespace correctly triggers a 404.

### Testing
* Run `make test` to verify the new `TestStopHandler_WrongAgency` assertions pass successfully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the stop endpoint to enforce agency namespace ownership: requests with a mismatched or non-existent agency namespace now return **404 Not Found**.
  * Stops without associated routes follow existence-based agency validation, and reference population respects the same ownership rules.
* **Tests**
  * Added coverage for wrong-namespace scenarios, verifying both routed and orphan stop cases (including behavior when reference inclusion is disabled).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->