### PR TITLE
fix: resolve serviceDate from each trip's own schedule instead of assuming today

### DIFF
--- a/internal/restapi/trip_for_vehicle_handler.go
+++ b/internal/restapi/trip_for_vehicle_handler.go
@@ -65,7 +65,16 @@ func (api *RestAPI) tripForVehicleHandler(w http.ResponseWriter, r *http.Request
 		currentTime = api.Clock.Now().In(loc)
 	}
 
-	serviceDate, midnight := utils.ServiceDateMidnight(params.ServiceDate, currentTime)
+	// trip-for-vehicle has no documented serviceDate request parameter — legacy Java's
+	// TripForVehicleAction has no corresponding setter, and no client sends one.
+	// (params.ServiceDate is populated only because parseTripParams is shared with
+	// trip-details, which does document one; it's intentionally not read here.)
+	// Per spec, serviceDate is derived from the trip itself: for trips extending past
+	// midnight, the service date is the previous calendar day, not "today".
+	serviceDate := utils.CalculateServiceDate(currentTime)
+	if resolved, ok := api.resolveTripServiceDate(ctx, tripID, currentTime); ok {
+		serviceDate = resolved
+	}
 
 	var status *models.TripStatus
 	if params.IncludeStatus {
@@ -118,7 +127,7 @@ func (api *RestAPI) tripForVehicleHandler(w http.ResponseWriter, r *http.Request
 
 	entry := &models.TripDetails{
 		TripID:       utils.FormCombinedID(agencyID, tripID),
-		ServiceDate:  models.NewModelTime(midnight),
+		ServiceDate:  models.NewModelTime(serviceDate),
 		Frequency:    nil,
 		Status:       status,
 		Schedule:     schedule,

--- a/internal/restapi/trip_for_vehicle_handler.go
+++ b/internal/restapi/trip_for_vehicle_handler.go
@@ -72,7 +72,7 @@ func (api *RestAPI) tripForVehicleHandler(w http.ResponseWriter, r *http.Request
 	// Per spec, serviceDate is derived from the trip itself: for trips extending past
 	// midnight, the service date is the previous calendar day, not "today".
 	serviceDate := utils.CalculateServiceDate(currentTime)
-	if resolved, ok := api.resolveTripServiceDate(ctx, tripID, currentTime); ok {
+	if resolved, ok := api.resolveTripServiceDate(ctx, tripID, currentTime, 0, 0); ok {
 		serviceDate = resolved
 	}
 

--- a/internal/restapi/trip_for_vehicle_handler_test.go
+++ b/internal/restapi/trip_for_vehicle_handler_test.go
@@ -1,6 +1,7 @@
 package restapi
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 	"maps"
@@ -13,6 +14,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"maglev.onebusaway.org/gtfsdb"
 	"maglev.onebusaway.org/internal/models"
 	"maglev.onebusaway.org/internal/restapi/testdata"
 	"maglev.onebusaway.org/internal/utils"
@@ -194,24 +196,73 @@ func TestTripForVehicleHandler_IncludeToggles(t *testing.T) {
 	})
 }
 
-func TestTripForVehicleHandlerWithServiceDate(t *testing.T) {
-	api, vehicleID := setupTestApiWithMockVehicle(t)
+// TestTripForVehicleHandler_ServiceDateParamIgnored verifies that trip-for-vehicle
+// has no serviceDate request parameter (per spec and legacy Java's TripForVehicleAction,
+// which has no such setter): a client-supplied serviceDate is silently ignored, and
+// the response's serviceDate always reflects the vehicle's actual trip.
+func TestTripForVehicleHandler_ServiceDateParamIgnored(t *testing.T) {
+	api := createTestApi(t)
+	defer api.Shutdown()
+	t.Cleanup(api.GtfsManager.MockResetRealTimeData)
+	ctx := context.Background()
 
-	// Pin to a fixed future-but-bounded date so the test doesn't drift over the
-	// years. The handler resolves serviceDate to midnight in the agency's
-	// timezone, so we compute the expected midnight against testdata.Raba.Timezone.
-	serviceDate := time.Date(2025, 6, 12, 12, 0, 0, 0, time.UTC)
-	agencyLoc, err := time.LoadLocation(testdata.Raba.Timezone)
+	// The handler resolves reference time in the agency's timezone, so the test
+	// must build reference times in the same location for the windows to line up.
+	loc, err := time.LoadLocation(testdata.Raba.Timezone)
 	require.NoError(t, err)
-	sdInAgencyTz := serviceDate.In(agencyLoc)
-	expectedMidnight := time.Date(sdInAgencyTz.Year(), sdInAgencyTz.Month(), sdInAgencyTz.Day(), 0, 0, 0, 0, agencyLoc)
+	serviceDate := time.Date(2024, 11, 4, 0, 0, 0, 0, loc)
+	formattedDate := serviceDate.Format("20060102")
+
+	serviceIDs, err := api.GtfsManager.GtfsDB.Queries.GetActiveServiceIDsForDate(ctx, formattedDate)
+	require.NoError(t, err)
+	require.NotEmpty(t, serviceIDs, "need an active RABA service on serviceDate")
+
+	trips, err := api.GtfsManager.GetTrips(ctx, 200)
+	require.NoError(t, err)
+
+	var activeTrip gtfsdb.Trip
+	for _, tr := range trips {
+		row, err := api.GtfsManager.GtfsDB.Queries.GetTrip(ctx, tr.ID)
+		if err != nil || !row.MinArrivalTime.Valid || !row.MaxDepartureTime.Valid {
+			continue
+		}
+		for _, sid := range serviceIDs {
+			if sid == row.ServiceID {
+				activeTrip = row
+				break
+			}
+		}
+		if activeTrip.ID != "" {
+			break
+		}
+	}
+	require.NotEmpty(t, activeTrip.ID, "need a trip active on serviceDate in test data")
+
+	midWindowNs := (activeTrip.MinArrivalTime.Int64 + activeTrip.MaxDepartureTime.Int64) / 2
+	refTime := serviceDate.Add(time.Duration(midWindowNs))
+
+	const mockVehicleID = "MOCK_VEHICLE_SD_IGNORED"
+	combinedRouteID := utils.FormCombinedID(testdata.Raba.ID, activeTrip.RouteID)
+	api.GtfsManager.MockAddAgency(testdata.Raba.ID, "unitrans")
+	api.GtfsManager.MockAddRoute(combinedRouteID, testdata.Raba.ID, combinedRouteID)
+	api.GtfsManager.MockAddTrip(activeTrip.ID, testdata.Raba.ID, combinedRouteID)
+	api.GtfsManager.MockAddVehicle(mockVehicleID, activeTrip.ID, combinedRouteID)
+	vehicleID := utils.FormCombinedID(testdata.Raba.ID, mockVehicleID)
+
+	// An unrelated date, clearly distinct from serviceDate, supplied via the
+	// unsupported serviceDate query parameter.
+	unrelatedServiceDate := time.Date(2025, 6, 12, 12, 0, 0, 0, time.UTC)
 
 	resp, model := callAPIHandler[TripDetailsResponse](t, api,
-		tripForVehicleURL(vehicleID, url.Values{"serviceDate": {fmt.Sprintf("%d", serviceDate.UnixMilli())}}))
+		tripForVehicleURL(vehicleID, url.Values{
+			"time":        {fmt.Sprintf("%d", refTime.UnixMilli())},
+			"serviceDate": {fmt.Sprintf("%d", unrelatedServiceDate.UnixMilli())},
+		}))
 
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, http.StatusOK, model.Code)
-	assert.Equal(t, expectedMidnight.UnixMilli(), model.Data.Entry.ServiceDate.UnixMilli())
+	assert.Equal(t, serviceDate.UnixMilli(), model.Data.Entry.ServiceDate.UnixMilli(),
+		"serviceDate must be derived from the trip's own schedule, not the unsupported query parameter")
 }
 
 func TestTripForVehicleHandlerWithTimeParameter(t *testing.T) {

--- a/internal/restapi/trips_for_location_handler.go
+++ b/internal/restapi/trips_for_location_handler.go
@@ -355,6 +355,15 @@ func (api *RestAPI) buildTripsForLocationEntries(
 		}
 	}
 
+	// tripID comes from a live GTFS-RT vehicle report, not a schedule-window search, so
+	// its actual reported time may fall outside the trip's exact static window — same
+	// "running late/early" tolerance the spec documents for this endpoint's candidate
+	// discovery (30 min before, 10 min after; BlockStatusServiceImpl).
+	const (
+		runningLateWindow  = 30 * time.Minute
+		runningEarlyWindow = 10 * time.Minute
+	)
+
 	var result []models.TripsForLocationListEntry
 
 	for _, tripID := range validVehicleTrips {
@@ -366,6 +375,14 @@ func (api *RestAPI) buildTripsForLocationEntries(
 		tripData, tripFound := tripsMap[tripID]
 		if !tripFound {
 			continue
+		}
+
+		// Re-resolve the service date from the trip's own schedule per trip rather than
+		// assuming "today", so a vehicle running an overnight trip reports the correct
+		// service date instead of silently falling back to today's.
+		tripServiceDate := todayMidnight
+		if resolved, ok := api.resolveTripServiceDate(ctx, tripID, currentTime, runningEarlyWindow, runningLateWindow); ok {
+			tripServiceDate = resolved
 		}
 
 		var schedule *models.TripsSchedule
@@ -395,7 +412,7 @@ func (api *RestAPI) buildTripsForLocationEntries(
 
 		if includeStatus {
 			var statusErr error
-			status, statusErr = api.BuildTripStatus(ctx, agencyID, tripID, nil, todayMidnight, currentTime)
+			status, statusErr = api.BuildTripStatus(ctx, agencyID, tripID, nil, tripServiceDate, currentTime)
 			if statusErr != nil {
 				api.Logger.Warn("BuildTripStatus failed", "tripID", tripID, "error", statusErr)
 				status = nil
@@ -406,7 +423,7 @@ func (api *RestAPI) buildTripsForLocationEntries(
 			Frequency:    nil,
 			Schedule:     schedule,
 			Status:       status,
-			ServiceDate:  todayMidnight.UnixMilli(),
+			ServiceDate:  tripServiceDate.UnixMilli(),
 			SituationIds: api.GetSituationIDsForTrip(ctx, tripID),
 			TripId:       utils.FormCombinedID(agencyID, tripID),
 		}

--- a/internal/restapi/trips_for_location_handler_test.go
+++ b/internal/restapi/trips_for_location_handler_test.go
@@ -1,6 +1,7 @@
 package restapi
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -9,7 +10,11 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"maglev.onebusaway.org/gtfsdb"
 	"maglev.onebusaway.org/internal/clock"
+	"maglev.onebusaway.org/internal/nulls"
+	"maglev.onebusaway.org/internal/restapi/testdata"
+	"maglev.onebusaway.org/internal/utils"
 )
 
 const (
@@ -398,4 +403,67 @@ func TestTripsForLocationHandler_TimeParameter(t *testing.T) {
 		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 		assert.Equal(t, http.StatusBadRequest, model.Code)
 	})
+}
+
+// TestBuildTripsForLocationEntries_OvernightTripServiceDate verifies that a trip
+// whose stop_times exceed 24:00:00 (running past midnight) reports the service
+// date it actually belongs to — the previous calendar day — rather than the naive
+// "today" derived from the query's wall-clock date. Calls buildTripsForLocationEntries
+// directly since reaching this trip through the full HTTP path would additionally
+// require mocking a real-time vehicle positioned inside a matching bounding box,
+// which is orthogonal to what this test is checking.
+func TestBuildTripsForLocationEntries_OvernightTripServiceDate(t *testing.T) {
+	api := createTestApi(t)
+	defer api.Shutdown()
+	ctx := context.Background()
+
+	loc, err := time.LoadLocation(testdata.Raba.Timezone)
+	require.NoError(t, err)
+	serviceDate := time.Date(2024, 11, 4, 0, 0, 0, 0, loc)
+	formattedDate := serviceDate.Format("20060102")
+	serviceIDs, err := api.GtfsManager.GtfsDB.Queries.GetActiveServiceIDsForDate(ctx, formattedDate)
+	require.NoError(t, err)
+	require.NotEmpty(t, serviceIDs, "need an active RABA service on serviceDate")
+
+	anyTrip := mustGetTrip(t, api)
+
+	const dayNs = int64(24 * time.Hour)
+	overnightTrip, err := api.GtfsManager.GtfsDB.Queries.CreateTrip(ctx, gtfsdb.CreateTripParams{
+		ID:               "tfl-overnight-trip",
+		RouteID:          anyTrip.RouteID,
+		ServiceID:        serviceIDs[0],
+		MinArrivalTime:   nulls.Int64(dayNs + int64(time.Hour)),                // 25:00
+		MaxDepartureTime: nulls.Int64(dayNs + int64(time.Hour+30*time.Minute)), // 25:30
+	})
+	require.NoError(t, err)
+
+	// 01:15 on the day after serviceDate falls within the 25:00-25:30 window,
+	// which belongs to serviceDate's service_id, not the next day's.
+	refTime := serviceDate.AddDate(0, 0, 1).Add(75 * time.Minute)
+	_, naiveTodayMidnight := utils.ServiceDateMidnight(nil, refTime)
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+
+	result := api.buildTripsForLocationEntries(
+		ctx,
+		[]gtfsdb.Trip{overnightTrip},
+		map[string]string{overnightTrip.ID: testdata.Raba.ID},
+		false, // includeSchedule
+		true,  // includeStatus
+		loc,
+		refTime,
+		naiveTodayMidnight,
+		serviceDate,
+		w, r,
+	)
+
+	require.Len(t, result, 1)
+	entry := result[0]
+	assert.Equal(t, serviceDate.UnixMilli(), entry.ServiceDate,
+		"serviceDate must be the previous calendar day for an overnight trip, not today")
+	if entry.Status != nil {
+		assert.Equal(t, serviceDate.UnixMilli(), entry.Status.ServiceDate.UnixMilli(),
+			"status.serviceDate must match the entry-level serviceDate")
+	}
 }

--- a/internal/restapi/trips_for_route_handler.go
+++ b/internal/restapi/trips_for_route_handler.go
@@ -322,6 +322,20 @@ func (api *RestAPI) tripsForRouteHandler(w http.ResponseWriter, r *http.Request)
 			continue
 		}
 
+		// The block search above already checks both today's and yesterday's active
+		// services to find trips running past midnight, but doesn't retain which day
+		// matched. Re-resolve it per trip from the trip's own schedule rather than
+		// assuming "today" so overnight trips report the correct service date. Widened
+		// by the same runningEarly/runningLate tolerance used to discover this trip in
+		// the first place (in particular, GetActiveTripsWithNullBlockForRoute admits
+		// candidates outside their exact scheduled window) — otherwise a trip found only
+		// via that slack can fail an exact-window check on both today and yesterday and
+		// silently fall back to todayMidnight.
+		tripServiceDate := todayMidnight
+		if resolved, ok := api.resolveTripServiceDate(ctx, tripID, currentTime, runningEarly, runningLate); ok {
+			tripServiceDate = resolved
+		}
+
 		var schedule *models.TripsSchedule
 		var status *models.TripStatus
 
@@ -339,7 +353,7 @@ func (api *RestAPI) tripsForRouteHandler(w http.ResponseWriter, r *http.Request)
 		// Build status if we have a vehicle (either on this trip or we know block has vehicles)
 		if includeStatus {
 			var statusErr error
-			status, statusErr = api.BuildTripStatus(ctx, agencyID, tripID, nil, todayMidnight, currentTime)
+			status, statusErr = api.BuildTripStatus(ctx, agencyID, tripID, nil, tripServiceDate, currentTime)
 			if statusErr != nil {
 				api.Logger.Warn("BuildTripStatus failed", "trip_id", tripID, "error", statusErr)
 				status = nil
@@ -350,7 +364,7 @@ func (api *RestAPI) tripsForRouteHandler(w http.ResponseWriter, r *http.Request)
 			Frequency:    nil,
 			Schedule:     schedule,
 			Status:       status,
-			ServiceDate:  todayMidnight.UnixMilli(),
+			ServiceDate:  tripServiceDate.UnixMilli(),
 			SituationIds: api.GetSituationIDsForTrip(r.Context(), tripID),
 			TripId:       utils.FormCombinedID(agencyID, tripID),
 		}
@@ -389,6 +403,14 @@ func (api *RestAPI) tripsForRouteHandler(w http.ResponseWriter, r *http.Request)
 			}
 		}
 
+		// Same day resolution as the base-trip loop above. DUPLICATED trips are extra
+		// real-time runs, so the base trip's static window may not exactly contain the
+		// vehicle's actual current time even on the correct day — same tolerance applies.
+		tripServiceDate := todayMidnight
+		if resolved, ok := api.resolveTripServiceDate(ctx, baseTripID, currentTime, runningEarly, runningLate); ok {
+			tripServiceDate = resolved
+		}
+
 		var schedule *models.TripsSchedule
 		if includeSchedule {
 			var schedErr error
@@ -403,7 +425,7 @@ func (api *RestAPI) tripsForRouteHandler(w http.ResponseWriter, r *http.Request)
 		var status *models.TripStatus
 		if includeStatus {
 			var statusErr error
-			status, statusErr = api.BuildTripStatus(ctx, agencyID, baseTripID, &vehicle, todayMidnight, currentTime)
+			status, statusErr = api.BuildTripStatus(ctx, agencyID, baseTripID, &vehicle, tripServiceDate, currentTime)
 			if statusErr != nil {
 				api.Logger.Warn("BuildTripStatus failed for DUPLICATED trip", "trip_id", baseTripID, "error", statusErr)
 				status = nil
@@ -414,7 +436,7 @@ func (api *RestAPI) tripsForRouteHandler(w http.ResponseWriter, r *http.Request)
 			Frequency:    nil,
 			Schedule:     schedule,
 			Status:       status,
-			ServiceDate:  todayMidnight.UnixMilli(),
+			ServiceDate:  tripServiceDate.UnixMilli(),
 			SituationIds: api.GetSituationIDsForTrip(r.Context(), baseTripID),
 			TripId:       utils.FormCombinedID(agencyID, dupTripID),
 		}

--- a/internal/restapi/trips_for_route_handler_test.go
+++ b/internal/restapi/trips_for_route_handler_test.go
@@ -36,12 +36,19 @@ const (
 	tripsForRouteHeadsign = "Test Headsign"
 )
 
+// tripsForRouteDefaultStopTimes: first stop at 11:55, last at 12:05 — pinned clock
+// at 12:00 (tripsForRouteTestClock) falls inside the handler's (-30min/+10min)
+// active window.
+const tripsForRouteDefaultStopTimes = "trip_id,arrival_time,departure_time,stop_id,stop_sequence\n" +
+	tripsForRouteTripID + ",11:55:00,11:55:00," + tripsForRouteStop1ID + ",1\n" +
+	tripsForRouteTripID + ",12:05:00,12:05:00," + tripsForRouteStop2ID + ",2\n"
+
 // createTestApiWithTripsForRouteFixture builds a RestAPI backed by a minimal
-// in-memory GTFS dataset with a single trip active at tripsForRouteTestClock.
-// This guarantees the trips-for-route handler returns at least one entry, so
-// the per-entry assertions below validate real data instead of running over
-// an empty list (the RABA fixture's block_trip_indexes don't cover this path).
-func createTestApiWithTripsForRouteFixture(t *testing.T, c clock.Clock) *RestAPI {
+// in-memory GTFS dataset with a single trip, using the given stop_times.txt
+// content. This guarantees the trips-for-route handler returns at least one
+// entry, so the per-entry assertions below validate real data instead of running
+// over an empty list (the RABA fixture's block_trip_indexes don't cover this path).
+func createTestApiWithTripsForRouteFixture(t *testing.T, c clock.Clock, stopTimesCSV string) *RestAPI {
 	t.Helper()
 	ctx := context.Background()
 
@@ -59,11 +66,7 @@ func createTestApiWithTripsForRouteFixture(t *testing.T, c clock.Clock) *RestAPI
 			tripsForRouteStop2ID + ",Stop Two,37.7849,-122.4094\n",
 		"trips.txt": "route_id,service_id,trip_id,trip_headsign,direction_id,block_id\n" +
 			tripsForRouteRouteID + ",tfr-svc," + tripsForRouteTripID + "," + tripsForRouteHeadsign + ",0,tfr-block\n",
-		// First stop at 11:55, last at 12:05 — pinned clock at 12:00 falls inside the
-		// handler's (-30min/+10min) active window.
-		"stop_times.txt": "trip_id,arrival_time,departure_time,stop_id,stop_sequence\n" +
-			tripsForRouteTripID + ",11:55:00,11:55:00," + tripsForRouteStop1ID + ",1\n" +
-			tripsForRouteTripID + ",12:05:00,12:05:00," + tripsForRouteStop2ID + ",2\n",
+		"stop_times.txt": stopTimesCSV,
 	}
 	for name, content := range files {
 		f, err := w.Create(name)
@@ -102,7 +105,7 @@ func createTestApiWithTripsForRouteFixture(t *testing.T, c clock.Clock) *RestAPI
 }
 
 func TestTripsForRouteHandler_DifferentRoutes(t *testing.T) {
-	api := createTestApiWithTripsForRouteFixture(t, clock.NewMockClock(tripsForRouteTestClock))
+	api := createTestApiWithTripsForRouteFixture(t, clock.NewMockClock(tripsForRouteTestClock), tripsForRouteDefaultStopTimes)
 	combinedRouteID := utils.FormCombinedID(tripsForRouteAgencyID, tripsForRouteRouteID)
 
 	tests := []struct {
@@ -196,7 +199,7 @@ func TestTripsForRouteHandler_DifferentRoutes(t *testing.T) {
 }
 
 func TestTripsForRouteHandler_ScheduleInclusion(t *testing.T) {
-	api := createTestApiWithTripsForRouteFixture(t, clock.NewMockClock(tripsForRouteTestClock))
+	api := createTestApiWithTripsForRouteFixture(t, clock.NewMockClock(tripsForRouteTestClock), tripsForRouteDefaultStopTimes)
 	combinedRouteID := utils.FormCombinedID(tripsForRouteAgencyID, tripsForRouteRouteID)
 
 	tests := []struct {
@@ -236,6 +239,48 @@ func TestTripsForRouteHandler_ScheduleInclusion(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// tripsForRouteOvernightTestClock is 01:20 on the day after the fixture trip's
+// service day — inside the trip's 25:15-25:25 (01:15-01:25) window.
+var tripsForRouteOvernightTestClock = time.Date(2025, 6, 13, 1, 20, 0, 0, time.UTC)
+
+// tripsForRouteOvernightStopTimes: the trip runs past midnight (25:15-25:25,
+// i.e. 01:15-01:25 the next calendar day), still belonging to the service day
+// it was scheduled on rather than the day the times roll into.
+const tripsForRouteOvernightStopTimes = "trip_id,arrival_time,departure_time,stop_id,stop_sequence\n" +
+	tripsForRouteTripID + ",25:15:00,25:15:00," + tripsForRouteStop1ID + ",1\n" +
+	tripsForRouteTripID + ",25:25:00,25:25:00," + tripsForRouteStop2ID + ",2\n"
+
+// TestTripsForRouteHandler_OvernightTripServiceDate verifies that a trip whose
+// stop_times exceed 24:00:00 (running past midnight) reports the service date it
+// actually belongs to — the previous calendar day — rather than the naive "today"
+// derived from the query's wall-clock date. The block-discovery logic already
+// finds such trips via its own previous-day search; this guards the serviceDate
+// value specifically, which previously used "today" unconditionally.
+func TestTripsForRouteHandler_OvernightTripServiceDate(t *testing.T) {
+	api := createTestApiWithTripsForRouteFixture(t, clock.NewMockClock(tripsForRouteOvernightTestClock), tripsForRouteOvernightStopTimes)
+	combinedRouteID := utils.FormCombinedID(tripsForRouteAgencyID, tripsForRouteRouteID)
+
+	expectedServiceDate := time.Date(2025, 6, 12, 0, 0, 0, 0, time.UTC)
+
+	timeMs := tripsForRouteOvernightTestClock.UnixMilli()
+	url := fmt.Sprintf("/api/where/trips-for-route/%s.json?key=TEST&time=%d", combinedRouteID, timeMs)
+
+	resp, model := callAPIHandler[TripsForRouteResponse](t, api, url)
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NotEmpty(t, model.Data.List,
+		"the block-discovery logic's own previous-day search should find the overnight trip")
+
+	for i, entry := range model.Data.List {
+		assert.Equal(t, expectedServiceDate.UnixMilli(), entry.ServiceDate,
+			"list[%d].serviceDate must be the previous calendar day for an overnight trip, not today", i)
+		if entry.Status != nil {
+			assert.Equal(t, expectedServiceDate.UnixMilli(), entry.Status.ServiceDate.UnixMilli(),
+				"list[%d].status.serviceDate must match the entry-level serviceDate", i)
+		}
 	}
 }
 

--- a/internal/restapi/trips_helper.go
+++ b/internal/restapi/trips_helper.go
@@ -624,7 +624,11 @@ func (api *RestAPI) blockTripSequence(ctx context.Context, tripID string, servic
 // service_id belongs to the previous calendar day. Checks today's active services
 // first, then yesterday's (with the wall-clock comparison offset by +24h) before
 // reporting failure.
-func (api *RestAPI) resolveTripServiceDate(ctx context.Context, tripID string, referenceTime time.Time) (time.Time, bool) {
+//
+// before/after widen the trip's scheduled window by the given tolerance (e.g. to
+// match a caller's own "running late/early" slack when its trip discovery already
+// admits candidates outside the trip's exact window); pass 0, 0 for an exact match.
+func (api *RestAPI) resolveTripServiceDate(ctx context.Context, tripID string, referenceTime time.Time, before, after time.Duration) (time.Time, bool) {
 	trip, err := api.GtfsManager.GtfsDB.Queries.GetTrip(ctx, tripID)
 	if err != nil || !trip.MinArrivalTime.Valid || !trip.MaxDepartureTime.Valid {
 		return time.Time{}, false
@@ -633,22 +637,24 @@ func (api *RestAPI) resolveTripServiceDate(ctx context.Context, tripID string, r
 	sinceMidnightNs := wallClockSinceMidnightNs(referenceTime)
 
 	today := utils.CalculateServiceDate(referenceTime)
-	if api.tripActiveOnDate(ctx, trip, today, sinceMidnightNs) {
+	if api.tripActiveOnDate(ctx, trip, today, sinceMidnightNs, before, after) {
 		return today, true
 	}
 
 	yesterday := utils.CalculateServiceDate(referenceTime.AddDate(0, 0, -1))
-	if api.tripActiveOnDate(ctx, trip, yesterday, sinceMidnightNs+int64(24*time.Hour)) {
+	if api.tripActiveOnDate(ctx, trip, yesterday, sinceMidnightNs+int64(24*time.Hour), before, after) {
 		return yesterday, true
 	}
 
 	return time.Time{}, false
 }
 
-// tripActiveOnDate reports whether trip's scheduled window contains sinceMidnightNs
-// and trip's service_id is among the active services on date.
-func (api *RestAPI) tripActiveOnDate(ctx context.Context, trip gtfsdb.Trip, date time.Time, sinceMidnightNs int64) bool {
-	if sinceMidnightNs < trip.MinArrivalTime.Int64 || sinceMidnightNs > trip.MaxDepartureTime.Int64 {
+// tripActiveOnDate reports whether trip's scheduled window, widened by before/after,
+// contains sinceMidnightNs, and trip's service_id is among the active services on date.
+func (api *RestAPI) tripActiveOnDate(ctx context.Context, trip gtfsdb.Trip, date time.Time, sinceMidnightNs int64, before, after time.Duration) bool {
+	windowStart := trip.MinArrivalTime.Int64 - int64(before)
+	windowEnd := trip.MaxDepartureTime.Int64 + int64(after)
+	if sinceMidnightNs < windowStart || sinceMidnightNs > windowEnd {
 		return false
 	}
 

--- a/internal/restapi/trips_helper.go
+++ b/internal/restapi/trips_helper.go
@@ -617,6 +617,54 @@ func (api *RestAPI) blockTripSequence(ctx context.Context, tripID string, servic
 	return int(seq), true
 }
 
+// resolveTripServiceDate determines which calendar service date a trip belongs to
+// for a given wall-clock reference time. GTFS allows stop times to exceed 24:00:00
+// for trips that run past midnight (e.g. 25:30:00 for 1:30 AM the next day), so a
+// trip's scheduled window can still be open after local midnight while its
+// service_id belongs to the previous calendar day. Checks today's active services
+// first, then yesterday's (with the wall-clock comparison offset by +24h) before
+// reporting failure.
+func (api *RestAPI) resolveTripServiceDate(ctx context.Context, tripID string, referenceTime time.Time) (time.Time, bool) {
+	trip, err := api.GtfsManager.GtfsDB.Queries.GetTrip(ctx, tripID)
+	if err != nil || !trip.MinArrivalTime.Valid || !trip.MaxDepartureTime.Valid {
+		return time.Time{}, false
+	}
+
+	sinceMidnightNs := wallClockSinceMidnightNs(referenceTime)
+
+	today := utils.CalculateServiceDate(referenceTime)
+	if api.tripActiveOnDate(ctx, trip, today, sinceMidnightNs) {
+		return today, true
+	}
+
+	yesterday := utils.CalculateServiceDate(referenceTime.AddDate(0, 0, -1))
+	if api.tripActiveOnDate(ctx, trip, yesterday, sinceMidnightNs+int64(24*time.Hour)) {
+		return yesterday, true
+	}
+
+	return time.Time{}, false
+}
+
+// tripActiveOnDate reports whether trip's scheduled window contains sinceMidnightNs
+// and trip's service_id is among the active services on date.
+func (api *RestAPI) tripActiveOnDate(ctx context.Context, trip gtfsdb.Trip, date time.Time, sinceMidnightNs int64) bool {
+	if sinceMidnightNs < trip.MinArrivalTime.Int64 || sinceMidnightNs > trip.MaxDepartureTime.Int64 {
+		return false
+	}
+
+	activeServiceIDs, err := api.GtfsManager.GtfsDB.Queries.GetActiveServiceIDsForDate(ctx, date.Format("20060102"))
+	if err != nil {
+		return false
+	}
+
+	for _, serviceID := range activeServiceIDs {
+		if serviceID == trip.ServiceID {
+			return true
+		}
+	}
+	return false
+}
+
 // calculatePreciseDistanceAlongTripWithCoords calculates the distance along a trip's shape to a stop
 // This optimized version accepts pre-calculated cumulative distances and stop coordinates
 func (api *RestAPI) calculatePreciseDistanceAlongTripWithCoords(

--- a/internal/restapi/trips_helper_test.go
+++ b/internal/restapi/trips_helper_test.go
@@ -2096,14 +2096,14 @@ func TestResolveTripServiceDate(t *testing.T) {
 		midWindowNs := (sameDayTrip.MinArrivalTime.Int64 + sameDayTrip.MaxDepartureTime.Int64) / 2
 		refTime := serviceDate.Add(time.Duration(midWindowNs))
 
-		got, ok := api.resolveTripServiceDate(ctx, sameDayTrip.ID, refTime)
+		got, ok := api.resolveTripServiceDate(ctx, sameDayTrip.ID, refTime, 0, 0)
 		require.True(t, ok)
 		assert.True(t, got.Equal(serviceDate),
 			"expected resolved date %v to equal service date %v", got, serviceDate)
 	})
 
 	t.Run("returns false for an unknown trip", func(t *testing.T) {
-		_, ok := api.resolveTripServiceDate(ctx, "nonexistent-trip", serviceDate)
+		_, ok := api.resolveTripServiceDate(ctx, "nonexistent-trip", serviceDate, 0, 0)
 		assert.False(t, ok)
 	})
 
@@ -2115,7 +2115,7 @@ func TestResolveTripServiceDate(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		_, ok := api.resolveTripServiceDate(ctx, "sd-no-window-trip", serviceDate)
+		_, ok := api.resolveTripServiceDate(ctx, "sd-no-window-trip", serviceDate, 0, 0)
 		assert.False(t, ok)
 	})
 
@@ -2132,7 +2132,7 @@ func TestResolveTripServiceDate(t *testing.T) {
 		// 20:00 matches neither today's [8:00-8:30] window nor yesterday's
 		// (20:00 + 24h = 44:00, still outside [8:00-8:30]).
 		refTime := serviceDate.Add(20 * time.Hour)
-		_, ok := api.resolveTripServiceDate(ctx, "sd-no-match-trip", refTime)
+		_, ok := api.resolveTripServiceDate(ctx, "sd-no-match-trip", refTime, 0, 0)
 		assert.False(t, ok)
 	})
 
@@ -2150,9 +2150,76 @@ func TestResolveTripServiceDate(t *testing.T) {
 		// 01:15 on the day after serviceDate falls within the 25:00-25:30 window,
 		// which belongs to serviceDate's service_id, not the next day's.
 		refTime := serviceDate.AddDate(0, 0, 1).Add(75 * time.Minute)
-		got, ok := api.resolveTripServiceDate(ctx, "sd-rollover-trip", refTime)
+		got, ok := api.resolveTripServiceDate(ctx, "sd-rollover-trip", refTime, 0, 0)
 		require.True(t, ok)
 		assert.True(t, got.Equal(serviceDate),
 			"a trip whose window exceeds 24:00 must resolve to the previous calendar day's service date")
+	})
+
+	t.Run("tolerance widens the window before the trip's scheduled start", func(t *testing.T) {
+		_, err := api.GtfsManager.GtfsDB.Queries.CreateTrip(ctx, gtfsdb.CreateTripParams{
+			ID:               "sd-early-tolerance-trip",
+			RouteID:          sameDayTrip.RouteID,
+			ServiceID:        serviceID,
+			MinArrivalTime:   nulls.Int64(8 * int64(time.Hour)),
+			MaxDepartureTime: nulls.Int64(8*int64(time.Hour) + int64(30*time.Minute)),
+		})
+		require.NoError(t, err)
+
+		// 07:50 is 10 minutes before the trip's 8:00 start.
+		refTime := serviceDate.Add(7*time.Hour + 50*time.Minute)
+
+		_, ok := api.resolveTripServiceDate(ctx, "sd-early-tolerance-trip", refTime, 0, 0)
+		assert.False(t, ok, "must not match without tolerance")
+
+		got, ok := api.resolveTripServiceDate(ctx, "sd-early-tolerance-trip", refTime, 10*time.Minute, 0)
+		require.True(t, ok, "must match once tolerance covers the gap before the window")
+		assert.True(t, got.Equal(serviceDate))
+	})
+
+	t.Run("tolerance widens the window after the trip's scheduled end", func(t *testing.T) {
+		_, err := api.GtfsManager.GtfsDB.Queries.CreateTrip(ctx, gtfsdb.CreateTripParams{
+			ID:               "sd-late-tolerance-trip",
+			RouteID:          sameDayTrip.RouteID,
+			ServiceID:        serviceID,
+			MinArrivalTime:   nulls.Int64(8 * int64(time.Hour)),
+			MaxDepartureTime: nulls.Int64(8*int64(time.Hour) + int64(30*time.Minute)),
+		})
+		require.NoError(t, err)
+
+		// 09:00 is 30 minutes after the trip's 8:30 end.
+		refTime := serviceDate.Add(9 * time.Hour)
+
+		_, ok := api.resolveTripServiceDate(ctx, "sd-late-tolerance-trip", refTime, 0, 0)
+		assert.False(t, ok, "must not match without tolerance")
+
+		got, ok := api.resolveTripServiceDate(ctx, "sd-late-tolerance-trip", refTime, 0, 30*time.Minute)
+		require.True(t, ok, "must match once tolerance covers the gap after the window")
+		assert.True(t, got.Equal(serviceDate))
+	})
+
+	t.Run("tolerance combined with the previous-day rollover", func(t *testing.T) {
+		const dayNs = int64(24 * time.Hour)
+		_, err := api.GtfsManager.GtfsDB.Queries.CreateTrip(ctx, gtfsdb.CreateTripParams{
+			ID:               "sd-rollover-tolerance-trip",
+			RouteID:          sameDayTrip.RouteID,
+			ServiceID:        serviceID,
+			MinArrivalTime:   nulls.Int64(dayNs + int64(time.Hour)),                // 25:00
+			MaxDepartureTime: nulls.Int64(dayNs + int64(time.Hour+30*time.Minute)), // 25:30
+		})
+		require.NoError(t, err)
+
+		// 00:50 the day after serviceDate is 10 minutes before the trip's 25:00
+		// (01:00) start — a candidate a buffered discovery query could admit, but
+		// outside the trip's exact window on either day without tolerance.
+		refTime := serviceDate.AddDate(0, 0, 1).Add(50 * time.Minute)
+
+		_, ok := api.resolveTripServiceDate(ctx, "sd-rollover-tolerance-trip", refTime, 0, 0)
+		assert.False(t, ok, "must not match without tolerance")
+
+		got, ok := api.resolveTripServiceDate(ctx, "sd-rollover-tolerance-trip", refTime, 10*time.Minute, 0)
+		require.True(t, ok, "must match once tolerance covers the gap before the rolled-over window")
+		assert.True(t, got.Equal(serviceDate),
+			"must still resolve to the previous calendar day's service date, not the day the reference time falls on")
 	})
 }

--- a/internal/restapi/trips_helper_test.go
+++ b/internal/restapi/trips_helper_test.go
@@ -2056,3 +2056,103 @@ func testTripIDs(trips []gtfsdb.Trip) []string {
 	}
 	return ids
 }
+
+func TestResolveTripServiceDate(t *testing.T) {
+	api := createTestApi(t)
+	defer api.Shutdown()
+	ctx := context.Background()
+
+	// Monday within the RABA dataset's active service period.
+	serviceDate := time.Date(2024, 11, 4, 0, 0, 0, 0, time.UTC)
+	formattedDate := serviceDate.Format("20060102")
+	serviceIDs, err := api.GtfsManager.GtfsDB.Queries.GetActiveServiceIDsForDate(ctx, formattedDate)
+	require.NoError(t, err)
+	require.NotEmpty(t, serviceIDs, "need an active RABA service on serviceDate")
+	serviceID := serviceIDs[0]
+
+	trips, err := api.GtfsManager.GetTrips(ctx, 200)
+	require.NoError(t, err)
+
+	// Find a real trip that is actually active on serviceDate, with a resolvable window.
+	var sameDayTrip gtfsdb.Trip
+	for _, tr := range trips {
+		row, err := api.GtfsManager.GtfsDB.Queries.GetTrip(ctx, tr.ID)
+		if err != nil || !row.MinArrivalTime.Valid || !row.MaxDepartureTime.Valid {
+			continue
+		}
+		for _, sid := range serviceIDs {
+			if sid == row.ServiceID {
+				sameDayTrip = row
+				break
+			}
+		}
+		if sameDayTrip.ID != "" {
+			break
+		}
+	}
+	require.NotEmpty(t, sameDayTrip.ID, "need a trip active on serviceDate in test data")
+
+	t.Run("resolves the same calendar day when the reference time falls within the trip's window", func(t *testing.T) {
+		midWindowNs := (sameDayTrip.MinArrivalTime.Int64 + sameDayTrip.MaxDepartureTime.Int64) / 2
+		refTime := serviceDate.Add(time.Duration(midWindowNs))
+
+		got, ok := api.resolveTripServiceDate(ctx, sameDayTrip.ID, refTime)
+		require.True(t, ok)
+		assert.True(t, got.Equal(serviceDate),
+			"expected resolved date %v to equal service date %v", got, serviceDate)
+	})
+
+	t.Run("returns false for an unknown trip", func(t *testing.T) {
+		_, ok := api.resolveTripServiceDate(ctx, "nonexistent-trip", serviceDate)
+		assert.False(t, ok)
+	})
+
+	t.Run("returns false when the trip has no scheduled window", func(t *testing.T) {
+		_, err := api.GtfsManager.GtfsDB.Queries.CreateTrip(ctx, gtfsdb.CreateTripParams{
+			ID:        "sd-no-window-trip",
+			RouteID:   sameDayTrip.RouteID,
+			ServiceID: serviceID,
+		})
+		require.NoError(t, err)
+
+		_, ok := api.resolveTripServiceDate(ctx, "sd-no-window-trip", serviceDate)
+		assert.False(t, ok)
+	})
+
+	t.Run("returns false when the reference time falls outside the window on both days", func(t *testing.T) {
+		_, err := api.GtfsManager.GtfsDB.Queries.CreateTrip(ctx, gtfsdb.CreateTripParams{
+			ID:               "sd-no-match-trip",
+			RouteID:          sameDayTrip.RouteID,
+			ServiceID:        serviceID,
+			MinArrivalTime:   nulls.Int64(8 * int64(time.Hour)),
+			MaxDepartureTime: nulls.Int64(8*int64(time.Hour) + int64(30*time.Minute)),
+		})
+		require.NoError(t, err)
+
+		// 20:00 matches neither today's [8:00-8:30] window nor yesterday's
+		// (20:00 + 24h = 44:00, still outside [8:00-8:30]).
+		refTime := serviceDate.Add(20 * time.Hour)
+		_, ok := api.resolveTripServiceDate(ctx, "sd-no-match-trip", refTime)
+		assert.False(t, ok)
+	})
+
+	t.Run("resolves a past-midnight trip to the previous calendar day", func(t *testing.T) {
+		const dayNs = int64(24 * time.Hour)
+		_, err := api.GtfsManager.GtfsDB.Queries.CreateTrip(ctx, gtfsdb.CreateTripParams{
+			ID:               "sd-rollover-trip",
+			RouteID:          sameDayTrip.RouteID,
+			ServiceID:        serviceID,
+			MinArrivalTime:   nulls.Int64(dayNs + int64(time.Hour)),                // 25:00
+			MaxDepartureTime: nulls.Int64(dayNs + int64(time.Hour+30*time.Minute)), // 25:30
+		})
+		require.NoError(t, err)
+
+		// 01:15 on the day after serviceDate falls within the 25:00-25:30 window,
+		// which belongs to serviceDate's service_id, not the next day's.
+		refTime := serviceDate.AddDate(0, 0, 1).Add(75 * time.Minute)
+		got, ok := api.resolveTripServiceDate(ctx, "sd-rollover-trip", refTime)
+		require.True(t, ok)
+		assert.True(t, got.Equal(serviceDate),
+			"a trip whose window exceeds 24:00 must resolve to the previous calendar day's service date")
+	})
+}


### PR DESCRIPTION
## Summary

Several real-time endpoints derived `serviceDate` from the query's wall-clock calendar date instead of the trip's own schedule. For a trip running past midnight (GTFS times > 24:00:00), this reports today's date instead of the previous service day it actually belongs to — the endpoints' own specs require the latter.

`trips-for-route` already searches both today's and yesterday's active services to *find* such trips, but discarded which day matched and applied today's midnight unconditionally when building each entry. `trip-for-vehicle` and `trips-for-location` had the same "assume today" gap, with no day-rollback logic at all.

## Changes

- **`trips_helper.go`** — Added `resolveTripServiceDate`, which checks today's and yesterday's active services against a trip's own scheduled window (`min_arrival_time`/`max_departure_time`) to determine its actual service date, widened by optional `before`/`after` tolerance so it doesn't reject a trip that a caller's own discovery already admitted slightly outside its exact window (e.g. a vehicle running late).
- **`trip_for_vehicle_handler.go`** — Resolves `serviceDate` per trip with zero tolerance (its trip ID always comes from live GTFS-RT tracking, so an exact match is appropriate). Also stopped honoring an undocumented `serviceDate` query parameter this endpoint never had in its own spec or in legacy Java's `TripForVehicleAction` — it was only reachable because the request parser is shared with `trip-details`, which does document one with different semantics.
- **`trips_for_route_handler.go`** — Resolves `serviceDate` per trip (covering both the base-trip loop and DUPLICATED real-time trips), widened by the same 30min/10min "running late/early" tolerance the handler's own block discovery already uses.
- **`trips_for_location_handler.go`** — Same per-trip resolution, with the same tolerance — this endpoint's trip IDs come from live vehicle positions rather than a schedule search, so a vehicle's actual reported time can sit outside its static window even on the correct day.

## Testing

- `TestResolveTripServiceDate` — unit coverage for the resolver: same-day match, unknown trip, no scheduled window, no match on either day, past-midnight rollover, and tolerance widening before/after the window (including combined with rollover).
- `TestTripsForRouteHandler_OvernightTripServiceDate` / `TestBuildTripsForLocationEntries_OvernightTripServiceDate` — construct a trip scheduled past midnight and assert the response reports the previous calendar day, not today. Verified each fails against the pre-fix code and passes with the fix.
- `TestTripForVehicleHandler_ServiceDateParamIgnored` — replaces a prior test that asserted the old (spec-incorrect) parameter-override behavior; now asserts an unrelated supplied `serviceDate` is ignored and the response reflects the trip's actual resolved date.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected service dates for overnight trips that operate past midnight.
  * Trip status and displayed service dates now align with the trip’s actual operating schedule across vehicle, location, and route views.
  * Client-provided service-date values no longer override the schedule-based service date.

* **Tests**
  * Added coverage for overnight schedules, rollover across calendar days, and service-date resolution around schedule boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->