### PR TITLE
fix(trip-details): omit status key when tracking is absent

### DIFF
--- a/internal/models/trip_details.go
+++ b/internal/models/trip_details.go
@@ -66,6 +66,13 @@ type TripStatus struct {
 	Scheduled                  bool       `json:"scheduled"` // (Scheduled = !Predicted) ,this field is not part of the OpenAPI TripStatus schema but is retained for compatibility with existing API consumers. Tracked as a known spec deviation.
 }
 
+// IsUntracked reports whether this TripStatus is merely the default placeholder
+// returned by BuildTripStatus when no real-time tracking record exists.
+// Extension 4e requires the status key to be omitted in this case.
+func (ts *TripStatus) IsUntracked() bool {
+	return ts.Status == "default" && !ts.Predicted
+}
+
 func (ts *TripStatus) SetPredicted(predicted bool) {
 	ts.Predicted = predicted
 	ts.Scheduled = !predicted

--- a/internal/models/trip_details.go
+++ b/internal/models/trip_details.go
@@ -66,11 +66,13 @@ type TripStatus struct {
 	Scheduled                  bool       `json:"scheduled"` // (Scheduled = !Predicted) ,this field is not part of the OpenAPI TripStatus schema but is retained for compatibility with existing API consumers. Tracked as a known spec deviation.
 }
 
+const DefaultTripStatusValue = "default"
+
 // IsUntracked reports whether this TripStatus is merely the default placeholder
 // returned by BuildTripStatus when no real-time tracking record exists.
 // Extension 4e requires the status key to be omitted in this case.
 func (ts *TripStatus) IsUntracked() bool {
-	return ts.Status == "default" && !ts.Predicted
+	return ts.Status == DefaultTripStatusValue && !ts.Predicted
 }
 
 func (ts *TripStatus) SetPredicted(predicted bool) {

--- a/internal/models/trip_details_test.go
+++ b/internal/models/trip_details_test.go
@@ -181,7 +181,7 @@ func TestTripStatusJSON(t *testing.T) {
 
 func TestTripStatus_JSONAlwaysPresent(t *testing.T) {
 	status := *NewTripStatus()
-	status.Status = "default"
+	status.Status = DefaultTripStatusValue
 
 	data, err := json.Marshal(status)
 	require.NoError(t, err)
@@ -212,14 +212,14 @@ func TestTripStatus_JSONAlwaysPresent(t *testing.T) {
 func TestTripStatus_IsUntracked(t *testing.T) {
 	t.Run("default placeholder is untracked", func(t *testing.T) {
 		status := NewTripStatus()
-		status.Status = "default"
+		status.Status = DefaultTripStatusValue
 		// NewTripStatus sets Predicted=false by default
 		assert.True(t, status.IsUntracked())
 	})
 
 	t.Run("predicted status is not untracked", func(t *testing.T) {
 		status := NewTripStatus()
-		status.Status = "default"
+		status.Status = DefaultTripStatusValue
 		status.SetPredicted(true)
 		assert.False(t, status.IsUntracked())
 	})

--- a/internal/models/trip_details_test.go
+++ b/internal/models/trip_details_test.go
@@ -208,3 +208,32 @@ func TestTripStatus_JSONAlwaysPresent(t *testing.T) {
 	assert.Contains(t, jsonStr, `"occupancyStatus":""`, "occupancyStatus must always be present")
 	assert.Contains(t, jsonStr, `"vehicleId":""`, "vehicleId must always be present")
 }
+
+func TestTripStatus_IsUntracked(t *testing.T) {
+	t.Run("default placeholder is untracked", func(t *testing.T) {
+		status := NewTripStatus()
+		status.Status = "default"
+		// NewTripStatus sets Predicted=false by default
+		assert.True(t, status.IsUntracked())
+	})
+
+	t.Run("predicted status is not untracked", func(t *testing.T) {
+		status := NewTripStatus()
+		status.Status = "default"
+		status.SetPredicted(true)
+		assert.False(t, status.IsUntracked())
+	})
+
+	t.Run("non-default status is not untracked", func(t *testing.T) {
+		status := NewTripStatus()
+		status.Status = "SCHEDULED"
+		assert.False(t, status.IsUntracked())
+	})
+
+	t.Run("active tracking is not untracked", func(t *testing.T) {
+		status := NewTripStatus()
+		status.Status = "in_progress"
+		status.SetPredicted(true)
+		assert.False(t, status.IsUntracked())
+	})
+}

--- a/internal/restapi/servicedate_timezone_regression_test.go
+++ b/internal/restapi/servicedate_timezone_regression_test.go
@@ -228,6 +228,10 @@ func TestServiceDateTimezoneRegression_BlockTripSequence(t *testing.T) {
 
 			setupTzTestGTFS(t, api.GtfsManager.GtfsDB.Queries, td, days)
 
+			// Add a vehicle for the trip so BuildTripStatus returns a tracked
+			// status (extension 4e omits the status key when no tracking exists).
+			api.GtfsManager.MockAddVehicle(tc.prefix+"V", td.TripID2, td.RouteID)
+
 			combinedTrip := utils.FormCombinedID(td.AgencyID, td.TripID2)
 			endpoint := fmt.Sprintf(
 				"/api/where/trip-details/%s.json?key=TEST&serviceDate=%d&includeStatus=true",
@@ -239,6 +243,7 @@ func TestServiceDateTimezoneRegression_BlockTripSequence(t *testing.T) {
 
 			data := model.Data.(map[string]any)
 			entry := data["entry"].(map[string]any)
+			require.Contains(t, entry, "status", "status should be present when a vehicle is tracked")
 			status := entry["status"].(map[string]any)
 
 			blockTripSeq := int(status["blockTripSequence"].(float64))

--- a/internal/restapi/trip_details_handler.go
+++ b/internal/restapi/trip_details_handler.go
@@ -200,7 +200,7 @@ func (api *RestAPI) tripDetailsHandler(w http.ResponseWriter, r *http.Request) {
 
 		// Extension 4e: Explicitly nil out the status if there is no actual tracking record.
 		// BuildTripStatus returns a default placeholder when tracking is absent, so we nil it to trigger JSON omitempty.
-		if status != nil && status.Status == "default" && !status.Predicted {
+		if status != nil && status.IsUntracked() {
 			status = nil
 		}
 	}

--- a/internal/restapi/trip_details_handler.go
+++ b/internal/restapi/trip_details_handler.go
@@ -197,6 +197,12 @@ func (api *RestAPI) tripDetailsHandler(w http.ResponseWriter, r *http.Request) {
 				"error", statusErr.Error())
 			status = nil
 		}
+
+		// Extension 4e: Explicitly nil out the status if there is no actual tracking record.
+		// BuildTripStatus returns a default placeholder when tracking is absent, so we nil it to trigger JSON omitempty.
+		if status != nil && status.Status == "default" && !status.Predicted {
+			status = nil
+		}
 	}
 
 	if params.IncludeSchedule {

--- a/internal/restapi/trip_details_handler_test.go
+++ b/internal/restapi/trip_details_handler_test.go
@@ -181,6 +181,26 @@ func TestTripDetailsHandlerWithIncludeStatus(t *testing.T) {
 	assert.Nil(t, model.Data.Entry.Status)
 }
 
+// TestTripDetailsHandlerStatusOmittedWhenNoTracking verifies Extension 4e:
+// The status key must be absent entirely when there is no tracking record, even if includeStatus=true.
+func TestTripDetailsHandlerStatusOmittedWhenNoTracking(t *testing.T) {
+	api := createTestApi(t)
+	defer api.Shutdown()
+	t.Cleanup(api.GtfsManager.MockResetRealTimeData)
+
+	agency := mustGetAgencies(t, api)[0]
+	trip := mustGetTrip(t, api)
+	tripID := utils.FormCombinedID(agency.ID, trip.ID)
+
+	// No vehicle, no trip updates — purely scheduled, no tracking record.
+	resp, model := callAPIHandler[TripDetailsResponse](t, api,
+		"/api/where/trip-details/"+tripID+".json?key=TEST&includeStatus=true")
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Nil(t, model.Data.Entry.Status,
+		"status must be absent when the block has no current tracking record (extension 4e)")
+}
+
 func TestTripDetailsHandlerWithTimeParameter(t *testing.T) {
 	api := createTestApi(t)
 	defer api.Shutdown()

--- a/internal/restapi/trip_details_handler_test.go
+++ b/internal/restapi/trip_details_handler_test.go
@@ -199,6 +199,16 @@ func TestTripDetailsHandlerStatusOmittedWhenNoTracking(t *testing.T) {
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Nil(t, model.Data.Entry.Status,
 		"status must be absent when the block has no current tracking record (extension 4e)")
+
+	// Verify at the raw JSON level that "status" key is truly absent, not just null.
+	// assert.Nil passes for both absent and null after unmarshal; the spec requires absence.
+	_, rawModel := callAPIHandler[map[string]any](t, api,
+		"/api/where/trip-details/"+tripID+".json?key=TEST&includeStatus=true")
+	data := rawModel["data"].(map[string]any)
+	entry := data["entry"].(map[string]any)
+	_, hasStatus := entry["status"]
+	assert.False(t, hasStatus,
+		"status key must not be present in JSON (not even as null) per extension 4e")
 }
 
 func TestTripDetailsHandlerWithTimeParameter(t *testing.T) {


### PR DESCRIPTION
## Description
This PR addresses **Extension 4e** of the `trip-details` specification, which requires the `status` key to be entirely absent from the response if the block has no current tracking record.

Previously, `BuildTripStatus` returned a default non-nil placeholder (`Status="default"`, `Predicted=false`) when no vehicle was tracked, which prevented the `omitempty` JSON tag from dropping the field. 

**Changes made:**
* Explicitly set the `status` pointer to `nil` in `tripDetailsHandler` when the returned status is just the default placeholder.
* Added `TestTripDetailsHandlerStatusOmittedWhenNoTracking` to explicitly verify compliance with Extension 4e.
* Updated `TestServiceDateTimezoneRegression_BlockTripSequence` to inject a mock vehicle, ensuring the timezone calculation still has valid tracking data to test against.

Closes: #1086 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the trip-details API to omit the `status` field entirely when no vehicle tracking data is available (instead of returning an untracked placeholder).  
  * Added/updated coverage to ensure the endpoint doesn’t include `status` in the raw JSON response when tracking is missing, and added unit tests for the untracked status detection logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->