### PR TITLE
Support includeReferences query parameter in trips-for-location

### DIFF
--- a/internal/restapi/trips_for_location_handler.go
+++ b/internal/restapi/trips_for_location_handler.go
@@ -113,11 +113,18 @@ func (api *RestAPI) tripsForLocationHandler(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	references := api.BuildReference(w, r, ctx, ReferenceParams{
-		IncludeTrip: includeTrip,
-		Stops:       stops,
-		Trips:       result,
-	})
+	references := *models.NewEmptyReferences()
+
+	includeReferences := ShouldIncludeReferences(r)
+
+	if includeReferences {
+		references = api.BuildReference(w, r, ctx, ReferenceParams{
+			IncludeTrip: includeTrip,
+			Stops:       stops,
+			Trips:       result,
+		})
+	}
+
 	response := models.NewListResponseWithRange(result, references, api.GtfsManager.CheckIfOutOfBounds(locationParams), api.Clock, false)
 	api.sendResponse(w, r, response)
 }

--- a/internal/restapi/trips_for_location_handler_test.go
+++ b/internal/restapi/trips_for_location_handler_test.go
@@ -206,3 +206,36 @@ func TestTripsForLocationHandler_MissingParameters(t *testing.T) {
 		})
 	}
 }
+
+func TestTripsForLocationHandler_IncludeReferences(t *testing.T) {
+	api, cleanup := createTestApiWithRealTimeData(t, clock.RealClock{})
+	defer cleanup()
+
+	time.Sleep(500 * time.Millisecond)
+
+	// Verify standard behavior (includeReferences=true implicitly)
+	urlTrue := tripsForLocationURL(2.0, 3.0, "includeSchedule=true")
+	respTrue, modelTrue := callAPIHandler[TripsForLocationResponse](t, api, urlTrue)
+	require.Equal(t, http.StatusOK, respTrue.StatusCode)
+	require.NotEmpty(t, modelTrue.Data.List, "list must be populated when includeReferences is true or absent")
+	assert.NotEmpty(t, modelTrue.Data.References.Stops, "Stops should be populated when includeReferences is true or absent")
+	assert.NotEmpty(t, modelTrue.Data.References.Routes, "Routes should be populated when includeReferences is true or absent")
+	assert.NotEmpty(t, modelTrue.Data.References.Agencies, "Agencies should be populated when includeReferences is true or absent")
+
+	// Verify explicit includeReferences=false behavior
+	urlFalse := tripsForLocationURL(2.0, 3.0, "includeSchedule=true", "includeReferences=false")
+	respFalse, modelFalse := callAPIHandler[TripsForLocationResponse](t, api, urlFalse)
+	require.Equal(t, http.StatusOK, respFalse.StatusCode)
+
+	// Ensure the list of trip entries is preserved and matches standard behavior
+	assert.NotEmpty(t, modelFalse.Data.List, "list must still be populated when includeReferences=false")
+	assert.Equal(t, len(modelTrue.Data.List), len(modelFalse.Data.List), "list length must match whether includeReferences is true or false")
+
+	// Verify the references object is present but all arrays are empty (as per spec)
+	assert.Empty(t, modelFalse.Data.References.Agencies, "Agencies must be empty when includeReferences=false")
+	assert.Empty(t, modelFalse.Data.References.Routes, "Routes must be empty when includeReferences=false")
+	assert.Empty(t, modelFalse.Data.References.Stops, "Stops must be empty when includeReferences=false")
+	assert.Empty(t, modelFalse.Data.References.StopTimes, "StopTimes must be empty when includeReferences=false")
+	assert.Empty(t, modelFalse.Data.References.Trips, "Trips must be empty when includeReferences=false")
+	assert.Empty(t, modelFalse.Data.References.Situations, "Situations must be empty when includeReferences=false")
+}


### PR DESCRIPTION


### Summary
This PR adds support for the `includeReferences` query parameter to the `/api/where/trips-for-location.json` endpoint, aligning it with the Wiki API Spec.

### Changes Made
- **Handler (`internal/restapi/trips_for_location_handler.go`)**: Checked `ShouldIncludeReferences(r)` before constructing the reference payload. When `includeReferences=false` is passed, the endpoint skips database reference collection and returns empty reference arrays (`[]`) while preserving the `list` of trip entries.
- **Tests (`internal/restapi/trips_for_location_handler_test.go`)**: Added `TestTripsForLocationHandler_IncludeReferences` to verify both implicit `true` (standard behavior) and explicit `false` query responses.

### Verification
- Verified via unit tests 

Closes #1136


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Trip results for a location now return reference data only when requested, keeping responses lighter by default.
  * When reference data is not included, the response still contains an empty references section for consistency.
* **Tests**
  * Added coverage for trip-by-location responses with references enabled, omitted, and explicitly disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->