### PR TITLE
Add includeReferences parameter to trips-for-route

### DIFF
--- a/internal/restapi/trips_for_route_handler.go
+++ b/internal/restapi/trips_for_route_handler.go
@@ -439,22 +439,22 @@ func (api *RestAPI) tripsForRouteHandler(w http.ResponseWriter, r *http.Request)
 		result = []models.TripsForRouteListEntry{}
 	}
 
-	var stops []gtfsdb.Stop
-	if len(stopIDsMap) > 0 {
-		stopIDs := make([]string, 0, len(stopIDsMap))
-		for stopID := range stopIDsMap {
-			stopIDs = append(stopIDs, stopID)
-		}
-		var err error
-		stops, err = api.GtfsManager.GtfsDB.Queries.GetStopsByIDs(ctx, stopIDs)
-		if err != nil {
-			api.Logger.Warn("failed to fetch stops for references", "error", err, "count", len(stopIDs))
-			stops = []gtfsdb.Stop{}
-		}
-	}
-
 	var references models.ReferencesModel
 	if includeReferences {
+		var stops []gtfsdb.Stop
+		if len(stopIDsMap) > 0 {
+			stopIDs := make([]string, 0, len(stopIDsMap))
+			for stopID := range stopIDsMap {
+				stopIDs = append(stopIDs, stopID)
+			}
+			var err error
+			stops, err = api.GtfsManager.GtfsDB.Queries.GetStopsByIDs(ctx, stopIDs)
+			if err != nil {
+				api.Logger.Warn("failed to fetch stops for references", "error", err, "count", len(stopIDs))
+				stops = []gtfsdb.Stop{}
+			}
+		}
+
 		references = buildTripReferences(api, ctx, includeSchedule, result, stops, fetchedTrips)
 	} else {
 		references = *models.NewEmptyReferences()

--- a/internal/restapi/trips_for_route_handler.go
+++ b/internal/restapi/trips_for_route_handler.go
@@ -29,6 +29,7 @@ func (api *RestAPI) tripsForRouteHandler(w http.ResponseWriter, r *http.Request)
 
 	includeSchedule := r.URL.Query().Get("includeSchedule") != "false"
 	includeStatus := r.URL.Query().Get("includeStatus") != "false"
+	includeReferences := ShouldIncludeReferences(r)
 
 	currentAgency, err := api.GtfsManager.GtfsDB.Queries.GetAgency(ctx, agencyID)
 	if err != nil {
@@ -182,7 +183,12 @@ func (api *RestAPI) tripsForRouteHandler(w http.ResponseWriter, r *http.Request)
 	}
 
 	if len(allLinkedBlocks) == 0 && len(nullBlockTrips) == 0 {
-		references := buildTripReferences(api, ctx, includeSchedule, []models.TripsForRouteListEntry{}, []gtfsdb.Stop{}, nil)
+		var references models.ReferencesModel
+		if includeReferences {
+			references = buildTripReferences(api, ctx, includeSchedule, []models.TripsForRouteListEntry{}, []gtfsdb.Stop{}, nil)
+		} else {
+			references = *models.NewEmptyReferences()
+		}
 		response := models.NewListResponseWithRange([]models.TripsForRouteListEntry{}, references, false, api.Clock, false)
 		api.sendResponse(w, r, response)
 		return
@@ -447,7 +453,12 @@ func (api *RestAPI) tripsForRouteHandler(w http.ResponseWriter, r *http.Request)
 		}
 	}
 
-	references := buildTripReferences(api, ctx, includeSchedule, result, stops, fetchedTrips)
+	var references models.ReferencesModel
+	if includeReferences {
+		references = buildTripReferences(api, ctx, includeSchedule, result, stops, fetchedTrips)
+	} else {
+		references = *models.NewEmptyReferences()
+	}
 	response := models.NewListResponseWithRange(result, references, false, api.Clock, false)
 	api.sendResponse(w, r, response)
 }

