### PR TITLE
fix: honor includeReferences parameter

### DIFF
--- a/internal/restapi/vehicles_for_agency_handler.go
+++ b/internal/restapi/vehicles_for_agency_handler.go
@@ -218,16 +218,19 @@ func (api *RestAPI) vehiclesForAgencyHandler(w http.ResponseWriter, r *http.Requ
 		tripRefList = append(tripRefList, tripRef)
 	}
 
+	// Omit references entirely when includeReferences=false.
 	references := models.NewEmptyReferences()
-	references.Agencies = []models.AgencyReference{models.AgencyReferenceFromDatabase(agency)}
-	references.Routes = routeRefList
-	references.Trips = tripRefList
+	if ShouldIncludeReferences(r) {
+		references.Agencies = []models.AgencyReference{models.AgencyReferenceFromDatabase(agency)}
+		references.Routes = routeRefList
+		references.Trips = tripRefList
 
-	alerts := deduplicateAlerts(
-		api.collectAlertsForRoutes(routeIDs),
-		api.GtfsManager.GetAlertsByIDs("", "", id),
-	)
-	references.Situations = append(references.Situations, api.BuildSituationReferences(alerts)...)
+		alerts := deduplicateAlerts(
+			api.collectAlertsForRoutes(routeIDs),
+			api.GtfsManager.GetAlertsByIDs("", "", id),
+		)
+		references.Situations = append(references.Situations, api.BuildSituationReferences(alerts)...)
+	}
 
 	response := models.NewListResponse(vehiclesList, *references, limitExceeded, api.Clock)
 	api.sendResponse(w, r, response)

--- a/internal/restapi/vehicles_for_agency_handler_test.go
+++ b/internal/restapi/vehicles_for_agency_handler_test.go
@@ -238,6 +238,57 @@ func TestVehiclesForAgencyHandler_RouteIDUsesCombinedID(t *testing.T) {
 		"expected a trip reference with routeId=%q (combined agencyID_routeID format)", expectedRouteID)
 }
 
+// TestVehiclesForAgencyHandler_IncludeReferencesFalse verifies that
+// includeReferences=false empties the references block while keeping the list.
+func TestVehiclesForAgencyHandler_IncludeReferencesFalse(t *testing.T) {
+	api := createTestApi(t)
+	defer api.Shutdown()
+	t.Cleanup(api.GtfsManager.MockResetRealTimeData)
+
+	trip := mustGetTrip(t, api)
+	api.GtfsManager.MockAddVehicleWithOptions("v_refs_false", trip.ID, trip.RouteID, gtfs.MockVehicleOptions{})
+
+	params := url.Values{"includeReferences": {"false"}}
+	resp, model := callAPIHandler[VehiclesForAgencyResponse](t, api, vehiclesForAgencyURL(testdata.Raba.ID, params))
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NotEmpty(t, model.Data.List, "list must still be populated when includeReferences=false")
+
+	refs := model.Data.References
+	assert.Empty(t, refs.Agencies, "agencies should be empty when includeReferences=false")
+	assert.Empty(t, refs.Routes, "routes should be empty when includeReferences=false")
+	assert.Empty(t, refs.Trips, "trips should be empty when includeReferences=false")
+	assert.Empty(t, refs.Stops, "stops should be empty when includeReferences=false")
+	assert.Empty(t, refs.Situations, "situations should be empty when includeReferences=false")
+}
+
+// TestVehiclesForAgencyHandler_IncludeReferencesDefault verifies that references
+// are populated when includeReferences is absent or explicitly true.
+func TestVehiclesForAgencyHandler_IncludeReferencesDefault(t *testing.T) {
+	tests := []struct {
+		name   string
+		params []url.Values
+	}{
+		{"absent", nil},
+		{"explicit true", []url.Values{{"includeReferences": {"true"}}}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			api := createTestApi(t)
+			defer api.Shutdown()
+			t.Cleanup(api.GtfsManager.MockResetRealTimeData)
+
+			trip := mustGetTrip(t, api)
+			api.GtfsManager.MockAddVehicleWithOptions("v_refs_default", trip.ID, trip.RouteID, gtfs.MockVehicleOptions{})
+
+			_, model := callAPIHandler[VehiclesForAgencyResponse](t, api, vehiclesForAgencyURL(testdata.Raba.ID, tc.params...))
+
+			assert.NotEmpty(t, model.Data.References.Agencies,
+				"agencies should be populated when includeReferences is true/absent")
+		})
+	}
+}
+
 // vehiclesRealTimeDataClock is pinned just past the latest timestamp in
 // testdata/raba-vehicle-positions.pb (2025-06-08 21:08:26 UTC) so vehicles fall
 // inside the handler's 15-minute stale-vehicle window. With clock.RealClock{},


### PR DESCRIPTION
### Summary

Fixes a spec gap where the `vehicles-for-agency` endpoint ignored the `includeReferences` parameter and always populated the references block.

### Problem

The spec states that passing `includeReferences=false` should omit the references block to reduce payload size. The handler was unconditionally building and returning all references (agencies, routes, trips, situations), wasting both bandwidth and server resources.

### Changes

- Wrapped the references population logic in the existing `ShouldIncludeReferences(r)` helper.
- When `false`, the response now correctly returns empty arrays for the references block using `models.NewEmptyReferences()`.
- Database queries for alerts/situations are now correctly bypassed when references are excluded, improving performance.
- Added test coverage for `includeReferences=false` (asserting empty references) and `true`/absent (asserting populated references using table-driven tests).

Closes #1104 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Vehicle list responses now respect the `includeReferences` option, returning reference data only when requested.
  * When reference data is disabled, the response still includes vehicles but leaves related reference sections empty.
  * Alerts and situation details are no longer fetched or added unless reference data is included.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->