### PR TITLE
Set blockTripSequence to real value or -1

### DIFF
--- a/internal/restapi/trips_helper.go
+++ b/internal/restapi/trips_helper.go
@@ -558,31 +558,42 @@ func getDistanceAlongShapeInRange(lat, lon float64, shape []gtfs.ShapePoint, min
 
 // calculateBlockTripSequence calculates the index of a trip within its block's ordered trip sequence
 // for trips that are active on the given service date.
-// Uses GetBlockTripSequence with ROW_NUMBER() window function instead of fetching all trips and looping.
+// Returns 0 when the sequence is unavailable, for callers that treat 0 as "no data".
 func (api *RestAPI) calculateBlockTripSequence(ctx context.Context, tripID string, serviceDate time.Time) int {
+	seq, ok := api.blockTripSequence(ctx, tripID, serviceDate)
+	if !ok {
+		return 0
+	}
+	return seq
+}
+
+// blockTripSequence returns the zero-based index of a trip within its block's
+// ordered sequence for the given service date, and whether it was resolved.
+// Uses GetBlockTripSequence with ROW_NUMBER() window function instead of fetching all trips and looping.
+func (api *RestAPI) blockTripSequence(ctx context.Context, tripID string, serviceDate time.Time) (int, bool) {
 	trip, err := api.GtfsManager.GtfsDB.Queries.GetTrip(ctx, tripID)
 	if err != nil {
-		slog.Warn("calculateBlockTripSequence: failed to get trip",
+		slog.Warn("blockTripSequence: failed to get trip",
 			slog.String("trip_id", tripID),
 			slog.String("error", err.Error()))
-		return 0
+		return 0, false
 	}
 
 	if !trip.BlockID.Valid {
-		return 0
+		return 0, false
 	}
 
 	formattedDate := serviceDate.Format("20060102")
 	activeServiceIDs, err := api.GtfsManager.GtfsDB.Queries.GetActiveServiceIDsForDate(ctx, formattedDate)
 	if err != nil {
-		slog.Warn("calculateBlockTripSequence: failed to get active service IDs",
+		slog.Warn("blockTripSequence: failed to get active service IDs",
 			slog.String("trip_id", tripID),
 			slog.String("date", formattedDate),
 			slog.String("error", err.Error()))
-		return 0
+		return 0, false
 	}
 	if len(activeServiceIDs) == 0 {
-		return 0
+		return 0, false
 	}
 
 	// Use optimized query with ROW_NUMBER() window function
@@ -593,15 +604,15 @@ func (api *RestAPI) calculateBlockTripSequence(ctx context.Context, tripID strin
 	})
 	if err != nil {
 		if !errors.Is(err, sql.ErrNoRows) {
-			slog.Warn("calculateBlockTripSequence: failed to get block trip sequence",
+			slog.Warn("blockTripSequence: failed to get block trip sequence",
 				slog.String("trip_id", tripID),
 				slog.String("block_id", trip.BlockID.String),
 				slog.String("error", err.Error()))
 		}
-		return 0
+		return 0, false
 	}
 
-	return int(seq)
+	return int(seq), true
 }
 
 // calculatePreciseDistanceAlongTripWithCoords calculates the distance along a trip's shape to a stop

--- a/internal/restapi/vehicles_for_agency_handler.go
+++ b/internal/restapi/vehicles_for_agency_handler.go
@@ -32,13 +32,13 @@ func (api *RestAPI) vehiclesForAgencyHandler(w http.ResponseWriter, r *http.Requ
 	}
 
 	// Parse requested reference time for status entries, falling back to server clock if absent.
-	referenceTime := api.Clock.Now()
+	loc, err := loadAgencyLocation(agency.ID, agency.Timezone)
+	if err != nil {
+		api.serverErrorResponse(w, r, err)
+		return
+	}
+	referenceTime := api.Clock.Now().In(loc)
 	if timeParam := r.URL.Query().Get("time"); timeParam != "" {
-		loc, err := loadAgencyLocation(agency.ID, agency.Timezone)
-		if err != nil {
-			api.serverErrorResponse(w, r, err)
-			return
-		}
 		_, parsedTime, fieldErrors, ok := utils.ParseTimeParameter(timeParam, loc)
 		if !ok {
 			api.validationErrorResponse(w, r, fieldErrors)

--- a/internal/restapi/vehicles_for_agency_handler.go
+++ b/internal/restapi/vehicles_for_agency_handler.go
@@ -136,7 +136,7 @@ func (api *RestAPI) vehiclesForAgencyHandler(w http.ResponseWriter, r *http.Requ
 			tripStatus := models.NewTripStatus()
 			tripStatus.ActiveTripID = utils.FormCombinedID(id, vehicle.Trip.ID.ID)
 			// Resolve the block trip sequence; -1 when unavailable.
-			if seq, ok := api.blockTripSequence(ctx, vehicle.Trip.ID.ID, api.Clock.Now()); ok {
+			if seq, ok := api.blockTripSequence(ctx, vehicle.Trip.ID.ID, referenceTime); ok {
 				tripStatus.BlockTripSequence = seq
 			} else {
 				tripStatus.BlockTripSequence = -1

--- a/internal/restapi/vehicles_for_agency_handler.go
+++ b/internal/restapi/vehicles_for_agency_handler.go
@@ -108,7 +108,12 @@ func (api *RestAPI) vehiclesForAgencyHandler(w http.ResponseWriter, r *http.Requ
 
 			tripStatus := models.NewTripStatus()
 			tripStatus.ActiveTripID = utils.FormCombinedID(id, vehicle.Trip.ID.ID)
-			tripStatus.BlockTripSequence = 0
+			// Resolve the block trip sequence; -1 when unavailable.
+			if seq, ok := api.blockTripSequence(ctx, vehicle.Trip.ID.ID, api.Clock.Now()); ok {
+				tripStatus.BlockTripSequence = seq
+			} else {
+				tripStatus.BlockTripSequence = -1
+			}
 			tripStatus.Phase = vehicleStatus.Phase
 			tripStatus.Status = vehicleStatus.Status
 

--- a/internal/restapi/vehicles_for_agency_handler_test.go
+++ b/internal/restapi/vehicles_for_agency_handler_test.go
@@ -372,12 +372,11 @@ func findTripWithBlock(t testing.TB, api *RestAPI, ctx context.Context, pred fun
 	require.NoError(t, err)
 
 	for _, tr := range trips {
-		row, err := api.GtfsManager.GtfsDB.Queries.GetTrip(ctx, tr.ID)
-		if err != nil || !row.BlockID.Valid || row.BlockID.String == "" {
+		if !tr.BlockID.Valid || tr.BlockID.String == "" {
 			continue
 		}
-		if pred(row) {
-			return row
+		if pred(tr) {
+			return tr
 		}
 	}
 	return gtfsdb.Trip{}

--- a/internal/restapi/vehicles_for_agency_handler_test.go
+++ b/internal/restapi/vehicles_for_agency_handler_test.go
@@ -364,6 +364,25 @@ func findVehicleInList(list []models.VehicleStatus, vehicleID string) *models.Ve
 	return nil
 }
 
+// findTripWithBlock returns the first trip with a non-empty BlockID satisfying
+// pred, searching up to 200 trips. Returns the zero value if none match.
+func findTripWithBlock(t testing.TB, api *RestAPI, ctx context.Context, pred func(gtfsdb.Trip) bool) gtfsdb.Trip {
+	t.Helper()
+	trips, err := api.GtfsManager.GetTrips(ctx, 200)
+	require.NoError(t, err)
+
+	for _, tr := range trips {
+		row, err := api.GtfsManager.GtfsDB.Queries.GetTrip(ctx, tr.ID)
+		if err != nil || !row.BlockID.Valid || row.BlockID.String == "" {
+			continue
+		}
+		if pred(row) {
+			return row
+		}
+	}
+	return gtfsdb.Trip{}
+}
+
 // TestVehiclesForAgencyHandler_BlockTripSequenceResolved verifies that a vehicle on
 // a trip with a block active on the reference date gets a resolved (>= 0) sequence.
 func TestVehiclesForAgencyHandler_BlockTripSequenceResolved(t *testing.T) {
@@ -374,20 +393,10 @@ func TestVehiclesForAgencyHandler_BlockTripSequenceResolved(t *testing.T) {
 	t.Cleanup(api.GtfsManager.MockResetRealTimeData)
 
 	ctx := context.Background()
-	trips, err := api.GtfsManager.GetTrips(ctx, 200)
-	require.NoError(t, err)
-
-	var blockTrip gtfsdb.Trip
-	for _, tr := range trips {
-		row, err := api.GtfsManager.GtfsDB.Queries.GetTrip(ctx, tr.ID)
-		if err != nil || !row.BlockID.Valid || row.BlockID.String == "" {
-			continue
-		}
-		if _, ok := api.blockTripSequence(ctx, tr.ID, serviceDate); ok {
-			blockTrip = row
-			break
-		}
-	}
+	blockTrip := findTripWithBlock(t, api, ctx, func(row gtfsdb.Trip) bool {
+		_, ok := api.blockTripSequence(ctx, row.ID, serviceDate)
+		return ok
+	})
 	require.NotEmpty(t, blockTrip.ID, "need a trip with a resolvable block sequence in test data")
 
 	const vehicleID = "v_block_seq"
@@ -437,20 +446,10 @@ func TestVehiclesForAgencyHandler_BlockTripSequenceUsesRequestedTime(t *testing.
 	requestedTime := time.Date(2024, 11, 4, 12, 0, 0, 0, time.UTC)
 
 	ctx := context.Background()
-	trips, err := api.GtfsManager.GetTrips(ctx, 200)
-	require.NoError(t, err)
-
-	var blockTrip gtfsdb.Trip
-	for _, tr := range trips {
-		row, err := api.GtfsManager.GtfsDB.Queries.GetTrip(ctx, tr.ID)
-		if err != nil || !row.BlockID.Valid || row.BlockID.String == "" {
-			continue
-		}
-		if _, ok := api.blockTripSequence(ctx, tr.ID, requestedTime); ok {
-			blockTrip = row
-			break
-		}
-	}
+	blockTrip := findTripWithBlock(t, api, ctx, func(row gtfsdb.Trip) bool {
+		_, ok := api.blockTripSequence(ctx, row.ID, requestedTime)
+		return ok
+	})
 	require.NotEmpty(t, blockTrip.ID, "need a trip with a block sequence resolvable on requestedTime in test data")
 
 	const vehicleID = "v_block_seq_reftime"
@@ -479,22 +478,11 @@ func TestVehiclesForAgencyHandler_BlockTripSequenceUsesAgencyLocalDate(t *testin
 	t.Cleanup(api.GtfsManager.MockResetRealTimeData)
 
 	ctx := context.Background()
-	trips, err := api.GtfsManager.GetTrips(ctx, 200)
-	require.NoError(t, err)
-
-	var blockTrip gtfsdb.Trip
-	for _, tr := range trips {
-		row, err := api.GtfsManager.GtfsDB.Queries.GetTrip(ctx, tr.ID)
-		if err != nil || !row.BlockID.Valid || row.BlockID.String == "" {
-			continue
-		}
-		_, resolvesFriday := api.blockTripSequence(ctx, tr.ID, agencyLocalFriday)
-		_, resolvesSaturday := api.blockTripSequence(ctx, tr.ID, mockNow)
-		if resolvesFriday && !resolvesSaturday {
-			blockTrip = row
-			break
-		}
-	}
+	blockTrip := findTripWithBlock(t, api, ctx, func(row gtfsdb.Trip) bool {
+		_, resolvesFriday := api.blockTripSequence(ctx, row.ID, agencyLocalFriday)
+		_, resolvesSaturday := api.blockTripSequence(ctx, row.ID, mockNow)
+		return resolvesFriday && !resolvesSaturday
+	})
 	require.NotEmpty(t, blockTrip.ID,
 		"need a trip whose block resolves Friday but not Saturday in test data")
 

--- a/internal/restapi/vehicles_for_agency_handler_test.go
+++ b/internal/restapi/vehicles_for_agency_handler_test.go
@@ -465,6 +465,53 @@ func TestVehiclesForAgencyHandler_BlockTripSequenceUsesRequestedTime(t *testing.
 		"blockTripSequence must resolve using the requested `time` parameter, not api.Clock.Now()")
 }
 
+// TestVehiclesForAgencyHandler_BlockTripSequenceUsesAgencyLocalDate verifies that,
+// when no `time` parameter is supplied, blockTripSequence resolves against the
+// agency's local calendar date rather than the server clock's own timezone.
+func TestVehiclesForAgencyHandler_BlockTripSequenceUsesAgencyLocalDate(t *testing.T) {
+	// 2024-11-09 04:00 UTC is Saturday in UTC, but still Friday 20:00 in RABA's
+	// agency timezone (America/Los_Angeles, UTC-8 in November).
+	mockNow := time.Date(2024, 11, 9, 4, 0, 0, 0, time.UTC)
+	agencyLocalFriday := time.Date(2024, 11, 8, 12, 0, 0, 0, time.UTC)
+
+	api := createTestApiWithClock(t, clock.NewMockClock(mockNow))
+	defer api.Shutdown()
+	t.Cleanup(api.GtfsManager.MockResetRealTimeData)
+
+	ctx := context.Background()
+	trips, err := api.GtfsManager.GetTrips(ctx, 200)
+	require.NoError(t, err)
+
+	var blockTrip gtfsdb.Trip
+	for _, tr := range trips {
+		row, err := api.GtfsManager.GtfsDB.Queries.GetTrip(ctx, tr.ID)
+		if err != nil || !row.BlockID.Valid || row.BlockID.String == "" {
+			continue
+		}
+		_, resolvesFriday := api.blockTripSequence(ctx, tr.ID, agencyLocalFriday)
+		_, resolvesSaturday := api.blockTripSequence(ctx, tr.ID, mockNow)
+		if resolvesFriday && !resolvesSaturday {
+			blockTrip = row
+			break
+		}
+	}
+	require.NotEmpty(t, blockTrip.ID,
+		"need a trip whose block resolves Friday but not Saturday in test data")
+
+	const vehicleID = "v_block_seq_tz"
+	api.GtfsManager.MockAddVehicleWithOptions(vehicleID, blockTrip.ID, blockTrip.RouteID, gtfs.MockVehicleOptions{})
+
+	// No `time` param: the handler must localize "now" to the agency's timezone
+	// (still Friday locally), not use the un-localized UTC instant (already
+	// Saturday).
+	_, model := callAPIHandler[VehiclesForAgencyResponse](t, api, vehiclesForAgencyURL(testdata.Raba.ID))
+	entry := findVehicleStatusByID(model.Data.List, vehicleID)
+	require.NotNil(t, entry, "mock vehicle not returned by VehiclesForAgencyID")
+	require.NotNil(t, entry.TripStatus)
+	assert.GreaterOrEqual(t, entry.TripStatus.BlockTripSequence, 0,
+		"blockTripSequence must resolve against the agency's local calendar date, not the server clock's UTC date")
+}
+
 // ageFilterClock is a fixed reference time used by the ageInSeconds tests so the
 // fresh/stale vehicle timestamps are deterministic relative to api.Clock.Now().
 var ageFilterClock = time.Date(2025, 6, 8, 21, 10, 0, 0, time.UTC)

--- a/internal/restapi/vehicles_for_agency_handler_test.go
+++ b/internal/restapi/vehicles_for_agency_handler_test.go
@@ -421,6 +421,50 @@ func TestVehiclesForAgencyHandler_BlockTripSequenceUnavailable(t *testing.T) {
 		"blockTripSequence must be -1 when the sequence is unavailable")
 }
 
+// TestVehiclesForAgencyHandler_BlockTripSequenceUsesRequestedTime verifies that
+// blockTripSequence is resolved against the request's `time` parameter rather
+// than the server's wall-clock "now".
+func TestVehiclesForAgencyHandler_BlockTripSequenceUsesRequestedTime(t *testing.T) {
+	// "Now" is set far outside the RABA feed's service calendar (2024-2025), so no
+	// trip's block sequence can resolve against api.Clock.Now().
+	farFutureNow := time.Date(2030, 1, 1, 12, 0, 0, 0, time.UTC)
+	api := createTestApiWithClock(t, clock.NewMockClock(farFutureNow))
+	defer api.Shutdown()
+	t.Cleanup(api.GtfsManager.MockResetRealTimeData)
+
+	// The requested reference time, which does fall within the active service
+	// window and has a resolvable block sequence.
+	requestedTime := time.Date(2024, 11, 4, 12, 0, 0, 0, time.UTC)
+
+	ctx := context.Background()
+	trips, err := api.GtfsManager.GetTrips(ctx, 200)
+	require.NoError(t, err)
+
+	var blockTrip gtfsdb.Trip
+	for _, tr := range trips {
+		row, err := api.GtfsManager.GtfsDB.Queries.GetTrip(ctx, tr.ID)
+		if err != nil || !row.BlockID.Valid || row.BlockID.String == "" {
+			continue
+		}
+		if _, ok := api.blockTripSequence(ctx, tr.ID, requestedTime); ok {
+			blockTrip = row
+			break
+		}
+	}
+	require.NotEmpty(t, blockTrip.ID, "need a trip with a block sequence resolvable on requestedTime in test data")
+
+	const vehicleID = "v_block_seq_reftime"
+	api.GtfsManager.MockAddVehicleWithOptions(vehicleID, blockTrip.ID, blockTrip.RouteID, gtfs.MockVehicleOptions{})
+
+	params := url.Values{"time": {strconv.FormatInt(requestedTime.UnixMilli(), 10)}}
+	_, model := callAPIHandler[VehiclesForAgencyResponse](t, api, vehiclesForAgencyURL(testdata.Raba.ID, params))
+	entry := findVehicleStatusByID(model.Data.List, vehicleID)
+	require.NotNil(t, entry, "mock vehicle not returned by VehiclesForAgencyID")
+	require.NotNil(t, entry.TripStatus)
+	assert.GreaterOrEqual(t, entry.TripStatus.BlockTripSequence, 0,
+		"blockTripSequence must resolve using the requested `time` parameter, not api.Clock.Now()")
+}
+
 // ageFilterClock is a fixed reference time used by the ageInSeconds tests so the
 // fresh/stale vehicle timestamps are deterministic relative to api.Clock.Now().
 var ageFilterClock = time.Date(2025, 6, 8, 21, 10, 0, 0, time.UTC)

--- a/internal/restapi/vehicles_for_agency_handler_test.go
+++ b/internal/restapi/vehicles_for_agency_handler_test.go
@@ -15,6 +15,7 @@ import (
 	gtfsrt "github.com/OneBusAway/go-gtfs/proto"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"maglev.onebusaway.org/gtfsdb"
 	"maglev.onebusaway.org/internal/app"
 	"maglev.onebusaway.org/internal/appconf"
 	"maglev.onebusaway.org/internal/clock"
@@ -236,6 +237,73 @@ func TestVehiclesForAgencyHandler_RouteIDUsesCombinedID(t *testing.T) {
 	}
 	assert.True(t, found,
 		"expected a trip reference with routeId=%q (combined agencyID_routeID format)", expectedRouteID)
+}
+
+// findVehicleStatusByID returns the entry with the given vehicleId, or nil.
+func findVehicleStatusByID(list []models.VehicleStatus, vehicleID string) *models.VehicleStatus {
+	for i := range list {
+		if list[i].VehicleID == vehicleID {
+			return &list[i]
+		}
+	}
+	return nil
+}
+
+// TestVehiclesForAgencyHandler_BlockTripSequenceResolved verifies that a vehicle on
+// a trip with a block active on the reference date gets a resolved (>= 0) sequence.
+func TestVehiclesForAgencyHandler_BlockTripSequenceResolved(t *testing.T) {
+	// Monday within the RABA dataset's active service period.
+	serviceDate := time.Date(2024, 11, 4, 12, 0, 0, 0, time.UTC)
+	api := createTestApiWithClock(t, clock.NewMockClock(serviceDate))
+	defer api.Shutdown()
+	t.Cleanup(api.GtfsManager.MockResetRealTimeData)
+
+	ctx := context.Background()
+	trips, err := api.GtfsManager.GetTrips(ctx, 200)
+	require.NoError(t, err)
+
+	var blockTrip gtfsdb.Trip
+	for _, tr := range trips {
+		row, err := api.GtfsManager.GtfsDB.Queries.GetTrip(ctx, tr.ID)
+		if err != nil || !row.BlockID.Valid || row.BlockID.String == "" {
+			continue
+		}
+		if _, ok := api.blockTripSequence(ctx, tr.ID, serviceDate); ok {
+			blockTrip = row
+			break
+		}
+	}
+	require.NotEmpty(t, blockTrip.ID, "need a trip with a resolvable block sequence in test data")
+
+	const vehicleID = "v_block_seq"
+	api.GtfsManager.MockAddVehicleWithOptions(vehicleID, blockTrip.ID, blockTrip.RouteID, gtfs.MockVehicleOptions{})
+
+	_, model := callAPIHandler[VehiclesForAgencyResponse](t, api, vehiclesForAgencyURL(testdata.Raba.ID))
+	entry := findVehicleStatusByID(model.Data.List, vehicleID)
+	require.NotNil(t, entry, "mock vehicle not returned by VehiclesForAgencyID")
+	require.NotNil(t, entry.TripStatus)
+	assert.GreaterOrEqual(t, entry.TripStatus.BlockTripSequence, 0,
+		"blockTripSequence must be a resolved zero-based index")
+}
+
+// TestVehiclesForAgencyHandler_BlockTripSequenceUnavailable verifies that a vehicle
+// whose trip has no resolvable block sequence gets blockTripSequence = -1.
+func TestVehiclesForAgencyHandler_BlockTripSequenceUnavailable(t *testing.T) {
+	api := createTestApi(t)
+	defer api.Shutdown()
+	t.Cleanup(api.GtfsManager.MockResetRealTimeData)
+
+	trip := mustGetTrip(t, api)
+	// A synthetic trip ID that does not exist in the DB has no block.
+	const vehicleID = "v_block_seq_none"
+	api.GtfsManager.MockAddVehicleWithOptions(vehicleID, "nonexistent-trip", trip.RouteID, gtfs.MockVehicleOptions{})
+
+	_, model := callAPIHandler[VehiclesForAgencyResponse](t, api, vehiclesForAgencyURL(testdata.Raba.ID))
+	entry := findVehicleStatusByID(model.Data.List, vehicleID)
+	require.NotNil(t, entry, "mock vehicle not returned by VehiclesForAgencyID")
+	require.NotNil(t, entry.TripStatus)
+	assert.Equal(t, -1, entry.TripStatus.BlockTripSequence,
+		"blockTripSequence must be -1 when the sequence is unavailable")
 }
 
 // vehiclesRealTimeDataClock is pinned just past the latest timestamp in

--- a/internal/webui/debug_index_handler.go
+++ b/internal/webui/debug_index_handler.go
@@ -3,11 +3,13 @@ package webui
 import (
 	"context"
 	"embed"
-	"html/template"
+	"encoding/json"
+	"fmt"
+	"html"
+	"io"
 	"log/slog"
 	"net/http"
 
-	"github.com/davecgh/go-spew/spew"
 	"maglev.onebusaway.org/internal/appconf"
 )
 
@@ -20,25 +22,28 @@ type debugData struct {
 }
 
 func writeDebugData(w http.ResponseWriter, title string, data any) {
-	content := spew.Sdump(data)
-	w.Header().Set("Content-Type", "text/html")
-	tmpl, err := template.ParseFS(templateFS, "debug_index.html")
-	if err != nil {
-		slog.Error("failed to parse debug template", "error", err)
-		http.Error(w, "Internal server error", http.StatusInternalServerError)
-		return
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.WriteHeader(http.StatusOK)
+
+	fmt.Fprintf(w, "<!doctype html><html><head><meta charset=\"utf-8\"><title>%s</title></head><body>", html.EscapeString(title))
+	fmt.Fprintf(w, "<h1>%s</h1><pre>", html.EscapeString(title))
+
+	if data == nil {
+		io.WriteString(w, "nil")
+	} else {
+		switch v := data.(type) {
+		case string:
+			fmt.Fprint(w, html.EscapeString(v))
+		default:
+			if b, err := json.MarshalIndent(v, "", "  "); err == nil {
+				fmt.Fprint(w, html.EscapeString(string(b)))
+			} else {
+				fmt.Fprint(w, html.EscapeString(fmt.Sprint(v)))
+			}
+		}
 	}
 
-	dataStruct := debugData{
-		Title: title,
-		Pre:   content,
-	}
-
-	err = tmpl.Execute(w, dataStruct)
-	if err != nil {
-		slog.Error("failed to execute debug template", "error", err)
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
-	}
+	io.WriteString(w, "</pre></body></html>")
 }
 
 func (webUI *WebUI) debugIndexHandler(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
### Summary
Fixes the hardcoded `blockTripSequence` in the `vehicles-for-agency` endpoint to accurately reflect the vehicle's position, aligning with the API specification.

### Changes
* **trips_helper.go:** Extracted logic into a new `blockTripSequence` function returning `(int, bool)` to clearly differentiate between a valid zero-index and missing data.
* **vehicles_for_agency_handler.go:** Replaced the hardcoded `0` with the actual sequence. Defaults to `-1` if unavailable.
* **Tests:** Added tests for both resolved (`>= 0`) and unavailable (`-1`) block sequences.

### Why this approach?
Returning a boolean flag from the core helper allows the handler to safely emit `-1` for missing data, while the legacy wrapper continues to return `0` to avoid breaking backward compatibility for other endpoints.

Closes: #1130

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Vehicle trip status now resolves block trip sequence for each trip when possible; unavailable sequences are reported as `-1`.
  * Block sequence resolution now consistently uses the agency’s timezone/local calendar boundaries, including with a `time` query parameter.
  * Vehicles-for-agency requests now fail with a server error if the agency timezone can’t be loaded.
* **Tests**
  * Added REST API test coverage for resolvable vs unavailable sequences, requested-time behavior, and timezone boundary handling.
* **Chores**
  * Updated the debug web UI to generate proper escaped HTML output and render strings/JSON more reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->