### PR TITLE
Add oba-api-review skill for API change review

### DIFF
--- a/.claude/skills/lib/resolve-oba-repo.sh
+++ b/.claude/skills/lib/resolve-oba-repo.sh
@@ -78,8 +78,10 @@ warn_if_stale() {
   remote_rev="$(git -C "$path" rev-parse "$upstream_ref")"
   if [[ "$local_rev" != "$remote_rev" ]]; then
     behind="$(git -C "$path" rev-list --count "HEAD..$upstream_ref" 2>/dev/null || echo "?")"
-    last_date="$(git -C "$path" log -1 --format=%ad --date=short)"
-    echo "Warning: $REPO at $path (branch $branch) is $behind commit(s) behind origin/$branch (last local commit: $last_date). This checkout was found independently, not cloned by this script, so it was not updated automatically - results below may reflect stale code. Run 'git -C $path pull' to update it, or unset OBA_WORKSPACE / move it aside to let this script manage a fresh copy in its cache instead." >&2
+    if [[ "$behind" != "0" ]]; then
+      last_date="$(git -C "$path" log -1 --format=%ad --date=short)"
+      echo "Warning: $REPO at $path (branch $branch) is $behind commit(s) behind origin/$branch (last local commit: $last_date). This checkout was found independently, not cloned by this script, so it was not updated automatically - results below may reflect stale code. Run 'git -C $path pull' to update it, or unset OBA_WORKSPACE / move it aside to let this script manage a fresh copy in its cache instead." >&2
+    fi
   fi
 }
 

--- a/.claude/skills/lib/resolve-oba-repo.sh
+++ b/.claude/skills/lib/resolve-oba-repo.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# resolve-oba-repo.sh <repo-name>
+#
+# Prints the local filesystem path to a checkout of one of the other OBA
+# repos used by the oba-api-review skill family (oba-api-review,
+# oba-api-client-impact, oba-api-spec-check, oba-api-verify). These skills
+# ship inside maglev/ and must work with only maglev checked out, so this
+# script resolves each dependent repo on demand instead of assuming a fixed
+# multi-repo workspace layout.
+#
+# Resolution order:
+#   1. $OBA_WORKSPACE/<repo>        - explicit override, if set
+#   2. <maglev-root>/../<repo>      - sibling checkout, if this maglev
+#                                      checkout lives in a multi-repo workspace
+#   3. cache dir, cloning if absent - fallback for a maglev-only checkout
+#
+# Repos found via (1) or (2) were checked out independently of this script,
+# so it never mutates them - it only does a read-only freshness check
+# (fetch + compare, no reset/pull) and prints a warning to stderr if the
+# checkout looks behind its own upstream. Repos in the cache dir (3) *are*
+# managed by this script, so those are kept up to date automatically
+# instead of just flagged.
+#
+# Only the resolved path is printed to stdout; all progress/diagnostic
+# output goes to stderr, so this is safe to use as:
+#   path="$(.claude/skills/lib/resolve-oba-repo.sh wayfinder)"
+
+set -euo pipefail
+
+usage() {
+  echo "Usage: $(basename "$0") <repo-name>" >&2
+  echo "Known repos: wayfinder, js-sdk, onebusaway-ios, onebusaway-android, maglev.wiki" >&2
+}
+
+REPO="${1:-}"
+if [ -z "$REPO" ]; then
+  usage
+  exit 1
+fi
+
+case "$REPO" in
+  wayfinder)          URL="https://github.com/onebusaway/wayfinder.git" ;;
+  js-sdk)              URL="https://github.com/onebusaway/js-sdk.git" ;;
+  onebusaway-ios)      URL="https://github.com/onebusaway/onebusaway-ios.git" ;;
+  onebusaway-android)  URL="https://github.com/onebusaway/onebusaway-android.git" ;;
+  maglev.wiki)         URL="https://github.com/onebusaway/maglev.wiki.git" ;;
+  *)
+    echo "Unknown repo: $REPO" >&2
+    usage
+    exit 1
+    ;;
+esac
+
+# Read-only staleness check for a checkout this script does not manage
+# (found via OBA_WORKSPACE or as a sibling). Fetches the current branch's
+# upstream and compares - never resets/pulls/mutates the working tree.
+warn_if_stale() {
+  local path="$1"
+  local branch upstream_ref local_rev remote_rev behind last_date
+
+  branch="$(git -C "$path" symbolic-ref --short HEAD 2>/dev/null || echo "")"
+  if [ -z "$branch" ]; then
+    echo "Note: $REPO at $path is in a detached HEAD state; skipping staleness check." >&2
+    return
+  fi
+
+  if ! git -C "$path" fetch --quiet origin "$branch" 2>/dev/null; then
+    echo "Note: could not fetch to check staleness of $REPO at $path (offline, or no matching branch upstream)." >&2
+    return
+  fi
+
+  upstream_ref="refs/remotes/origin/$branch"
+  if ! git -C "$path" rev-parse --verify --quiet "$upstream_ref" >/dev/null; then
+    return
+  fi
+
+  local_rev="$(git -C "$path" rev-parse HEAD)"
+  remote_rev="$(git -C "$path" rev-parse "$upstream_ref")"
+  if [ "$local_rev" != "$remote_rev" ]; then
+    behind="$(git -C "$path" rev-list --count "HEAD..$upstream_ref" 2>/dev/null || echo "?")"
+    last_date="$(git -C "$path" log -1 --format=%ad --date=short)"
+    echo "Warning: $REPO at $path (branch $branch) is $behind commit(s) behind origin/$branch (last local commit: $last_date). This checkout was found independently, not cloned by this script, so it was not updated automatically - results below may reflect stale code. Run 'git -C $path pull' to update it, or unset OBA_WORKSPACE / move it aside to let this script manage a fresh copy in its cache instead." >&2
+  fi
+}
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# 1. Explicit workspace override
+if [ -n "${OBA_WORKSPACE:-}" ] && [ -d "$OBA_WORKSPACE/$REPO" ]; then
+  warn_if_stale "$OBA_WORKSPACE/$REPO"
+  echo "$OBA_WORKSPACE/$REPO"
+  exit 0
+fi
+
+# 2. Sibling of the maglev checkout this script lives in (script is at
+#    <maglev-root>/.claude/skills/lib/resolve-oba-repo.sh)
+MAGLEV_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+SIBLING="$(dirname "$MAGLEV_ROOT")/$REPO"
+if [ -d "$SIBLING/.git" ]; then
+  warn_if_stale "$SIBLING"
+  echo "$SIBLING"
+  exit 0
+fi
+
+# 3. Cache dir - clone on first use, best-effort refresh on later runs
+CACHE_ROOT="${OBA_SKILL_CACHE:-$HOME/.cache/oba-api-review}/repos"
+TARGET="$CACHE_ROOT/$REPO"
+
+if [ -d "$TARGET/.git" ]; then
+  BRANCH="$(git -C "$TARGET" symbolic-ref --short HEAD 2>/dev/null || echo "")"
+  if [ -n "$BRANCH" ]; then
+    echo "Updating cached checkout of $REPO..." >&2
+    if git -C "$TARGET" fetch --depth 1 origin "$BRANCH" >&2; then
+      git -C "$TARGET" reset --hard "origin/$BRANCH" >&2 || true
+    else
+      echo "Warning: fetch failed, using cached copy of $REPO as-is (last commit: $(git -C "$TARGET" log -1 --format=%ad --date=short))" >&2
+    fi
+  else
+    echo "Note: cached checkout of $REPO at $TARGET is in a detached HEAD state; leaving as-is (last commit: $(git -C "$TARGET" log -1 --format=%ad --date=short))." >&2
+  fi
+else
+  echo "Cloning $REPO into $TARGET (first use)..." >&2
+  mkdir -p "$CACHE_ROOT"
+  git clone --depth 1 "$URL" "$TARGET" >&2
+fi
+
+echo "$TARGET"