--- a/internal/restapi/trips_for_route_handler_test.go
+++ b/internal/restapi/trips_for_route_handler_test.go
@@ -279,6 +279,10 @@ func TestTripsForRouteHandler_ReferencesInclusion(t *testing.T) {
 
 	timeMs := tripsForRouteTestClock.UnixMilli()
 
+	baselineURL := fmt.Sprintf("/api/where/trips-for-route/%s.json?key=TEST&includeSchedule=true&time=%d", combinedRouteID, timeMs)
+	_, baselineModel := callAPIHandler[TripsForRouteResponse](t, api, baselineURL)
+	expectedList := baselineModel.Data.List
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			url := fmt.Sprintf("/api/where/trips-for-route/%s.json?key=TEST&includeSchedule=true&time=%d",
@@ -290,6 +294,7 @@ func TestTripsForRouteHandler_ReferencesInclusion(t *testing.T) {
 			resp, model := callAPIHandler[TripsForRouteResponse](t, api, url)
 
 			assert.Equal(t, http.StatusOK, resp.StatusCode)
+			assert.Equal(t, expectedList, model.Data.List, "data.list should remain exactly the same regardless of includeReferences flag")
 			require.NotEmpty(t, model.Data.List,
 				"fixture guarantees a trip at the pinned clock")
 
@@ -320,7 +325,7 @@ func TestTripsForRouteHandler_ReferencesInclusion_EmptyList(t *testing.T) {
 	api := createTestApiWithTripsForRouteFixture(t, clock.NewMockClock(tripsForRouteTestClock))
 	combinedRouteID := utils.FormCombinedID(tripsForRouteAgencyID, tripsForRouteRouteID)
 
-	outOfServiceTimeMs := tripsForRouteTestClock.UnixMilli() + (12 * 60 * 60 * 1000)
+	outOfServiceTimeMs := tripsForRouteTestClock.Add(12 * time.Hour).UnixMilli()
 
 	tests := []struct {
 		name              string

--- a/internal/restapi/trips_for_route_handler_test.go
+++ b/internal/restapi/trips_for_route_handler_test.go
@@ -251,6 +251,71 @@ func TestTripsForRouteHandlerWithMalformedID(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, model.Code)
 }
 
+func TestTripsForRouteHandler_ReferencesInclusion(t *testing.T) {
+	api := createTestApiWithTripsForRouteFixture(t, clock.NewMockClock(tripsForRouteTestClock))
+	combinedRouteID := utils.FormCombinedID(tripsForRouteAgencyID, tripsForRouteRouteID)
+
+	tests := []struct {
+		name              string
+		includeReferences string
+		wantRefsPopulated bool
+	}{
+		{
+			name:              "Include References (default)",
+			includeReferences: "",
+			wantRefsPopulated: true,
+		},
+		{
+			name:              "Include References Explicit",
+			includeReferences: "true",
+			wantRefsPopulated: true,
+		},
+		{
+			name:              "Exclude References",
+			includeReferences: "false",
+			wantRefsPopulated: false,
+		},
+	}
+
+	timeMs := tripsForRouteTestClock.UnixMilli()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			url := fmt.Sprintf("/api/where/trips-for-route/%s.json?key=TEST&includeSchedule=true&time=%d",
+				combinedRouteID, timeMs)
+			if tt.includeReferences != "" {
+				url += "&includeReferences=" + tt.includeReferences
+			}
+
+			resp, model := callAPIHandler[TripsForRouteResponse](t, api, url)
+
+			assert.Equal(t, http.StatusOK, resp.StatusCode)
+			require.NotEmpty(t, model.Data.List,
+				"fixture guarantees a trip at the pinned clock")
+
+			if tt.wantRefsPopulated {
+				assert.NotEmpty(t, model.Data.References.Agencies,
+					"references.agencies should be populated")
+				assert.NotEmpty(t, model.Data.References.Routes,
+					"references.routes should be populated")
+				assert.NotEmpty(t, model.Data.References.Trips,
+					"references.trips should be populated")
+				assert.NotEmpty(t, model.Data.References.Stops,
+					"references.stops should be populated when includeSchedule=true")
+			} else {
+				assert.Empty(t, model.Data.References.Agencies,
+					"references.agencies should be empty")
+				assert.Empty(t, model.Data.References.Routes,
+					"references.routes should be empty")
+				assert.Empty(t, model.Data.References.Trips,
+					"references.trips should be empty")
+				assert.Empty(t, model.Data.References.Stops,
+					"references.stops should be empty")
+			}
+		})
+	}
+}
+
 func TestStripNumericSuffix(t *testing.T) {
 	tests := []struct {
 		input    string

--- a/internal/restapi/trips_for_route_handler_test.go
+++ b/internal/restapi/trips_for_route_handler_test.go
@@ -303,15 +303,65 @@ func TestTripsForRouteHandler_ReferencesInclusion(t *testing.T) {
 				assert.NotEmpty(t, model.Data.References.Stops,
 					"references.stops should be populated when includeSchedule=true")
 			} else {
-				assert.Empty(t, model.Data.References.Agencies,
-					"references.agencies should be empty")
-				assert.Empty(t, model.Data.References.Routes,
-					"references.routes should be empty")
-				assert.Empty(t, model.Data.References.Trips,
-					"references.trips should be empty")
-				assert.Empty(t, model.Data.References.Stops,
-					"references.stops should be empty")
+				assert.NotNil(t, model.Data.References.Agencies, "references.agencies should be non-nil")
+				assert.Empty(t, model.Data.References.Agencies, "references.agencies should be empty")
+				assert.NotNil(t, model.Data.References.Routes, "references.routes should be non-nil")
+				assert.Empty(t, model.Data.References.Routes, "references.routes should be empty")
+				assert.NotNil(t, model.Data.References.Trips, "references.trips should be non-nil")
+				assert.Empty(t, model.Data.References.Trips, "references.trips should be empty")
+				assert.NotNil(t, model.Data.References.Stops, "references.stops should be non-nil")
+				assert.Empty(t, model.Data.References.Stops, "references.stops should be empty")
 			}
+		})
+	}
+}
+
+func TestTripsForRouteHandler_ReferencesInclusion_EmptyList(t *testing.T) {
+	api := createTestApiWithTripsForRouteFixture(t, clock.NewMockClock(tripsForRouteTestClock))
+	combinedRouteID := utils.FormCombinedID(tripsForRouteAgencyID, tripsForRouteRouteID)
+
+	outOfServiceTimeMs := tripsForRouteTestClock.UnixMilli() + (12 * 60 * 60 * 1000)
+
+	tests := []struct {
+		name              string
+		includeReferences string
+		wantRefsPopulated bool
+	}{
+		{
+			name:              "Empty List - Include References Explicit",
+			includeReferences: "true",
+			wantRefsPopulated: true,
+		},
+		{
+			name:              "Empty List - Exclude References",
+			includeReferences: "false",
+			wantRefsPopulated: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			url := fmt.Sprintf("/api/where/trips-for-route/%s.json?key=TEST&includeSchedule=true&time=%d",
+				combinedRouteID, outOfServiceTimeMs)
+
+			if tt.includeReferences != "" {
+				url += "&includeReferences=" + tt.includeReferences
+			}
+
+			resp, model := callAPIHandler[TripsForRouteResponse](t, api, url)
+
+			assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+			require.Empty(t, model.Data.List, "fixture should guarantee NO trips at this out-of-service time")
+
+			assert.NotNil(t, model.Data.References.Agencies, "references.agencies should be non-nil")
+			assert.Empty(t, model.Data.References.Agencies, "references.agencies should be empty")
+			assert.NotNil(t, model.Data.References.Routes, "references.routes should be non-nil")
+			assert.Empty(t, model.Data.References.Routes, "references.routes should be empty")
+			assert.NotNil(t, model.Data.References.Trips, "references.trips should be non-nil")
+			assert.Empty(t, model.Data.References.Trips, "references.trips should be empty")
+			assert.NotNil(t, model.Data.References.Stops, "references.stops should be non-nil")
+			assert.Empty(t, model.Data.References.Stops, "references.stops should be empty")
 		})
 	}
 }


