### PR TITLE
stops-for-route: match Java polyline output

### DIFF
--- a/internal/restapi/stops_for_route_handler.go
+++ b/internal/restapi/stops_for_route_handler.go
@@ -7,7 +7,6 @@ import (
 	"slices"
 	"time"
 
-	"github.com/twpayne/go-polyline"
 	"maglev.onebusaway.org/gtfsdb"
 	"maglev.onebusaway.org/internal/models"
 	"maglev.onebusaway.org/internal/nulls"
@@ -98,7 +97,6 @@ func (api *RestAPI) stopsForRouteHandler(w http.ResponseWriter, r *http.Request)
 
 func (api *RestAPI) processRouteStops(ctx context.Context, agencyID string, routeID string, serviceIDs []string, includePolylines bool) (models.RouteEntry, []models.Stop, error) {
 	allStops := make(map[string]bool)
-	allPolylines := make([]models.Polyline, 0, 100)
 	var stopGroupings []models.StopGrouping
 
 	// Get trips for route that are active on the service date
@@ -106,29 +104,32 @@ func (api *RestAPI) processRouteStops(ctx context.Context, agencyID string, rout
 		RouteID:    routeID,
 		ServiceIds: serviceIDs,
 	})
-
 	if err != nil {
 		return models.RouteEntry{}, nil, err
 	}
 
-	if len(trips) == 0 {
+	effectiveTrips := trips
+	if len(effectiveTrips) == 0 {
 		// Fallback: get all trips for this route regardless of service date
-		allTrips, err := api.GtfsManager.GtfsDB.Queries.GetAllTripsForRoute(ctx, routeID)
+		effectiveTrips, err = api.GtfsManager.GtfsDB.Queries.GetAllTripsForRoute(ctx, routeID)
 		if err != nil {
-			return models.RouteEntry{}, nil, err
-		}
-		if err := processTripGroups(ctx, api, agencyID, routeID, allTrips, &stopGroupings, allStops, &allPolylines); err != nil {
-			return models.RouteEntry{}, nil, err
-		}
-	} else {
-		// Process trips for the current service date
-		if err := processTripGroups(ctx, api, agencyID, routeID, trips, &stopGroupings, allStops, &allPolylines); err != nil {
 			return models.RouteEntry{}, nil, err
 		}
 	}
 
-	if !includePolylines {
-		allPolylines = []models.Polyline{}
+	if err := processTripGroups(ctx, api, agencyID, routeID, effectiveTrips, &stopGroupings, allStops, includePolylines); err != nil {
+		return models.RouteEntry{}, nil, err
+	}
+
+	// Entry-level polylines are an independent merge over the shapes of every
+	// qualifying trip, mirroring Java's getEncodedPolylinesForRoute — not a
+	// concatenation of the per-direction group polylines.
+	entryPolylines := []models.Polyline{}
+	if includePolylines {
+		entryPolylines, err = api.mergePolylinesForShapeIDs(ctx, distinctShapeIDs(effectiveTrips))
+		if err != nil {
+			return models.RouteEntry{}, nil, err
+		}
 	}
 
 	allStopsIds := formatStopIDs(agencyID, allStops)
@@ -138,7 +139,7 @@ func (api *RestAPI) processRouteStops(ctx context.Context, agencyID string, rout
 	}
 
 	result := models.RouteEntry{
-		Polylines:     allPolylines,
+		Polylines:     entryPolylines,
 		RouteID:       utils.FormCombinedID(agencyID, routeID),
 		StopGroupings: stopGroupings,
 		StopIds:       allStopsIds,
@@ -239,7 +240,7 @@ func processTripGroups(
 	trips []gtfsdb.Trip,
 	stopGroupings *[]models.StopGrouping,
 	allStops map[string]bool,
-	allPolylines *[]models.Polyline,
+	includePolylines bool,
 ) error {
 	dirGroups := groupTripsByDirection(trips)
 
@@ -296,27 +297,17 @@ func processTripGroups(
 			}
 		}
 
-		seenHeadsigns := make(map[string]bool)
-		var groupPolylines []models.Polyline
-		for _, trip := range tripsInGroup {
-			hs := trip.TripHeadsign.String
-			if seenHeadsigns[hs] {
-				continue
-			}
-			seenHeadsigns[hs] = true
-			shape, err := api.GtfsManager.GtfsDB.Queries.GetShapesGroupedByTripHeadSign(ctx,
-				gtfsdb.GetShapesGroupedByTripHeadSignParams{
-					RouteID:      routeID,
-					TripHeadsign: trip.TripHeadsign,
-				})
+		// groupPolylines stays a non-nil empty slice so it serializes as [] (not
+		// null) when includePolylines is false or a group has no shapes. The
+		// polylines are merged from the distinct shapes of this direction's trips,
+		// mirroring Java's getShapeIdsForStopSequenceBlock + merge.
+		groupPolylines := []models.Polyline{}
+		if includePolylines {
+			groupPolylines, err = api.mergePolylinesForShapeIDs(ctx, distinctShapeIDs(tripsInGroup))
 			if err != nil {
-				api.Logger.Warn("failed to fetch shapes for trip group", "route_id", routeID, "headsign", hs, "error", err)
-				continue
+				return err
 			}
-			pl := generatePolylines(shape)
-			groupPolylines = append(groupPolylines, pl...)
 		}
-		*allPolylines = append(*allPolylines, groupPolylines...)
 
 		formattedStopIDs := make([]string, len(orderedStopIDs))
 		for idx, id := range orderedStopIDs {
@@ -353,20 +344,107 @@ func processTripGroups(
 	return nil
 }
 
-func generatePolylines(shapes []gtfsdb.GetShapesGroupedByTripHeadSignRow) []models.Polyline {
-	var polylines []models.Polyline
-	// This prevents repeated memory re-allocation during the loop.
-	coords := make([][]float64, 0, len(shapes))
-	for _, shape := range shapes {
-		coords = append(coords, []float64{shape.Lat, shape.Lon})
+// distinctShapeIDs returns the unique, non-empty shape IDs of the given trips in
+// sorted order. Java iterates a HashSet of shape IDs (unspecified order); we sort
+// for deterministic output.
+func distinctShapeIDs(trips []gtfsdb.Trip) []string {
+	seen := make(map[string]bool)
+	var shapeIDs []string
+	for _, trip := range trips {
+		if !trip.ShapeID.Valid || trip.ShapeID.String == "" {
+			continue
+		}
+		if seen[trip.ShapeID.String] {
+			continue
+		}
+		seen[trip.ShapeID.String] = true
+		shapeIDs = append(shapeIDs, trip.ShapeID.String)
 	}
-	encodedPoints := polyline.EncodeCoords(coords)
-	polylines = append(polylines, models.Polyline{
-		Length: len(shapes),
-		Levels: "",
-		Points: string(encodedPoints),
-	})
-	return polylines
+	slices.Sort(shapeIDs)
+	return shapeIDs
+}
+
+// coordPoint is an exact-valued lat/lon used as a map key for edge de-duplication.
+type coordPoint struct {
+	lat float64
+	lon float64
+}
+
+// edgeKey is an undirected edge between two coordinate points, normalized so that
+// (a,b) and (b,a) compare equal — matching Java's Edge class in ShapeBeanServiceImpl.
+type edgeKey struct {
+	a coordPoint
+	b coordPoint
+}
+
+func makeEdge(p, q coordPoint) edgeKey {
+	if p.lat < q.lat || (p.lat == q.lat && p.lon <= q.lon) {
+		return edgeKey{a: p, b: q}
+	}
+	return edgeKey{a: q, b: p}
+}
+
+// mergePolylinesForShapeIDs ports Java's ShapeBeanServiceImpl.getMergedPolylinesForShapeIds.
+// It walks the ordered points of each shape while maintaining a shared set of
+// undirected edges. Consecutive duplicate points are dropped; when an edge has
+// already been seen, the current line is flushed as one polyline and a new line
+// begins, de-overlapping shared track. Each line is floor-encoded via
+// utils.EncodePolyline with length = the merged line's point count.
+func (api *RestAPI) mergePolylinesForShapeIDs(ctx context.Context, shapeIDs []string) ([]models.Polyline, error) {
+	polylines := []models.Polyline{}
+	if len(shapeIDs) == 0 {
+		return polylines, nil
+	}
+
+	edges := make(map[edgeKey]struct{})
+	var currentLine [][]float64
+
+	flush := func() {
+		if len(currentLine) > 1 {
+			polylines = append(polylines, models.Polyline{
+				Length: len(currentLine),
+				Levels: "",
+				Points: utils.EncodePolyline(currentLine),
+			})
+		}
+		currentLine = nil
+	}
+
+	for _, shapeID := range shapeIDs {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+		points, err := api.GtfsManager.GtfsDB.Queries.GetShapeByID(ctx, shapeID)
+		if err != nil {
+			return nil, err
+		}
+		if len(points) == 0 {
+			api.Logger.Warn("no shape points for shape", "shape_id", shapeID)
+			continue
+		}
+
+		var prev coordPoint
+		havePrev := false
+		for _, p := range points {
+			loc := coordPoint{lat: p.Lat, lon: p.Lon}
+			if havePrev && prev != loc {
+				edge := makeEdge(prev, loc)
+				if _, seen := edges[edge]; seen {
+					flush()
+				} else {
+					edges[edge] = struct{}{}
+				}
+			}
+			if !havePrev || prev != loc {
+				currentLine = append(currentLine, []float64{loc.lat, loc.lon})
+			}
+			prev = loc
+			havePrev = true
+		}
+		flush()
+	}
+
+	return polylines, nil
 }
 
 func formatStopIDs(agencyID string, stops map[string]bool) []string {

--- a/internal/restapi/stops_for_route_handler.go
+++ b/internal/restapi/stops_for_route_handler.go
@@ -262,17 +262,15 @@ func processTripGroups(
 		allStopGroups = append(allStopGroups, stopGroup)
 	}
 
-	if len(allStopGroups) > 0 {
-		slices.SortFunc(allStopGroups, func(a, b models.StopGroup) int {
-			return cmp.Compare(a.Name.Name, b.Name.Name)
-		})
+	slices.SortFunc(allStopGroups, func(a, b models.StopGroup) int {
+		return cmp.Compare(a.Name.Name, b.Name.Name)
+	})
 
-		*stopGroupings = append(*stopGroupings, models.StopGrouping{
-			Ordered:    true,
-			StopGroups: allStopGroups,
-			Type:       "direction",
-		})
-	}
+	*stopGroupings = append(*stopGroupings, models.StopGrouping{
+		Ordered:    true,
+		StopGroups: allStopGroups,
+		Type:       "direction",
+	})
 	return nil
 }
 

--- a/internal/restapi/stops_for_route_handler.go
+++ b/internal/restapi/stops_for_route_handler.go
@@ -67,11 +67,24 @@ func (api *RestAPI) stopsForRouteHandler(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
+	// The service-date filter is only applied when a time is supplied. With no
+	// time, the endpoint returns stops/shapes across all service dates, matching
+	// the Java reference default (display.serviceDateFiltering defaults to off).
 	timeParam := r.URL.Query().Get("time")
-	formattedDate, _, fieldErrors, success := utils.ParseTimeParameter(timeParam, currentLocation)
-	if !success {
-		api.validationErrorResponse(w, r, fieldErrors)
-		return
+	filterByDate := timeParam != ""
+
+	var serviceIDs []string
+	if filterByDate {
+		formattedDate, _, fieldErrors, success := utils.ParseTimeParameter(timeParam, currentLocation)
+		if !success {
+			api.validationErrorResponse(w, r, fieldErrors)
+			return
+		}
+		serviceIDs, err = api.GtfsManager.GtfsDB.Queries.GetActiveServiceIDsForDate(ctx, formattedDate)
+		if err != nil {
+			api.serverErrorResponse(w, r, err)
+			return
+		}
 	}
 
 	_, err = api.GtfsManager.GtfsDB.Queries.GetRoute(ctx, routeID)
@@ -80,13 +93,7 @@ func (api *RestAPI) stopsForRouteHandler(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	serviceIDs, err := api.GtfsManager.GtfsDB.Queries.GetActiveServiceIDsForDate(ctx, formattedDate)
-	if err != nil {
-		api.serverErrorResponse(w, r, err)
-		return
-	}
-
-	result, stopsList, err := api.processRouteStops(ctx, agencyID, routeID, serviceIDs, params.IncludePolylines)
+	result, stopsList, err := api.processRouteStops(ctx, agencyID, routeID, serviceIDs, filterByDate, params.IncludePolylines)
 	if err != nil {
 		api.serverErrorResponse(w, r, err)
 		return
@@ -95,26 +102,24 @@ func (api *RestAPI) stopsForRouteHandler(w http.ResponseWriter, r *http.Request)
 	api.buildAndSendResponse(w, r, ctx, result, stopsList, currentAgency)
 }
 
-func (api *RestAPI) processRouteStops(ctx context.Context, agencyID string, routeID string, serviceIDs []string, includePolylines bool) (models.RouteEntry, []models.Stop, error) {
+func (api *RestAPI) processRouteStops(ctx context.Context, agencyID string, routeID string, serviceIDs []string, filterByDate bool, includePolylines bool) (models.RouteEntry, []models.Stop, error) {
 	allStops := make(map[string]bool)
 	var stopGroupings []models.StopGrouping
 
-	// Get trips for route that are active on the service date
-	trips, err := api.GtfsManager.GtfsDB.Queries.GetTripsForRouteInActiveServiceIDs(ctx, gtfsdb.GetTripsForRouteInActiveServiceIDsParams{
-		RouteID:    routeID,
-		ServiceIds: serviceIDs,
-	})
+	var effectiveTrips []gtfsdb.Trip
+	var err error
+	if filterByDate {
+		// A time was supplied: restrict to trips active on that service date.
+		effectiveTrips, err = api.GtfsManager.GtfsDB.Queries.GetTripsForRouteInActiveServiceIDs(ctx, gtfsdb.GetTripsForRouteInActiveServiceIDsParams{
+			RouteID:    routeID,
+			ServiceIds: serviceIDs,
+		})
+	} else {
+		// No time: use every trip for the route, across all service dates.
+		effectiveTrips, err = api.GtfsManager.GtfsDB.Queries.GetAllTripsForRoute(ctx, routeID)
+	}
 	if err != nil {
 		return models.RouteEntry{}, nil, err
-	}
-
-	effectiveTrips := trips
-	if len(effectiveTrips) == 0 {
-		// Fallback: get all trips for this route regardless of service date
-		effectiveTrips, err = api.GtfsManager.GtfsDB.Queries.GetAllTripsForRoute(ctx, routeID)
-		if err != nil {
-			return models.RouteEntry{}, nil, err
-		}
 	}
 
 	if err := processTripGroups(ctx, api, agencyID, routeID, effectiveTrips, &stopGroupings, allStops, includePolylines); err != nil {

--- a/internal/restapi/stops_for_route_handler.go
+++ b/internal/restapi/stops_for_route_handler.go
@@ -255,83 +255,10 @@ func processTripGroups(
 		if ctx.Err() != nil {
 			return ctx.Err()
 		}
-
-		tripsInGroup := group.Trips
-
-		headsignCounts := make(map[string]int)
-		var dirServiceIDs []string
-		seenServiceIDs := make(map[string]bool)
-		for _, trip := range tripsInGroup {
-			headsignCounts[trip.TripHeadsign.String]++
-			if !seenServiceIDs[trip.ServiceID] {
-				seenServiceIDs[trip.ServiceID] = true
-				dirServiceIDs = append(dirServiceIDs, trip.ServiceID)
-			}
-		}
-
-		var orderedStopIDs []string
-		var err error
-		if !group.DirectionID.Valid {
-			/*
-				direction_id is NULL in the GTFS data. SQL NULL = NULL evaluates to
-				UNKNOWN, not TRUE, so GetOrderedStopIDsForRouteDirection would return
-				zero rows. Fall back to single-trip ordering instead.
-			*/
-			orderedStopIDs, err = api.GtfsManager.GtfsDB.Queries.GetOrderedStopIDsForTrip(ctx, tripsInGroup[0].ID)
-		} else {
-			orderedStopIDs, err = api.GtfsManager.GtfsDB.Queries.GetOrderedStopIDsForRouteDirection(ctx,
-				gtfsdb.GetOrderedStopIDsForRouteDirectionParams{
-					RouteID:     routeID,
-					DirectionID: group.DirectionID,
-					ServiceIds:  dirServiceIDs,
-				})
-		}
+		stopGroup, err := buildStopGroup(ctx, api, agencyID, routeID, group, allStops, includePolylines)
 		if err != nil {
 			return err
 		}
-		for _, stopID := range orderedStopIDs {
-			allStops[stopID] = true
-		}
-
-		groupHeadsign := ""
-		maxCount := 0
-		for headsign, count := range headsignCounts {
-			if count > maxCount || (count == maxCount && headsign < groupHeadsign) {
-				groupHeadsign = headsign
-				maxCount = count
-			}
-		}
-
-		// groupPolylines stays a non-nil empty slice so it serializes as [] (not
-		// null) when includePolylines is false or a group has no shapes. The
-		// polylines are merged from the distinct shapes of this direction's trips,
-		// mirroring Java's getShapeIdsForStopSequenceBlock + merge.
-		groupPolylines := []models.Polyline{}
-		if includePolylines {
-			groupPolylines, err = api.mergePolylinesForShapeIDs(ctx, distinctShapeIDs(tripsInGroup))
-			if err != nil {
-				return err
-			}
-		}
-
-		formattedStopIDs := make([]string, len(orderedStopIDs))
-		for idx, id := range orderedStopIDs {
-			formattedStopIDs[idx] = utils.FormCombinedID(agencyID, id)
-		}
-
-		groupID := group.GroupID
-
-		stopGroup := models.StopGroup{
-			ID: groupID,
-			Name: models.StopGroupName{
-				Name:  groupHeadsign,
-				Names: []string{groupHeadsign},
-				Type:  "destination",
-			},
-			StopIds:   formattedStopIDs,
-			Polylines: groupPolylines,
-		}
-
 		allStopGroups = append(allStopGroups, stopGroup)
 	}
 
@@ -347,6 +274,98 @@ func processTripGroups(
 		})
 	}
 	return nil
+}
+
+// buildStopGroup assembles a single direction's StopGroup: its ordered stop IDs,
+// most-common headsign name, and merged polylines. It also records the group's
+// stops in allStops.
+func buildStopGroup(ctx context.Context, api *RestAPI, agencyID string, routeID string, group directionGroup, allStops map[string]bool, includePolylines bool) (models.StopGroup, error) {
+	headsignCounts, dirServiceIDs := summarizeTrips(group.Trips)
+
+	orderedStopIDs, err := orderedStopIDsForGroup(ctx, api, routeID, group, dirServiceIDs)
+	if err != nil {
+		return models.StopGroup{}, err
+	}
+	for _, stopID := range orderedStopIDs {
+		allStops[stopID] = true
+	}
+
+	// groupPolylines stays a non-nil empty slice so it serializes as [] (not null)
+	// when includePolylines is false or a group has no shapes. The polylines are
+	// merged from the distinct shapes of this direction's trips, mirroring Java's
+	// getShapeIdsForStopSequenceBlock + merge.
+	groupPolylines := []models.Polyline{}
+	if includePolylines {
+		groupPolylines, err = api.mergePolylinesForShapeIDs(ctx, distinctShapeIDs(group.Trips))
+		if err != nil {
+			return models.StopGroup{}, err
+		}
+	}
+
+	formattedStopIDs := make([]string, len(orderedStopIDs))
+	for idx, id := range orderedStopIDs {
+		formattedStopIDs[idx] = utils.FormCombinedID(agencyID, id)
+	}
+
+	groupHeadsign := mostCommonHeadsign(headsignCounts)
+	return models.StopGroup{
+		ID: group.GroupID,
+		Name: models.StopGroupName{
+			Name:  groupHeadsign,
+			Names: []string{groupHeadsign},
+			Type:  "destination",
+		},
+		StopIds:   formattedStopIDs,
+		Polylines: groupPolylines,
+	}, nil
+}
+
+// summarizeTrips counts trip headsigns and collects the distinct service IDs of a
+// direction's trips (preserving first-seen order).
+func summarizeTrips(trips []gtfsdb.Trip) (map[string]int, []string) {
+	headsignCounts := make(map[string]int)
+	var dirServiceIDs []string
+	seenServiceIDs := make(map[string]bool)
+	for _, trip := range trips {
+		headsignCounts[trip.TripHeadsign.String]++
+		if !seenServiceIDs[trip.ServiceID] {
+			seenServiceIDs[trip.ServiceID] = true
+			dirServiceIDs = append(dirServiceIDs, trip.ServiceID)
+		}
+	}
+	return headsignCounts, dirServiceIDs
+}
+
+// orderedStopIDsForGroup returns the stop IDs of a direction in route sequence.
+func orderedStopIDsForGroup(ctx context.Context, api *RestAPI, routeID string, group directionGroup, dirServiceIDs []string) ([]string, error) {
+	if !group.DirectionID.Valid {
+		/*
+			direction_id is NULL in the GTFS data. SQL NULL = NULL evaluates to
+			UNKNOWN, not TRUE, so GetOrderedStopIDsForRouteDirection would return
+			zero rows. Fall back to single-trip ordering instead.
+		*/
+		return api.GtfsManager.GtfsDB.Queries.GetOrderedStopIDsForTrip(ctx, group.Trips[0].ID)
+	}
+	return api.GtfsManager.GtfsDB.Queries.GetOrderedStopIDsForRouteDirection(ctx,
+		gtfsdb.GetOrderedStopIDsForRouteDirectionParams{
+			RouteID:     routeID,
+			DirectionID: group.DirectionID,
+			ServiceIds:  dirServiceIDs,
+		})
+}
+
+// mostCommonHeadsign returns the headsign with the highest count, breaking ties by
+// the lexicographically smaller headsign.
+func mostCommonHeadsign(headsignCounts map[string]int) string {
+	groupHeadsign := ""
+	maxCount := 0
+	for headsign, count := range headsignCounts {
+		if count > maxCount || (count == maxCount && headsign < groupHeadsign) {
+			groupHeadsign = headsign
+			maxCount = count
+		}
+	}
+	return groupHeadsign
 }
 
 // distinctShapeIDs returns the unique, non-empty shape IDs of the given trips in
@@ -396,25 +415,7 @@ func makeEdge(p, q coordPoint) edgeKey {
 // begins, de-overlapping shared track. Each line is floor-encoded via
 // utils.EncodePolyline with length = the merged line's point count.
 func (api *RestAPI) mergePolylinesForShapeIDs(ctx context.Context, shapeIDs []string) ([]models.Polyline, error) {
-	polylines := []models.Polyline{}
-	if len(shapeIDs) == 0 {
-		return polylines, nil
-	}
-
-	edges := make(map[edgeKey]struct{})
-	var currentLine [][]float64
-
-	flush := func() {
-		if len(currentLine) > 1 {
-			polylines = append(polylines, models.Polyline{
-				Length: len(currentLine),
-				Levels: "",
-				Points: utils.EncodePolyline(currentLine),
-			})
-		}
-		currentLine = nil
-	}
-
+	merger := newPolylineMerger()
 	for _, shapeID := range shapeIDs {
 		if ctx.Err() != nil {
 			return nil, ctx.Err()
@@ -427,29 +428,61 @@ func (api *RestAPI) mergePolylinesForShapeIDs(ctx context.Context, shapeIDs []st
 			api.Logger.Warn("no shape points for shape", "shape_id", shapeID)
 			continue
 		}
-
-		var prev coordPoint
-		havePrev := false
-		for _, p := range points {
-			loc := coordPoint{lat: p.Lat, lon: p.Lon}
-			if havePrev && prev != loc {
-				edge := makeEdge(prev, loc)
-				if _, seen := edges[edge]; seen {
-					flush()
-				} else {
-					edges[edge] = struct{}{}
-				}
-			}
-			if !havePrev || prev != loc {
-				currentLine = append(currentLine, []float64{loc.lat, loc.lon})
-			}
-			prev = loc
-			havePrev = true
-		}
-		flush()
+		merger.addShape(points)
 	}
+	return merger.polylines, nil
+}
 
-	return polylines, nil
+// polylineMerger accumulates shape points into de-overlapped polylines, tracking a
+// shared undirected edge set across all shapes added to it.
+type polylineMerger struct {
+	edges       map[edgeKey]struct{}
+	currentLine [][]float64
+	polylines   []models.Polyline
+}
+
+func newPolylineMerger() *polylineMerger {
+	return &polylineMerger{
+		edges:     make(map[edgeKey]struct{}),
+		polylines: []models.Polyline{},
+	}
+}
+
+// flush emits the current line as a polyline (if it has at least one segment) and
+// starts a new one.
+func (m *polylineMerger) flush() {
+	if len(m.currentLine) > 1 {
+		m.polylines = append(m.polylines, models.Polyline{
+			Length: len(m.currentLine),
+			Levels: "",
+			Points: utils.EncodePolyline(m.currentLine),
+		})
+	}
+	m.currentLine = nil
+}
+
+// addShape walks a shape's ordered points, dropping consecutive duplicates and
+// flushing whenever an already-seen edge is encountered.
+func (m *polylineMerger) addShape(points []gtfsdb.Shape) {
+	var prev coordPoint
+	havePrev := false
+	for _, p := range points {
+		loc := coordPoint{lat: p.Lat, lon: p.Lon}
+		if havePrev && prev != loc {
+			edge := makeEdge(prev, loc)
+			if _, seen := m.edges[edge]; seen {
+				m.flush()
+			} else {
+				m.edges[edge] = struct{}{}
+			}
+		}
+		if !havePrev || prev != loc {
+			m.currentLine = append(m.currentLine, []float64{loc.lat, loc.lon})
+		}
+		prev = loc
+		havePrev = true
+	}
+	m.flush()
 }
 
 func formatStopIDs(agencyID string, stops map[string]bool) []string {

--- a/internal/restapi/stops_for_route_handler_test.go
+++ b/internal/restapi/stops_for_route_handler_test.go
@@ -121,6 +121,39 @@ func TestStopsForRouteIncludePolylinesFalse(t *testing.T) {
 	}
 }
 
+// TestStopsForRouteTimeFilter_ActiveDate verifies that supplying a time parameter
+// restricts results to trips active on that service date.
+func TestStopsForRouteTimeFilter_ActiveDate(t *testing.T) {
+	api := createTestApi(t)
+	defer api.Shutdown()
+
+	// 2025-01-06 is a Monday; RABA route 151 runs Mon–Fri (service c_1658_b_18260_d_31).
+	_, model := callAPIHandler[StopsForRouteResponse](t, api,
+		"/api/where/stops-for-route/"+testdata.Route1.ID+".json?key=TEST&time=2025-01-06")
+
+	entry := model.Data.Entry
+	assert.NotEmpty(t, entry.StopIds, "weekday date should return stops")
+	require.Len(t, entry.StopGroupings, 1)
+	assert.NotEmpty(t, entry.StopGroupings[0].StopGroups, "weekday date should produce direction groups")
+}
+
+// TestStopsForRouteTimeFilter_NoServiceDate verifies that when the requested date
+// has no active service the stop list and direction groups are empty, but the
+// direction grouping element is still present.
+func TestStopsForRouteTimeFilter_NoServiceDate(t *testing.T) {
+	api := createTestApi(t)
+	defer api.Shutdown()
+
+	// 2025-01-05 is a Sunday; RABA route 151 has no Sunday service.
+	_, model := callAPIHandler[StopsForRouteResponse](t, api,
+		"/api/where/stops-for-route/"+testdata.Route1.ID+".json?key=TEST&time=2025-01-05")
+
+	entry := model.Data.Entry
+	assert.Empty(t, entry.StopIds, "no-service date should return empty stop list")
+	require.Len(t, entry.StopGroupings, 1, "direction grouping element must still be present")
+	assert.Empty(t, entry.StopGroupings[0].StopGroups, "no-service date should return empty direction groups")
+}
+
 // TestStopsForRouteNoDuplicateStopGroups guards against the regression where
 // trips with different headsigns in the same direction produced duplicate group
 // IDs (e.g. "0", "0", "1" instead of "0", "1").

--- a/internal/restapi/stops_for_route_handler_test.go
+++ b/internal/restapi/stops_for_route_handler_test.go
@@ -34,13 +34,13 @@ func TestStopsForRouteHandlerEndToEnd(t *testing.T) {
 	entry := model.Data.Entry
 	assert.Equal(t, testdata.Route1.ID, entry.RouteID)
 
-	assert.Len(t, entry.Polylines, 2)
-	assert.Equal(t, 250, entry.Polylines[0].Length)
+	// Entry-level polylines are an independent merge over both direction shapes
+	// (shared undirected edge set), so opposite directions that retrace the same
+	// track de-overlap into multiple segments.
+	assert.Len(t, entry.Polylines, 21)
+	assert.Equal(t, 47, entry.Polylines[0].Length)
 	assert.Equal(t, "", entry.Polylines[0].Levels)
-	assert.Contains(t, entry.Polylines[0].Points, "exhwFlt|")
-	assert.Equal(t, 250, entry.Polylines[1].Length)
-	assert.Equal(t, "", entry.Polylines[1].Levels)
-	assert.Contains(t, entry.Polylines[1].Points, "exhwFlt|")
+	assert.Contains(t, entry.Polylines[0].Points, "_luvFxw_jV")
 
 	assert.Len(t, entry.StopIds, 39)
 
@@ -57,13 +57,22 @@ func TestStopsForRouteHandlerEndToEnd(t *testing.T) {
 	assert.Equal(t, "destination", outbound.Name.Type)
 	assert.Equal(t, []string{"Shasta Lake"}, outbound.Name.Names)
 	assert.Len(t, outbound.StopIds, 21)
-	assert.Len(t, outbound.Polylines, 1)
+	// Direction-0 shape retraces two of its own edges, splitting into 3 polylines.
+	require.Len(t, outbound.Polylines, 3)
+	assert.Equal(t, 47, outbound.Polylines[0].Length)
+	assert.Equal(t, 31, outbound.Polylines[1].Length)
+	assert.Equal(t, 162, outbound.Polylines[2].Length)
+	assert.Contains(t, outbound.Polylines[0].Points, "_luvFxw_jV")
 
 	inbound := grouping.StopGroups[1]
 	assert.Equal(t, "1", inbound.ID)
 	assert.Equal(t, "Shasta Lake", inbound.Name.Name)
 	assert.Equal(t, "destination", inbound.Name.Type)
 	assert.Len(t, inbound.StopIds, 22)
+	// Direction-1 shape retraces one of its own edges, splitting into 2 polylines.
+	require.Len(t, inbound.Polylines, 2)
+	assert.Equal(t, 23, inbound.Polylines[0].Length)
+	assert.Equal(t, 208, inbound.Polylines[1].Length)
 
 	refs := model.Data.References
 	assert.ElementsMatch(t, []models.AgencyReference{testdata.Raba}, refs.Agencies)
@@ -73,6 +82,43 @@ func TestStopsForRouteHandlerEndToEnd(t *testing.T) {
 	assert.Empty(t, refs.Situations)
 	assert.Empty(t, refs.StopTimes)
 	assert.Empty(t, refs.Trips)
+}
+
+// TestStopsForRouteIncludePolylinesDefault verifies that with includePolylines
+// omitted (default true) the entry and every direction group carry polylines.
+func TestStopsForRouteIncludePolylinesDefault(t *testing.T) {
+	api := createTestApi(t)
+	defer api.Shutdown()
+
+	_, model := callAPIHandler[StopsForRouteResponse](t, api, "/api/where/stops-for-route/"+testdata.Route1.ID+".json?key=TEST")
+
+	entry := model.Data.Entry
+	assert.NotEmpty(t, entry.Polylines, "default should return entry-level polylines")
+
+	require.Len(t, entry.StopGroupings, 1)
+	for _, g := range entry.StopGroupings[0].StopGroups {
+		assert.NotEmpty(t, g.Polylines, "group %s should carry polylines by default", g.ID)
+	}
+}
+
+// TestStopsForRouteIncludePolylinesFalse verifies that includePolylines=false
+// empties both the entry-level and every group-level polylines, and that they
+// serialize as [] (not null).
+func TestStopsForRouteIncludePolylinesFalse(t *testing.T) {
+	api := createTestApi(t)
+	defer api.Shutdown()
+
+	_, model := callAPIHandler[StopsForRouteResponse](t, api, "/api/where/stops-for-route/"+testdata.Route1.ID+".json?key=TEST&includePolylines=false")
+
+	entry := model.Data.Entry
+	assert.NotNil(t, entry.Polylines, "entry polylines should be [] not null")
+	assert.Empty(t, entry.Polylines, "entry polylines should be empty when includePolylines=false")
+
+	require.Len(t, entry.StopGroupings, 1)
+	for _, g := range entry.StopGroupings[0].StopGroups {
+		assert.NotNil(t, g.Polylines, "group %s polylines should be [] not null", g.ID)
+		assert.Empty(t, g.Polylines, "group %s polylines should be empty when includePolylines=false", g.ID)
+	}
 }
 
 // TestStopsForRouteNoDuplicateStopGroups guards against the regression where


### PR DESCRIPTION
Fixes: #1118 #1119 #1122 #1124

# stops-for-route: Match the Java reference implementation for polyline output

This PR brings the `stops-for-route` polyline output—and the trip set used to build it—in line with the Java OneBusAway reference implementation.

The implementation has been verified against a live Java server. All 20 Unitrans routes now return the same:

* Stop IDs
* Direction groups
* Polyline counts
* Set of coordinate points

Each logical change is contained in its own commit.

## 1. Use the Java floor polyline encoder (#1118)

`generatePolylines` previously encoded coordinates using `github.com/twpayne/go-polyline`, which **rounds** coordinates. The Java reference (`PolylineEncoder`) instead **floors** them (`floor(coord * 1e5)`), causing encoded polylines to differ by up to one unit in the final digit.

This PR switches to the in-repo `utils.EncodePolyline`, which matches the Java implementation byte-for-byte. For single-shape routes, the encoded `points` are now identical to Java.

## 2. Clear group polylines when `includePolylines=false` (#1119)

When `includePolylines=false`, only the entry-level polylines were cleared. Direction groups still contained their polylines.

The Java implementation (and the API spec) expects both entry-level and group-level polylines to be present but empty.

Group polylines are now omitted when the flag is disabled and serialized as non-nil empty slices (`[]`) instead of `null`.

## 3. Build polylines using Java's shape-set merge (#1124)

Previously:

* Group polylines were built by deduplicating trips by **trip headsign** and selecting one `shape_id` per headsign.
* Entry-level polylines were created by concatenating the group polylines.

Neither behavior matches the Java implementation and produces incorrect results for routes with multiple shapes or loops (for example, route **Q** produced 2 polylines instead of Java's 9).

This PR ports the logic from `ShapeBeanServiceImpl.getMergedPolylinesForShapeIds`.

The new implementation:

* Builds group polylines from the distinct `shape_id`s of trips within each direction.
* Builds entry-level polylines independently from the distinct `shape_id`s across all qualifying trips for the route (rather than concatenating the group polylines, addressing #1122).
* Merges shapes by walking each shape's ordered points while maintaining a shared **undirected edge set**.
* Removes consecutive duplicate points.
* Starts a new polyline whenever an edge has already been visited, effectively de-overlapping shared track.
* Encodes each merged line using `utils.EncodePolyline`.

Because Java iterates `HashSet`s in an unspecified order, exact split boundaries cannot be reproduced byte-for-byte. However, the resulting shape set, polyline count, and rendered coverage are identical.

## 4. Default to all service dates when `time` is omitted

While validating Java parity, another behavioral difference surfaced.

Maglev previously defaulted the service date to **today**, meaning only trips running on the current day contributed to the merged polylines. For routes such as **Q**, this excluded valid shapes and produced only 2 polylines instead of 9.

The Java implementation defaults `display.serviceDateFiltering` to `false`. When no `time` parameter is supplied, stops and shapes are built from trips across **all service dates**.

This PR now matches that behavior:

* No `time` parameter → include trips from all service dates.
* `time` provided → filter trips to the requested service date.

This completes parity for multi-shape routes such as **Q**.

## 5. Tests

* Updated the end-to-end golden outputs for the new merged polyline behavior.
* Added tests covering:

  * the default `includePolylines` behavior,
  * `includePolylines=false`, ensuring both entry-level and group-level polylines are returned as empty arrays.

## Verification

Compared Maglev against a live Java server for every Unitrans route (`A`–`Z`) without a `time` parameter.

For all 20 routes, the following now match the Java implementation:

* Stop IDs
* Direction groups
* Polyline counts
* Complete set of coordinate points



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Route-stop results now apply the `time` filter only when `time` is provided, with validation and server errors handled accordingly.
  * Removed the prior “no matches” fallback behavior for `time`, ensuring trip selection stays consistent.
  * Improved and stabilized polyline generation and merging across route entries and direction groups.

* **New Features**
  * Enhanced `includePolylines` behavior: omitted/enabled returns polylines; `includePolylines=false` returns empty (non-null) polyline arrays.

* **Tests**
  * Updated polyline expectations and added coverage for default behavior and `includePolylines=false` across entry and direction stop groups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->