### PR TITLE
fix(api): partition and sort schedule-for-stop by direction ID

### DIFF
--- a/gtfsdb/query.sql
+++ b/gtfsdb/query.sql
@@ -559,7 +559,7 @@ WHERE
     )
     AND r.id IN (sqlc.slice('route_ids'))
 ORDER BY
-    r.id, t.direction_id, st.departure_time;
+    r.id, COALESCE(t.direction_id, 0), st.departure_time;
 
 
 -- name: GetImportMetadata :one

--- a/gtfsdb/query.sql
+++ b/gtfsdb/query.sql
@@ -514,11 +514,11 @@ SELECT
     st.departure_time,
     st.stop_headsign,
     t.service_id,
-    t.route_id,
     t.trip_headsign,
     t.block_id,
     t.min_arrival_time,
     t.max_departure_time,
+    t.direction_id,
     r.id as route_id,
     r.agency_id
 FROM
@@ -559,7 +559,7 @@ WHERE
     )
     AND r.id IN (sqlc.slice('route_ids'))
 ORDER BY
-    r.id, st.departure_time;
+    r.id, t.direction_id, st.departure_time;
 
 
 -- name: GetImportMetadata :one

--- a/gtfsdb/query.sql.go
+++ b/gtfsdb/query.sql.go
@@ -2994,7 +2994,7 @@ WHERE
     )
     AND r.id IN (/*SLICE:route_ids*/?)
 ORDER BY
