### PR TITLE
stops-for-route: honor includeReferences=false

### DIFF
--- a/internal/restapi/stops_for_route_handler.go
+++ b/internal/restapi/stops_for_route_handler.go
@@ -213,18 +213,7 @@ func (api *RestAPI) buildAndSendResponse(w http.ResponseWriter, r *http.Request,
 
 	// When includeReferences=false the references block is present but empty.
 	if ShouldIncludeReferences(r) {
-		agencyRef := models.NewAgencyReference(
-			currentAgency.ID,
-			currentAgency.Name,
-			currentAgency.Url,
-			currentAgency.Timezone,
-			currentAgency.Lang.String,
-			currentAgency.Phone.String,
-			currentAgency.Email.String,
-			currentAgency.FareUrl.String,
-			"",
-			false,
-		)
+		agencyRef := models.AgencyReferenceFromDatabase(&currentAgency)
 
 		routes, err := api.BuildRouteReferences(ctx, currentAgency.ID, stopsList)
 		if err != nil {

--- a/internal/restapi/stops_for_route_handler.go
+++ b/internal/restapi/stops_for_route_handler.go
@@ -203,29 +203,33 @@ func buildStopsList(ctx context.Context, api *RestAPI, agencyID string, allStops
 }
 
 func (api *RestAPI) buildAndSendResponse(w http.ResponseWriter, r *http.Request, ctx context.Context, result models.RouteEntry, stopsList []models.Stop, currentAgency gtfsdb.Agency) {
-	agencyRef := models.NewAgencyReference(
-		currentAgency.ID,
-		currentAgency.Name,
-		currentAgency.Url,
-		currentAgency.Timezone,
-		currentAgency.Lang.String,
-		currentAgency.Phone.String,
-		currentAgency.Email.String,
-		currentAgency.FareUrl.String,
-		"",
-		false,
-	)
-
-	routes, err := api.BuildRouteReferences(ctx, currentAgency.ID, stopsList)
-	if err != nil {
-		api.serverErrorResponse(w, r, err)
-		return
-	}
-
 	references := models.NewEmptyReferences()
-	references.Agencies = []models.AgencyReference{agencyRef}
-	references.Routes = routes
-	references.Stops = stopsList
+
+	// When includeReferences=false the references block is present but empty.
+	if ShouldIncludeReferences(r) {
+		agencyRef := models.NewAgencyReference(
+			currentAgency.ID,
+			currentAgency.Name,
+			currentAgency.Url,
+			currentAgency.Timezone,
+			currentAgency.Lang.String,
+			currentAgency.Phone.String,
+			currentAgency.Email.String,
+			currentAgency.FareUrl.String,
+			"",
+			false,
+		)
+
+		routes, err := api.BuildRouteReferences(ctx, currentAgency.ID, stopsList)
+		if err != nil {
+			api.serverErrorResponse(w, r, err)
+			return
+		}
+
+		references.Agencies = []models.AgencyReference{agencyRef}
+		references.Routes = routes
+		references.Stops = stopsList
+	}
 
 	response := models.NewEntryResponse(result, *references, api.Clock)
 	api.sendResponse(w, r, response)

--- a/internal/restapi/stops_for_route_handler_test.go
+++ b/internal/restapi/stops_for_route_handler_test.go
@@ -75,6 +75,41 @@ func TestStopsForRouteHandlerEndToEnd(t *testing.T) {
 	assert.Empty(t, refs.Trips)
 }
 
+// TestStopsForRouteIncludeReferencesFalse verifies that includeReferences=false
+// returns a references block that is present but empty.
+func TestStopsForRouteIncludeReferencesFalse(t *testing.T) {
+	api := createTestApi(t)
+	defer api.Shutdown()
+
+	_, model := callAPIHandler[StopsForRouteResponse](t, api, "/api/where/stops-for-route/"+testdata.Route1.ID+".json?key=TEST&includeReferences=false")
+
+	refs := model.Data.References
+	assert.Empty(t, refs.Agencies)
+	assert.Empty(t, refs.Routes)
+	assert.Empty(t, refs.Stops)
+	assert.Empty(t, refs.Trips)
+	assert.Empty(t, refs.Situations)
+	assert.Empty(t, refs.StopTimes)
+
+	// The entry payload is still populated.
+	assert.Equal(t, testdata.Route1.ID, model.Data.Entry.RouteID)
+	assert.NotEmpty(t, model.Data.Entry.StopIds)
+}
+
+// TestStopsForRouteIncludeReferencesDefault verifies that references are populated
+// when includeReferences is omitted (defaults to true).
+func TestStopsForRouteIncludeReferencesDefault(t *testing.T) {
+	api := createTestApi(t)
+	defer api.Shutdown()
+
+	_, model := callAPIHandler[StopsForRouteResponse](t, api, "/api/where/stops-for-route/"+testdata.Route1.ID+".json?key=TEST")
+
+	refs := model.Data.References
+	assert.NotEmpty(t, refs.Agencies)
+	assert.NotEmpty(t, refs.Routes)
+	assert.NotEmpty(t, refs.Stops)
+}
+
 // TestStopsForRouteNoDuplicateStopGroups guards against the regression where
 // trips with different headsigns in the same direction produced duplicate group
 // IDs (e.g. "0", "0", "1" instead of "0", "1").


### PR DESCRIPTION
fixes: #1121

## stops-for-route: honor includeReferences=false

Brings `stops-for-route` in line with the OpenAPI spec and the Java reference for
the `includeReferences` parameter. Previously the endpoint always returned the full
references block; it now returns an empty (but present) block when
`includeReferences=false`.

Each change is one commit; details below.

---

### 1. Honor includeReferences in stops-for-route (#1121)

`buildAndSendResponse` unconditionally populated `references.Agencies`, `.Routes`,
and `.Stops`. The spec (and Java) require an empty references block when
`includeReferences=false`.

Gated reference population on the existing `ShouldIncludeReferences(r)` helper
(already used by other handlers). When the parameter is `false`, the response
carries an empty `NewEmptyReferences()` block, which serializes as empty arrays
rather than `null`. The entry payload (routeId, stopIds, groupings, polylines) is
unaffected.

Verified against a live Java server for `unitrans_V`:

| includeReferences | Maglev | Java |
|-------------------|--------|------|
| `true` / omitted  | stops 9, routes 5, agencies 1 | stops 9, routes 5, agencies 1 |
| `false`           | stops 0, routes 0, agencies 0 | stops 0, routes 0, agencies 0 |

### 2. Test includeReferences parameter (refs #1123)

Added `TestStopsForRouteIncludeReferencesFalse` (empty references block, entry
still populated) and `TestStopsForRouteIncludeReferencesDefault` (references
populated by default).

`#1123` (parameter test coverage) is shared with the polyline PR, which adds the
`includePolylines` tests — hence `refs` rather than `fixes` here. Close #1123 once
both PRs merge.

---



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the `stops-for-route` response handling so reference data is only populated when `includeReferences` is requested.
  * When `includeReferences=false`, the response still returns the route/stop entry successfully, with an empty `references` block.

* **Tests**
  * Added end-to-end coverage for `includeReferences=false`.
  * Added end-to-end coverage for the default behavior when `includeReferences` is omitted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->