### PR TITLE
Support includeReferences=false in route-search

### DIFF
--- a/internal/restapi/route_search_handler.go
+++ b/internal/restapi/route_search_handler.go
@@ -12,6 +12,7 @@ import (
 // with optional geographic bounds filtering via lat, lon, and radius parameters.
 func (api *RestAPI) routeSearchHandler(w http.ResponseWriter, r *http.Request) {
 	queryParams := r.URL.Query()
+	includeReferences := ShouldIncludeReferences(r)
 
 	input := queryParams.Get("input")
 	sanitizedInput, err := utils.ValidateAndSanitizeQuery(input)
@@ -111,23 +112,26 @@ func (api *RestAPI) routeSearchHandler(w http.ResponseWriter, r *http.Request) {
 			textColor))
 	}
 
-	allAgencies, err := api.GtfsManager.GetAgencies(ctx)
-	if err != nil {
-		api.serverErrorResponse(w, r, err)
-		return
-	}
-	agencies := utils.FilterAgencies(allAgencies, agencyIDs)
-	// Populate situation references for alerts affecting the returned routes
-	resultRawRouteIDs := make([]string, 0, len(routes))
-	for _, routeRow := range routes {
-		resultRawRouteIDs = append(resultRawRouteIDs, routeRow.ID)
-	}
-	alerts := api.collectAlertsForRoutes(resultRawRouteIDs)
-	situations := api.BuildSituationReferences(alerts)
-
 	references := models.NewEmptyReferences()
-	references.Agencies = agencies
-	references.Situations = situations
+
+	if includeReferences {
+		allAgencies, err := api.GtfsManager.GetAgencies(ctx)
+		if err != nil {
+			api.serverErrorResponse(w, r, err)
+			return
+		}
+		agencies := utils.FilterAgencies(allAgencies, agencyIDs)
+		// Populate situation references for alerts affecting the returned routes
+		resultRawRouteIDs := make([]string, 0, len(routes))
+		for _, routeRow := range routes {
+			resultRawRouteIDs = append(resultRawRouteIDs, routeRow.ID)
+		}
+		alerts := api.collectAlertsForRoutes(resultRawRouteIDs)
+		situations := api.BuildSituationReferences(alerts)
+
+		references.Agencies = agencies
+		references.Situations = situations
+	}
 
 	response := models.NewListResponseWithRange(results, *references, false, api.Clock, false)
 	api.sendResponse(w, r, response)

--- a/internal/restapi/route_search_handler_test.go
+++ b/internal/restapi/route_search_handler_test.go
@@ -104,3 +104,19 @@ func TestRouteSearchHandlerMaxCountBoundaries(t *testing.T) {
 	resp, _ = callAPIHandler[RoutesResponse](t, api, routeSearchURL(url.Values{"input": {"shasta"}, "maxCount": {"101"}}))
 	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 }
+
+func TestRouteSearchHandlerIncludeReferencesFalse(t *testing.T) {
+	api := createTestApi(t)
+	defer api.Shutdown()
+
+	resp, model := callAPIHandler[RoutesResponse](t, api, routeSearchURL(url.Values{"input": {"shasta"}, "includeReferences": {"false"}}))
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, http.StatusOK, model.Code)
+	assert.NotEmpty(t, model.Data.List)
+
+	// When includeReferences is false, the references block should be completely empty
+	assert.Empty(t, model.Data.References.Agencies)
+	assert.Empty(t, model.Data.References.Routes)
+	assert.Empty(t, model.Data.References.Situations)
+}


### PR DESCRIPTION

### Description
This PR adds support for the `includeReferences` query parameter in the `search-route` endpoint, bringing it into compliance with the OBA spec and matching the behavior of sibling endpoints.

**Key Changes:**
- Leveraged the existing `ShouldIncludeReferences` utility to parse the query parameter.
- Skips database queries for agencies and situations when `includeReferences=false` is provided, returning an empty references block and reducing payload size.
- Added `TestRouteSearchHandlerIncludeReferencesFalse` to explicitly test this boundary condition and prevent regressions.

closes #1198


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to exclude supplementary agency, route, and situation references from route search responses.
  * Route search results remain available when references are excluded.

* **Bug Fixes**
  * Ensured reference sections are returned as empty objects when supplementary data is disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->