### PR TITLE
Fix trip references when includeTrip is false

### DIFF
--- a/internal/restapi/trip_details_handler.go
+++ b/internal/restapi/trip_details_handler.go
@@ -253,22 +253,28 @@ func (api *RestAPI) tripDetailsHandler(w http.ResponseWriter, r *http.Request) {
 	includeReferences := ShouldIncludeReferences(r)
 
 	if includeReferences {
+		tripsToInclude := []string{}
+
+		// Only include the main trip if includeTrip=true.
+		// Related trips (preceding/following/active) are appended independently.
 		if params.IncludeTrip {
-			tripsToInclude := []string{utils.FormCombinedID(agencyID, trip.ID)}
+			tripsToInclude = append(tripsToInclude, utils.FormCombinedID(agencyID, trip.ID))
+		}
 
-			if params.IncludeSchedule && schedule != nil {
-				if schedule.NextTripID != "" {
-					tripsToInclude = append(tripsToInclude, schedule.NextTripID)
-				}
-				if schedule.PreviousTripID != "" {
-					tripsToInclude = append(tripsToInclude, schedule.PreviousTripID)
-				}
+		if params.IncludeSchedule && schedule != nil {
+			if schedule.NextTripID != "" {
+				tripsToInclude = append(tripsToInclude, schedule.NextTripID)
 			}
-
-			if params.IncludeStatus && status != nil && status.ActiveTripID != "" {
-				tripsToInclude = append(tripsToInclude, status.ActiveTripID)
+			if schedule.PreviousTripID != "" {
+				tripsToInclude = append(tripsToInclude, schedule.PreviousTripID)
 			}
+		}
 
+		if params.IncludeStatus && status != nil && status.ActiveTripID != "" {
+			tripsToInclude = append(tripsToInclude, status.ActiveTripID)
+		}
+
+		if len(tripsToInclude) > 0 {
 			referencedTrips, err := api.buildReferencedTrips(ctx, agencyID, tripsToInclude, trip)
 			if err != nil {
 				api.serverErrorResponse(w, r, err)

--- a/internal/restapi/trip_details_handler_test.go
+++ b/internal/restapi/trip_details_handler_test.go
@@ -179,6 +179,9 @@ func TestTripDetailsHandlerIncludeTripFalseKeepsBlockTrips(t *testing.T) {
 		}
 	}
 
+	assert.NotEmpty(t, expectedBlockTrips,
+		"test fixture should include preceding/following trips to meaningfully test this behavior")
+
 	gotTrips := map[string]bool{}
 	for _, refTrip := range withoutTrip.Data.References.Trips {
 		gotTrips[refTrip.ID] = true

--- a/internal/restapi/trip_details_handler_test.go
+++ b/internal/restapi/trip_details_handler_test.go
@@ -147,7 +147,49 @@ func TestTripDetailsHandlerWithIncludeTrip(t *testing.T) {
 		"/api/where/trip-details/"+tripID+".json?key=TEST&includeTrip=false")
 
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
-	assert.Empty(t, model.Data.References.Trips)
+
+	// Verify includeTrip=false omits the main trip but keeps related block and active trips.
+	for _, refTrip := range model.Data.References.Trips {
+		assert.NotEqual(t, tripID, refTrip.ID,
+			"main trip should not be included in references when includeTrip=false")
+	}
+}
+
+func TestTripDetailsHandlerIncludeTripFalseKeepsBlockTrips(t *testing.T) {
+	api := createTestApi(t)
+	defer api.Shutdown()
+
+	agency := mustGetAgencies(t, api)[0]
+	trip := mustGetTrip(t, api)
+	tripID := utils.FormCombinedID(agency.ID, trip.ID)
+
+	_, withTrip := callAPIHandler[TripDetailsResponse](t, api,
+		"/api/where/trip-details/"+tripID+".json?key=TEST&includeTrip=true&includeSchedule=true")
+
+	resp, withoutTrip := callAPIHandler[TripDetailsResponse](t, api,
+		"/api/where/trip-details/"+tripID+".json?key=TEST&includeTrip=false&includeSchedule=true")
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	// Collect block trip IDs (excluding the main trip) from the includeTrip=true response.
+	expectedBlockTrips := map[string]bool{}
+	for _, refTrip := range withTrip.Data.References.Trips {
+		if refTrip.ID != tripID {
+			expectedBlockTrips[refTrip.ID] = true
+		}
+	}
+
+	gotTrips := map[string]bool{}
+	for _, refTrip := range withoutTrip.Data.References.Trips {
+		gotTrips[refTrip.ID] = true
+		assert.NotEqual(t, tripID, refTrip.ID,
+			"main trip should be excluded when includeTrip=false")
+	}
+
+	for blockTripID := range expectedBlockTrips {
+		assert.True(t, gotTrips[blockTripID],
+			"block trip %s should still be referenced when includeTrip=false", blockTripID)
+	}
 }
 
 func TestTripDetailsHandlerWithIncludeSchedule(t *testing.T) {


### PR DESCRIPTION
### Summary
Fixes the trip-details endpoint so that includeTrip=false correctly
omits the main trip from references.trips while preserving the
preceding and following block trips (when includeSchedule=true), as
required by OneBusAway spec Extension 4c.
### Problem
In tripDetailsHandler, the logic to resolve preceding/following
block trips was nested entirely inside the `if params.IncludeTrip`
block. As a result, requesting includeTrip=false skipped the whole
reference-resolution path and produced an empty references.trips
array, even when includeSchedule=true.

### Changes
- Add the main trip ID to tripsToInclude only when includeTrip=true.
- Always append next/previous trips (when includeSchedule=true) and
  the active trip (when includeStatus=true), regardless of the
  includeTrip value.
- Update TestTripDetailsHandlerWithIncludeTrip to assert the main
  trip is excluded rather than expecting an empty list.
- Add TestTripDetailsHandlerIncludeTripFalseKeepsBlockTrips to verify
  block trips are still referenced when includeTrip=false.

Closes: #1087 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Trip references from schedule and status data are now correctly included in responses, even when the main trip is excluded. This ensures more consistent and complete trip information availability based on your query parameters and available data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->