### PR TITLE
fix: default includeTrip query parameter to true

### DIFF
--- a/internal/restapi/trips_for_location_handler.go
+++ b/internal/restapi/trips_for_location_handler.go
@@ -135,8 +135,14 @@ func (api *RestAPI) parseAndValidateRequest(r *http.Request) (
 
 	queryParams := r.URL.Query()
 
-	includeTrip = queryParams.Get("includeTrip") == "true"
-	includeSchedule = queryParams.Get("includeSchedule") == "true"
+	if queryParams.Has("includeTrip") {
+		// Ignore parsing errors and default to false if the string is completely invalid
+		includeTrip, _ = strconv.ParseBool(queryParams.Get("includeTrip"))
+	} else {
+		includeTrip = true
+	}
+
+	includeSchedule, _ = strconv.ParseBool(queryParams.Get("includeSchedule"))
 
 	agencies, agenciesErr := api.GtfsManager.GetAgencies(r.Context())
 	if agenciesErr != nil || len(agencies) == 0 {

--- a/internal/restapi/trips_for_location_handler.go
+++ b/internal/restapi/trips_for_location_handler.go
@@ -34,7 +34,7 @@ func (api *RestAPI) tripsForLocationHandler(w http.ResponseWriter, r *http.Reque
 
 	// Intentionally defaulting includeStatus to false to align with includeSchedule
 	// behavior for this endpoint, even though trips-for-route defaults to true.
-	includeStatus := r.URL.Query().Get("includeStatus") == "true"
+	includeStatus, _ := strconv.ParseBool(r.URL.Query().Get("includeStatus"))
 	// Note: re-deriving currentTime here rather than returning it from parseAndValidateRequest(line: 150)
 	currentTime := api.Clock.Now().In(currentLocation)
 

--- a/internal/restapi/trips_for_location_handler.go
+++ b/internal/restapi/trips_for_location_handler.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"net/http"
+	"net/url"
 	"strconv"
 	"time"
 
@@ -143,13 +144,7 @@ func (api *RestAPI) parseAndValidateRequest(r *http.Request) (
 
 	queryParams := r.URL.Query()
 
-	if queryParams.Has("includeTrip") {
-		// Ignore parsing errors and default to false if the string is completely invalid
-		includeTrip, _ = strconv.ParseBool(queryParams.Get("includeTrip"))
-	} else {
-		includeTrip = true
-	}
-
+	includeTrip = parseIncludeTrip(queryParams)
 	includeSchedule, _ = strconv.ParseBool(queryParams.Get("includeSchedule"))
 
 	agencies, agenciesErr := api.GtfsManager.GetAgencies(r.Context())
@@ -163,21 +158,9 @@ func (api *RestAPI) parseAndValidateRequest(r *http.Request) (
 		return nil, false, false, nil, time.Time{}, time.Time{}, time.Time{}, nil, serverErr
 	}
 
-	timeParam := queryParams.Get("time")
-	if timeParam == "" {
-		currentTime = api.Clock.Now().In(currentLocation)
-	} else {
-		var timeFieldErrors map[string][]string
-		_, currentTime, timeFieldErrors, _ = utils.ParseTimeParameter(timeParam, currentLocation)
-		if len(timeFieldErrors) > 0 {
-			if fieldErrors == nil {
-				fieldErrors = make(map[string][]string)
-			}
-			for k, v := range timeFieldErrors {
-				fieldErrors[k] = append(fieldErrors[k], v...)
-			}
-		}
-	}
+	var timeFieldErrors map[string][]string
+	currentTime, timeFieldErrors = api.resolveCurrentTime(queryParams.Get("time"), currentLocation)
+	fieldErrors = mergeFieldErrors(fieldErrors, timeFieldErrors)
 
 	serviceDate, todayMidnight = utils.ServiceDateMidnight(nil, currentTime)
 
@@ -186,6 +169,40 @@ func (api *RestAPI) parseAndValidateRequest(r *http.Request) (
 	}
 
 	return loc, includeTrip, includeSchedule, currentLocation, currentTime, todayMidnight, serviceDate, nil, nil
+}
+
+// parseIncludeTrip parses the includeTrip query parameter, defaulting to true when omitted
+// and to false when present but not a valid boolean.
+func parseIncludeTrip(queryParams url.Values) bool {
+	if !queryParams.Has("includeTrip") {
+		return true
+	}
+	includeTrip, _ := strconv.ParseBool(queryParams.Get("includeTrip"))
+	return includeTrip
+}
+
+// resolveCurrentTime resolves the query time: the explicit time parameter if supplied,
+// otherwise the current server clock.
+func (api *RestAPI) resolveCurrentTime(timeParam string, currentLocation *time.Location) (time.Time, map[string][]string) {
+	if timeParam == "" {
+		return api.Clock.Now().In(currentLocation), nil
+	}
+	_, currentTime, timeFieldErrors, _ := utils.ParseTimeParameter(timeParam, currentLocation)
+	return currentTime, timeFieldErrors
+}
+
+// mergeFieldErrors appends src's entries onto dst, allocating dst if necessary.
+func mergeFieldErrors(dst, src map[string][]string) map[string][]string {
+	if len(src) == 0 {
+		return dst
+	}
+	if dst == nil {
+		dst = make(map[string][]string)
+	}
+	for k, v := range src {
+		dst[k] = append(dst[k], v...)
+	}
+	return dst
 }
 
 func extractStopIDs(stops []gtfsdb.Stop) []string {

--- a/internal/restapi/trips_for_location_handler_test.go
+++ b/internal/restapi/trips_for_location_handler_test.go
@@ -163,16 +163,24 @@ func TestTripsForLocationHandler_StatusInclusion(t *testing.T) {
 	time.Sleep(500 * time.Millisecond)
 
 	tests := []struct {
-		name          string
-		includeStatus bool
+		name           string
+		statusParam    string
+		expectedStatus bool
 	}{
-		{name: "With Status", includeStatus: true},
-		{name: "Without Status", includeStatus: false},
+		{name: "With Status (Explicit true)", statusParam: "includeStatus=true", expectedStatus: true},
+		{name: "With Status (Integer 1)", statusParam: "includeStatus=1", expectedStatus: true},
+		{name: "With Status (Uppercase TRUE)", statusParam: "includeStatus=TRUE", expectedStatus: true},
+		{name: "Without Status (Explicit false)", statusParam: "includeStatus=false", expectedStatus: false},
+		{name: "Without Status (Invalid value)", statusParam: "includeStatus=invalid_value", expectedStatus: false},
+		{name: "Without Status (Default/Omitted)", statusParam: "", expectedStatus: false},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			url := tripsForLocationURL(0.2, 0.2, fmt.Sprintf("includeStatus=%v", tt.includeStatus))
+			url := tripsForLocationURL(0.2, 0.2)
+			if tt.statusParam != "" {
+				url += "&" + tt.statusParam
+			}
 
 			resp, model := callAPIHandler[TripsForLocationResponse](t, api, url)
 
@@ -180,12 +188,12 @@ func TestTripsForLocationHandler_StatusInclusion(t *testing.T) {
 			require.NotEmpty(t, model.Data.List, "expected at least one trip in the response to verify status behavior")
 
 			for _, entry := range model.Data.List {
-				if tt.includeStatus {
-					if assert.NotNil(t, entry.Status, "expected status when includeStatus=true") {
+				if tt.expectedStatus {
+					if assert.NotNil(t, entry.Status, "expected status when includeStatus=true/1/TRUE") {
 						assert.NotEmpty(t, entry.Status.Phase)
 					}
 				} else {
-					assert.Nil(t, entry.Status, "expected status to be omitted when includeStatus=false")
+					assert.Nil(t, entry.Status, "expected status to be omitted when includeStatus=false/invalid/omitted")
 				}
 			}
 		})

--- a/internal/restapi/trips_for_location_handler_test.go
+++ b/internal/restapi/trips_for_location_handler_test.go
@@ -3,6 +3,7 @@ package restapi
 import (
 	"fmt"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -85,6 +86,7 @@ func TestTripsForLocationHandler_ReferencesAreConsistent(t *testing.T) {
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 	refs := model.Data.References
 	require.NotEmpty(t, refs.Stops, "expected stops in references")
+	require.NotEmpty(t, refs.Trips, "expected trips in references because includeTrip defaults to true when omitted")
 
 	routeIDs := make(map[string]bool, len(refs.Routes))
 	for _, r := range refs.Routes {
@@ -111,6 +113,12 @@ func TestTripsForLocationHandler_ReferencesAreConsistent(t *testing.T) {
 	for _, route := range refs.Routes {
 		assert.True(t, agencyIDs[route.AgencyID],
 			"agency %q referenced by route %q must appear in references.agencies", route.AgencyID, route.ID)
+	}
+
+	for _, trip := range refs.Trips {
+		assert.NotEmpty(t, trip.ID, "trip with empty ID found in references")
+		assert.Contains(t, trip.ID, "_", "trip ID %q should be in {agencyID}_{rawID} format", trip.ID)
+		assert.True(t, routeIDs[trip.RouteID], "route %q referenced by trip %q must appear in references.routes", trip.RouteID, trip.ID)
 	}
 }
 
@@ -203,6 +211,86 @@ func TestTripsForLocationHandler_MissingParameters(t *testing.T) {
 
 			assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 			assert.Equal(t, http.StatusBadRequest, model.Code)
+		})
+	}
+}
+
+func TestTripsForLocationHandler_ParseAndValidateRequest(t *testing.T) {
+	api := createTestApi(t)
+	defer api.Shutdown()
+
+	tests := []struct {
+		name                string
+		queryString         string
+		expectedIncludeTrip bool
+	}{
+		{
+			name:                "includeTrip omitted defaults to true",
+			queryString:         "lat=40.5865&lon=-122.3917&latSpan=0.1&lonSpan=0.1",
+			expectedIncludeTrip: true,
+		},
+		{
+			name:                "includeTrip=false returns false",
+			queryString:         "lat=40.5865&lon=-122.3917&latSpan=0.1&lonSpan=0.1&includeTrip=false",
+			expectedIncludeTrip: false,
+		},
+		{
+			name:                "includeTrip=true returns true",
+			queryString:         "lat=40.5865&lon=-122.3917&latSpan=0.1&lonSpan=0.1&includeTrip=true",
+			expectedIncludeTrip: true,
+		},
+		{
+			name:                "includeTrip=invalid_value safely defaults to false",
+			queryString:         "lat=40.5865&lon=-122.3917&latSpan=0.1&lonSpan=0.1&includeTrip=invalid_value",
+			expectedIncludeTrip: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/api/where/trips-for-location.json?"+tt.queryString, nil)
+
+			_, includeTrip, _, _, _, _, fieldErrors, err := api.parseAndValidateRequest(req)
+
+			assert.Empty(t, fieldErrors)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expectedIncludeTrip, includeTrip)
+		})
+	}
+}
+
+func TestTripsForLocationHandler_TripInclusion(t *testing.T) {
+	api, cleanup := createTestApiWithRealTimeData(t, clock.RealClock{})
+	defer cleanup()
+
+	time.Sleep(500 * time.Millisecond)
+
+	tests := []struct {
+		name         string
+		includeParam string
+		expected     bool
+	}{
+		{name: "With Trip (Default/Omitted)", includeParam: "", expected: true},
+		{name: "With Trip (Explicit true)", includeParam: "includeTrip=true", expected: true},
+		{name: "Without Trip (Explicit false)", includeParam: "includeTrip=false", expected: false},
+		{name: "Without Trip (Invalid value)", includeParam: "includeTrip=invalid_value", expected: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			url := tripsForLocationURL(2.0, 3.0, "includeSchedule=true")
+			if tt.includeParam != "" {
+				url += "&" + tt.includeParam
+			}
+
+			resp, model := callAPIHandler[TripsForLocationResponse](t, api, url)
+
+			assert.Equal(t, http.StatusOK, resp.StatusCode)
+			if tt.expected {
+				assert.NotEmpty(t, model.Data.References.Trips, "trips should be present in references when includeTrip is true or omitted")
+			} else {
+				assert.Empty(t, model.Data.References.Trips, "trips should be omitted when includeTrip=false or invalid")
+			}
 		})
 	}
 }


### PR DESCRIPTION
**Description**
This PR updates `/api/where/trips-for-location.json` to comply with the OneBusAway specification and improves boolean query parameter extraction.

**Changes:**
* Defaults `includeTrip` to `true` when the query parameter is omitted.
* Uses `strconv.ParseBool` for robust boolean parsing of `includeTrip`, `includeSchedule`, and `includeStatus` (handling `"true"`, `"1"`, `"TRUE"`, etc.).
* Adds unit and integration tests to verify parameter extraction and trip reference inclusion across valid, invalid, and default values.

Closes #1135

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Trip results are now included by default when the trip-inclusion query parameter is omitted.
  * Boolean query parameters for trip, schedule, and status inclusion now accept common truthy values (and treat missing/invalid values as false).

* **Tests**
  * Expanded handler tests to cover query parsing, reference consistency, and correct inclusion/exclusion behavior for default, explicit, and invalid parameter values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
