### PR TITLE
fix: include outOfRange field in vehicles-for-agency response

### DIFF
--- a/internal/restapi/vehicles_for_agency_handler.go
+++ b/internal/restapi/vehicles_for_agency_handler.go
@@ -24,8 +24,8 @@ func (api *RestAPI) vehiclesForAgencyHandler(w http.ResponseWriter, r *http.Requ
 	}
 
 	if agency == nil {
-		// return an empty list response.
-		api.sendResponse(w, r, models.NewListResponse([]any{}, *models.NewEmptyReferences(), false, api.Clock))
+		// Unknown/untracked agency: empty list, outOfRange=false.
+		api.sendResponse(w, r, models.NewListResponseWithRange([]any{}, *models.NewEmptyReferences(), false, api.Clock, false))
 		return
 	}
 
@@ -229,6 +229,7 @@ func (api *RestAPI) vehiclesForAgencyHandler(w http.ResponseWriter, r *http.Requ
 	)
 	references.Situations = append(references.Situations, api.BuildSituationReferences(alerts)...)
 
-	response := models.NewListResponse(vehiclesList, *references, limitExceeded, api.Clock)
+	// Agency is served by this instance, so outOfRange is always false.
+	response := models.NewListResponseWithRange(vehiclesList, *references, false, api.Clock, limitExceeded)
 	api.sendResponse(w, r, response)
 }

--- a/internal/restapi/vehicles_for_agency_handler_test.go
+++ b/internal/restapi/vehicles_for_agency_handler_test.go
@@ -2,6 +2,7 @@ package restapi
 
 import (
 	"context"
+	"encoding/json"
 	"maps"
 	"net/http"
 	"net/http/httptest"
@@ -31,6 +32,24 @@ func vehiclesForAgencyURL(agencyID string, params ...url.Values) string {
 		maps.Copy(q, p)
 	}
 	return "/api/where/vehicles-for-agency/" + agencyID + ".json?" + q.Encode()
+}
+
+// fetchRawData returns the response "data" object as raw JSON keys so tests can
+// assert field presence, not just decoded zero values.
+func fetchRawData(t testing.TB, api *RestAPI, endpoint string) map[string]json.RawMessage {
+	t.Helper()
+	server := httptest.NewServer(api.SetupAPIRoutes())
+	defer server.Close()
+
+	resp, err := http.Get(server.URL + endpoint)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	var envelope struct {
+		Data map[string]json.RawMessage `json:"data"`
+	}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&envelope))
+	return envelope.Data
 }
 
 func TestVehiclesForAgencyHandlerRequiresValidApiKey(t *testing.T) {
@@ -69,7 +88,11 @@ func TestVehiclesForAgencyHandlerWithNonExistentAgency(t *testing.T) {
 	assert.Equal(t, http.StatusOK, model.Code)
 	assert.Equal(t, "OK", model.Text)
 	assert.Empty(t, model.Data.List)
-	assert.False(t, model.Data.OutOfRange, "unknown agency must return outOfRange=false (Extension 3a)")
+
+	data := fetchRawData(t, api, vehiclesForAgencyURL("nonexistent"))
+	raw, ok := data["outOfRange"]
+	require.True(t, ok, "outOfRange key must be present in the response payload")
+	assert.JSONEq(t, "false", string(raw), "unknown agency must return outOfRange=false (Extension 3a)")
 }
 
 // TestVehiclesForAgencyHandler_OutOfRangeFalseForKnownAgency verifies the success
@@ -78,11 +101,10 @@ func TestVehiclesForAgencyHandler_OutOfRangeFalseForKnownAgency(t *testing.T) {
 	api := createTestApi(t)
 	defer api.Shutdown()
 
-	resp, model := callAPIHandler[VehiclesForAgencyResponse](t, api, vehiclesForAgencyURL(testdata.Raba.ID))
-
-	assert.Equal(t, http.StatusOK, resp.StatusCode)
-	assert.Equal(t, http.StatusOK, model.Code)
-	assert.False(t, model.Data.OutOfRange, "known agency must return outOfRange=false")
+	data := fetchRawData(t, api, vehiclesForAgencyURL(testdata.Raba.ID))
+	raw, ok := data["outOfRange"]
+	require.True(t, ok, "outOfRange key must be present in the response payload")
+	assert.JSONEq(t, "false", string(raw), "known agency must return outOfRange=false")
 }
 
 // TestVehiclesForAgencyHandler_OccupancyPropagation verifies that when a vehicle

--- a/internal/restapi/vehicles_for_agency_handler_test.go
+++ b/internal/restapi/vehicles_for_agency_handler_test.go
@@ -69,6 +69,20 @@ func TestVehiclesForAgencyHandlerWithNonExistentAgency(t *testing.T) {
 	assert.Equal(t, http.StatusOK, model.Code)
 	assert.Equal(t, "OK", model.Text)
 	assert.Empty(t, model.Data.List)
+	assert.False(t, model.Data.OutOfRange, "unknown agency must return outOfRange=false (Extension 3a)")
+}
+
+// TestVehiclesForAgencyHandler_OutOfRangeFalseForKnownAgency verifies the success
+// path emits outOfRange=false for an agency served by this instance.
+func TestVehiclesForAgencyHandler_OutOfRangeFalseForKnownAgency(t *testing.T) {
+	api := createTestApi(t)
+	defer api.Shutdown()
+
+	resp, model := callAPIHandler[VehiclesForAgencyResponse](t, api, vehiclesForAgencyURL(testdata.Raba.ID))
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, http.StatusOK, model.Code)
+	assert.False(t, model.Data.OutOfRange, "known agency must return outOfRange=false")
 }
 
 // TestVehiclesForAgencyHandler_OccupancyPropagation verifies that when a vehicle


### PR DESCRIPTION
### Summary

Fixes a spec gap where the `vehicles-for-agency` endpoint was missing the `outOfRange` boolean field in the response envelope's `data` object.

### Problem

The spec mandates that the `data` object must contain an `outOfRange` boolean to help clients distinguish between agencies that are simply unknown and those that are outside the server's service area. The previous implementation used `models.NewListResponse`, which completely omitted this field from the JSON output.

### Changes

- Updated the handler to use `models.NewListResponseWithRange(...)`.
- **Known Agencies:** Now explicitly emit `outOfRange: false` in the success path.
- **Unknown Agencies (Extension 3a):** Now explicitly emit `outOfRange: false` alongside the empty list when `agency == nil`.
- *Note:* Because Maglev currently operates as a single-instance architecture (it serves all agencies present in its GTFS DB), the "out of service area" scenario (Extension 4a / `outOfRange: true`) is not currently applicable. The key fix is ensuring the field is consistently present in the payload.
- Added test coverage to assert `outOfRange == false` for both known and non-existent agencies.

Closes #1113 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the vehicles-for-agency response so range information is returned consistently for both unknown and valid agencies.
  * Ensured the response correctly marks `outOfRange` as `false` in these cases.

* **Tests**
  * Added and updated coverage to verify the `outOfRange` field in vehicles-for-agency responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->