### PR TITLE
fix: correct FTS stop search ordering and limitExceeded boundary logic

### DIFF
--- a/gtfsdb/fts_queries.go
+++ b/gtfsdb/fts_queries.go
@@ -95,7 +95,7 @@ FROM stops s
 JOIN stops_fts fts
   ON s.rowid = fts.rowid
 WHERE fts.stop_name MATCH ?
-ORDER BY s.name
+ORDER BY s.id
 LIMIT ?
 `
 

--- a/gtfsdb/fts_queries_test.go
+++ b/gtfsdb/fts_queries_test.go
@@ -246,16 +246,18 @@ func TestSearchStopsByName(t *testing.T) {
 		assert.Len(t, results, 3)
 	})
 
-	t.Run("results ordered alphabetically", func(t *testing.T) {
+	t.Run("results follow lexicographic ordering by stop ID", func(t *testing.T) {
 		results, err := client.Queries.SearchStopsByName(ctx, SearchStopsByNameParams{
 			SearchQuery: "Main",
 			Limit:       10,
 		})
 		require.NoError(t, err)
 		require.Len(t, results, 3)
+
+		// Assert that the result set is ordered ascending by s.id (hub1 < s1 < s3).
 		assert.Equal(t, "Main Street Hub", results[0].Name.String)
-		assert.Equal(t, "Main Street Mall", results[1].Name.String)
-		assert.Equal(t, "Main Street Station", results[2].Name.String)
+		assert.Equal(t, "Main Street Station", results[1].Name.String)
+		assert.Equal(t, "Main Street Mall", results[2].Name.String)
 	})
 
 	t.Run("respects limit", func(t *testing.T) {

--- a/internal/restapi/search_stops_handler.go
+++ b/internal/restapi/search_stops_handler.go
@@ -86,7 +86,7 @@ func (api *RestAPI) searchStopsHandler(w http.ResponseWriter, r *http.Request) {
 
 	searchParams := gtfsdb.SearchStopsByNameParams{
 		SearchQuery: searchQuery,
-		Limit:       int64(limit),
+		Limit:       int64(limit + 1), // Request limit + 1 to accurately determine if pagination boundaries are exceeded.
 	}
 
 	// 3. Perform Full Text Search (with logged fallback)
@@ -123,6 +123,14 @@ func (api *RestAPI) searchStopsHandler(w http.ResponseWriter, r *http.Request) {
 			)
 			return
 		}
+	}
+
+	// Evaluate if we fetched more than the requested limit
+	isLimitExceeded := len(stops) > limit
+
+	// Truncate the slice back down to the actual limit if necessary
+	if isLimitExceeded {
+		stops = stops[:limit]
 	}
 
 	// 4. Batch Fetch Related Data
@@ -306,7 +314,7 @@ func (api *RestAPI) searchStopsHandler(w http.ResponseWriter, r *http.Request) {
 		OutOfRange    bool                   `json:"outOfRange"`
 		References    models.ReferencesModel `json:"references"`
 	}{
-		LimitExceeded: len(stops) >= limit,
+		LimitExceeded: isLimitExceeded,
 		List:          stopModels,
 		OutOfRange:    false,
 		References:    *references,

--- a/internal/restapi/search_stops_handler.go
+++ b/internal/restapi/search_stops_handler.go
@@ -125,13 +125,7 @@ func (api *RestAPI) searchStopsHandler(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// Evaluate if we fetched more than the requested limit
-	isLimitExceeded := len(stops) > limit
-
-	// Truncate the slice back down to the actual limit if necessary
-	if isLimitExceeded {
-		stops = stops[:limit]
-	}
+	stops, isLimitExceeded := utils.PaginateSlice(stops, 0, limit)
 
 	// 4. Batch Fetch Related Data
 	stopIDs := make([]string, len(stops))

--- a/internal/restapi/search_stops_handler_test.go
+++ b/internal/restapi/search_stops_handler_test.go
@@ -4,6 +4,7 @@ import (
 	"maps"
 	"net/http"
 	"net/url"
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -169,4 +170,31 @@ func TestSanitizeFTS5Query(t *testing.T) {
 			assert.Equal(t, tt.expected, out)
 		})
 	}
+}
+
+func TestSearchStopsHandlerLimitExceeded(t *testing.T) {
+	api := createTestApi(t)
+	defer api.Shutdown()
+
+	// Establish a baseline of total available records for the test query.
+	respAll, stopsRespAll := callAPIHandler[StopsResponse](t, api, searchStopsURL(url.Values{"input": {"Buenaventura"}, "maxCount": {"100"}}))
+	require.Equal(t, http.StatusOK, respAll.StatusCode)
+	require.False(t, stopsRespAll.Data.LimitExceeded, "Expected LimitExceeded to be false when retrieving the complete result set")
+
+	totalMatches := len(stopsRespAll.Data.List)
+	require.Greater(t, totalMatches, 1, "Test requires a minimum of 2 matching records in the mock data")
+
+	// Verify strict boundary condition where the requested limit equals total records.
+	exactCountStr := strconv.Itoa(totalMatches)
+	respExact, stopsRespExact := callAPIHandler[StopsResponse](t, api, searchStopsURL(url.Values{"input": {"Buenaventura"}, "maxCount": {exactCountStr}}))
+	assert.Equal(t, http.StatusOK, respExact.StatusCode)
+	assert.False(t, stopsRespExact.Data.LimitExceeded, "Expected LimitExceeded to be false when maxCount exactly matches total available records")
+	assert.Len(t, stopsRespExact.Data.List, totalMatches)
+
+	// Verify pagination flag triggers correctly when results exceed the requested limit.
+	exceededCountStr := strconv.Itoa(totalMatches - 1)
+	respExceeded, stopsRespExceeded := callAPIHandler[StopsResponse](t, api, searchStopsURL(url.Values{"input": {"Buenaventura"}, "maxCount": {exceededCountStr}}))
+	assert.Equal(t, http.StatusOK, respExceeded.StatusCode)
+	assert.True(t, stopsRespExceeded.Data.LimitExceeded, "Expected LimitExceeded to be true when available records exceed maxCount")
+	assert.Len(t, stopsRespExceeded.Data.List, totalMatches-1)
 }


### PR DESCRIPTION
### Description
This PR resolves two specification compliance issues with the `/api/where/search/stop` endpoint:

1. **Ordering:** The search results are now correctly sorted by the combined stop ID in ascending lexicographic order, rather than alphabetically by stop name.
2. **LimitExceeded Flag:** Fixed a false-positive bug where `limitExceeded` was set to `true` when the number of matches exactly equaled `maxCount`. The handler now queries for `limit + 1` rows to accurately verify if additional results exist before truncating the array.

### Changes
* **`gtfsdb/fts_queries.go`**: Updated the `searchStopsByName` SQL query to `ORDER BY s.id`.
* **`internal/restapi/search_stops_handler.go`**: Modified the database call to request `limit + 1` rows, properly evaluate `isLimitExceeded`, and truncate the final slice.
* **`gtfsdb/fts_queries_test.go`**: Updated the existing alphabetical ordering test to assert against the new lexicographic ID sorting.
* **`internal/restapi/search_stops_handler_test.go`**: Added `TestSearchStopsHandlerLimitExceeded` to explicitly verify the `limitExceeded` boundary logic.

closes #1154 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Search results are now consistently sorted by stop ID (lexicographic), ensuring stable ordering across searches.
  * Improved `maxCount`/pagination behavior so the `limitExceeded` response flag correctly reflects when additional matching stops are available, while still returning only the requested number of stops.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->