-    r.id, t.direction_id, st.departure_time
+    r.id, COALESCE(t.direction_id, 0), st.departure_time
 `
 
 type GetScheduleForStopOnDateParams struct {

--- a/gtfsdb/query.sql.go
+++ b/gtfsdb/query.sql.go
@@ -2949,11 +2949,11 @@ SELECT
     st.departure_time,
     st.stop_headsign,
     t.service_id,
-    t.route_id,
     t.trip_headsign,
     t.block_id,
     t.min_arrival_time,
     t.max_departure_time,
+    t.direction_id,
     r.id as route_id,
     r.agency_id
 FROM
@@ -2994,7 +2994,7 @@ WHERE
     )
     AND r.id IN (/*SLICE:route_ids*/?)
 ORDER BY
-    r.id, st.departure_time
+    r.id, t.direction_id, st.departure_time
 `
 
 type GetScheduleForStopOnDateParams struct {
@@ -3010,12 +3010,12 @@ type GetScheduleForStopOnDateRow struct {
 	DepartureTime    int64
 	StopHeadsign     sql.NullString
 	ServiceID        string
-	RouteID          string
 	TripHeadsign     sql.NullString
 	BlockID          sql.NullString
 	MinArrivalTime   sql.NullInt64
 	MaxDepartureTime sql.NullInt64
-	RouteID_2        string
+	DirectionID      sql.NullInt64
+	RouteID          string
 	AgencyID         string
 }
 
@@ -3047,12 +3047,12 @@ func (q *Queries) GetScheduleForStopOnDate(ctx context.Context, arg GetScheduleF
 			&i.DepartureTime,
 			&i.StopHeadsign,
 			&i.ServiceID,
-			&i.RouteID,
 			&i.TripHeadsign,
 			&i.BlockID,
 			&i.MinArrivalTime,
 			&i.MaxDepartureTime,
-			&i.RouteID_2,
+			&i.DirectionID,
+			&i.RouteID,
 			&i.AgencyID,
 		); err != nil {
 			return nil, err

--- a/internal/restapi/schedule_for_stop_handler.go
+++ b/internal/restapi/schedule_for_stop_handler.go
@@ -2,6 +2,7 @@ package restapi
 
 import (
 	"cmp"
+	"context"
 	"database/sql"
 	"net/http"
 	"slices"
@@ -237,81 +238,14 @@ func (api *RestAPI) scheduleForStopHandler(w http.ResponseWriter, r *http.Reques
 		}
 	}
 
-	// Group schedule data by route -> direction -> slice of stop times
-	routeDirectionScheduleMap := make(map[string]map[string][]models.ScheduleStopTime)
-	// Track headsign counts per route -> direction -> headsign -> count
-	routeDirectionHeadsignCounts := make(map[string]map[string]map[string]int)
-
-	for _, row := range scheduleRows {
-		if ctx.Err() != nil {
-			api.clientCanceledResponse(w, r, ctx.Err())
-			return
-		}
-
-		directionID := "0"
-		if row.DirectionID.Valid {
-			directionID = strconv.FormatInt(row.DirectionID.Int64, 10)
-		}
-
-		combinedRouteID := utils.FormCombinedID(agencyID, row.RouteID)
-		combinedTripID := utils.FormCombinedID(agencyID, row.TripID)
-
-		// Convert GTFS time (nanoseconds since midnight) to Unix timestamp in the agency's timezone in milliseconds
-		// GTFS times are stored as time.Duration values (nanoseconds), need to add to the target date
-		arrivalDuration := time.Duration(row.ArrivalTime)
-		departureDuration := time.Duration(row.DepartureTime)
-		arrivalTimeMs := startOfDay.Add(arrivalDuration).UnixMilli()
-		departureTimeMs := startOfDay.Add(departureDuration).UnixMilli()
-
-		stopTime := models.NewScheduleStopTime(
-			arrivalTimeMs,
-			departureTimeMs,
-			utils.FormCombinedID(agencyID, row.ServiceID),
-			row.StopHeadsign.String,
-			combinedTripID,
-		)
-
-		// Determine the arrival/departure capabilities for this stop time based on its
-		// position within the vehicle's entire block for the service day.
-
-		// First, verify if the stop is at the temporal boundaries of its individual trip.
-		isFirstInTrip := row.MinArrivalTime.Valid && row.ArrivalTime == row.MinArrivalTime.Int64
-		isLastInTrip := row.MaxDepartureTime.Valid && row.DepartureTime == row.MaxDepartureTime.Int64
-
-		isFirstInBlock := isFirstInTrip
-		isLastInBlock := isLastInTrip
-
-		// If the trip belongs to a block, refine the boundaries to the block level.
-		if row.BlockID.Valid && row.BlockID.String != "" {
-			if bTrips, exists := blockTripsMap[row.BlockID.String]; exists && len(bTrips) > 0 {
-				isFirstInBlock = isFirstInTrip && (bTrips[0].ID == row.TripID)
-				isLastInBlock = isLastInTrip && (bTrips[len(bTrips)-1].ID == row.TripID)
-			}
-		}
-
-		// Disable arrivals for the first stop of a block (vehicle starts service here).
-		if isFirstInBlock {
-			stopTime.ArrivalEnabled = false
-		}
-		// Disable departures for the last stop of a block (vehicle ends service here).
-		if isLastInBlock {
-			stopTime.DepartureEnabled = false
-		}
-
-		if routeDirectionScheduleMap[combinedRouteID] == nil {
-			routeDirectionScheduleMap[combinedRouteID] = make(map[string][]models.ScheduleStopTime)
-		}
-		routeDirectionScheduleMap[combinedRouteID][directionID] = append(routeDirectionScheduleMap[combinedRouteID][directionID], stopTime)
-
-		if row.TripHeadsign.Valid && row.TripHeadsign.String != "" {
-			if routeDirectionHeadsignCounts[combinedRouteID] == nil {
-				routeDirectionHeadsignCounts[combinedRouteID] = make(map[string]map[string]int)
-			}
-			if routeDirectionHeadsignCounts[combinedRouteID][directionID] == nil {
-				routeDirectionHeadsignCounts[combinedRouteID][directionID] = make(map[string]int)
-			}
-			routeDirectionHeadsignCounts[combinedRouteID][directionID][row.TripHeadsign.String]++
-		}
+	// Group schedule data by route -> direction -> slice of stop times, and track
+	// per-direction headsign vote counts, per spec steps 6-7.
+	routeDirectionScheduleMap, routeDirectionHeadsignCounts, err := groupScheduleRowsByRouteAndDirection(
+		ctx, scheduleRows, agencyID, startOfDay, blockTripsMap,
+	)
+	if err != nil {
+		api.clientCanceledResponse(w, r, err)
+		return
 	}
 
 	// Build the route schedules in the natural-sort order established above (spec step 10):
@@ -389,4 +323,97 @@ func (api *RestAPI) scheduleForStopHandler(w http.ResponseWriter, r *http.Reques
 	// Create and send response
 	response := models.NewEntryResponse(entry, *references, api.Clock)
 	api.sendResponse(w, r, response)
+}
+
+// groupScheduleRowsByRouteAndDirection partitions schedule rows first by route, then by
+// GTFS direction_id (defaulting to "0" when absent), per spec steps 6-7. It returns the
+// grouped stop times alongside per-direction headsign vote counts used to pick each
+// direction group's representative tripHeadsign. Returns a non-nil error only if ctx is
+// canceled mid-computation.
+func groupScheduleRowsByRouteAndDirection(
+	ctx context.Context,
+	scheduleRows []gtfsdb.GetScheduleForStopOnDateRow,
+	agencyID string,
+	startOfDay time.Time,
+	blockTripsMap map[string][]gtfsdb.GetTripsByBlockIDsRow,
+) (
+	routeDirectionScheduleMap map[string]map[string][]models.ScheduleStopTime,
+	routeDirectionHeadsignCounts map[string]map[string]map[string]int,
+	err error,
+) {
+	routeDirectionScheduleMap = make(map[string]map[string][]models.ScheduleStopTime)
+	routeDirectionHeadsignCounts = make(map[string]map[string]map[string]int)
+
+	for _, row := range scheduleRows {
+		if ctx.Err() != nil {
+			return nil, nil, ctx.Err()
+		}
+
+		directionID := "0"
+		if row.DirectionID.Valid {
+			directionID = strconv.FormatInt(row.DirectionID.Int64, 10)
+		}
+
+		combinedRouteID := utils.FormCombinedID(agencyID, row.RouteID)
+		combinedTripID := utils.FormCombinedID(agencyID, row.TripID)
+
+		// Convert GTFS time (nanoseconds since midnight) to Unix timestamp in the agency's timezone in milliseconds
+		// GTFS times are stored as time.Duration values (nanoseconds), need to add to the target date
+		arrivalDuration := time.Duration(row.ArrivalTime)
+		departureDuration := time.Duration(row.DepartureTime)
+		arrivalTimeMs := startOfDay.Add(arrivalDuration).UnixMilli()
+		departureTimeMs := startOfDay.Add(departureDuration).UnixMilli()
+
+		stopTime := models.NewScheduleStopTime(
+			arrivalTimeMs,
+			departureTimeMs,
+			utils.FormCombinedID(agencyID, row.ServiceID),
+			row.StopHeadsign.String,
+			combinedTripID,
+		)
+
+		// Determine the arrival/departure capabilities for this stop time based on its
+		// position within the vehicle's entire block for the service day.
+
+		// First, verify if the stop is at the temporal boundaries of its individual trip.
+		isFirstInTrip := row.MinArrivalTime.Valid && row.ArrivalTime == row.MinArrivalTime.Int64
+		isLastInTrip := row.MaxDepartureTime.Valid && row.DepartureTime == row.MaxDepartureTime.Int64
+
+		isFirstInBlock := isFirstInTrip
+		isLastInBlock := isLastInTrip
+
+		// If the trip belongs to a block, refine the boundaries to the block level.
+		if row.BlockID.Valid && row.BlockID.String != "" {
+			if bTrips, exists := blockTripsMap[row.BlockID.String]; exists && len(bTrips) > 0 {
+				isFirstInBlock = isFirstInTrip && (bTrips[0].ID == row.TripID)
+				isLastInBlock = isLastInTrip && (bTrips[len(bTrips)-1].ID == row.TripID)
+			}
+		}
+
+		// Disable arrivals for the first stop of a block (vehicle starts service here).
+		if isFirstInBlock {
+			stopTime.ArrivalEnabled = false
+		}
+		// Disable departures for the last stop of a block (vehicle ends service here).
+		if isLastInBlock {
+			stopTime.DepartureEnabled = false
+		}
+
+		if routeDirectionScheduleMap[combinedRouteID] == nil {
+			routeDirectionScheduleMap[combinedRouteID] = make(map[string][]models.ScheduleStopTime)
+		}
+		routeDirectionScheduleMap[combinedRouteID][directionID] = append(routeDirectionScheduleMap[combinedRouteID][directionID], stopTime)
+
+		if row.TripHeadsign.Valid && row.TripHeadsign.String != "" {
+			if routeDirectionHeadsignCounts[combinedRouteID] == nil {
+				routeDirectionHeadsignCounts[combinedRouteID] = make(map[string]map[string]int)
+			}
+			if routeDirectionHeadsignCounts[combinedRouteID][directionID] == nil {
+				routeDirectionHeadsignCounts[combinedRouteID][directionID] = make(map[string]int)
+			}
+			routeDirectionHeadsignCounts[combinedRouteID][directionID][row.TripHeadsign.String]++
+		}
+	}
+
+	return routeDirectionScheduleMap, routeDirectionHeadsignCounts, nil
 }

--- a/internal/restapi/schedule_for_stop_handler.go
+++ b/internal/restapi/schedule_for_stop_handler.go
@@ -1,8 +1,10 @@
 package restapi
 
 import (
+	"cmp"
 	"database/sql"
 	"net/http"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -231,15 +233,20 @@ func (api *RestAPI) scheduleForStopHandler(w http.ResponseWriter, r *http.Reques
 		}
 	}
 
-	// Group schedule data by route
-	routeScheduleMap := make(map[string][]models.ScheduleStopTime)
-	// Track headsign counts to pick the most common one
-	routeHeadsignCounts := make(map[string]map[string]int)
+	// Group schedule data by route -> direction -> slice of stop times
+	routeDirectionScheduleMap := make(map[string]map[string][]models.ScheduleStopTime)
+	// Track headsign counts per route -> direction -> headsign -> count
+	routeDirectionHeadsignCounts := make(map[string]map[string]map[string]int)
 
 	for _, row := range scheduleRows {
 		if ctx.Err() != nil {
 			api.clientCanceledResponse(w, r, ctx.Err())
 			return
+		}
+
+		directionID := "0"
+		if row.DirectionID.Valid {
+			directionID = strconv.FormatInt(row.DirectionID.Int64, 10)
 		}
 
 		combinedRouteID := utils.FormCombinedID(agencyID, row.RouteID)
@@ -287,33 +294,49 @@ func (api *RestAPI) scheduleForStopHandler(w http.ResponseWriter, r *http.Reques
 			stopTime.DepartureEnabled = false
 		}
 
-		routeScheduleMap[combinedRouteID] = append(routeScheduleMap[combinedRouteID], stopTime)
+		if routeDirectionScheduleMap[combinedRouteID] == nil {
+			routeDirectionScheduleMap[combinedRouteID] = make(map[string][]models.ScheduleStopTime)
+		}
+		routeDirectionScheduleMap[combinedRouteID][directionID] = append(routeDirectionScheduleMap[combinedRouteID][directionID], stopTime)
 
 		if row.TripHeadsign.Valid && row.TripHeadsign.String != "" {
-			if routeHeadsignCounts[combinedRouteID] == nil {
-				routeHeadsignCounts[combinedRouteID] = make(map[string]int)
+			if routeDirectionHeadsignCounts[combinedRouteID] == nil {
+				routeDirectionHeadsignCounts[combinedRouteID] = make(map[string]map[string]int)
 			}
-			routeHeadsignCounts[combinedRouteID][row.TripHeadsign.String]++
+			if routeDirectionHeadsignCounts[combinedRouteID][directionID] == nil {
+				routeDirectionHeadsignCounts[combinedRouteID][directionID] = make(map[string]int)
+			}
+			routeDirectionHeadsignCounts[combinedRouteID][directionID][row.TripHeadsign.String]++
 		}
 	}
 
 	// Build the route schedules
 	var routeSchedules []models.StopRouteSchedule
-	for routeID, stopTimes := range routeScheduleMap {
-		// Select the most common headsign for this route
-		tripHeadsign := ""
-		maxCount := 0
-		if headsigns, exists := routeHeadsignCounts[routeID]; exists {
-			for headsign, count := range headsigns {
-				if count > maxCount {
-					maxCount = count
-					tripHeadsign = headsign
+	for routeID, directionMap := range routeDirectionScheduleMap {
+		var directionSchedules []models.StopRouteDirectionSchedule
+
+		for dirID, stopTimes := range directionMap {
+			tripHeadsign := ""
+			maxCount := 0
+			if dirHeadsigns, exists := routeDirectionHeadsignCounts[routeID][dirID]; exists {
+				for headsign, count := range dirHeadsigns {
+					if count > maxCount {
+						maxCount = count
+						tripHeadsign = headsign
+					}
 				}
 			}
+
+			directionSchedule := models.NewStopRouteDirectionSchedule(tripHeadsign, stopTimes, nil)
+			directionSchedules = append(directionSchedules, directionSchedule)
 		}
 
-		directionSchedule := models.NewStopRouteDirectionSchedule(tripHeadsign, stopTimes, nil)
-		routeSchedule := models.NewStopRouteSchedule(routeID, []models.StopRouteDirectionSchedule{directionSchedule})
+		// Sort direction groups alphabetically by headsign
+		slices.SortFunc(directionSchedules, func(a, b models.StopRouteDirectionSchedule) int {
+			return cmp.Compare(a.TripHeadsign, b.TripHeadsign)
+		})
+
+		routeSchedule := models.NewStopRouteSchedule(routeID, directionSchedules)
 		routeSchedules = append(routeSchedules, routeSchedule)
 	}
 

--- a/internal/restapi/schedule_for_stop_handler.go
+++ b/internal/restapi/schedule_for_stop_handler.go
@@ -210,7 +210,7 @@ func (api *RestAPI) scheduleForStopHandler(w http.ResponseWriter, r *http.Reques
 
 	// Batch fetch all trips within the identified blocks for the active service day
 	// This allows us to establish the chronological sequence of trips per vehicle
-	blockTripsMap := make(map[string][]gtfsdb.GetTripsByBlockIDsRow)
+	activeServiceBlockTripsMap := make(map[string][]gtfsdb.GetTripsByBlockIDsRow)
 	uniqueBlockIDs := make([]sql.NullString, 0, len(uniqueBlockIDsMap))
 	for blockID := range uniqueBlockIDsMap {
 		uniqueBlockIDs = append(uniqueBlockIDs, nulls.String(blockID))
@@ -233,7 +233,7 @@ func (api *RestAPI) scheduleForStopHandler(w http.ResponseWriter, r *http.Reques
 			}
 			// Group trips by block ID. The underlying query inherently sorts by min_arrival_time ASC.
 			for _, bt := range blockTrips {
-				blockTripsMap[bt.BlockID.String] = append(blockTripsMap[bt.BlockID.String], bt)
+				activeServiceBlockTripsMap[bt.BlockID.String] = append(activeServiceBlockTripsMap[bt.BlockID.String], bt)
 			}
 		}
 	}
@@ -241,7 +241,11 @@ func (api *RestAPI) scheduleForStopHandler(w http.ResponseWriter, r *http.Reques
 	// Group schedule data by route -> direction -> slice of stop times, and track
 	// per-direction headsign vote counts, per spec steps 6-7.
 	routeDirectionScheduleMap, routeDirectionHeadsignCounts, err := groupScheduleRowsByRouteAndDirection(
-		ctx, scheduleRows, agencyID, startOfDay, blockTripsMap,
+		ctx, scheduleRows, scheduleRowContext{
+			agencyID:                   agencyID,
+			startOfDay:                 startOfDay,
+			activeServiceBlockTripsMap: activeServiceBlockTripsMap,
+		},
 	)
 	if err != nil {
 		api.clientCanceledResponse(w, r, err)
@@ -325,6 +329,19 @@ func (api *RestAPI) scheduleForStopHandler(w http.ResponseWriter, r *http.Reques
 	api.sendResponse(w, r, response)
 }
 
+// scheduleRowContext holds the values that stay constant across every row while building
+// a stop's schedule, so callers don't have to thread each one individually through the
+// row-building helpers below.
+type scheduleRowContext struct {
+	agencyID   string
+	startOfDay time.Time
+	// activeServiceBlockTripsMap maps block ID to that block's trips, already filtered to
+	// the queried date's active service IDs (see GetActiveServiceIDsForDate). The name is
+	// load-bearing: blockBoundaries's first/last-in-block comparisons are only correct
+	// against a map pre-filtered this way.
+	activeServiceBlockTripsMap map[string][]gtfsdb.GetTripsByBlockIDsRow
+}
+
 // groupScheduleRowsByRouteAndDirection partitions schedule rows first by route, then by
 // GTFS direction_id (defaulting to "0" when absent), per spec steps 6-7. It returns the
 // grouped stop times alongside per-direction headsign vote counts used to pick each
@@ -333,9 +350,7 @@ func (api *RestAPI) scheduleForStopHandler(w http.ResponseWriter, r *http.Reques
 func groupScheduleRowsByRouteAndDirection(
 	ctx context.Context,
 	scheduleRows []gtfsdb.GetScheduleForStopOnDateRow,
-	agencyID string,
-	startOfDay time.Time,
-	blockTripsMap map[string][]gtfsdb.GetTripsByBlockIDsRow,
+	rowCtx scheduleRowContext,
 ) (
 	routeDirectionScheduleMap map[string]map[string][]models.ScheduleStopTime,
 	routeDirectionHeadsignCounts map[string]map[string]map[string]int,
@@ -349,71 +364,112 @@ func groupScheduleRowsByRouteAndDirection(
 			return nil, nil, ctx.Err()
 		}
 
-		directionID := "0"
-		if row.DirectionID.Valid {
-			directionID = strconv.FormatInt(row.DirectionID.Int64, 10)
-		}
+		directionID := directionIDForRow(row)
+		combinedRouteID := utils.FormCombinedID(rowCtx.agencyID, row.RouteID)
+		stopTime := buildScheduleStopTime(row, rowCtx)
 
-		combinedRouteID := utils.FormCombinedID(agencyID, row.RouteID)
-		combinedTripID := utils.FormCombinedID(agencyID, row.TripID)
-
-		// Convert GTFS time (nanoseconds since midnight) to Unix timestamp in the agency's timezone in milliseconds
-		// GTFS times are stored as time.Duration values (nanoseconds), need to add to the target date
-		arrivalDuration := time.Duration(row.ArrivalTime)
-		departureDuration := time.Duration(row.DepartureTime)
-		arrivalTimeMs := startOfDay.Add(arrivalDuration).UnixMilli()
-		departureTimeMs := startOfDay.Add(departureDuration).UnixMilli()
-
-		stopTime := models.NewScheduleStopTime(
-			arrivalTimeMs,
-			departureTimeMs,
-			utils.FormCombinedID(agencyID, row.ServiceID),
-			row.StopHeadsign.String,
-			combinedTripID,
-		)
-
-		// Determine the arrival/departure capabilities for this stop time based on its
-		// position within the vehicle's entire block for the service day.
-
-		// First, verify if the stop is at the temporal boundaries of its individual trip.
-		isFirstInTrip := row.MinArrivalTime.Valid && row.ArrivalTime == row.MinArrivalTime.Int64
-		isLastInTrip := row.MaxDepartureTime.Valid && row.DepartureTime == row.MaxDepartureTime.Int64
-
-		isFirstInBlock := isFirstInTrip
-		isLastInBlock := isLastInTrip
-
-		// If the trip belongs to a block, refine the boundaries to the block level.
-		if row.BlockID.Valid && row.BlockID.String != "" {
-			if bTrips, exists := blockTripsMap[row.BlockID.String]; exists && len(bTrips) > 0 {
-				isFirstInBlock = isFirstInTrip && (bTrips[0].ID == row.TripID)
-				isLastInBlock = isLastInTrip && (bTrips[len(bTrips)-1].ID == row.TripID)
-			}
-		}
-
-		// Disable arrivals for the first stop of a block (vehicle starts service here).
-		if isFirstInBlock {
-			stopTime.ArrivalEnabled = false
-		}
-		// Disable departures for the last stop of a block (vehicle ends service here).
-		if isLastInBlock {
-			stopTime.DepartureEnabled = false
-		}
-
-		if routeDirectionScheduleMap[combinedRouteID] == nil {
-			routeDirectionScheduleMap[combinedRouteID] = make(map[string][]models.ScheduleStopTime)
-		}
-		routeDirectionScheduleMap[combinedRouteID][directionID] = append(routeDirectionScheduleMap[combinedRouteID][directionID], stopTime)
-
-		if row.TripHeadsign.Valid && row.TripHeadsign.String != "" {
-			if routeDirectionHeadsignCounts[combinedRouteID] == nil {
-				routeDirectionHeadsignCounts[combinedRouteID] = make(map[string]map[string]int)
-			}
-			if routeDirectionHeadsignCounts[combinedRouteID][directionID] == nil {
-				routeDirectionHeadsignCounts[combinedRouteID][directionID] = make(map[string]int)
-			}
-			routeDirectionHeadsignCounts[combinedRouteID][directionID][row.TripHeadsign.String]++
-		}
+		addStopTimeToDirectionGroup(routeDirectionScheduleMap, combinedRouteID, directionID, stopTime)
+		recordHeadsignVote(routeDirectionHeadsignCounts, combinedRouteID, directionID, row.TripHeadsign)
 	}
 
 	return routeDirectionScheduleMap, routeDirectionHeadsignCounts, nil
+}
+
+// directionIDForRow returns the row's GTFS direction_id as a string, defaulting to "0"
+// when the feed does not specify one.
+func directionIDForRow(row gtfsdb.GetScheduleForStopOnDateRow) string {
+	if row.DirectionID.Valid {
+		return strconv.FormatInt(row.DirectionID.Int64, 10)
+	}
+	return "0"
+}
+
+// buildScheduleStopTime converts a schedule row into a ScheduleStopTime, converting GTFS
+// times (nanoseconds since midnight) to Unix millisecond timestamps and disabling the
+// arrival/departure flags at the boundaries of the vehicle's block for the service day.
+func buildScheduleStopTime(row gtfsdb.GetScheduleForStopOnDateRow, rowCtx scheduleRowContext) models.ScheduleStopTime {
+	arrivalTimeMs := rowCtx.startOfDay.Add(time.Duration(row.ArrivalTime)).UnixMilli()
+	departureTimeMs := rowCtx.startOfDay.Add(time.Duration(row.DepartureTime)).UnixMilli()
+
+	stopTime := models.NewScheduleStopTime(
+		arrivalTimeMs,
+		departureTimeMs,
+		utils.FormCombinedID(rowCtx.agencyID, row.ServiceID),
+		row.StopHeadsign.String,
+		utils.FormCombinedID(rowCtx.agencyID, row.TripID),
+	)
+
+	isFirstInBlock, isLastInBlock := blockBoundaries(row, rowCtx.activeServiceBlockTripsMap)
+	// Disable arrivals for the first stop of a block (vehicle starts service here).
+	if isFirstInBlock {
+		stopTime.ArrivalEnabled = false
+	}
+	// Disable departures for the last stop of a block (vehicle ends service here).
+	if isLastInBlock {
+		stopTime.DepartureEnabled = false
+	}
+
+	return stopTime
+}
+
+// blockBoundaries reports whether this stop time is the first (or last) stop time in the
+// vehicle's entire block for the service day, meaning there is no inbound arrival (or
+// onward departure) to speak of. activeServiceBlockTripsMap must already be filtered to
+// the queried date's active service IDs; passing an unfiltered map will silently produce
+// wrong results.
+func blockBoundaries(
+	row gtfsdb.GetScheduleForStopOnDateRow,
+	activeServiceBlockTripsMap map[string][]gtfsdb.GetTripsByBlockIDsRow,
+) (isFirstInBlock, isLastInBlock bool) {
+	// First, verify if the stop is at the temporal boundaries of its individual trip.
+	isFirstInTrip := row.MinArrivalTime.Valid && row.ArrivalTime == row.MinArrivalTime.Int64
+	isLastInTrip := row.MaxDepartureTime.Valid && row.DepartureTime == row.MaxDepartureTime.Int64
+
+	if !row.BlockID.Valid || row.BlockID.String == "" {
+		return isFirstInTrip, isLastInTrip
+	}
+
+	// If the trip belongs to a block, refine the boundaries to the block level.
+	bTrips, exists := activeServiceBlockTripsMap[row.BlockID.String]
+	if !exists || len(bTrips) == 0 {
+		return isFirstInTrip, isLastInTrip
+	}
+
+	isFirstInBlock = isFirstInTrip && bTrips[0].ID == row.TripID
+	isLastInBlock = isLastInTrip && bTrips[len(bTrips)-1].ID == row.TripID
+	return isFirstInBlock, isLastInBlock
+}
+
+// addStopTimeToDirectionGroup appends stopTime to the route's direction bucket, creating
+// the intermediate map when this is the route's first stop time seen so far.
+func addStopTimeToDirectionGroup(
+	routeDirectionScheduleMap map[string]map[string][]models.ScheduleStopTime,
+	combinedRouteID, directionID string,
+	stopTime models.ScheduleStopTime,
+) {
+	if routeDirectionScheduleMap[combinedRouteID] == nil {
+		routeDirectionScheduleMap[combinedRouteID] = make(map[string][]models.ScheduleStopTime)
+	}
+	routeDirectionScheduleMap[combinedRouteID][directionID] = append(routeDirectionScheduleMap[combinedRouteID][directionID], stopTime)
+}
+
+// recordHeadsignVote tallies one vote for headsign under the route's direction bucket, used
+// later to pick each direction group's plurality tripHeadsign. Blank/absent headsigns cast
+// no vote.
+func recordHeadsignVote(
+	routeDirectionHeadsignCounts map[string]map[string]map[string]int,
+	combinedRouteID, directionID string,
+	headsign sql.NullString,
+) {
+	if !headsign.Valid || headsign.String == "" {
+		return
+	}
+
+	if routeDirectionHeadsignCounts[combinedRouteID] == nil {
+		routeDirectionHeadsignCounts[combinedRouteID] = make(map[string]map[string]int)
+	}
+	if routeDirectionHeadsignCounts[combinedRouteID][directionID] == nil {
+		routeDirectionHeadsignCounts[combinedRouteID][directionID] = make(map[string]int)
+	}
+	routeDirectionHeadsignCounts[combinedRouteID][directionID][headsign.String]++
 }

--- a/internal/restapi/schedule_for_stop_handler.go
+++ b/internal/restapi/schedule_for_stop_handler.go
@@ -338,7 +338,7 @@ func (api *RestAPI) scheduleForStopHandler(w http.ResponseWriter, r *http.Reques
 		}
 
 		// Sort direction groups alphabetically by headsign
-		slices.SortFunc(directionSchedules, func(a, b models.StopRouteDirectionSchedule) int {
+		slices.SortStableFunc(directionSchedules, func(a, b models.StopRouteDirectionSchedule) int {
 			return cmp.Compare(a.TripHeadsign, b.TripHeadsign)
 		})
 

--- a/internal/restapi/schedule_for_stop_handler.go
+++ b/internal/restapi/schedule_for_stop_handler.go
@@ -346,6 +346,11 @@ func (api *RestAPI) scheduleForStopHandler(w http.ResponseWriter, r *http.Reques
 		routeSchedules = append(routeSchedules, routeSchedule)
 	}
 
+	// Sort route schedules by route ID for deterministic ordering
+	slices.SortStableFunc(routeSchedules, func(a, b models.StopRouteSchedule) int {
+		return cmp.Compare(a.RouteID, b.RouteID)
+	})
+
 	// Create the entry
 	combinedStopID := utils.FormCombinedID(agencyID, stopID)
 	entry := models.NewScheduleForStopEntry(combinedStopID, responseDate, routeSchedules)

--- a/internal/restapi/schedule_for_stop_handler.go
+++ b/internal/restapi/schedule_for_stop_handler.go
@@ -85,6 +85,10 @@ func (api *RestAPI) scheduleForStopHandler(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
+	// Natural-sort by short name (falling back to long name, then agency/route ID) so that
+	// stopRouteSchedules can later be emitted in this same order, per spec.
+	utils.SortRoutesByName(routesForStop)
+
 	routeIDs := make([]string, 0, len(routesForStop))
 	for _, rt := range routesForStop {
 		routeIDs = append(routeIDs, rt.ID)
@@ -310,15 +314,22 @@ func (api *RestAPI) scheduleForStopHandler(w http.ResponseWriter, r *http.Reques
 		}
 	}
 
-	// Build the route schedules
+	// Build the route schedules in the natural-sort order established above (spec step 10):
+	// by route short name, falling back to long name, then agency/route ID.
 	var routeSchedules []models.StopRouteSchedule
-	for routeID, directionMap := range routeDirectionScheduleMap {
+	for _, rt := range routesForStop {
+		combinedRouteID := utils.FormCombinedID(agencyID, rt.ID)
+		directionMap, hasSchedule := routeDirectionScheduleMap[combinedRouteID]
+		if !hasSchedule {
+			continue
+		}
+
 		var directionSchedules []models.StopRouteDirectionSchedule
 
 		for dirID, stopTimes := range directionMap {
 			tripHeadsign := ""
 			maxCount := 0
-			if dirHeadsigns, exists := routeDirectionHeadsignCounts[routeID][dirID]; exists {
+			if dirHeadsigns, exists := routeDirectionHeadsignCounts[combinedRouteID][dirID]; exists {
 				headsigns := make([]string, 0, len(dirHeadsigns))
 				for headsign := range dirHeadsigns {
 					headsigns = append(headsigns, headsign)
@@ -342,14 +353,9 @@ func (api *RestAPI) scheduleForStopHandler(w http.ResponseWriter, r *http.Reques
 			return cmp.Compare(a.TripHeadsign, b.TripHeadsign)
 		})
 
-		routeSchedule := models.NewStopRouteSchedule(routeID, directionSchedules)
+		routeSchedule := models.NewStopRouteSchedule(combinedRouteID, directionSchedules)
 		routeSchedules = append(routeSchedules, routeSchedule)
 	}
-
-	// Sort route schedules by route ID for deterministic ordering
-	slices.SortStableFunc(routeSchedules, func(a, b models.StopRouteSchedule) int {
-		return cmp.Compare(a.RouteID, b.RouteID)
-	})
 
 	// Create the entry
 	combinedStopID := utils.FormCombinedID(agencyID, stopID)

--- a/internal/restapi/schedule_for_stop_handler.go
+++ b/internal/restapi/schedule_for_stop_handler.go
@@ -87,7 +87,7 @@ func (api *RestAPI) scheduleForStopHandler(w http.ResponseWriter, r *http.Reques
 
 	// Natural-sort by short name (falling back to long name, then agency/route ID) so that
 	// stopRouteSchedules can later be emitted in this same order, per spec.
-	utils.SortRoutesByName(routesForStop)
+	utils.SortRoutesForStopRowsByName(routesForStop)
 
 	routeIDs := make([]string, 0, len(routesForStop))
 	for _, rt := range routesForStop {

--- a/internal/restapi/schedule_for_stop_handler.go
+++ b/internal/restapi/schedule_for_stop_handler.go
@@ -319,7 +319,13 @@ func (api *RestAPI) scheduleForStopHandler(w http.ResponseWriter, r *http.Reques
 			tripHeadsign := ""
 			maxCount := 0
 			if dirHeadsigns, exists := routeDirectionHeadsignCounts[routeID][dirID]; exists {
-				for headsign, count := range dirHeadsigns {
+				headsigns := make([]string, 0, len(dirHeadsigns))
+				for headsign := range dirHeadsigns {
+					headsigns = append(headsigns, headsign)
+				}
+				slices.Sort(headsigns)
+				for _, headsign := range headsigns {
+					count := dirHeadsigns[headsign]
 					if count > maxCount {
 						maxCount = count
 						tripHeadsign = headsign

--- a/internal/restapi/schedule_for_stop_handler_test.go
+++ b/internal/restapi/schedule_for_stop_handler_test.go
@@ -650,6 +650,15 @@ func TestScheduleForStopHandlerDirectionPartitioning(t *testing.T) {
 			schedules, ok := entry["stopRouteSchedules"].([]any)
 			require.True(ok)
 
+			// Route schedules must be sorted alphabetically by routeId
+			for i := 0; i < len(schedules)-1; i++ {
+				currSched := schedules[i].(map[string]any)
+				nextSched := schedules[i+1].(map[string]any)
+				currRouteID, _ := currSched["routeId"].(string)
+				nextRouteID, _ := nextSched["routeId"].(string)
+				assert.LessOrEqual(t, currRouteID, nextRouteID, "Route schedules must be sorted alphabetically by routeId")
+			}
+
 			for _, schedAny := range schedules {
 				sched := schedAny.(map[string]any)
 				dirSchedules, ok := sched["stopRouteDirectionSchedules"].([]any)

--- a/internal/restapi/schedule_for_stop_handler_test.go
+++ b/internal/restapi/schedule_for_stop_handler_test.go
@@ -529,9 +529,9 @@ func TestScheduleForStopQueryValidation(t *testing.T) {
 		// Check if we have schedules with stop times
 		if schedules, ok := entry["stopRouteSchedules"].([]any); ok && len(schedules) > 0 {
 			firstSchedule := schedules[0].(map[string]any)
-			if dirSchedules, ok := firstSchedule["schedules"].([]any); ok && len(dirSchedules) > 0 {
+			if dirSchedules, ok := firstSchedule["stopRouteDirectionSchedules"].([]any); ok && len(dirSchedules) > 0 {
 				dirSchedule := dirSchedules[0].(map[string]any)
-				if stopTimes, ok := dirSchedule["stopTimes"].([]any); ok && len(stopTimes) > 0 {
+				if stopTimes, ok := dirSchedule["scheduleStopTimes"].([]any); ok && len(stopTimes) > 0 {
 					stopTime := stopTimes[0].(map[string]any)
 
 					// Verify arrival and departure times are timestamps
@@ -623,5 +623,47 @@ func TestScheduleForStopHandlerBlockSequenceLogic(t *testing.T) {
 		require.True(ok, "trip not found in response for last stop")
 		assert.True(t, st["arrivalEnabled"].(bool), "arrivalEnabled must be TRUE")
 		assert.False(t, st["departureEnabled"].(bool), "departureEnabled must be FALSE for the absolute last stop")
+	})
+}
+
+func TestScheduleForStopHandlerDirectionPartitioning(t *testing.T) {
+	api := createTestApi(t)
+	defer api.Shutdown()
+
+	agencies := mustGetAgencies(t, api)
+	stops := mustGetStops(t, api)
+	require := assert.New(t)
+
+	t.Run("Validates direction partitioning and alphabetical sorting by headsign", func(t *testing.T) {
+		// Iterate through all stops on active test date 2025-06-12
+		for _, stop := range stops {
+			stopID := utils.FormCombinedID(agencies[0].ID, stop.ID)
+			endpoint := "/api/where/schedule-for-stop/" + stopID + ".json?key=org.onebusaway.iphone&date=2025-06-12"
+			resp, model := serveApiAndRetrieveEndpoint(t, api, endpoint)
+			require.Equal(http.StatusOK, resp.StatusCode)
+
+			data, ok := model.Data.(map[string]any)
+			require.True(ok)
+			entry, ok := data["entry"].(map[string]any)
+			require.True(ok)
+
+			schedules, ok := entry["stopRouteSchedules"].([]any)
+			require.True(ok)
+
+			for _, schedAny := range schedules {
+				sched := schedAny.(map[string]any)
+				dirSchedules, ok := sched["stopRouteDirectionSchedules"].([]any)
+				require.True(ok, "stopRouteDirectionSchedules should be an array")
+
+				// Direction groups within each route are sorted alphabetically by headsign
+				for i := 0; i < len(dirSchedules)-1; i++ {
+					currDir := dirSchedules[i].(map[string]any)
+					nextDir := dirSchedules[i+1].(map[string]any)
+					currHeadsign, _ := currDir["tripHeadsign"].(string)
+					nextHeadsign, _ := nextDir["tripHeadsign"].(string)
+					assert.LessOrEqual(t, currHeadsign, nextHeadsign, "Direction schedules must be sorted alphabetically by tripHeadsign")
+				}
+			}
+		}
 	})
 }

--- a/internal/restapi/schedule_for_stop_handler_test.go
+++ b/internal/restapi/schedule_for_stop_handler_test.go
@@ -650,13 +650,37 @@ func TestScheduleForStopHandlerDirectionPartitioning(t *testing.T) {
 			schedules, ok := entry["stopRouteSchedules"].([]any)
 			require.True(ok)
 
-			// Route schedules must be sorted alphabetically by routeId
+			references, ok := data["references"].(map[string]any)
+			require.True(ok)
+			routeRefs, ok := references["routes"].([]any)
+			require.True(ok)
+
+			// Build routeId -> sort name (shortName, falling back to longName) from references,
+			// matching the natural-sort key the spec requires for stopRouteSchedules ordering.
+			routeSortNameByID := make(map[string]string, len(routeRefs))
+			for _, routeAny := range routeRefs {
+				route := routeAny.(map[string]any)
+				id, _ := route["id"].(string)
+				shortName, _ := route["shortName"].(string)
+				longName, _ := route["longName"].(string)
+				name := shortName
+				if name == "" {
+					name = longName
+				}
+				routeSortNameByID[id] = name
+			}
+
+			// Route schedules must be sorted by route short name (falling back to long name)
+			// using a natural (numeric-aware) string sort, not a plain lexicographic sort on routeId.
 			for i := 0; i < len(schedules)-1; i++ {
 				currSched := schedules[i].(map[string]any)
 				nextSched := schedules[i+1].(map[string]any)
 				currRouteID, _ := currSched["routeId"].(string)
 				nextRouteID, _ := nextSched["routeId"].(string)
-				assert.LessOrEqual(t, currRouteID, nextRouteID, "Route schedules must be sorted alphabetically by routeId")
+				currName := routeSortNameByID[currRouteID]
+				nextName := routeSortNameByID[nextRouteID]
+				assert.LessOrEqual(t, utils.NaturalCompare(currName, nextName), 0,
+					"Route schedules must be sorted naturally by route short/long name (%q vs %q)", currName, nextName)
 			}
 
 			for _, schedAny := range schedules {

--- a/internal/restapi/schedule_for_stop_handler_test.go
+++ b/internal/restapi/schedule_for_stop_handler_test.go
@@ -707,6 +707,7 @@ func TestScheduleForStopHandlerDirectionPartitioning(t *testing.T) {
 func TestGroupScheduleRowsByRouteAndDirection(t *testing.T) {
 	startOfDay := time.Date(2025, 6, 12, 0, 0, 0, 0, time.UTC)
 	agencyID := "1"
+	rowCtx := scheduleRowContext{agencyID: agencyID, startOfDay: startOfDay}
 
 	makeRow := func(tripID, routeID string, directionID sql.NullInt64, headsign string) gtfsdb.GetScheduleForStopOnDateRow {
 		return gtfsdb.GetScheduleForStopOnDateRow{
@@ -727,7 +728,7 @@ func TestGroupScheduleRowsByRouteAndDirection(t *testing.T) {
 			makeRow("trip-in", "10", sql.NullInt64{Int64: 1, Valid: true}, "Uptown"),
 		}
 
-		schedules, _, err := groupScheduleRowsByRouteAndDirection(context.Background(), rows, agencyID, startOfDay, nil)
+		schedules, _, err := groupScheduleRowsByRouteAndDirection(context.Background(), rows, rowCtx)
 		assert.NoError(t, err)
 
 		routeGroups, ok := schedules["1_10"]
@@ -747,7 +748,7 @@ func TestGroupScheduleRowsByRouteAndDirection(t *testing.T) {
 			makeRow("trip-b", "10", sql.NullInt64{Int64: 0, Valid: true}, "Downtown"),
 		}
 
-		schedules, headsignCounts, err := groupScheduleRowsByRouteAndDirection(context.Background(), rows, agencyID, startOfDay, nil)
+		schedules, headsignCounts, err := groupScheduleRowsByRouteAndDirection(context.Background(), rows, rowCtx)
 		assert.NoError(t, err)
 
 		assert.Len(t, schedules["1_10"], 1, "expected a single direction bucket")
@@ -760,7 +761,7 @@ func TestGroupScheduleRowsByRouteAndDirection(t *testing.T) {
 			makeRow("trip-a", "10", sql.NullInt64{Valid: false}, "Downtown"),
 		}
 
-		schedules, _, err := groupScheduleRowsByRouteAndDirection(context.Background(), rows, agencyID, startOfDay, nil)
+		schedules, _, err := groupScheduleRowsByRouteAndDirection(context.Background(), rows, rowCtx)
 		assert.NoError(t, err)
 
 		assert.Len(t, schedules["1_10"], 1)
@@ -775,7 +776,7 @@ func TestGroupScheduleRowsByRouteAndDirection(t *testing.T) {
 			makeRow("trip-in-1", "10", sql.NullInt64{Int64: 1, Valid: true}, "Uptown"),
 		}
 
-		_, headsignCounts, err := groupScheduleRowsByRouteAndDirection(context.Background(), rows, agencyID, startOfDay, nil)
+		_, headsignCounts, err := groupScheduleRowsByRouteAndDirection(context.Background(), rows, rowCtx)
 		assert.NoError(t, err)
 
 		assert.Equal(t, 2, headsignCounts["1_10"]["0"]["Downtown"])
@@ -791,7 +792,7 @@ func TestGroupScheduleRowsByRouteAndDirection(t *testing.T) {
 			makeRow("trip-a", "10", sql.NullInt64{Int64: 0, Valid: true}, "Downtown"),
 		}
 
-		_, _, err := groupScheduleRowsByRouteAndDirection(ctx, rows, agencyID, startOfDay, nil)
+		_, _, err := groupScheduleRowsByRouteAndDirection(ctx, rows, rowCtx)
 		assert.ErrorIs(t, err, context.Canceled)
 	})
 }

--- a/internal/restapi/schedule_for_stop_handler_test.go
+++ b/internal/restapi/schedule_for_stop_handler_test.go
@@ -1,12 +1,15 @@
 package restapi
 
 import (
+	"context"
+	"database/sql"
 	"fmt"
 	"net/http"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"maglev.onebusaway.org/gtfsdb"
 	"maglev.onebusaway.org/internal/clock"
 	"maglev.onebusaway.org/internal/utils"
 )
@@ -698,5 +701,97 @@ func TestScheduleForStopHandlerDirectionPartitioning(t *testing.T) {
 				}
 			}
 		}
+	})
+}
+
+func TestGroupScheduleRowsByRouteAndDirection(t *testing.T) {
+	startOfDay := time.Date(2025, 6, 12, 0, 0, 0, 0, time.UTC)
+	agencyID := "1"
+
+	makeRow := func(tripID, routeID string, directionID sql.NullInt64, headsign string) gtfsdb.GetScheduleForStopOnDateRow {
+		return gtfsdb.GetScheduleForStopOnDateRow{
+			TripID:        tripID,
+			ArrivalTime:   int64(8 * time.Hour),
+			DepartureTime: int64(8 * time.Hour),
+			ServiceID:     "svc1",
+			RouteID:       routeID,
+			AgencyID:      agencyID,
+			DirectionID:   directionID,
+			TripHeadsign:  sql.NullString{String: headsign, Valid: headsign != ""},
+		}
+	}
+
+	t.Run("splits rows on the same route into separate direction groups", func(t *testing.T) {
+		rows := []gtfsdb.GetScheduleForStopOnDateRow{
+			makeRow("trip-out", "10", sql.NullInt64{Int64: 0, Valid: true}, "Downtown"),
+			makeRow("trip-in", "10", sql.NullInt64{Int64: 1, Valid: true}, "Uptown"),
+		}
+
+		schedules, _, err := groupScheduleRowsByRouteAndDirection(context.Background(), rows, agencyID, startOfDay, nil)
+		assert.NoError(t, err)
+
+		routeGroups, ok := schedules["1_10"]
+		assert.True(t, ok, "expected a group for route 1_10")
+		assert.Len(t, routeGroups, 2, "expected two distinct direction buckets")
+
+		assert.Len(t, routeGroups["0"], 1)
+		assert.Equal(t, "1_trip-out", routeGroups["0"][0].TripID)
+
+		assert.Len(t, routeGroups["1"], 1)
+		assert.Equal(t, "1_trip-in", routeGroups["1"][0].TripID)
+	})
+
+	t.Run("groups rows on the same route and direction together", func(t *testing.T) {
+		rows := []gtfsdb.GetScheduleForStopOnDateRow{
+			makeRow("trip-a", "10", sql.NullInt64{Int64: 0, Valid: true}, "Downtown"),
+			makeRow("trip-b", "10", sql.NullInt64{Int64: 0, Valid: true}, "Downtown"),
+		}
+
+		schedules, headsignCounts, err := groupScheduleRowsByRouteAndDirection(context.Background(), rows, agencyID, startOfDay, nil)
+		assert.NoError(t, err)
+
+		assert.Len(t, schedules["1_10"], 1, "expected a single direction bucket")
+		assert.Len(t, schedules["1_10"]["0"], 2, "expected both stop times grouped together")
+		assert.Equal(t, 2, headsignCounts["1_10"]["0"]["Downtown"])
+	})
+
+	t.Run("defaults a missing direction_id to bucket 0", func(t *testing.T) {
+		rows := []gtfsdb.GetScheduleForStopOnDateRow{
+			makeRow("trip-a", "10", sql.NullInt64{Valid: false}, "Downtown"),
+		}
+
+		schedules, _, err := groupScheduleRowsByRouteAndDirection(context.Background(), rows, agencyID, startOfDay, nil)
+		assert.NoError(t, err)
+
+		assert.Len(t, schedules["1_10"], 1)
+		assert.Contains(t, schedules["1_10"], "0")
+		assert.Len(t, schedules["1_10"]["0"], 1)
+	})
+
+	t.Run("tracks headsign votes separately per direction", func(t *testing.T) {
+		rows := []gtfsdb.GetScheduleForStopOnDateRow{
+			makeRow("trip-out-1", "10", sql.NullInt64{Int64: 0, Valid: true}, "Downtown"),
+			makeRow("trip-out-2", "10", sql.NullInt64{Int64: 0, Valid: true}, "Downtown"),
+			makeRow("trip-in-1", "10", sql.NullInt64{Int64: 1, Valid: true}, "Uptown"),
+		}
+
+		_, headsignCounts, err := groupScheduleRowsByRouteAndDirection(context.Background(), rows, agencyID, startOfDay, nil)
+		assert.NoError(t, err)
+
+		assert.Equal(t, 2, headsignCounts["1_10"]["0"]["Downtown"])
+		assert.Equal(t, 1, headsignCounts["1_10"]["1"]["Uptown"])
+		assert.Equal(t, 0, headsignCounts["1_10"]["1"]["Downtown"], "direction 1 should not see direction 0's headsign votes")
+	})
+
+	t.Run("returns an error when the context is already canceled", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		rows := []gtfsdb.GetScheduleForStopOnDateRow{
+			makeRow("trip-a", "10", sql.NullInt64{Int64: 0, Valid: true}, "Downtown"),
+		}
+
+		_, _, err := groupScheduleRowsByRouteAndDirection(ctx, rows, agencyID, startOfDay, nil)
+		assert.ErrorIs(t, err, context.Canceled)
 	})
 }

--- a/testdata/openapi.yml
+++ b/testdata/openapi.yml
@@ -1,5 +1,5 @@
 # Source: https://github.com/OneBusAway/sdk-config/blob/main/openapi.yml
-# Fetched: 2026-06-03
+# Fetched: 2026-07-08
 openapi: 3.0.0
 info:
   title: OneBusAway
@@ -682,7 +682,8 @@ paths:
           required: false
           schema:
             type: boolean
-          description: Whether to include full trip elements in the references section. Defaults to false.
+            default: true
+          description: Whether to include full trip elements in the references section. Defaults to true.
         - name: includeSchedule
           in: query
           required: false


### PR DESCRIPTION
### Description
Partitions the `schedule-for-stop` API response by `direction_id` and sorts direction groups alphabetically by `tripHeadsign` 

### Spec Requirement
Stop times for each route must be grouped into `stopRouteDirectionSchedules` by direction ID. When a route serves multiple directions at a stop, the direction groups must be sorted alphabetically by `tripHeadsign`.

### Implementation Gap
- Database queries did not select or order by `direction_id`.
- The handler returned a flat list under a single route entry rather than separating stop times into direction sub-groups.
- Direction groups were not sorted by headsign.

### Acceptance Criteria
- [x] Stop times are partitioned into `stopRouteDirectionSchedules` by `direction_id`.
- [x] Direction groups within each route are sorted alphabetically by `tripHeadsign`.
- [x] Unit and integration test suite (`make test`) passes with full verification.

closes #1027
closes #1028

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Schedule responses now return separate entries per **route + direction**, including direction-specific trip headsigns.
* **Bug Fixes**
  * Improved deterministic schedule ordering by **route**, **direction** (defaulting when missing), and **departure time**.
* **Tests**
  * Updated schedule-for-stop assertions to use the revised direction-partitioned response fields.
  * Added coverage to verify route ordering by name (natural sort) and direction ordering by ascending trip headsign.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->