### PR TITLE
Fix: Parse includeReferences in agencies-with-coverage endpoint

### DIFF
--- a/internal/restapi/agencies_with_coverage_handler.go
+++ b/internal/restapi/agencies_with_coverage_handler.go
@@ -39,7 +39,13 @@ func (api *RestAPI) agenciesWithCoverageHandler(w http.ResponseWriter, r *http.R
 	}
 
 	references := models.NewEmptyReferences()
-	references.Agencies = buildAgencyReferences(agencies)
+
+	includeReferences := ShouldIncludeReferences(r)
+
+	if includeReferences {
+		references.Agencies = buildAgencyReferences(agencies)
+	}
+
 	response := models.NewListResponse(agenciesWithCoverage, *references, limitExceeded, api.Clock)
 	api.sendResponse(w, r, response)
 }

--- a/internal/restapi/agencies_with_coverage_handler_test.go
+++ b/internal/restapi/agencies_with_coverage_handler_test.go
@@ -78,6 +78,7 @@ func TestAgenciesWithCoverageHandlerIncludeReferencesFalse(t *testing.T) {
 	assert.Len(t, model.Data.List, 1)
 
 	// But References.Agencies should be explicitly empty, not containing Raba
+	assert.NotNil(t, model.Data.References.Agencies)
 	assert.Empty(t, model.Data.References.Agencies)
 	assert.Empty(t, model.Data.References.Routes)
 	assert.Empty(t, model.Data.References.Situations)

--- a/internal/restapi/agencies_with_coverage_handler_test.go
+++ b/internal/restapi/agencies_with_coverage_handler_test.go
@@ -11,6 +11,7 @@ import (
 
 func TestAgenciesWithCoverageHandlerRequiresValidApiKey(t *testing.T) {
 	api := createTestApi(t)
+	defer api.Shutdown()
 
 	resp, model := callAPIHandler[CoverageResponse](t, api, "/api/where/agencies-with-coverage.json?key=invalid")
 
@@ -21,6 +22,7 @@ func TestAgenciesWithCoverageHandlerRequiresValidApiKey(t *testing.T) {
 
 func TestAgenciesWithCoverageHandlerEndToEnd(t *testing.T) {
 	api := createTestApi(t)
+	defer api.Shutdown()
 
 	resp, model := callAPIHandler[CoverageResponse](t, api, "/api/where/agencies-with-coverage.json?key=TEST")
 
@@ -47,6 +49,7 @@ func TestAgenciesWithCoverageHandlerEndToEnd(t *testing.T) {
 func TestAgenciesWithCoverageHandlerPagination(t *testing.T) {
 	// Test data (raba.zip) has 1 agency
 	api := createTestApi(t)
+	defer api.Shutdown()
 
 	_, model := callAPIHandler[CoverageResponse](t, api, "/api/where/agencies-with-coverage.json?key=TEST&limit=1")
 	assert.Len(t, model.Data.List, 1)
@@ -59,4 +62,26 @@ func TestAgenciesWithCoverageHandlerPagination(t *testing.T) {
 	_, model = callAPIHandler[CoverageResponse](t, api, "/api/where/agencies-with-coverage.json?key=TEST&offset=1")
 	assert.Len(t, model.Data.List, 0)
 	assert.False(t, model.Data.LimitExceeded)
+}
+
+func TestAgenciesWithCoverageHandlerIncludeReferencesFalse(t *testing.T) {
+	api := createTestApi(t)
+	defer api.Shutdown()
+
+	resp, model := callAPIHandler[CoverageResponse](t, api, "/api/where/agencies-with-coverage.json?key=TEST&includeReferences=false")
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, http.StatusOK, model.Code)
+	assert.Equal(t, "OK", model.Text)
+
+	// List should still be present and correct
+	assert.Len(t, model.Data.List, 1)
+
+	// But References.Agencies should be explicitly empty, not containing Raba
+	assert.Empty(t, model.Data.References.Agencies)
+	assert.Empty(t, model.Data.References.Routes)
+	assert.Empty(t, model.Data.References.Situations)
+	assert.Empty(t, model.Data.References.StopTimes)
+	assert.Empty(t, model.Data.References.Stops)
+	assert.Empty(t, model.Data.References.Trips)
 }


### PR DESCRIPTION
### Description
This PR resolves an issue where the `/api/where/agencies-with-coverage.json` endpoint unconditionally returned agency references, ignoring the `includeReferences` query parameter. 

The handler has been updated to parse the `includeReferences` flag and conditionally populate the `data.references` block, bringing the endpoint into full compliance with the OneBusAway specification.

### Changes Made
- Evaluates the `includeReferences` query parameter using the standard `ShouldIncludeReferences()` utility before building the references block.
- Adds a new unit test (`TestAgenciesWithCoverageHandlerIncludeReferencesFalse`) to ensure the `data.references.agencies` array remains empty when the flag is set to `false`.
- Adds missing `defer api.Shutdown()` cleanups across the `agencies-with-coverage` test suite to prevent context timeouts and ensure proper database teardown.


Closes #1211


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added support for `includeReferences=false` to return agency coverage responses without populating reference-related subfields, while still returning the agency list.
  * Reference sections are now consistently empty when excluded.
* **Tests**
  * Improved test reliability and added an end-to-end test to verify the correct behavior when reference data is disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->