--- a/.claude/skills/lib/resolve-oba-repo.sh
+++ b/.claude/skills/lib/resolve-oba-repo.sh
@@ -33,7 +33,7 @@ usage() {
 }
 
 REPO="${1:-}"
-if [ -z "$REPO" ]; then
+if [[ -z "$REPO" ]]; then
   usage
   exit 1
 fi
@@ -59,7 +59,7 @@ warn_if_stale() {
   local branch upstream_ref local_rev remote_rev behind last_date
 
   branch="$(git -C "$path" symbolic-ref --short HEAD 2>/dev/null || echo "")"
-  if [ -z "$branch" ]; then
+  if [[ -z "$branch" ]]; then
     echo "Note: $REPO at $path is in a detached HEAD state; skipping staleness check." >&2
     return
   fi
@@ -76,7 +76,7 @@ warn_if_stale() {
 
   local_rev="$(git -C "$path" rev-parse HEAD)"
   remote_rev="$(git -C "$path" rev-parse "$upstream_ref")"
-  if [ "$local_rev" != "$remote_rev" ]; then
+  if [[ "$local_rev" != "$remote_rev" ]]; then
     behind="$(git -C "$path" rev-list --count "HEAD..$upstream_ref" 2>/dev/null || echo "?")"
     last_date="$(git -C "$path" log -1 --format=%ad --date=short)"
     echo "Warning: $REPO at $path (branch $branch) is $behind commit(s) behind origin/$branch (last local commit: $last_date). This checkout was found independently, not cloned by this script, so it was not updated automatically - results below may reflect stale code. Run 'git -C $path pull' to update it, or unset OBA_WORKSPACE / move it aside to let this script manage a fresh copy in its cache instead." >&2
@@ -86,7 +86,7 @@ warn_if_stale() {
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # 1. Explicit workspace override
-if [ -n "${OBA_WORKSPACE:-}" ] && [ -d "$OBA_WORKSPACE/$REPO" ]; then
+if [[ -n "${OBA_WORKSPACE:-}" && -d "$OBA_WORKSPACE/$REPO" ]]; then
   warn_if_stale "$OBA_WORKSPACE/$REPO"
   echo "$OBA_WORKSPACE/$REPO"
   exit 0
@@ -96,7 +96,7 @@ fi
 #    <maglev-root>/.claude/skills/lib/resolve-oba-repo.sh)
 MAGLEV_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
 SIBLING="$(dirname "$MAGLEV_ROOT")/$REPO"
-if [ -d "$SIBLING/.git" ]; then
+if [[ -d "$SIBLING/.git" ]]; then
   warn_if_stale "$SIBLING"
   echo "$SIBLING"
   exit 0
@@ -106,9 +106,9 @@ fi
 CACHE_ROOT="${OBA_SKILL_CACHE:-$HOME/.cache/oba-api-review}/repos"
 TARGET="$CACHE_ROOT/$REPO"
 
-if [ -d "$TARGET/.git" ]; then
+if [[ -d "$TARGET/.git" ]]; then
   BRANCH="$(git -C "$TARGET" symbolic-ref --short HEAD 2>/dev/null || echo "")"
-  if [ -n "$BRANCH" ]; then
+  if [[ -n "$BRANCH" ]]; then
     echo "Updating cached checkout of $REPO..." >&2
     if git -C "$TARGET" fetch --depth 1 origin "$BRANCH" >&2; then
       git -C "$TARGET" reset --hard "origin/$BRANCH" >&2 || true

--- a/.claude/skills/oba-api-client-impact/SKILL.md
+++ b/.claude/skills/oba-api-client-impact/SKILL.md
@@ -1,0 +1,74 @@
+# OBA API Client Impact
+
+Assess the impact of a production change (or proposed change) on the three OBA clients: Wayfinder + JS SDK, iOS, and Android.
+
+Typically invoked by `oba-api-review`. Can be called directly when you want to isolate client analysis from other review concerns. Run with the current working directory set to the root of your `maglev` checkout.
+
+## Arguments
+
+1. The endpoint name.
+2. The diff source — PR number, branch name, working tree (empty), or a plain-English description of the proposed change.
+
+## Workspace layout
+
+Each client repo is resolved on demand with `.claude/skills/lib/resolve-oba-repo.sh <repo-name>`, which prints the repo's local path — cloning it to a local cache on first use if it isn't already checked out as a sibling of `maglev`. Paths below are relative to that resolved root:
+
+- **JS SDK resource** (repo: `js-sdk`): `src/resources/<endpoint>.ts`, `src/resources/shared.ts`
+- **Wayfinder API route** (repo: `wayfinder`): `src/routes/api/oba/<endpoint>/+server.js` (if it exists) — note `.js`, not `.ts`. If the endpoint takes a path parameter, the file lives one level deeper under a bracketed folder named for that parameter, e.g. `src/routes/api/oba/stops-for-route/[routeId]/+server.js` — the bracket name varies per endpoint (`[id]`, `[stopId]`, `[tripId]`, …), so list the endpoint's directory rather than guessing the exact folder name.
+- **iOS endpoint method** (repo: `onebusaway-ios`): `OBAKitCore/Network/RESTAPIService/RESTAPIService+Get.swift`
+- **iOS response models** (repo: `onebusaway-ios`): `OBAKitCore/Models/REST/` — shared reference models (stop, route, agency, …) live one level deeper, under `OBAKitCore/Models/REST/References/`.
+- **Android endpoint definition** (repo: `onebusaway-android`): `onebusaway-android/src/main/java/org/onebusaway/android/api/contract/ObaWebService.kt` — a single Retrofit interface with one `@GET`-annotated method per endpoint, named in camelCase to match (e.g. `stopsForRoute`, `tripDetails`).
+- **Android response models** (repo: `onebusaway-android`): `onebusaway-android/src/main/java/org/onebusaway/android/api/contract/ObaApiModels.kt` — a single file with one `kotlinx.serialization` `data class` per response shape, named to match (e.g. `StopsForRoute`).
+- **Android data/adapter layer** (repo: `onebusaway-android`, secondary): `onebusaway-android/src/main/java/org/onebusaway/android/api/data/` (per-feature `*DataSource.kt`, e.g. `RouteStopsDataSource.kt`) and `.../api/adapters/` (per-domain `*Adapters.kt`, e.g. `RouteAdapters.kt`) hold business logic and DTO-to-app-model mapping. These aren't named 1:1 per endpoint — grep for the endpoint's Retrofit method name or response model class name to find the consuming files.
+
+This skill always needs all four client repos, so resolve `js-sdk`, `wayfinder`, `onebusaway-ios`, and `onebusaway-android` up front, before starting step 2. First use may take a minute to clone; later runs just refresh the cache.
+
+If a repo was found as a sibling checkout or via `OBA_WORKSPACE` rather than cloned into the cache, the resolver does not update it automatically and instead prints a `Warning: ... commit(s) behind ...` to stderr if it's stale. Watch for these — if one appears, note it as a caveat in the final report (the analysis for that client may be based on out-of-date source) rather than silently proceeding as if the checkout were current.
+
+## Steps
+
+### 1. Identify the changed behaviours
+
+From the diff or description, list every production behaviour that is changing: fields added, removed, or renamed; response structure changes; parameter handling changes; error response changes; default value changes.
+
+For description mode, derive the likely behaviour changes from the stated intent.
+
+### 2. Wayfinder + JS SDK
+
+For each changed behaviour:
+
+- Does `src/resources/<endpoint>.ts` or `src/resources/shared.ts` in the resolved `js-sdk` repo define a TypeScript type that maps the affected field or structure? If a field is removed, will the type need updating? If a field is added, is it missing from the type?
+- Does any Wayfinder component or API proxy route in the resolved `wayfinder` repo's `src/` read, display, or depend on the affected field or behaviour?
+
+State: *impact found* (describe it) or *no impact found*.
+
+### 3. iOS
+
+For each changed behaviour:
+
+- Does `OBAKitCore/Network/RESTAPIService/RESTAPIService+Get.swift` in the resolved `onebusaway-ios` repo call this endpoint?
+- Does a Swift model in `OBAKitCore/Models/REST/` decode the affected field? Note whether decoding uses `try` (required — will throw if field absent) or optional chaining (will silently produce nil).
+- Does any UI code downstream of the model handle a nil value defensively?
+
+State: *impact found* (describe it) or *no impact found*.
+
+### 4. Android
+
+For each changed behaviour:
+
+- Does the endpoint's `@GET` method in `ObaWebService.kt` (in the resolved `onebusaway-android` repo) send any parameter that is now handled differently?
+- Does the matching `data class` in `ObaApiModels.kt` map the affected field? These are `kotlinx.serialization` models where most fields carry a default (e.g. `= emptyList()`, `= 0`) rather than being nullable — a missing/renamed field silently deserializes to that default instead of throwing or producing null. Check whether the `*DataSource.kt`/`*Adapters.kt` code downstream treats the default as "absent" or as a legitimate value.
+
+State: *impact found* (describe it) or *no impact found*.
+
+### 5. Report
+
+**Client impact: `<endpoint>`**
+
+For each changed behaviour, one row:
+
+| Behaviour | Wayfinder/SDK | iOS | Android |
+|-----------|--------------|-----|---------|
+| [description] | impact / none | impact / none | impact / none |
+
+Expand on any *impact found* entries with specifics: what changes for the client and how — field absent, value different, type mismatch, silent null, user-visible difference, etc. Do not assess whether the client should or could be updated; that is the reader's decision.

--- a/.claude/skills/oba-api-review/README.md
+++ b/.claude/skills/oba-api-review/README.md
@@ -11,6 +11,8 @@ Four [Claude Code](https://claude.com/claude-code) skills for reviewing changes 
 
 Usually you only need `oba-api-review` — it dispatches to the other three as appropriate. Call one of the others directly if you want to isolate a single concern (e.g. just the client-impact analysis).
 
+**A note on spec changes:** `oba-api-spec-check` will sometimes flag that `maglev.wiki` needs updating — a missing Implementation Decisions entry, a gap in coverage, and so on. It only flags this; it doesn't edit the wiki. Treat any actual spec change as needing broader review than the PR it came up in — raise it in Slack first rather than updating the wiki unilaterally.
+
 ## Where these came from
 
 These skills were built to support the [OBA API Spec Review project](https://github.com/orgs/OneBusAway/projects/11), which tracks reviewing all 27 OneBusAway API endpoints' behavioural specs against Maglev's implementation: each endpoint gets reviewed, gaps get filed as linked `spec-gap` issues, and PRs close them out.

--- a/.claude/skills/oba-api-review/README.md
+++ b/.claude/skills/oba-api-review/README.md
@@ -1,0 +1,43 @@
+# OBA API review skills
+
+Four [Claude Code](https://claude.com/claude-code) skills for reviewing changes to the maglev OBA REST API:
+
+| Skill | Purpose |
+|---|---|
+| `oba-api-review` | Entry point. Figures out which of the other three apply and runs them. |
+| `oba-api-verify` | Checks whether a change fully accomplishes a stated goal (a spec-gap issue, PR description, etc.), including test coverage. |
+| `oba-api-client-impact` | Checks whether a change affects Wayfinder + the JS SDK, iOS, or Android. |
+| `oba-api-spec-check` | Checks a change against the endpoint's `maglev.wiki` spec, and that any deliberate deviation from legacy behaviour is recorded. |
+
+Usually you only need `oba-api-review` — it dispatches to the other three as appropriate. Call one of the others directly if you want to isolate a single concern (e.g. just the client-impact analysis).
+
+## Where these came from
+
+These skills were built to support the [OBA API Spec Review project](https://github.com/orgs/OneBusAway/projects/11), which tracks reviewing all 27 OneBusAway API endpoints' behavioural specs against Maglev's implementation: each endpoint gets reviewed, gaps get filed as linked `spec-gap` issues, and PRs close them out.
+
+That said, nothing here is specific to that project. Point `oba-api-review` at any PR, branch, or working tree that touches the maglev API — a bug fix, a new endpoint, an unrelated feature — and it'll do the same analysis: goal verification (if there's a stated goal), spec consistency, and client impact.
+
+## Prerequisites
+
+- [Claude Code](https://claude.com/claude-code), run from the root of a `maglev` checkout.
+- `git`, and network access the first time you use a skill that needs one of the other OBA repos (see below) — later runs reuse what's already been fetched.
+- [`gh`](https://cli.github.com/), authenticated against the `OneBusAway` org, for PR-number and linked-issue lookups.
+
+## Using them
+
+```
+/oba-api-review 123                                   # PR #123 in OneBusAway/maglev
+/oba-api-review fix/route-ids-paging                  # a branch, diffed against main
+/oba-api-review                                        # current working tree
+/oba-api-review "remove situationIds from stops-for-route"   # a proposed change, described in English
+```
+
+## How cross-repo resolution works
+
+`oba-api-client-impact` and `oba-api-spec-check` need source from `wayfinder`, `js-sdk`, `onebusaway-ios`, `onebusaway-android`, and `maglev.wiki` — none of which need to be checked out ahead of time. `.claude/skills/lib/resolve-oba-repo.sh <repo-name>` finds each one automatically:
+
+1. `$OBA_WORKSPACE/<repo>`, if you've set that env var to point at a directory containing your own checkout.
+2. A sibling directory of your `maglev` checkout (i.e. `../<repo>`), if you happen to have the other repos checked out that way already.
+3. Otherwise, it's cloned into a local cache (`~/.cache/oba-api-review` by default, override with `OBA_SKILL_CACHE`) the first time it's needed, and kept up to date automatically on later runs.
+
+Repos found via (1) or (2) aren't managed by this script, so they're never modified — instead, each is checked (read-only) against its upstream, and a skill's output will flag it if the checkout looks stale enough that the analysis might be based on outdated code.

--- a/.claude/skills/oba-api-review/SKILL.md
+++ b/.claude/skills/oba-api-review/SKILL.md
@@ -1,0 +1,118 @@
+# OBA API Review
+
+Entry point for reviewing a change to the OBA API. Determines which analyses are relevant and runs them.
+
+Lives inside the `maglev` repo and is meant to be usable with only `maglev` checked out. `oba-api-client-impact` and `oba-api-spec-check` need source from `wayfinder`, `js-sdk`, `onebusaway-ios`, `onebusaway-android`, and `maglev.wiki` — they resolve those automatically via `.claude/skills/lib/resolve-oba-repo.sh` (see that script's header for details). First use clones what's missing into a local cache (`~/.cache/oba-api-review` by default), so it needs `git` and network access; later runs reuse and refresh the cache. If you already have some of these repos checked out elsewhere, set `OBA_WORKSPACE` to the parent directory and they'll be used directly instead of being cloned.
+
+Run this skill with the current working directory set to the root of your `maglev` checkout.
+
+## Argument
+
+One of four forms:
+
+| Form | Detection | Example |
+|------|-----------|---------|
+| PR number | Numeric / `#NNN` | `123` |
+| Branch name | Single token, no spaces, not numeric | `fix/route-ids-paging` |
+| Description | Contains spaces | `remove the situationIds field from stops-for-route` |
+| *(empty)* | No argument | *(none)* → current working tree |
+
+## Steps
+
+### 1. Resolve the diff source
+
+**PR (`123` or `#NNN`):**
+```bash
+gh pr view <PR> --repo OneBusAway/maglev
+```
+Note the PR title, body, and any linked issues. Fetch linked spec-gap issue if present:
+```bash
+gh issue view <issue> --repo OneBusAway/maglev
+```
+
+**Branch (single token, not numeric):**
+```bash
+git diff main...<branch> --name-only
+```
+Check whether the branch is linked to a GitHub issue. If so, fetch it.
+
+**Description (contains spaces):** No diff to fetch. The argument is the stated intent. Skip to step 3.
+
+**Working tree (empty argument):**
+```bash
+git diff HEAD --name-only
+git status --short
+```
+Check whether the current branch is linked to a GitHub issue. If so, fetch it.
+
+### 2. Partition the changes
+
+For PR, branch, and working-tree modes, categorise every changed file:
+
+- **Production changes** — handler code, models, DB queries, middleware, or any non-test file that affects what Maglev returns at runtime.
+- **Test changes** — `*_test.go` files, test helpers, fixtures, test-only DB helpers.
+
+Record whether the diff contains production changes, test changes, or both.
+
+### 3. Write the overview
+
+Before running any sub-skills, write an **Overview** section for the report. This orients the reader — someone who may not have read the PR, the issue, or the spec — so they can follow the analysis that comes after.
+
+The overview has two parts:
+
+**What this change does** — a plain-English explanation of the problem and the fix (or feature). Walk through the before/after behaviour concretely: what the endpoint returned before, what it returns after, and under what conditions the difference matters. Use a specific scenario if one helps (e.g. "Route X ends in December but the feed runs until June — querying January used to return Y, now returns Z"). Reference the linked issue and spec section where relevant.
+
+**Domain background** — explain any GTFS, transit-operations, or OBA API concepts that a reader needs to follow the change. Examples: how `calendar` vs `calendar_dates` determine active service; what a "feed end date" is vs a route's service window; what 510/ServiceDateOutOfRange means in the OBA API. Only cover concepts that are actually relevant to *this* change — don't recite the full GTFS spec. Aim for a reader who knows Go and SQL but not transit data.
+
+Sources to draw on:
+- The PR description and linked issue
+- The `maglev.wiki` spec for the affected endpoint (see `oba-api-spec-check` for how it's resolved)
+- GTFS specification concepts (calendar, calendar_dates, routes, trips, service_id)
+- The diff itself (for understanding the mechanics of the fix)
+
+### 4. Determine which sub-skills to run
+
+| Condition | Run |
+|-----------|-----|
+| A gap description is available — linked spec-gap issue on a PR, or description-mode argument | `oba-api-verify` |
+| Production changes exist (PR / branch / working tree) | `oba-api-client-impact`, `oba-api-spec-check` |
+| Description mode | `oba-api-client-impact`, `oba-api-spec-check` (prospective) |
+| Test changes only, no gap description | None — report this and stop |
+
+### 5. Run the relevant sub-skills
+
+Invoke each applicable sub-skill in order, passing the relevant context (gap description, endpoint name, diff source):
+
+1. `oba-api-verify` — if a gap description is available
+2. `oba-api-client-impact` — if production changes exist or description mode
+3. `oba-api-spec-check` — if production changes exist or description mode
+
+### 6. Synthesise the report
+
+Combine the sub-skill outputs into a single report:
+
+---
+
+## OBA API Review: `<source>` — `<endpoint>`
+
+**Input**: [PR #NNN / branch `<name>` / working tree / proposed change]
+**Stated goal**: [from linked issue, description argument, or "none"]
+**Changes**: [production / test-only / both / description only]
+
+### Overview
+[Plain-English explanation of the change and relevant domain concepts, from step 3.]
+
+### Goal check
+[Output of `oba-api-verify`, or "No stated goal — not assessed."]
+
+### Client impact
+[Output of `oba-api-client-impact`, or "Test-only changes — not applicable."]
+
+### Spec check
+[Output of `oba-api-spec-check`, or "Test-only changes — not applicable."]
+
+### Summary
+
+A short plain-English summary of what the analysis found. Note anything that is incomplete, incorrect, or that the change touches beyond its stated scope. Do not prescribe what should happen — that is the reader's decision.
+
+---

--- a/.claude/skills/oba-api-spec-check/SKILL.md
+++ b/.claude/skills/oba-api-spec-check/SKILL.md
@@ -4,6 +4,8 @@ Assess whether a change is consistent with the relevant `maglev.wiki` spec, and 
 
 Typically invoked by `oba-api-review`. Can be called directly when you want to isolate spec alignment from other review concerns. Run with the current working directory set to the root of your `maglev` checkout.
 
+**This skill identifies where a spec is inconsistent, incomplete, or needs a new Implementation Decisions entry — it does not edit `maglev.wiki` itself.** A spec change affects every client and every future review, so it needs broader review than a single PR: raise it in Slack first rather than editing the wiki unilaterally, even to close out this skill's findings.
+
 ## Arguments
 
 1. The endpoint name.
@@ -43,7 +45,7 @@ For each production change (or proposed change):
 
 For any change that deviates from legacy behaviour (i.e. touches a Suspected Defect or introduces a deliberate difference):
 - Does an **Implementation Decisions** entry already exist for this deviation?
-- If not, flag it: the spec must be updated before the change is merged to maintain the audit trail.
+- If not, flag it: the spec needs a new entry to maintain the audit trail. Don't add it yourself — raise it in Slack so the entry gets broader review before it's added.
 
 For description mode this is prospective: "if this change were implemented, would a new Implementation Decisions entry be required?"
 

--- a/.claude/skills/oba-api-spec-check/SKILL.md
+++ b/.claude/skills/oba-api-spec-check/SKILL.md
@@ -1,0 +1,60 @@
+# OBA API Spec Check
+
+Assess whether a change is consistent with the relevant `maglev.wiki` spec, and verify that any deviation from legacy behaviour is recorded in the spec's Implementation Decisions section.
+
+Typically invoked by `oba-api-review`. Can be called directly when you want to isolate spec alignment from other review concerns. Run with the current working directory set to the root of your `maglev` checkout.
+
+## Arguments
+
+1. The endpoint name.
+2. The diff source — PR number, branch name, working tree (empty), or a plain-English description of the proposed change.
+
+## Workspace layout
+
+- **Spec**: `<endpoint>.md` in the `maglev.wiki` repo — resolve the repo's local path with `.claude/skills/lib/resolve-oba-repo.sh maglev.wiki` (clones it to a local cache on first use if it isn't already checked out as a sibling of `maglev`).
+- **Maglev handler**: `internal/restapi/<endpoint>_handler.go` (relative to the `maglev` repo root) — handler filenames use underscores throughout, e.g. `stops-for-route` → `stops_for_route_handler.go`, so convert every hyphen in the endpoint name to an underscore before looking for the file.
+
+## Steps
+
+### 1. Read the spec in full
+
+Run `.claude/skills/lib/resolve-oba-repo.sh maglev.wiki` to get the wiki repo's local path. If it was found as a sibling checkout or via `OBA_WORKSPACE` rather than cloned into the cache, the resolver doesn't update it automatically and will print a `Warning: ... commit(s) behind ...` to stderr if it's stale — if that happens, note it as a caveat in the final report, since the spec being read may be out of date. Then read `<path>/<endpoint>.md` entirely. Note:
+- The specified behaviour for each request parameter, response field, and error case.
+- The **Suspected Defects** section — known divergences from ideal behaviour in the legacy implementation.
+- The **Implementation Decisions** section — deliberate deviations Maglev has chosen to make, with rationale.
+
+### 2. Get the diff
+
+- **PR**: `gh pr diff <PR> --repo OneBusAway/maglev`
+- **Branch**: `git diff main...<branch>`
+- **Working tree**: `git diff HEAD`
+
+For description mode, work from the stated intent rather than an actual diff.
+
+### 3. Check spec consistency
+
+For each production change (or proposed change):
+- Does the spec permit or require this change?
+- Does the change contradict the spec?
+- Does the change address a **Suspected Defect** — intentionally or as a side effect?
+- Does the change affect behaviour the spec does not yet cover? If so, the spec may need to be updated.
+
+### 4. Check deviation recording
+
+For any change that deviates from legacy behaviour (i.e. touches a Suspected Defect or introduces a deliberate difference):
+- Does an **Implementation Decisions** entry already exist for this deviation?
+- If not, flag it: the spec must be updated before the change is merged to maintain the audit trail.
+
+For description mode this is prospective: "if this change were implemented, would a new Implementation Decisions entry be required?"
+
+### 5. Report
+
+**Spec check: `<endpoint>`**
+
+For each changed behaviour:
+- **Consistent** — change matches what the spec requires or permits.
+- **Inconsistent** — change contradicts the spec; describe the conflict.
+- **Spec gap** — spec does not cover this behaviour; spec should be updated.
+- **Deviation** — change deviates from legacy; Implementation Decisions entry exists ✓ / missing ✗.
+
+Overall: **spec-consistent** / **conflicts noted** / **spec update required**

--- a/.claude/skills/oba-api-verify/SKILL.md
+++ b/.claude/skills/oba-api-verify/SKILL.md
@@ -1,0 +1,63 @@
+# OBA API Verify
+
+Assess whether a change fully accomplishes its stated goal, including adequate test coverage for every sub-gap.
+
+Typically invoked by `oba-api-review`. Can be called directly when you have a specific gap description and a diff to check against it. Run with the current working directory set to the root of your `maglev` checkout.
+
+## Arguments
+
+1. The stated goal or gap description — from a spec-gap issue, a PR body, or a user-supplied description of intent.
+2. The diff source — PR number, branch name, or working tree (empty).
+
+## Workspace layout
+
+- **Spec**: `<endpoint>.md` in the `maglev.wiki` repo — resolve the repo's local path with `.claude/skills/lib/resolve-oba-repo.sh maglev.wiki` (clones it to a local cache on first use if it isn't already checked out as a sibling of `maglev`).
+- **Maglev handler**: `internal/restapi/<endpoint>_handler.go` (relative to the `maglev` repo root) — handler filenames use underscores throughout, e.g. `stops-for-route` → `stops_for_route_handler.go`, so convert every hyphen in the endpoint name to an underscore before looking for the file.
+- **Maglev tests**: `internal/restapi/<endpoint>_handler_test.go` (relative to the `maglev` repo root, same hyphen-to-underscore conversion).
+
+## Steps
+
+### 1. Parse the stated goal
+
+Extract the endpoint name and the specific behaviours, fields, parameters, or error cases the change is meant to address. If the goal lists sub-gaps (e.g. a numbered list in a spec-gap issue), enumerate them — each will need individual coverage.
+
+### 2. Read the relevant spec section
+
+Run `.claude/skills/lib/resolve-oba-repo.sh maglev.wiki` to get the wiki repo's local path. If it was found as a sibling checkout or via `OBA_WORKSPACE` rather than cloned into the cache, the resolver doesn't update it automatically and will print a `Warning: ... commit(s) behind ...` to stderr if it's stale — if that happens, note it as a caveat in the final report, since the spec being read may be out of date. Then read the section(s) of `<path>/<endpoint>.md` that correspond to the stated goal. Confirm what correct behaviour looks like according to the spec.
+
+### 3. Get the diff
+
+- **PR**: `gh pr diff <PR> --repo OneBusAway/maglev`
+- **Branch**: `git diff main...<branch>`
+- **Working tree**: `git diff HEAD`
+
+Read the handler file and test file in context if the diff alone is insufficient.
+
+### 4. Assess production changes against the goal
+
+For each sub-gap or behaviour named in the stated goal:
+- Is it addressed by a production change in the diff?
+- Does the production change correctly implement what the spec requires?
+- Are any adjacent behaviours accidentally affected?
+
+Flag anything the diff claims to address but does not, and anything the diff changes that was not part of the stated goal.
+
+### 5. Assess test coverage
+
+For each sub-gap or behaviour named in the stated goal:
+- Is there at least one test or assertion that would catch a regression?
+- Are assertions specific enough — not just `assert.NotNil` or a shape check with the wrong expected value?
+- Is the test scenario correctly structured: right endpoint called, test data valid for the scenario, proper isolation and cleanup?
+- Does any existing assertion get weakened or removed by the diff?
+
+### 6. Report
+
+**Goal check: `<endpoint>`**
+
+Stated goal: [summary]
+
+For each sub-gap: ✓ addressed / ✗ missing / ⚠ partial — with a brief note.
+
+Test coverage: [adequate / gaps noted — list any uncovered sub-gaps or weak assertions]
+
+Overall: **fully closed** / **partially closed** / **not closed**

--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@ __debug_bin*
 *.db-wal
 /cmd/api/api
 gtfsdb/tmp/main
-.claude
+.claude/settings.local.json
 .idea
 config.json
 configs/*.json


### PR DESCRIPTION
## Summary

- Add four Claude Code skills (`oba-api-review` plus `oba-api-verify`, `oba-api-client-impact`, `oba-api-spec-check`) that review a maglev API change against the `maglev.wiki` behavioural specs and assess impact on the three OBA clients (Wayfinder + JS SDK, iOS, Android).
- Add `.claude/skills/lib/resolve-oba-repo.sh`, a shared script that resolves each dependent repo (`wayfinder`, `js-sdk`, `onebusaway-ios`, `onebusaway-android`, `maglev.wiki`) on demand — using a nearby checkout or `OBA_WORKSPACE` override if present, otherwise cloning into a local cache. Checkouts it didn't create itself are never mutated; a read-only freshness check warns if one looks stale instead of silently trusting it.
- Narrow `.gitignore`'s `.claude` entry down to just `settings.local.json`, so this config and any future project skills can be tracked.

This makes the skill set usable with only `maglev` checked out, cloning whatever else it needs the first time it's used.

## Test plan

- [x] Verified the resolver script's three resolution paths (`OBA_WORKSPACE` override, sibling checkout, cache-dir clone) in isolation, confirming stdout only ever contains the resolved path.
- [x] Ran a cold-start test in an isolated checkout with no sibling repos and an empty cache: all 5 repos resolved and cloned correctly, and every documented file path (JS SDK, Wayfinder route, iOS service/models, Android contract/models, maglev handler) was checked against the real repos and corrected where stale.
- [x] Verified the staleness-warning path against known out-of-date checkouts: warnings fire with the correct behind-count, stdout stays clean, and the checkouts' working trees are provably untouched (`git status`/HEAD unchanged before and after).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added guided workflows for reviewing OBA API changes: verify goals, check spec consistency, and assess client impact across supported platforms.
  - Added automated repository resolution to map requested OBA repositories to local checkout paths for the workflows.

- **Documentation**
  - Added new skill guides with argument rules, diff-source handling (PR/branch/working tree), per-client checklists, and standardized report templates.

- **Chores**
  - Updated ignore rules to exclude only the local settings file rather than the entire configuration directory.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->