### PR TITLE
fix(restapi): honor time query parameter in trips-for-location

### DIFF
--- a/internal/restapi/trips_for_location_handler.go
+++ b/internal/restapi/trips_for_location_handler.go
@@ -137,7 +137,9 @@ func (api *RestAPI) parseAndValidateRequest(r *http.Request) (
 	fieldErrors map[string][]string,
 	serverErr error,
 ) {
-	loc, fieldErrors := api.parseLocationParams(r, nil)
+
+	var loc *internalgtfs.LocationParams
+	loc, fieldErrors = api.parseLocationParams(r, nil)
 
 	queryParams := r.URL.Query()
 

--- a/internal/restapi/trips_for_location_handler.go
+++ b/internal/restapi/trips_for_location_handler.go
@@ -22,7 +22,7 @@ import (
 func (api *RestAPI) tripsForLocationHandler(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
-	locationParams, includeTrip, includeSchedule, currentLocation, todayMidnight, serviceDate, fieldErrors, err := api.parseAndValidateRequest(r)
+	locationParams, includeTrip, includeSchedule, currentLocation, currentTime, todayMidnight, serviceDate, fieldErrors, err := api.parseAndValidateRequest(r)
 	if len(fieldErrors) > 0 {
 		api.validationErrorResponse(w, r, fieldErrors)
 		return
@@ -35,8 +35,6 @@ func (api *RestAPI) tripsForLocationHandler(w http.ResponseWriter, r *http.Reque
 	// Intentionally defaulting includeStatus to false to align with includeSchedule
 	// behavior for this endpoint, even though trips-for-route defaults to true.
 	includeStatus := r.URL.Query().Get("includeStatus") == "true"
-	// Note: re-deriving currentTime here rather than returning it from parseAndValidateRequest(line: 150)
-	currentTime := api.Clock.Now().In(currentLocation)
 
 	stops := api.GtfsManager.GetStopsInBounds(ctx, locationParams, 100)
 	stopIDs := extractStopIDs(stops)
@@ -126,6 +124,7 @@ func (api *RestAPI) parseAndValidateRequest(r *http.Request) (
 	location *internalgtfs.LocationParams,
 	includeTrip, includeSchedule bool,
 	currentLocation *time.Location,
+	currentTime time.Time,
 	todayMidnight time.Time,
 	serviceDate time.Time,
 	fieldErrors map[string][]string,
@@ -140,35 +139,39 @@ func (api *RestAPI) parseAndValidateRequest(r *http.Request) (
 
 	agencies, agenciesErr := api.GtfsManager.GetAgencies(r.Context())
 	if agenciesErr != nil || len(agencies) == 0 {
-		return nil, false, false, nil, time.Time{}, time.Time{}, nil, errors.New("no agencies configured in GTFS manager")
+		return nil, false, false, nil, time.Time{}, time.Time{}, time.Time{}, nil, errors.New("no agencies configured in GTFS manager")
 	}
 
 	currentAgency := agencies[0]
 	currentLocation, serverErr = loadAgencyLocation(currentAgency.ID, currentAgency.Timezone)
 	if serverErr != nil {
-		return nil, false, false, nil, time.Time{}, time.Time{}, nil, serverErr
+		return nil, false, false, nil, time.Time{}, time.Time{}, time.Time{}, nil, serverErr
 	}
 
 	timeParam := queryParams.Get("time")
-	currentTime := api.Clock.Now().In(currentLocation)
-	todayMidnight = time.Date(currentTime.Year(), currentTime.Month(), currentTime.Day(), 0, 0, 0, 0, currentLocation)
-
-	var timeFieldErrors map[string][]string
-	_, serviceDate, timeFieldErrors, _ = utils.ParseTimeParameter(timeParam, currentLocation)
-	if len(timeFieldErrors) > 0 {
-		if fieldErrors == nil {
-			fieldErrors = make(map[string][]string)
-		}
-		for k, v := range timeFieldErrors {
-			fieldErrors[k] = append(fieldErrors[k], v...)
+	if timeParam == "" {
+		currentTime = api.Clock.Now().In(currentLocation)
+	} else {
+		var timeFieldErrors map[string][]string
+		_, currentTime, timeFieldErrors, _ = utils.ParseTimeParameter(timeParam, currentLocation)
+		if len(timeFieldErrors) > 0 {
+			if fieldErrors == nil {
+				fieldErrors = make(map[string][]string)
+			}
+			for k, v := range timeFieldErrors {
+				fieldErrors[k] = append(fieldErrors[k], v...)
+			}
 		}
 	}
+
+	todayMidnight = time.Date(currentTime.Year(), currentTime.Month(), currentTime.Day(), 0, 0, 0, 0, currentLocation)
+	serviceDate = todayMidnight
 
 	if len(fieldErrors) > 0 {
-		return nil, false, false, nil, time.Time{}, time.Time{}, fieldErrors, nil
+		return nil, false, false, nil, time.Time{}, time.Time{}, time.Time{}, fieldErrors, nil
 	}
 
-	return loc, includeTrip, includeSchedule, currentLocation, todayMidnight, serviceDate, nil, nil
+	return loc, includeTrip, includeSchedule, currentLocation, currentTime, todayMidnight, serviceDate, nil, nil
 }
 
 func extractStopIDs(stops []gtfsdb.Stop) []string {

--- a/internal/restapi/trips_for_location_handler.go
+++ b/internal/restapi/trips_for_location_handler.go
@@ -171,8 +171,7 @@ func (api *RestAPI) parseAndValidateRequest(r *http.Request) (
 		}
 	}
 
-	todayMidnight = time.Date(currentTime.Year(), currentTime.Month(), currentTime.Day(), 0, 0, 0, 0, currentLocation)
-	serviceDate = todayMidnight
+	serviceDate, todayMidnight = utils.ServiceDateMidnight(nil, currentTime)
 
 	if len(fieldErrors) > 0 {
 		return nil, false, false, nil, time.Time{}, time.Time{}, time.Time{}, fieldErrors, nil

--- a/internal/restapi/trips_for_location_handler_test.go
+++ b/internal/restapi/trips_for_location_handler_test.go
@@ -206,3 +206,37 @@ func TestTripsForLocationHandler_MissingParameters(t *testing.T) {
 		})
 	}
 }
+
+func TestTripsForLocationHandler_TimeParameter(t *testing.T) {
+	api, cleanup := createTestApiWithRealTimeData(t, clock.RealClock{})
+	defer cleanup()
+
+	time.Sleep(500 * time.Millisecond)
+
+	t.Run("Valid Time Parameter", func(t *testing.T) {
+		loc, err := time.LoadLocation("America/Los_Angeles")
+		require.NoError(t, err)
+
+		targetTime := time.Date(2025, 6, 15, 14, 30, 0, 0, loc)
+		targetMidnight := time.Date(targetTime.Year(), targetTime.Month(), targetTime.Day(), 0, 0, 0, 0, loc)
+		url := tripsForLocationURL(1.0, 1.0, fmt.Sprintf("includeStatus=true&time=%d", targetTime.UnixMilli()))
+
+		resp, model := callAPIHandler[TripsForLocationResponse](t, api, url)
+
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		for _, entry := range model.Data.List {
+			assert.Equal(t, targetMidnight.UnixMilli(), entry.ServiceDate, "entry.ServiceDate should match midnight of the requested time parameter")
+			if entry.Status != nil {
+				assert.Equal(t, targetMidnight.UnixMilli(), entry.Status.ServiceDate.UnixMilli(), "entry.Status.ServiceDate should match midnight of the requested time parameter")
+			}
+		}
+	})
+
+	t.Run("Invalid Time Parameter", func(t *testing.T) {
+		url := tripsForLocationURL(1.0, 1.0, "time=invalid-time-format")
+		resp, model := callAPIHandler[TripsForLocationResponse](t, api, url)
+
+		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+		assert.Equal(t, http.StatusBadRequest, model.Code)
+	})
+}

--- a/internal/restapi/trips_for_location_handler_test.go
+++ b/internal/restapi/trips_for_location_handler_test.go
@@ -224,6 +224,7 @@ func TestTripsForLocationHandler_TimeParameter(t *testing.T) {
 		resp, model := callAPIHandler[TripsForLocationResponse](t, api, url)
 
 		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		require.NotEmpty(t, model.Data.List, "expected at least one trip entry to verify ServiceDate")
 		for _, entry := range model.Data.List {
 			assert.Equal(t, targetMidnight.UnixMilli(), entry.ServiceDate, "entry.ServiceDate should match midnight of the requested time parameter")
 			if entry.Status != nil {


### PR DESCRIPTION
## Summary
Resolves a specification gap where the `/api/where/trips-for-location.json` endpoint parsed the optional `time` query parameter but ignored it during vehicle status and position calculations, defaulting to live server wall-clock time.

## Changes
- **Parameter Propagation**: Updated `parseAndValidateRequest` to return the target `currentTime` (and derived `serviceDate` / `todayMidnight`) when `time` is provided.
- **Handler Fix**: Removed the wall-clock override (`api.Clock.Now()`) in `tripsForLocationHandler` so `buildTripsForLocationEntries` and `BuildTripStatus` evaluate vehicle offsets and stale-data checks against the requested timestamp.
- **Unit Testing**: Added `TestTripsForLocationHandler_TimeParameter` to assert accurate `ServiceDate` calculations and verify `HTTP 400 Bad Request` responses for malformed time parameters.

## Verification
- Ran `make test`

closes #1137 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the trips-for-location endpoint’s handling of the `time` query so trip service dates correctly match the requested local day (midnight).
  * Invalid `time` values now return a consistent HTTP 400 response.
  * When status details are included, the status service-date fields also align with the computed local midnight.
* **Tests**
  * Added coverage to validate correct behavior for both valid and invalid `time` query values on the trips-for-location endpoint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->