### PR TITLE
Use go vet instead of golangci-lint for make lint

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ All commands are managed through the Makefile:
 - `make build` - Build the application binary to `bin/maglev`
 - `make test` - Run all tests
 - `make load-test` - Run smoketest and stresstest (k6)
-- `make lint` - Run golangci-lint (requires: `go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest`)
+- `make lint` - Run `go vet`
 - `make coverage` - Generate test coverage report with HTML output
 - `make coverage-report` - Output per-package test coverage as JSON for CI parsing (requires jq)
 - `make models` - Regenerate sqlc models from SQL queries

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ LDFLAGS := -ldflags "-X 'maglev.onebusaway.org/internal/buildinfo.CommitHash=$(G
                     -X 'maglev.onebusaway.org/internal/buildinfo.Host=$(BUILD_HOST)'"
 
 .PHONY: build build-debug clean coverage-report check-jq check-k6 coverage test run lint watch fmt \
-        gtfstidy models check-golangci-lint \
+        gtfstidy models \
         test-latency bench-sqlite-all bench-sqlite-perftest \
         docker-build docker-push docker-run docker-stop docker-compose-up docker-compose-down docker-compose-dev docker-clean docker-clean-all \
         update-openapi check-openapi \
@@ -75,11 +75,8 @@ coverage:
 	$(SET_ENV) go test -tags "$(BUILD_TAGS)" -coverprofile=coverage.out ./...
 	go tool cover -html=coverage.out
 
-check-golangci-lint:
-	@which golangci-lint > /dev/null 2>&1 || (echo "Error: golangci-lint is not installed. Please install it by running: go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest" && exit 1)
-
-lint: check-golangci-lint
-	golangci-lint run --build-tags "$(BUILD_TAGS)"
+lint:
+	$(SET_ENV) go vet -tags "$(BUILD_TAGS)" ./...
 
 fmt:
 	go fmt ./...


### PR DESCRIPTION
## Summary
- Switches the `lint` Makefile target from `golangci-lint run` to `go vet`, so `make lint` works out of the box with just the Go toolchain instead of requiring a separate golangci-lint install.
- Updates the `make lint` description in CLAUDE.md to match.

## Test plan
- [x] `make lint` runs `go vet` and passes cleanly