### PR TITLE
Docs: Clarify pagination deviation in agencies-with-coverage endpoint

### DIFF
--- a/internal/restapi/agencies_with_coverage_handler.go
+++ b/internal/restapi/agencies_with_coverage_handler.go
@@ -23,7 +23,11 @@ func (api *RestAPI) agenciesWithCoverageHandler(w http.ResponseWriter, r *http.R
 		return
 	}
 
-	// Apply pagination
+	// Apply pagination.
+	// Note: The legacy OBA specification explicitly documents a defect for this endpoint
+	// where maxCount was accepted but never applied (limitExceeded was always false).
+	// We intentionally deviate from the legacy behavior here to correctly implement
+	// pagination and limitExceeded, fixing the known defect.
 	offset, limit := utils.ParsePaginationParams(r)
 	agencies, limitExceeded := utils.PaginateSlice(agencies, offset, limit)
 


### PR DESCRIPTION
### Description
This PR resolves an architectural ambiguity regarding how pagination is handled in the `/api/where/agencies-with-coverage.json` endpoint.

The legacy OneBusAway server had a known defect where it accepted a `maxCount` parameter but never applied it, meaning `limitExceeded` was always `false` and all agencies were returned. Maglev currently fixes this by properly applying `maxCount` and truncating the list. 

If we have decided to preserve our working pagination rather than mimicking the legacy bug, this PR adds a detailed inline comment documenting this intentional deviation from the legacy specification.

### Changes Made
- Added a code comment above the pagination logic in `agencies_with_coverage_handler.go` explicitly noting the legacy defect and confirming that our deviation is deliberate.