### PR DESCRIPTION
### Summary
Implements the `includeReferences` query parameter for the `trips-for-route` endpoint. When `includeReferences=false`, the `data.references` block is returned with all arrays empty, while the list entries remain unaffected. This aligns the handler with the API spec and the established behavior of peer handlers.

### Changes
- **`internal/restapi/trips_for_route_handler.go`:**
  - Added `includeReferences := ShouldIncludeReferences(r)` to correctly parse the flag using the existing shared helper.
  - Updated both the empty-list early return path and the main response path to conditionally skip `buildTripReferences` and use `models.NewEmptyReferences()` when the parameter is false.
- **`internal/restapi/trips_for_route_handler_test.go`:**
  - Added a new table-driven test `TestTripsForRouteHandler_ReferencesInclusion` to verify three cases: parameter omitted (default true), explicit true, and explicit false.
  - The tests assert that all nested reference collections (`Agencies`, `Routes`, `Trips`, `Stops`) are properly emptied without affecting `data.list`.
 
Closes: #1209 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for optionally including reference data in trips-for-route responses via the `includeReferences` query parameter.

* **Bug Fixes**
  * When `includeReferences` is disabled, reference fields are now consistently empty (but non-nil) while trip results are still returned, including edge cases with no matching trips.

* **Tests**
  * Added table-driven tests covering reference inclusion/exclusion (including empty-results scenarios) and validating Agencies, Routes, Trips, and Stops behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->