### PR TITLE
fix(api): honor includeReferences=false in schedule-for-stop endpoint

### DIFF
--- a/internal/restapi/schedule_for_stop_handler.go
+++ b/internal/restapi/schedule_for_stop_handler.go
@@ -111,17 +111,6 @@ func (api *RestAPI) scheduleForStopHandler(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	includeReferences := ShouldIncludeReferences(r)
-	references := models.NewEmptyReferences()
-
-	if includeReferences {
-		references, err = api.buildScheduleForStopReferences(ctx, agencyID, agency, stop, scheduleRows, routeIDs)
-		if err != nil {
-			api.serverErrorResponse(w, r, err)
-			return
-		}
-	}
-
 	// Extract unique block IDs directly from the scheduled rows
 	uniqueBlockIDsMap := make(map[string]bool)
 	for _, row := range scheduleRows {
@@ -249,6 +238,15 @@ func (api *RestAPI) scheduleForStopHandler(w http.ResponseWriter, r *http.Reques
 	// Create the entry
 	combinedStopID := utils.FormCombinedID(agencyID, stopID)
 	entry := models.NewScheduleForStopEntry(combinedStopID, responseDate, routeSchedules)
+
+	references := models.NewEmptyReferences()
+	if ShouldIncludeReferences(r) {
+		references, err = api.buildScheduleForStopReferences(ctx, agencyID, agency, stop, scheduleRows, routeIDs)
+		if err != nil {
+			api.serverErrorResponse(w, r, err)
+			return
+		}
+	}
 
 	// Create and send response
 	response := models.NewEntryResponse(entry, *references, api.Clock)

--- a/internal/restapi/schedule_for_stop_handler.go
+++ b/internal/restapi/schedule_for_stop_handler.go
@@ -110,86 +110,92 @@ func (api *RestAPI) scheduleForStopHandler(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
+	includeReferences := ShouldIncludeReferences(r)
+
 	// Build references maps
-	agencyRefs := make(map[string]models.AgencyReference)
+	var agencyRefs map[string]models.AgencyReference
+	var routeRefs map[string]models.Route
 
-	// add the already fetched agency
-	agencyRefs[agencyID] = models.NewAgencyReference(
-		agency.ID,
-		agency.Name,
-		agency.Url,
-		agency.Timezone,
-		agency.Lang.String,
-		agency.Phone.String,
-		agency.Email.String,
-		agency.FareUrl.String,
-		"",    // disclaimer
-		false, // privateService
-	)
+	if includeReferences {
+		agencyRefs = make(map[string]models.AgencyReference)
+		routeRefs = make(map[string]models.Route)
 
-	routeRefs := make(map[string]models.Route)
+		// add the already fetched agency
+		agencyRefs[agencyID] = models.NewAgencyReference(
+			agency.ID,
+			agency.Name,
+			agency.Url,
+			agency.Timezone,
+			agency.Lang.String,
+			agency.Phone.String,
+			agency.Email.String,
+			agency.FareUrl.String,
+			"",    // disclaimer
+			false, // privateService
+		)
 
-	// Pre-process to gather unique IDs for batch fetching
-	uniqueRouteIDsMap := make(map[string]bool)
-	uniqueAgencyIDsMap := make(map[string]bool)
+		// Pre-process to gather unique IDs for batch fetching
+		uniqueRouteIDsMap := make(map[string]bool)
+		uniqueAgencyIDsMap := make(map[string]bool)
 
-	for _, row := range scheduleRows {
-		uniqueRouteIDsMap[row.RouteID] = true
-		uniqueAgencyIDsMap[row.AgencyID] = true
-	}
+		for _, row := range scheduleRows {
+			uniqueRouteIDsMap[row.RouteID] = true
+			uniqueAgencyIDsMap[row.AgencyID] = true
+		}
 
-	// Batch fetch routes
-	routeIDsToFetch := make([]string, 0, len(uniqueRouteIDsMap))
-	for routeID := range uniqueRouteIDsMap {
-		routeIDsToFetch = append(routeIDsToFetch, routeID)
-	}
+		// Batch fetch routes
+		routeIDsToFetch := make([]string, 0, len(uniqueRouteIDsMap))
+		for routeID := range uniqueRouteIDsMap {
+			routeIDsToFetch = append(routeIDsToFetch, routeID)
+		}
 
-	if len(routeIDsToFetch) > 0 {
-		fetchedRoutes, err := api.GtfsManager.GtfsDB.Queries.GetRoutesByIDs(ctx, routeIDsToFetch)
+		if len(routeIDsToFetch) > 0 {
+			fetchedRoutes, err := api.GtfsManager.GtfsDB.Queries.GetRoutesByIDs(ctx, routeIDsToFetch)
+			if err != nil {
+				api.serverErrorResponse(w, r, err)
+				return
+			}
+
+			for _, route := range fetchedRoutes {
+				combinedRouteID := utils.FormCombinedID(agencyID, route.ID)
+				routeRefs[combinedRouteID] = models.NewRoute(
+					combinedRouteID,
+					route.AgencyID,
+					route.ShortName.String,
+					route.LongName.String,
+					route.Desc.String,
+					models.RouteType(route.Type),
+					route.Url.String,
+					route.Color.String,
+					route.TextColor.String)
+			}
+		}
+
+		agencyIDsToFetch := make([]string, 0, len(uniqueAgencyIDsMap))
+		for agencyID := range uniqueAgencyIDsMap {
+			agencyIDsToFetch = append(agencyIDsToFetch, agencyID)
+		}
+
+		fetchedAgencies, err := api.GtfsManager.GtfsDB.Queries.GetAgenciesByIDs(ctx, agencyIDsToFetch)
 		if err != nil {
 			api.serverErrorResponse(w, r, err)
 			return
 		}
-
-		for _, route := range fetchedRoutes {
-			combinedRouteID := utils.FormCombinedID(agencyID, route.ID)
-			routeRefs[combinedRouteID] = models.NewRoute(
-				combinedRouteID,
-				route.AgencyID,
-				route.ShortName.String,
-				route.LongName.String,
-				route.Desc.String,
-				models.RouteType(route.Type),
-				route.Url.String,
-				route.Color.String,
-				route.TextColor.String)
-		}
-	}
-
-	agencyIDsToFetch := make([]string, 0, len(uniqueAgencyIDsMap))
-	for agencyID := range uniqueAgencyIDsMap {
-		agencyIDsToFetch = append(agencyIDsToFetch, agencyID)
-	}
-
-	fetchedAgencies, err := api.GtfsManager.GtfsDB.Queries.GetAgenciesByIDs(ctx, agencyIDsToFetch)
-	if err != nil {
-		api.serverErrorResponse(w, r, err)
-		return
-	}
-	for _, a := range fetchedAgencies {
-		if _, exists := agencyRefs[a.ID]; !exists {
-			agencyRefs[a.ID] = models.NewAgencyReference(
-				a.ID,
-				a.Name,
-				a.Url,
-				a.Timezone,
-				nulls.StringOrEmpty(a.Lang),
-				a.Phone.String,
-				a.Email.String,
-				a.FareUrl.String,
-				"",    // disclaimer
-				false, // privateService
-			)
+		for _, a := range fetchedAgencies {
+			if _, exists := agencyRefs[a.ID]; !exists {
+				agencyRefs[a.ID] = models.NewAgencyReference(
+					a.ID,
+					a.Name,
+					a.Url,
+					a.Timezone,
+					nulls.StringOrEmpty(a.Lang),
+					a.Phone.String,
+					a.Email.String,
+					a.FareUrl.String,
+					"",    // disclaimer
+					false, // privateService
+				)
+			}
 		}
 	}
 
@@ -323,29 +329,33 @@ func (api *RestAPI) scheduleForStopHandler(w http.ResponseWriter, r *http.Reques
 
 	// Convert reference maps to slices
 	references := models.NewEmptyReferences()
-	references.Agencies = utils.MapValues(agencyRefs)
-	references.Routes = utils.MapValues(routeRefs)
 
-	routeIDsWithAgency := make([]string, 0, len(routeIDs))
-	for _, ri := range routeIDs {
-		routeIDsWithAgency = append(routeIDsWithAgency, utils.FormCombinedID(agencyID, ri))
+	if includeReferences {
+
+		references.Agencies = utils.MapValues(agencyRefs)
+		references.Routes = utils.MapValues(routeRefs)
+
+		routeIDsWithAgency := make([]string, 0, len(routeIDs))
+		for _, ri := range routeIDs {
+			routeIDsWithAgency = append(routeIDsWithAgency, utils.FormCombinedID(agencyID, ri))
+		}
+
+		stopRef := models.NewStop(
+			nulls.StringOrEmpty(stop.Code),
+			nulls.StringOrEmpty(stop.Direction),
+			utils.FormCombinedID(agencyID, stop.ID),
+			nulls.StringOrEmpty(stop.Name),
+			"",
+			utils.MapWheelchairBoarding(nulls.WheelchairBoardingOrUnknown(stop.WheelchairBoarding)),
+			stop.Lat,
+			stop.Lon,
+			int(stop.LocationType.Int64),
+			routeIDsWithAgency,
+			routeIDsWithAgency,
+		)
+
+		references.Stops = append(references.Stops, stopRef)
 	}
-
-	stopRef := models.NewStop(
-		nulls.StringOrEmpty(stop.Code),
-		nulls.StringOrEmpty(stop.Direction),
-		utils.FormCombinedID(agencyID, stop.ID),
-		nulls.StringOrEmpty(stop.Name),
-		"",
-		utils.MapWheelchairBoarding(nulls.WheelchairBoardingOrUnknown(stop.WheelchairBoarding)),
-		stop.Lat,
-		stop.Lon,
-		int(stop.LocationType.Int64),
-		routeIDsWithAgency,
-		routeIDsWithAgency,
-	)
-
-	references.Stops = append(references.Stops, stopRef)
 	// Create and send response
 	response := models.NewEntryResponse(entry, *references, api.Clock)
 	api.sendResponse(w, r, response)

--- a/internal/restapi/schedule_for_stop_handler.go
+++ b/internal/restapi/schedule_for_stop_handler.go
@@ -1,6 +1,7 @@
 package restapi
 
 import (
+	"context"
 	"database/sql"
 	"net/http"
 	"strconv"
@@ -114,111 +115,11 @@ func (api *RestAPI) scheduleForStopHandler(w http.ResponseWriter, r *http.Reques
 	references := models.NewEmptyReferences()
 
 	if includeReferences {
-		// Build references maps
-		agencyRefs := make(map[string]models.AgencyReference)
-		routeRefs := make(map[string]models.Route)
-
-		// add the already fetched agency
-		agencyRefs[agencyID] = models.NewAgencyReference(
-			agency.ID,
-			agency.Name,
-			agency.Url,
-			agency.Timezone,
-			agency.Lang.String,
-			agency.Phone.String,
-			agency.Email.String,
-			agency.FareUrl.String,
-			"",    // disclaimer
-			false, // privateService
-		)
-
-		// Pre-process to gather unique IDs for batch fetching
-		uniqueRouteIDsMap := make(map[string]bool)
-		uniqueAgencyIDsMap := make(map[string]bool)
-
-		for _, row := range scheduleRows {
-			uniqueRouteIDsMap[row.RouteID] = true
-			uniqueAgencyIDsMap[row.AgencyID] = true
-		}
-
-		// Batch fetch routes
-		routeIDsToFetch := make([]string, 0, len(uniqueRouteIDsMap))
-		for routeID := range uniqueRouteIDsMap {
-			routeIDsToFetch = append(routeIDsToFetch, routeID)
-		}
-
-		if len(routeIDsToFetch) > 0 {
-			fetchedRoutes, err := api.GtfsManager.GtfsDB.Queries.GetRoutesByIDs(ctx, routeIDsToFetch)
-			if err != nil {
-				api.serverErrorResponse(w, r, err)
-				return
-			}
-
-			for _, route := range fetchedRoutes {
-				combinedRouteID := utils.FormCombinedID(agencyID, route.ID)
-				routeRefs[combinedRouteID] = models.NewRoute(
-					combinedRouteID,
-					route.AgencyID,
-					route.ShortName.String,
-					route.LongName.String,
-					route.Desc.String,
-					models.RouteType(route.Type),
-					route.Url.String,
-					route.Color.String,
-					route.TextColor.String)
-			}
-		}
-
-		agencyIDsToFetch := make([]string, 0, len(uniqueAgencyIDsMap))
-		for agencyID := range uniqueAgencyIDsMap {
-			agencyIDsToFetch = append(agencyIDsToFetch, agencyID)
-		}
-
-		fetchedAgencies, err := api.GtfsManager.GtfsDB.Queries.GetAgenciesByIDs(ctx, agencyIDsToFetch)
+		references, err = api.buildScheduleForStopReferences(ctx, agencyID, agency, stop, scheduleRows, routeIDs)
 		if err != nil {
 			api.serverErrorResponse(w, r, err)
 			return
 		}
-		for _, a := range fetchedAgencies {
-			if _, exists := agencyRefs[a.ID]; !exists {
-				agencyRefs[a.ID] = models.NewAgencyReference(
-					a.ID,
-					a.Name,
-					a.Url,
-					a.Timezone,
-					nulls.StringOrEmpty(a.Lang),
-					a.Phone.String,
-					a.Email.String,
-					a.FareUrl.String,
-					"",    // disclaimer
-					false, // privateService
-				)
-			}
-		}
-
-		references.Agencies = utils.MapValues(agencyRefs)
-		references.Routes = utils.MapValues(routeRefs)
-
-		routeIDsWithAgency := make([]string, 0, len(routeIDs))
-		for _, ri := range routeIDs {
-			routeIDsWithAgency = append(routeIDsWithAgency, utils.FormCombinedID(agencyID, ri))
-		}
-
-		stopRef := models.NewStop(
-			nulls.StringOrEmpty(stop.Code),
-			nulls.StringOrEmpty(stop.Direction),
-			utils.FormCombinedID(agencyID, stop.ID),
-			nulls.StringOrEmpty(stop.Name),
-			"",
-			utils.MapWheelchairBoarding(nulls.WheelchairBoardingOrUnknown(stop.WheelchairBoarding)),
-			stop.Lat,
-			stop.Lon,
-			int(stop.LocationType.Int64),
-			routeIDsWithAgency,
-			routeIDsWithAgency,
-		)
-
-		references.Stops = append(references.Stops, stopRef)
 	}
 
 	// Extract unique block IDs directly from the scheduled rows
@@ -352,4 +253,123 @@ func (api *RestAPI) scheduleForStopHandler(w http.ResponseWriter, r *http.Reques
 	// Create and send response
 	response := models.NewEntryResponse(entry, *references, api.Clock)
 	api.sendResponse(w, r, response)
+}
+
+// buildScheduleForStopReferences builds the agency, route, and stop references
+// for the schedule-for-stop entry. Only called when includeReferences=true.
+func (api *RestAPI) buildScheduleForStopReferences(
+	ctx context.Context,
+	agencyID string,
+	agency gtfsdb.Agency,
+	stop gtfsdb.Stop,
+	scheduleRows []gtfsdb.GetScheduleForStopOnDateRow,
+	routeIDs []string,
+) (*models.ReferencesModel, error) {
+	references := models.NewEmptyReferences()
+
+	// Build references maps
+	agencyRefs := make(map[string]models.AgencyReference)
+	routeRefs := make(map[string]models.Route)
+
+	// add the already fetched agency
+	agencyRefs[agencyID] = models.NewAgencyReference(
+		agency.ID,
+		agency.Name,
+		agency.Url,
+		agency.Timezone,
+		agency.Lang.String,
+		agency.Phone.String,
+		agency.Email.String,
+		agency.FareUrl.String,
+		"",    // disclaimer
+		false, // privateService
+	)
+
+	// Pre-process to gather unique IDs for batch fetching
+	uniqueRouteIDsMap := make(map[string]bool)
+	uniqueAgencyIDsMap := make(map[string]bool)
+
+	for _, row := range scheduleRows {
+		uniqueRouteIDsMap[row.RouteID] = true
+		uniqueAgencyIDsMap[row.AgencyID] = true
+	}
+
+	// Batch fetch routes
+	routeIDsToFetch := make([]string, 0, len(uniqueRouteIDsMap))
+	for routeID := range uniqueRouteIDsMap {
+		routeIDsToFetch = append(routeIDsToFetch, routeID)
+	}
+
+	if len(routeIDsToFetch) > 0 {
+		fetchedRoutes, err := api.GtfsManager.GtfsDB.Queries.GetRoutesByIDs(ctx, routeIDsToFetch)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, route := range fetchedRoutes {
+			combinedRouteID := utils.FormCombinedID(agencyID, route.ID)
+			routeRefs[combinedRouteID] = models.NewRoute(
+				combinedRouteID,
+				route.AgencyID,
+				route.ShortName.String,
+				route.LongName.String,
+				route.Desc.String,
+				models.RouteType(route.Type),
+				route.Url.String,
+				route.Color.String,
+				route.TextColor.String)
+		}
+	}
+
+	agencyIDsToFetch := make([]string, 0, len(uniqueAgencyIDsMap))
+	for id := range uniqueAgencyIDsMap {
+		agencyIDsToFetch = append(agencyIDsToFetch, id)
+	}
+
+	fetchedAgencies, err := api.GtfsManager.GtfsDB.Queries.GetAgenciesByIDs(ctx, agencyIDsToFetch)
+	if err != nil {
+		return nil, err
+	}
+	for _, a := range fetchedAgencies {
+		if _, exists := agencyRefs[a.ID]; !exists {
+			agencyRefs[a.ID] = models.NewAgencyReference(
+				a.ID,
+				a.Name,
+				a.Url,
+				a.Timezone,
+				nulls.StringOrEmpty(a.Lang),
+				a.Phone.String,
+				a.Email.String,
+				a.FareUrl.String,
+				"",    // disclaimer
+				false, // privateService
+			)
+		}
+	}
+
+	references.Agencies = utils.MapValues(agencyRefs)
+	references.Routes = utils.MapValues(routeRefs)
+
+	routeIDsWithAgency := make([]string, 0, len(routeIDs))
+	for _, ri := range routeIDs {
+		routeIDsWithAgency = append(routeIDsWithAgency, utils.FormCombinedID(agencyID, ri))
+	}
+
+	stopRef := models.NewStop(
+		nulls.StringOrEmpty(stop.Code),
+		nulls.StringOrEmpty(stop.Direction),
+		utils.FormCombinedID(agencyID, stop.ID),
+		nulls.StringOrEmpty(stop.Name),
+		"",
+		utils.MapWheelchairBoarding(nulls.WheelchairBoardingOrUnknown(stop.WheelchairBoarding)),
+		stop.Lat,
+		stop.Lon,
+		int(stop.LocationType.Int64),
+		routeIDsWithAgency,
+		routeIDsWithAgency,
+	)
+
+	references.Stops = append(references.Stops, stopRef)
+
+	return references, nil
 }

--- a/internal/restapi/schedule_for_stop_handler.go
+++ b/internal/restapi/schedule_for_stop_handler.go
@@ -111,14 +111,12 @@ func (api *RestAPI) scheduleForStopHandler(w http.ResponseWriter, r *http.Reques
 	}
 
 	includeReferences := ShouldIncludeReferences(r)
-
-	// Build references maps
-	var agencyRefs map[string]models.AgencyReference
-	var routeRefs map[string]models.Route
+	references := models.NewEmptyReferences()
 
 	if includeReferences {
-		agencyRefs = make(map[string]models.AgencyReference)
-		routeRefs = make(map[string]models.Route)
+		// Build references maps
+		agencyRefs := make(map[string]models.AgencyReference)
+		routeRefs := make(map[string]models.Route)
 
 		// add the already fetched agency
 		agencyRefs[agencyID] = models.NewAgencyReference(
@@ -197,6 +195,30 @@ func (api *RestAPI) scheduleForStopHandler(w http.ResponseWriter, r *http.Reques
 				)
 			}
 		}
+
+		references.Agencies = utils.MapValues(agencyRefs)
+		references.Routes = utils.MapValues(routeRefs)
+
+		routeIDsWithAgency := make([]string, 0, len(routeIDs))
+		for _, ri := range routeIDs {
+			routeIDsWithAgency = append(routeIDsWithAgency, utils.FormCombinedID(agencyID, ri))
+		}
+
+		stopRef := models.NewStop(
+			nulls.StringOrEmpty(stop.Code),
+			nulls.StringOrEmpty(stop.Direction),
+			utils.FormCombinedID(agencyID, stop.ID),
+			nulls.StringOrEmpty(stop.Name),
+			"",
+			utils.MapWheelchairBoarding(nulls.WheelchairBoardingOrUnknown(stop.WheelchairBoarding)),
+			stop.Lat,
+			stop.Lon,
+			int(stop.LocationType.Int64),
+			routeIDsWithAgency,
+			routeIDsWithAgency,
+		)
+
+		references.Stops = append(references.Stops, stopRef)
 	}
 
 	// Extract unique block IDs directly from the scheduled rows
@@ -327,35 +349,6 @@ func (api *RestAPI) scheduleForStopHandler(w http.ResponseWriter, r *http.Reques
 	combinedStopID := utils.FormCombinedID(agencyID, stopID)
 	entry := models.NewScheduleForStopEntry(combinedStopID, responseDate, routeSchedules)
 
-	// Convert reference maps to slices
-	references := models.NewEmptyReferences()
-
-	if includeReferences {
-
-		references.Agencies = utils.MapValues(agencyRefs)
-		references.Routes = utils.MapValues(routeRefs)
-
-		routeIDsWithAgency := make([]string, 0, len(routeIDs))
-		for _, ri := range routeIDs {
-			routeIDsWithAgency = append(routeIDsWithAgency, utils.FormCombinedID(agencyID, ri))
-		}
-
-		stopRef := models.NewStop(
-			nulls.StringOrEmpty(stop.Code),
-			nulls.StringOrEmpty(stop.Direction),
-			utils.FormCombinedID(agencyID, stop.ID),
-			nulls.StringOrEmpty(stop.Name),
-			"",
-			utils.MapWheelchairBoarding(nulls.WheelchairBoardingOrUnknown(stop.WheelchairBoarding)),
-			stop.Lat,
-			stop.Lon,
-			int(stop.LocationType.Int64),
-			routeIDsWithAgency,
-			routeIDsWithAgency,
-		)
-
-		references.Stops = append(references.Stops, stopRef)
-	}
 	// Create and send response
 	response := models.NewEntryResponse(entry, *references, api.Clock)
 	api.sendResponse(w, r, response)

--- a/internal/restapi/schedule_for_stop_handler.go
+++ b/internal/restapi/schedule_for_stop_handler.go
@@ -265,97 +265,108 @@ func (api *RestAPI) buildScheduleForStopReferences(
 	scheduleRows []gtfsdb.GetScheduleForStopOnDateRow,
 	routeIDs []string,
 ) (*models.ReferencesModel, error) {
-	references := models.NewEmptyReferences()
+	routeIDsToFetch, agencyIDsToFetch := collectRouteAndAgencyIDs(scheduleRows)
 
-	// Build references maps
-	agencyRefs := make(map[string]models.AgencyReference)
-	routeRefs := make(map[string]models.Route)
-
-	// add the already fetched agency
-	agencyRefs[agencyID] = models.NewAgencyReference(
-		agency.ID,
-		agency.Name,
-		agency.Url,
-		agency.Timezone,
-		agency.Lang.String,
-		agency.Phone.String,
-		agency.Email.String,
-		agency.FareUrl.String,
-		"",    // disclaimer
-		false, // privateService
-	)
-
-	// Pre-process to gather unique IDs for batch fetching
-	uniqueRouteIDsMap := make(map[string]bool)
-	uniqueAgencyIDsMap := make(map[string]bool)
-
-	for _, row := range scheduleRows {
-		uniqueRouteIDsMap[row.RouteID] = true
-		uniqueAgencyIDsMap[row.AgencyID] = true
-	}
-
-	// Batch fetch routes
-	routeIDsToFetch := make([]string, 0, len(uniqueRouteIDsMap))
-	for routeID := range uniqueRouteIDsMap {
-		routeIDsToFetch = append(routeIDsToFetch, routeID)
-	}
-
-	if len(routeIDsToFetch) > 0 {
-		fetchedRoutes, err := api.GtfsManager.GtfsDB.Queries.GetRoutesByIDs(ctx, routeIDsToFetch)
-		if err != nil {
-			return nil, err
-		}
-
-		for _, route := range fetchedRoutes {
-			combinedRouteID := utils.FormCombinedID(agencyID, route.ID)
-			routeRefs[combinedRouteID] = models.NewRoute(
-				combinedRouteID,
-				route.AgencyID,
-				route.ShortName.String,
-				route.LongName.String,
-				route.Desc.String,
-				models.RouteType(route.Type),
-				route.Url.String,
-				route.Color.String,
-				route.TextColor.String)
-		}
-	}
-
-	agencyIDsToFetch := make([]string, 0, len(uniqueAgencyIDsMap))
-	for id := range uniqueAgencyIDsMap {
-		agencyIDsToFetch = append(agencyIDsToFetch, id)
-	}
-
-	fetchedAgencies, err := api.GtfsManager.GtfsDB.Queries.GetAgenciesByIDs(ctx, agencyIDsToFetch)
+	routeRefs, err := api.fetchRouteRefs(ctx, agencyID, routeIDsToFetch)
 	if err != nil {
 		return nil, err
 	}
+
+	agencyRefs, err := api.fetchAgencyRefs(ctx, agency, agencyIDsToFetch)
+	if err != nil {
+		return nil, err
+	}
+
+	references := models.NewEmptyReferences()
+	references.Routes = utils.MapValues(routeRefs)
+	references.Agencies = utils.MapValues(agencyRefs)
+	references.Stops = append(references.Stops, buildQueriedStopRef(agencyID, stop, routeIDs))
+
+	return references, nil
+}
+
+// collectRouteAndAgencyIDs collects the distinct route and agency IDs referenced
+// across a stop's schedule rows, for batch fetching.
+func collectRouteAndAgencyIDs(scheduleRows []gtfsdb.GetScheduleForStopOnDateRow) (routeIDs, agencyIDs []string) {
+	uniqueRouteIDs := make(map[string]bool)
+	uniqueAgencyIDs := make(map[string]bool)
+
+	for _, row := range scheduleRows {
+		uniqueRouteIDs[row.RouteID] = true
+		uniqueAgencyIDs[row.AgencyID] = true
+	}
+
+	routeIDs = make([]string, 0, len(uniqueRouteIDs))
+	for id := range uniqueRouteIDs {
+		routeIDs = append(routeIDs, id)
+	}
+
+	agencyIDs = make([]string, 0, len(uniqueAgencyIDs))
+	for id := range uniqueAgencyIDs {
+		agencyIDs = append(agencyIDs, id)
+	}
+
+	return routeIDs, agencyIDs
+}
+
+// fetchRouteRefs batch-fetches routes by ID and builds their
+// combined-ID-keyed reference map.
+func (api *RestAPI) fetchRouteRefs(ctx context.Context, agencyID string, routeIDs []string) (map[string]models.Route, error) {
+	routeRefs := make(map[string]models.Route)
+	if len(routeIDs) == 0 {
+		return routeRefs, nil
+	}
+
+	fetchedRoutes, err := api.GtfsManager.GtfsDB.Queries.GetRoutesByIDs(ctx, routeIDs)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, route := range fetchedRoutes {
+		combinedRouteID := utils.FormCombinedID(agencyID, route.ID)
+		routeRefs[combinedRouteID] = models.NewRoute(
+			combinedRouteID,
+			route.AgencyID,
+			route.ShortName.String,
+			route.LongName.String,
+			route.Desc.String,
+			models.RouteType(route.Type),
+			route.Url.String,
+			route.Color.String,
+			route.TextColor.String)
+	}
+
+	return routeRefs, nil
+}
+
+// fetchAgencyRefs batch-fetches agencies by ID and builds their
+// ID-keyed reference map, seeded with the stop's own already-fetched agency.
+func (api *RestAPI) fetchAgencyRefs(ctx context.Context, seedAgency gtfsdb.Agency, agencyIDs []string) (map[string]models.AgencyReference, error) {
+	agencyRefs := make(map[string]models.AgencyReference)
+	agencyRefs[seedAgency.ID] = models.AgencyReferenceFromDatabase(&seedAgency)
+
+	fetchedAgencies, err := api.GtfsManager.GtfsDB.Queries.GetAgenciesByIDs(ctx, agencyIDs)
+	if err != nil {
+		return nil, err
+	}
+
 	for _, a := range fetchedAgencies {
 		if _, exists := agencyRefs[a.ID]; !exists {
-			agencyRefs[a.ID] = models.NewAgencyReference(
-				a.ID,
-				a.Name,
-				a.Url,
-				a.Timezone,
-				nulls.StringOrEmpty(a.Lang),
-				a.Phone.String,
-				a.Email.String,
-				a.FareUrl.String,
-				"",    // disclaimer
-				false, // privateService
-			)
+			agencyRefs[a.ID] = models.AgencyReferenceFromDatabase(&a)
 		}
 	}
 
-	references.Agencies = utils.MapValues(agencyRefs)
-	references.Routes = utils.MapValues(routeRefs)
+	return agencyRefs, nil
+}
 
+// buildQueriedStopRef builds the full stop reference for the queried stop.
+func buildQueriedStopRef(agencyID string, stop gtfsdb.Stop, routeIDs []string) models.Stop {
 	routeIDsWithAgency := make([]string, 0, len(routeIDs))
 	for _, ri := range routeIDs {
 		routeIDsWithAgency = append(routeIDsWithAgency, utils.FormCombinedID(agencyID, ri))
 	}
 
-	stopRef := models.NewStop(
+	return models.NewStop(
 		nulls.StringOrEmpty(stop.Code),
 		nulls.StringOrEmpty(stop.Direction),
 		utils.FormCombinedID(agencyID, stop.ID),
@@ -368,8 +379,4 @@ func (api *RestAPI) buildScheduleForStopReferences(
 		routeIDsWithAgency,
 		routeIDsWithAgency,
 	)
-
-	references.Stops = append(references.Stops, stopRef)
-
-	return references, nil
 }

--- a/internal/restapi/schedule_for_stop_handler_test.go
+++ b/internal/restapi/schedule_for_stop_handler_test.go
@@ -272,6 +272,31 @@ func TestScheduleForStopHandlerReferences(t *testing.T) {
 		_, ok = references["routes"].([]any)
 		assert.True(t, ok, "Routes should exist in references")
 	})
+
+	t.Run("Ignore references when includeReferences=false", func(t *testing.T) {
+		endpoint := "/api/where/schedule-for-stop/" + stopID + ".json?key=TEST&date=2025-06-12&includeReferences=false"
+		resp, model := serveApiAndRetrieveEndpoint(t, api, endpoint)
+
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+		data, ok := model.Data.(map[string]any)
+		assert.True(t, ok, "Data should be a map")
+
+		references, ok := data["references"].(map[string]any)
+		assert.True(t, ok, "References should exist")
+
+		agenciesRef, ok := references["agencies"].([]any)
+		assert.True(t, ok, "Agencies should be an array")
+		assert.Len(t, agenciesRef, 0, "Agencies array should be empty")
+
+		stopsRef, ok := references["stops"].([]any)
+		assert.True(t, ok, "Stops should be an array")
+		assert.Len(t, stopsRef, 0, "Stops array should be empty")
+
+		routesRef, ok := references["routes"].([]any)
+		assert.True(t, ok, "Routes should be an array")
+		assert.Len(t, routesRef, 0, "Routes array should be empty")
+	})
 }
 
 func TestScheduleForStopHandlerInvalidDateFormat(t *testing.T) {


### PR DESCRIPTION
### Description
Updates the `schedule-for-stop` endpoint to honor the `includeReferences` query parameter. When `includeReferences=false` is provided, all reference-related database queries and dictionary allocations are skipped, returning empty reference arrays in accordance with the OneBusAway specification.

### Spec Requirement
When `includeReferences=false` is passed, the handler must omit reference population (`agencies`, `routes`, `stops`, and `trips`) to reduce payload size and database query overhead.

### Implementation Summary
- Evaluates `ShouldIncludeReferences(r)` early in the handler.
- Skips batch database lookups (`GetRoutesByIDs`, `GetAgenciesByIDs`) and map allocations when `includeReferences=false`.
- Returns `models.NewEmptyReferences()` when references are disabled.
- Added unit test in `schedule_for_stop_handler_test.go` verifying empty reference structures when `includeReferences=false`.

### Acceptance Criteria
- [x] Database queries for routes and agencies are bypassed when `includeReferences=false`.
- [x] Response payload returns empty reference arrays when `includeReferences=false`.
- [x] Unit and integration test suite (`make test`) passes with full verification.

Closes #1081


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Schedule responses now respect the request’s reference-inclusion setting.
  * When references are not requested, the schedule payload is still returned, but agency, route, and stop reference lists are empty instead of being populated.
* **Tests**
  * Added coverage to verify the schedule-for-stop endpoint behavior when reference inclusion is disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->