### PR TITLE
Return empty list for unknown route IDs

### DIFF
--- a/internal/restapi/trips_for_route_handler.go
+++ b/internal/restapi/trips_for_route_handler.go
@@ -32,7 +32,13 @@ func (api *RestAPI) tripsForRouteHandler(w http.ResponseWriter, r *http.Request)
 
 	currentAgency, err := api.GtfsManager.GtfsDB.Queries.GetAgency(ctx, agencyID)
 	if err != nil {
-		api.sendNotFound(w, r)
+		if errors.Is(err, sql.ErrNoRows) {
+			references := models.NewEmptyReferences()
+			response := models.NewListResponseWithRange([]models.TripsForRouteListEntry{}, *references, false, api.Clock, false)
+			api.sendResponse(w, r, response)
+			return
+		}
+		api.serverErrorResponse(w, r, err)
 		return
 	}
 

--- a/internal/restapi/trips_for_route_handler_test.go
+++ b/internal/restapi/trips_for_route_handler_test.go
@@ -120,7 +120,21 @@ func TestTripsForRouteHandler_DifferentRoutes(t *testing.T) {
 			expectStatus: http.StatusOK,
 		},
 		{
-			name:         "Non-existent Route",
+			name:         "Unknown Route in Known Agency",
+			routeID:      utils.FormCombinedID(tripsForRouteAgencyID, "NONEXISTENT_ROUTE"),
+			minExpected:  0,
+			maxExpected:  0,
+			expectStatus: http.StatusOK,
+		},
+		{
+			name:         "Unknown Agency",
+			routeID:      utils.FormCombinedID("UNKNOWN_AGENCY", "NONEXISTENT"),
+			minExpected:  0,
+			maxExpected:  0,
+			expectStatus: http.StatusOK,
+		},
+		{
+			name:         "Malformed ID — No Underscore",
 			routeID:      "NONEXISTENT",
 			minExpected:  0,
 			maxExpected:  0,
@@ -161,6 +175,10 @@ func TestTripsForRouteHandler_DifferentRoutes(t *testing.T) {
 
 			assert.GreaterOrEqual(t, len(model.Data.List), tt.minExpected)
 			assert.LessOrEqual(t, len(model.Data.List), tt.maxExpected)
+
+			if len(model.Data.List) == 0 {
+				return
+			}
 
 			expectedTripID := utils.FormCombinedID(tripsForRouteAgencyID, tripsForRouteTripID)
 			for i, entry := range model.Data.List {


### PR DESCRIPTION
### Summary
Updates the `trips-for-route` handler to return `200 OK` with an empty list when the route ID or agency ID is unknown, resolving a spec gap.

### Changes
- Distinguishes `sql.ErrNoRows` during the initial agency lookup to return `200 OK` with an empty `data.list` instead of `404 Not Found`.
- Preserves `500 Server Error` for genuine database failures and `400 Bad Request` for malformed combined IDs.
- Adds table-driven test cases for unknown routes and unknown agencies, safely bypassing further assertions via early return when the list is empty.

Closes: #1207 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Requests for unknown agencies or routes now return a successful response with an empty trip list.
  * Malformed route identifiers continue to return a clear bad-request response.
  * Improved handling of empty results to prevent invalid trip details from being displayed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->