### PR TITLE
refactor: migrate remaining models.NewAgencyReference call sites to models.AgencyReferenceFromDatabase

### DIFF
--- a/internal/restapi/arrival_and_departure_for_stop_handler.go
+++ b/internal/restapi/arrival_and_departure_for_stop_handler.go
@@ -403,35 +403,13 @@ func (api *RestAPI) arrivalAndDepartureForStopHandler(w http.ResponseWriter, r *
 	references := models.NewEmptyReferences()
 
 	// Add Stop Agency Reference
-	references.Agencies = append(references.Agencies, models.NewAgencyReference(
-		stopAgency.ID,
-		stopAgency.Name,
-		stopAgency.Url,
-		stopAgency.Timezone,
-		stopAgency.Lang.String,
-		stopAgency.Phone.String,
-		stopAgency.Email.String,
-		stopAgency.FareUrl.String,
-		"",
-		false,
-	))
+	references.Agencies = append(references.Agencies, models.AgencyReferenceFromDatabase(&stopAgency))
 
 	// Add Route Agency Reference if different from Stop Agency
 	if route.AgencyID != stopAgency.ID {
 		routeAgency, err := api.GtfsManager.GtfsDB.Queries.GetAgency(ctx, route.AgencyID)
 		if err == nil {
-			references.Agencies = append(references.Agencies, models.NewAgencyReference(
-				routeAgency.ID,
-				routeAgency.Name,
-				routeAgency.Url,
-				routeAgency.Timezone,
-				routeAgency.Lang.String,
-				routeAgency.Phone.String,
-				routeAgency.Email.String,
-				routeAgency.FareUrl.String,
-				"",
-				false,
-			))
+			references.Agencies = append(references.Agencies, models.AgencyReferenceFromDatabase(&routeAgency))
 		} else {
 			api.Logger.Warn("failed to fetch route agency for reference", "agencyID", route.AgencyID, "error", err)
 		}

--- a/internal/restapi/arrivals_and_departures_for_stop_handler.go
+++ b/internal/restapi/arrivals_and_departures_for_stop_handler.go
@@ -122,10 +122,7 @@ func (api *RestAPI) arrivalsAndDeparturesForStopHandler(w http.ResponseWriter, r
 	references := models.NewEmptyReferences()
 
 	// Add the stop's agency to references immediately
-	references.Agencies = append(references.Agencies, models.NewAgencyReference(
-		agency.ID, agency.Name, agency.Url, agency.Timezone, agency.Lang.String,
-		agency.Phone.String, agency.Email.String, agency.FareUrl.String, "", false,
-	))
+	references.Agencies = append(references.Agencies, models.AgencyReferenceFromDatabase(&agency))
 
 	// Track which agencies we have already added to avoid duplicates
 	addedAgencyIDs := make(map[string]bool)
@@ -589,10 +586,7 @@ func (api *RestAPI) arrivalsAndDeparturesForStopHandler(w http.ResponseWriter, r
 		if !addedAgencyIDs[route.AgencyID] {
 			routeAgency, err := api.GtfsManager.GtfsDB.Queries.GetAgency(ctx, route.AgencyID)
 			if err == nil {
-				references.Agencies = append(references.Agencies, models.NewAgencyReference(
-					routeAgency.ID, routeAgency.Name, routeAgency.Url, routeAgency.Timezone, routeAgency.Lang.String,
-					routeAgency.Phone.String, routeAgency.Email.String, routeAgency.FareUrl.String, "", false,
-				))
+				references.Agencies = append(references.Agencies, models.AgencyReferenceFromDatabase(&routeAgency))
 				addedAgencyIDs[route.AgencyID] = true
 			} else {
 				api.Logger.Warn("failed to fetch route agency for reference", "agencyID", route.AgencyID, "error", err)

--- a/internal/restapi/schedule_for_route_handler.go
+++ b/internal/restapi/schedule_for_route_handler.go
@@ -67,18 +67,7 @@ func (api *RestAPI) scheduleForRouteHandler(w http.ResponseWriter, r *http.Reque
 		scheduleDate = startOfDay.UnixMilli()
 	}
 
-	agencyModel := models.NewAgencyReference(
-		agency.ID,
-		agency.Name,
-		agency.Url,
-		agency.Timezone,
-		agency.Lang.String,
-		agency.Phone.String,
-		agency.Email.String,
-		agency.FareUrl.String,
-		"",
-		false,
-	)
+	agencyModel := models.AgencyReferenceFromDatabase(&agency)
 	routeModel := models.NewRoute(
 		utils.FormCombinedID(agencyID, route.ID),
 		route.AgencyID,

--- a/internal/restapi/trip_details_handler.go
+++ b/internal/restapi/trip_details_handler.go
@@ -323,18 +323,7 @@ func (api *RestAPI) tripDetailsHandler(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 
-		agencyModel := models.NewAgencyReference(
-			agency.ID,
-			agency.Name,
-			agency.Url,
-			agency.Timezone,
-			agency.Lang.String,
-			agency.Phone.String,
-			agency.Email.String,
-			agency.FareUrl.String,
-			"",
-			false,
-		)
+		agencyModel := models.AgencyReferenceFromDatabase(&agency)
 		references.Agencies = append(references.Agencies, agencyModel)
 
 		if len(situationsIDs) > 0 {

--- a/internal/restapi/trip_for_vehicle_handler.go
+++ b/internal/restapi/trip_for_vehicle_handler.go
@@ -128,18 +128,7 @@ func (api *RestAPI) tripForVehicleHandler(w http.ResponseWriter, r *http.Request
 	// Build references
 	references := models.NewEmptyReferences()
 
-	agencyModel := models.NewAgencyReference(
-		agency.ID,
-		agency.Name,
-		agency.Url,
-		agency.Timezone,
-		agency.Lang.String,
-		agency.Phone.String,
-		agency.Email.String,
-		agency.FareUrl.String,
-		"",
-		false,
-	)
+	agencyModel := models.AgencyReferenceFromDatabase(&agency)
 
 	stopIDs := []string{}
 

--- a/internal/restapi/trip_handler.go
+++ b/internal/restapi/trip_handler.go
@@ -86,18 +86,7 @@ func (api *RestAPI) tripHandler(w http.ResponseWriter, r *http.Request) {
 			route.Color.String,
 			route.TextColor.String))
 
-		references.Agencies = append(references.Agencies, models.NewAgencyReference(
-			agency.ID,
-			agency.Name,
-			agency.Url,
-			agency.Timezone,
-			agency.Lang.String,
-			agency.Phone.String,
-			agency.Email.String,
-			agency.FareUrl.String,
-			"",
-			false,
-		))
+		references.Agencies = append(references.Agencies, models.AgencyReferenceFromDatabase(&agency))
 	}
 
 	api.sendResponse(w, r, models.NewEntryResponse(tripResponse, *references, api.Clock))

--- a/internal/restapi/trips_for_location_handler.go
+++ b/internal/restapi/trips_for_location_handler.go
@@ -659,18 +659,7 @@ func (rb *referenceBuilder) collectAgenciesAndRoutes() error {
 	}
 
 	for _, agency := range agencies {
-		rb.presentAgencies[agency.ID] = models.NewAgencyReference(
-			agency.ID,
-			agency.Name,
-			agency.Url,
-			agency.Timezone,
-			agency.Lang.String,
-			agency.Phone.String,
-			agency.Email.String,
-			agency.FareUrl.String,
-			"",
-			false,
-		)
+		rb.presentAgencies[agency.ID] = models.AgencyReferenceFromDatabase(&agency)
 	}
 	return nil
 }

--- a/internal/utils/filters.go
+++ b/internal/utils/filters.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"context"
+
 	"maglev.onebusaway.org/gtfsdb"
 	"maglev.onebusaway.org/internal/models"
 )
@@ -12,11 +13,7 @@ func FilterAgencies(all []gtfsdb.Agency, present map[string]bool) []models.Agenc
 	var refs []models.AgencyReference
 	for _, a := range all {
 		if present[a.ID] {
-			refs = append(refs, models.NewAgencyReference(
-				a.ID, a.Name, a.Url, a.Timezone,
-				a.Lang.String, a.Phone.String, a.Email.String, a.FareUrl.String,
-				"", false,
-			))
+			refs = append(refs, models.AgencyReferenceFromDatabase(&a))
 		}
 	}
 	return refs


### PR DESCRIPTION
## Summary
Migrates call sites from manual field mapping with `models.NewAgencyReference` to the 
`AgencyReferenceFromDatabase` helper, following the pattern in `stops_for_route_handler.go`.

Closes #1150

## Changes
Changed the files specified in #1150 to call `models.AgencyReferenceFromDatabase()` (passing a 
pointer to a gtfsdb.Agency value as appropriate). instead of manually passing the 8 individual fields 
to the previously used `models.NewAgencyReference`

## Verification
Verified affected unit tests pass.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency of agency information across arrival, departure, schedule, trip, and location responses.
  * Ensured agency references are populated uniformly, including contact, fare, language, and timezone details.
  * Reduced discrepancies caused by manually mapped agency fields in API responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->