### PR TITLE
Return HTTP 404 when no stops match prefix query in search-stop

### DIFF
--- a/internal/restapi/search_stops_handler.go
+++ b/internal/restapi/search_stops_handler.go
@@ -74,8 +74,7 @@ func (api *RestAPI) searchStopsHandler(w http.ResponseWriter, r *http.Request) {
 	terms := extractFTS5Terms(sanitizedQuery)
 
 	if len(terms) == 0 {
-		response := models.NewListResponseWithRange([]models.Stop{}, *models.NewEmptyReferences(), false, api.Clock, false)
-		api.sendResponse(w, r, response)
+		api.sendNotFound(w, r)
 		return
 	}
 
@@ -129,6 +128,13 @@ func (api *RestAPI) searchStopsHandler(w http.ResponseWriter, r *http.Request) {
 			)
 			return
 		}
+	}
+
+	// Pre-filter check: if no stops matched the prefix query at all, return 404
+	// per OBA spec (Minimal Guarantees & Extensions 2a).
+	if len(stops) == 0 {
+		api.sendNotFound(w, r)
+		return
 	}
 
 	stops, isLimitExceeded := utils.PaginateSlice(stops, 0, limit)

--- a/internal/restapi/search_stops_handler_test.go
+++ b/internal/restapi/search_stops_handler_test.go
@@ -72,8 +72,9 @@ func TestSearchStopsHandlerNoResults(t *testing.T) {
 
 	resp, stopsResp := callAPIHandler[StopsResponse](t, api, searchStopsURL(url.Values{"input": {"NonExistentStopName12345"}}))
 
-	assert.Equal(t, http.StatusOK, resp.StatusCode)
-	assert.Empty(t, stopsResp.Data.List)
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+	assert.Equal(t, http.StatusNotFound, stopsResp.Code)
+	assert.Equal(t, "resource not found", stopsResp.Text)
 }
 
 func TestSearchStopsHandlerMaxCount(t *testing.T) {
@@ -92,8 +93,9 @@ func TestSearchStopsHandlerWhitespaceOnlyInput(t *testing.T) {
 
 	resp, stopsResp := callAPIHandler[StopsResponse](t, api, searchStopsURL(url.Values{"input": {"    "}}))
 
-	assert.Equal(t, http.StatusOK, resp.StatusCode)
-	assert.Empty(t, stopsResp.Data.List)
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+	assert.Equal(t, http.StatusNotFound, stopsResp.Code)
+	assert.Equal(t, "resource not found", stopsResp.Text)
 }
 
 func TestSearchStopsHandlerSpecialCharactersOnly(t *testing.T) {
@@ -102,8 +104,9 @@ func TestSearchStopsHandlerSpecialCharactersOnly(t *testing.T) {
 
 	resp, stopsResp := callAPIHandler[StopsResponse](t, api, searchStopsURL(url.Values{"input": {`*()"`}}))
 
-	assert.Equal(t, http.StatusOK, resp.StatusCode)
-	assert.Empty(t, stopsResp.Data.List)
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+	assert.Equal(t, http.StatusNotFound, stopsResp.Code)
+	assert.Equal(t, "resource not found", stopsResp.Text)
 }
 
 func TestSearchStopsHandlerMaxCountBoundaries(t *testing.T) {
@@ -146,10 +149,13 @@ func TestSearchStopsHandlerFTSInjectionAttempt(t *testing.T) {
 	api := createTestApi(t)
 	defer api.Shutdown()
 
+	// After sanitization the injection payload no longer contains FTS5 operators/quotes; in our test fixtures it matches no stops.
+	// The key assertion is that an injection attempt does not cause a 500 error (or return an unbounded result set).
 	resp, stopsResp := callAPIHandler[StopsResponse](t, api, searchStopsURL(url.Values{"input": {`test" OR "1"="1`}}))
 
-	assert.Equal(t, http.StatusOK, resp.StatusCode)
-	assert.LessOrEqual(t, len(stopsResp.Data.List), 20)
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+	assert.Equal(t, http.StatusNotFound, stopsResp.Code)
+	assert.Equal(t, "resource not found", stopsResp.Text)
 }
 
 func TestSanitizeFTS5Query(t *testing.T) {
@@ -217,9 +223,9 @@ func TestSearchStopsHandlerIgnoredPunctuation(t *testing.T) {
 	// since it lacks alphanumeric characters. This triggers the empty-query path.
 	resp, stopsResp := callAPIHandler[StopsResponse](t, api, searchStopsURL(url.Values{"input": {"-"}}))
 
-	assert.Equal(t, http.StatusOK, resp.StatusCode)
-	assert.Equal(t, http.StatusOK, stopsResp.Code)
-	assert.Empty(t, stopsResp.Data.List)
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+	assert.Equal(t, http.StatusNotFound, stopsResp.Code)
+	assert.Equal(t, "resource not found", stopsResp.Text)
 }
 
 func TestSearchStopsHandlerReferencesSorting(t *testing.T) {

--- a/internal/restapi/trips_for_location_handler_test.go
+++ b/internal/restapi/trips_for_location_handler_test.go
@@ -263,7 +263,7 @@ func TestTripsForLocationHandler_ParseAndValidateRequest(t *testing.T) {
 			parsedReq, fieldErrors, err := api.parseAndValidateRequest(req)
 
 			assert.Empty(t, fieldErrors)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, tt.expectedIncludeTrip, parsedReq.IncludeTrip)
 		})
 	}


### PR DESCRIPTION


## Problem
`searchStopsHandler` returns HTTP 200 with an empty list when no stops match
the prefix query. The OBA spec requires HTTP 404 with `code: 404` and
`text: "resource not found"` (Minimal Guarantees & Extensions 2a).

## Changes
- Return 404 via `sendNotFound` when the sanitized query is empty
- Return 404 via `sendNotFound` when `SearchStopsByName` returns zero rows (pre-filter)
- Update affected tests to assert HTTP 404 and the standard error envelope

Closes #1156

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Stop searches with no matching results now return **404 Not Found** instead of a successful response with an empty list.
  * Invalid, blank, punctuation-only, and sanitized search queries now consistently return a not-found response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->