### PR TITLE
Return trip-less vehicles for agency

### DIFF
--- a/internal/gtfs/gtfs_manager.go
+++ b/internal/gtfs/gtfs_manager.go
@@ -62,8 +62,7 @@ type Manager struct {
 	feedVehicles map[string][]gtfs.Vehicle
 	feedAlerts   map[string][]gtfs.Alert
 	// Per-feed agency filter: feedID -> set of allowed agency IDs.
-	// Populated once during InitGTFSManager before goroutines start; read-only thereafter.
-	// No lock is required for reads.
+	// Populated during InitGTFSManager; reads/writes are guarded by realTimeMutex.
 	feedAgencyFilter map[string]map[string]bool
 	// Per-feed, per-vehicle last-seen timestamps for stale vehicle expiry
 	feedVehicleLastSeen map[string]map[string]time.Time // feedID -> vehicleID -> lastSeen

--- a/internal/gtfs/gtfs_manager.go
+++ b/internal/gtfs/gtfs_manager.go
@@ -527,13 +527,23 @@ func (manager *Manager) VehiclesForAgencyID(ctx context.Context, agencyID string
 		routeIDs[route.ID] = true
 	}
 
-	// Step 2: Acquire real-time lock independently to read vehicles.
-	rtVehicles := manager.GetRealTimeVehicles()
+	manager.realTimeMutex.RLock()
+	defer manager.realTimeMutex.RUnlock()
 
 	var vehicles []gtfs.Vehicle
-	for _, v := range rtVehicles {
-		if v.Trip != nil && routeIDs[v.Trip.ID.RouteID] {
-			vehicles = append(vehicles, v)
+	for feedID, feedVehicles := range manager.feedVehicles {
+		for _, v := range feedVehicles {
+			if v.Trip != nil {
+				// Trip-bound vehicle: match via trip -> route -> agency.
+				if routeIDs[v.Trip.ID.RouteID] {
+					vehicles = append(vehicles, v)
+				}
+				continue
+			}
+			// Trip-less vehicle (spec Extension 5a): match via the feed's agency filter.
+			if filter := manager.feedAgencyFilter[feedID]; filter[agencyID] {
+				vehicles = append(vehicles, v)
+			}
 		}
 	}
 

--- a/internal/gtfs/gtfs_manager_mock.go
+++ b/internal/gtfs/gtfs_manager_mock.go
@@ -36,31 +36,7 @@ func (m *Manager) MockAddRoute(id, agencyID, name string) {
 	})
 }
 func (m *Manager) MockAddVehicle(vehicleID, tripID, routeID string) {
-	m.realTimeMutex.Lock()
-	defer m.realTimeMutex.Unlock()
-
-	for _, v := range m.realTimeVehicles {
-		if v.ID != nil && v.ID.ID == vehicleID {
-			return
-		}
-	}
-	now := time.Now()
-	m.realTimeVehicles = append(m.realTimeVehicles, gtfs.Vehicle{
-		ID:        &gtfs.VehicleID{ID: vehicleID},
-		Timestamp: &now,
-		Trip: &gtfs.Trip{
-			ID: gtfs.TripID{
-				ID:      tripID,
-				RouteID: routeID,
-			},
-		},
-	})
-
-	idx := len(m.realTimeVehicles) - 1
-	m.realTimeVehicleLookupByVehicle[vehicleID] = idx
-	if tripID != "" {
-		m.realTimeVehicleLookupByTrip[tripID] = idx
-	}
+	m.MockAddVehicleWithOptions(vehicleID, tripID, routeID, MockVehicleOptions{})
 }
 
 type MockVehicleOptions struct {
@@ -69,8 +45,9 @@ type MockVehicleOptions struct {
 	StopID              *string
 	CurrentStatus       *gtfs.CurrentStatus
 	OccupancyStatus     *gtfs.OccupancyStatus
-	NoTrip              bool // NoTrip creates a vehicle with Trip == nil, simulating a GTFS-RT vehicle with no current trip assignment, which VehiclesForAgencyID filters out.
-	NoID                bool // NoID creates a vehicle with ID == nil, simulating a GTFS-RT vehicle that omits the vehicle descriptor.
+	NoTrip              bool   // NoTrip creates a vehicle with Trip == nil, simulating a GTFS-RT vehicle with no current trip assignment.
+	NoID                bool   // NoID creates a vehicle with ID == nil, simulating a GTFS-RT vehicle that omits the vehicle descriptor.
+	FeedID              string // FeedID assigns the vehicle to a specific feed; defaults to "feed-0".
 }
 
 func (m *Manager) MockAddVehicleWithOptions(vehicleID, tripID, routeID string, opts MockVehicleOptions) {
@@ -109,15 +86,14 @@ func (m *Manager) MockAddVehicleWithOptions(vehicleID, tripID, routeID string, o
 		CurrentStatus:       opts.CurrentStatus,
 		OccupancyStatus:     opts.OccupancyStatus,
 	}
-	m.realTimeVehicles = append(m.realTimeVehicles, v)
 
-	idx := len(m.realTimeVehicles) - 1
-	if vehicleID != "" && !opts.NoID {
-		m.realTimeVehicleLookupByVehicle[vehicleID] = idx
+	// Store per-feed and rebuild the merged view so lookups match production.
+	feedID := opts.FeedID
+	if feedID == "" {
+		feedID = "feed-0"
 	}
-	if tripID != "" && !opts.NoTrip {
-		m.realTimeVehicleLookupByTrip[tripID] = idx
-	}
+	m.feedVehicles[feedID] = append(m.feedVehicles[feedID], v)
+	m.rebuildMergedRealtimeLocked()
 }
 
 func (m *Manager) MockAddTrip(tripID, agencyID, routeID string) {
@@ -156,6 +132,16 @@ func (m *Manager) MockAddAlert(feedID string, alert gtfs.Alert) {
 	m.rebuildMergedRealtimeLocked()
 }
 
+// MockSetFeedAgencyFilter assigns the set of agency IDs served by a feed, so
+// trip-less vehicles on that feed resolve to those agencies.
+func (m *Manager) MockSetFeedAgencyFilter(feedID string, agencyIDs ...string) {
+	filter := make(map[string]bool, len(agencyIDs))
+	for _, id := range agencyIDs {
+		filter[id] = true
+	}
+	m.feedAgencyFilter[feedID] = filter
+}
+
 // MockResetRealTimeData clears all mock real-time vehicles, trip updates, and alerts.
 func (m *Manager) MockResetRealTimeData() {
 	m.realTimeMutex.Lock()
@@ -167,6 +153,7 @@ func (m *Manager) MockResetRealTimeData() {
 	m.duplicatedVehicleByRoute = make(map[string][]gtfs.Vehicle)
 	m.realTimeTrips = nil
 	m.realTimeTripLookup = make(map[string]int)
+	m.feedVehicles = make(map[string][]gtfs.Vehicle)
 	m.feedAlerts = make(map[string][]gtfs.Alert)
 	m.rebuildMergedRealtimeLocked()
 }

--- a/internal/gtfs/gtfs_manager_mock.go
+++ b/internal/gtfs/gtfs_manager_mock.go
@@ -135,9 +135,15 @@ func (m *Manager) MockAddAlert(feedID string, alert gtfs.Alert) {
 // MockSetFeedAgencyFilter assigns the set of agency IDs served by a feed, so
 // trip-less vehicles on that feed resolve to those agencies.
 func (m *Manager) MockSetFeedAgencyFilter(feedID string, agencyIDs ...string) {
+	m.realTimeMutex.Lock()
+	defer m.realTimeMutex.Unlock()
+
 	filter := make(map[string]bool, len(agencyIDs))
 	for _, id := range agencyIDs {
 		filter[id] = true
+	}
+	if m.feedAgencyFilter == nil {
+		m.feedAgencyFilter = make(map[string]map[string]bool)
 	}
 	m.feedAgencyFilter[feedID] = filter
 }

--- a/internal/models/vehicle.go
+++ b/internal/models/vehicle.go
@@ -5,8 +5,8 @@ type VehicleStatus struct {
 	LastLocationUpdateTime ModelTime   `json:"lastLocationUpdateTime"`
 	LastUpdateTime         ModelTime   `json:"lastUpdateTime"`
 	Location               *Location   `json:"location"`
-	TripID                 string      `json:"tripId"`
-	TripStatus             *TripStatus `json:"tripStatus"`
+	TripID                 string      `json:"tripId,omitempty"`
+	TripStatus             *TripStatus `json:"tripStatus,omitempty"`
 	OccupancyCapacity      int         `json:"occupancyCapacity"`
 	OccupancyCount         int         `json:"occupancyCount"`
 	OccupancyStatus        string      `json:"occupancyStatus,omitempty"`

--- a/internal/models/vehicle_test.go
+++ b/internal/models/vehicle_test.go
@@ -25,8 +25,6 @@ func TestVehicleStatus_JSONFields(t *testing.T) {
 		assert.Contains(t, jsonStr, `"lastUpdateTime"`)
 		assert.Contains(t, jsonStr, `"lastLocationUpdateTime"`)
 		assert.Contains(t, jsonStr, `"location"`)
-		assert.Contains(t, jsonStr, `"tripId"`)
-		assert.Contains(t, jsonStr, `"tripStatus"`)
 
 		// Optional fields should be absent at the top level.
 		// Unmarshal to a map to avoid false positives from nested TripStatus JSON
@@ -42,8 +40,8 @@ func TestVehicleStatus_JSONFields(t *testing.T) {
 		assert.Equal(t, float64(0), top["lastUpdateTime"], "lastUpdateTime must serialize as 0 when not set")
 		assert.Equal(t, float64(0), top["lastLocationUpdateTime"], "lastLocationUpdateTime must serialize as 0 when not set")
 		assert.Nil(t, top["location"], "location must serialize as JSON null when not set")
-		assert.Nil(t, top["tripStatus"], "tripStatus must serialize as JSON null when not set")
-		assert.Equal(t, "", top["tripId"], "tripId must serialize as empty string when not set")
+		assert.NotContains(t, top, "tripStatus", "tripStatus must be absent when nil")
+		assert.NotContains(t, top, "tripId", "tripId must be absent when empty")
 	})
 
 	t.Run("optional fields appear only when set", func(t *testing.T) {

--- a/internal/restapi/vehicles_for_agency_handler.go
+++ b/internal/restapi/vehicles_for_agency_handler.go
@@ -195,14 +195,8 @@ func (api *RestAPI) vehiclesForAgencyHandler(w http.ResponseWriter, r *http.Requ
 					url, color, textColor)
 
 			}
-		} else {
-			defaultTripStatus := models.NewTripStatus()
-			defaultTripStatus.Status = "default"
-			defaultTripStatus.Phase = "scheduled"
-			defaultTripStatus.LastUpdateTime = currentTime
-			defaultTripStatus.LastLocationUpdateTime = currentTime
-			vehicleStatus.TripStatus = defaultTripStatus
 		}
+		// Trip-less vehicle: tripId and tripStatus stay absent (spec Extension 5a).
 
 		vehiclesList = append(vehiclesList, vehicleStatus)
 	}

--- a/internal/restapi/vehicles_for_agency_handler_test.go
+++ b/internal/restapi/vehicles_for_agency_handler_test.go
@@ -2,6 +2,7 @@ package restapi
 
 import (
 	"context"
+	"encoding/json"
 	"maps"
 	"net/http"
 	"net/http/httptest"
@@ -118,18 +119,45 @@ func TestVehiclesForAgencyHandler_VehicleWithoutTrip(t *testing.T) {
 		NoTrip: true,
 	})
 
-	_, model := callAPIHandler[VehiclesForAgencyResponse](t, api, vehiclesForAgencyURL(testdata.Raba.ID))
+	list := fetchVehiclesForAgencyRawList(t, api, vehiclesForAgencyURL(testdata.Raba.ID))
+	entry := rawEntryByVehicleID(t, list, noTripVehicleID)
+	require.NotNil(t, entry, "trip-less vehicle must be included in the response")
 
-	var entry *models.VehicleStatus
-	for i := range model.Data.List {
-		if model.Data.List[i].VehicleID == noTripVehicleID {
-			entry = &model.Data.List[i]
-			break
+	_, hasTripID := entry["tripId"]
+	_, hasTripStatus := entry["tripStatus"]
+	assert.False(t, hasTripID, "trip-less vehicle must have tripId absent from the payload")
+	assert.False(t, hasTripStatus, "trip-less vehicle must have tripStatus absent from the payload")
+}
+
+// fetchVehiclesForAgencyRawList returns the data.list entries as raw JSON maps so
+// tests can assert field presence, not just decoded zero values.
+func fetchVehiclesForAgencyRawList(t testing.TB, api *RestAPI, endpoint string) []map[string]json.RawMessage {
+	t.Helper()
+	server := httptest.NewServer(api.SetupAPIRoutes())
+	defer server.Close()
+
+	resp, err := http.Get(server.URL + endpoint)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	var envelope struct {
+		Data struct {
+			List []map[string]json.RawMessage `json:"list"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&envelope))
+	return envelope.Data.List
+}
+
+// rawEntryByVehicleID returns the raw entry whose vehicleId matches, or nil.
+func rawEntryByVehicleID(t testing.TB, list []map[string]json.RawMessage, vehicleID string) map[string]json.RawMessage {
+	t.Helper()
+	for _, entry := range list {
+		if string(entry["vehicleId"]) == `"`+vehicleID+`"` {
+			return entry
 		}
 	}
-	require.NotNil(t, entry, "trip-less vehicle must be included in the response")
-	assert.Empty(t, entry.TripID, "trip-less vehicle must have tripId absent")
-	assert.Nil(t, entry.TripStatus, "trip-less vehicle must have tripStatus absent")
+	return nil
 }
 
 // TestVehiclesForAgencyHandler_VehicleWithoutTripOtherAgency verifies a trip-less

--- a/internal/restapi/vehicles_for_agency_handler_test.go
+++ b/internal/restapi/vehicles_for_agency_handler_test.go
@@ -103,18 +103,46 @@ func TestVehiclesForAgencyHandler_OccupancyPropagation(t *testing.T) {
 		"tripStatus.occupancyStatus must receive the same GTFS-RT value")
 }
 
-// TestVehiclesForAgencyHandler_VehicleWithoutTrip verifies the invariant that vehicles
-// with Trip == nil are excluded from the vehicles-for-agency response.
+// TestVehiclesForAgencyHandler_VehicleWithoutTrip verifies that a trip-less vehicle
+// belonging to the agency is included with tripId and tripStatus absent (spec Extension 5a).
 func TestVehiclesForAgencyHandler_VehicleWithoutTrip(t *testing.T) {
 	api := createTestApi(t)
 	defer api.Shutdown()
 	t.Cleanup(api.GtfsManager.MockResetRealTimeData)
 
-	trip := mustGetTrip(t, api)
-	// Inject a vehicle with Trip == nil. It shares a routeID with static data so that
-	// if the nil-Trip filter is removed, the vehicle would propagate to the handler.
-	const noTripVehicleID = "v_no_trip_regression"
-	api.GtfsManager.MockAddVehicleWithOptions(noTripVehicleID, "", trip.RouteID, gtfs.MockVehicleOptions{
+	// Trip-less vehicles resolve to an agency via the feed's agency filter.
+	api.GtfsManager.MockSetFeedAgencyFilter("feed-0", testdata.Raba.ID)
+
+	const noTripVehicleID = "v_no_trip"
+	api.GtfsManager.MockAddVehicleWithOptions(noTripVehicleID, "", "", gtfs.MockVehicleOptions{
+		NoTrip: true,
+	})
+
+	_, model := callAPIHandler[VehiclesForAgencyResponse](t, api, vehiclesForAgencyURL(testdata.Raba.ID))
+
+	var entry *models.VehicleStatus
+	for i := range model.Data.List {
+		if model.Data.List[i].VehicleID == noTripVehicleID {
+			entry = &model.Data.List[i]
+			break
+		}
+	}
+	require.NotNil(t, entry, "trip-less vehicle must be included in the response")
+	assert.Empty(t, entry.TripID, "trip-less vehicle must have tripId absent")
+	assert.Nil(t, entry.TripStatus, "trip-less vehicle must have tripStatus absent")
+}
+
+// TestVehiclesForAgencyHandler_VehicleWithoutTripOtherAgency verifies a trip-less
+// vehicle on a feed serving a different agency is not returned.
+func TestVehiclesForAgencyHandler_VehicleWithoutTripOtherAgency(t *testing.T) {
+	api := createTestApi(t)
+	defer api.Shutdown()
+	t.Cleanup(api.GtfsManager.MockResetRealTimeData)
+
+	api.GtfsManager.MockSetFeedAgencyFilter("feed-0", "some-other-agency")
+
+	const noTripVehicleID = "v_no_trip_other"
+	api.GtfsManager.MockAddVehicleWithOptions(noTripVehicleID, "", "", gtfs.MockVehicleOptions{
 		NoTrip: true,
 	})
 
@@ -122,7 +150,7 @@ func TestVehiclesForAgencyHandler_VehicleWithoutTrip(t *testing.T) {
 
 	for _, v := range model.Data.List {
 		assert.NotEqual(t, noTripVehicleID, v.VehicleID,
-			"vehicle with Trip==nil must be excluded by VehiclesForAgencyID before reaching the handler")
+			"trip-less vehicle from another agency's feed must be excluded")
 	}
 }
 


### PR DESCRIPTION
### Summary
This PR aligns the `vehicles-for-agency` endpoint with Spec Extension 5a by including vehicles that currently lack a trip assignment, rather than dropping them. For these vehicles, `tripId` and `tripStatus` are explicitly omitted from the JSON response.

### Changes 
- **Agency Resolution (`gtfs_manager.go`):** Updated the loop to resolve trip-less vehicles using the `feedAgencyFilter` (mapping the feed to the agency) instead of relying solely on the `trip->route->agency` chain.
- **Handler (`vehicles_for_agency_handler.go`):** Removed the fallback logic that generated fabricated `TripStatus` objects for trip-less vehicles.
- **Models (`vehicle.go`):** Added `omitempty` to `TripID` and `TripStatus` in the exclusive `VehicleStatus` struct so they drop cleanly when nil/empty.
- **Mocks (`gtfs_manager_mock.go`):** Upgraded `MockAddVehicleWithOptions` to support `FeedID` and `NoTrip` flags, and added `MockSetFeedAgencyFilter` to accurately simulate production feed-to-agency resolution in tests.

### Testing
- Rewrote `TestVehiclesForAgencyHandler_VehicleWithoutTrip` to assert that trip-less vehicles are successfully returned and that trip fields are entirely absent.
- Added a negative cover test (`TestVehiclesForAgencyHandler_VehicleWithoutTripOtherAgency`) to ensure trip-less vehicles on feeds serving other agencies are correctly filtered out.

Closes: #1128 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Trip-less vehicles can now appear in the “vehicles for agency” response when they match the configured feed-to-agency mapping (instead of being excluded).
* **Bug Fixes**
  * `tripId` and `tripStatus` are no longer returned as placeholder values for vehicles without trip data.
  * “Vehicles for agency” selection now respects per-feed agency filtering and route ID matching for more accurate results.
* **Documentation / Tests**
  * Updated JSON behavior and API/JSON tests to confirm `tripId`/`tripStatus` are omitted when unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->