### PR TITLE
Return all stops for routes without `direction_id`

### DIFF
--- a/gtfsdb/db.go
+++ b/gtfsdb/db.go
@@ -216,6 +216,9 @@ func Prepare(ctx context.Context, db DBTX) (*Queries, error) {
 	if q.getOrderedStopIDsForTripStmt, err = db.PrepareContext(ctx, getOrderedStopIDsForTrip); err != nil {
 		return nil, fmt.Errorf("error preparing query GetOrderedStopIDsForTrip: %w", err)
 	}
+	if q.getOrderedStopIDsForTripsStmt, err = db.PrepareContext(ctx, getOrderedStopIDsForTrips); err != nil {
+		return nil, fmt.Errorf("error preparing query GetOrderedStopIDsForTrips: %w", err)
+	}
 	if q.getProblemReportsByStopStmt, err = db.PrepareContext(ctx, getProblemReportsByStop); err != nil {
 		return nil, fmt.Errorf("error preparing query GetProblemReportsByStop: %w", err)
 	}
@@ -712,6 +715,11 @@ func (q *Queries) Close() error {
 			err = fmt.Errorf("error closing getOrderedStopIDsForTripStmt: %w", cerr)
 		}
 	}
+	if q.getOrderedStopIDsForTripsStmt != nil {
+		if cerr := q.getOrderedStopIDsForTripsStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing getOrderedStopIDsForTripsStmt: %w", cerr)
+		}
+	}
 	if q.getProblemReportsByStopStmt != nil {
 		if cerr := q.getProblemReportsByStopStmt.Close(); cerr != nil {
 			err = fmt.Errorf("error closing getProblemReportsByStopStmt: %w", cerr)
@@ -1100,6 +1108,7 @@ type Queries struct {
 	getNextStopInTripStmt                         *sql.Stmt
 	getOrderedStopIDsForRouteDirectionStmt        *sql.Stmt
 	getOrderedStopIDsForTripStmt                  *sql.Stmt
+	getOrderedStopIDsForTripsStmt                 *sql.Stmt
 	getProblemReportsByStopStmt                   *sql.Stmt
 	getProblemReportsByTripStmt                   *sql.Stmt
 	getRouteStmt                                  *sql.Stmt
@@ -1227,6 +1236,7 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		getNextStopInTripStmt:                         q.getNextStopInTripStmt,
 		getOrderedStopIDsForRouteDirectionStmt:        q.getOrderedStopIDsForRouteDirectionStmt,
 		getOrderedStopIDsForTripStmt:                  q.getOrderedStopIDsForTripStmt,
+		getOrderedStopIDsForTripsStmt:                 q.getOrderedStopIDsForTripsStmt,
 		getProblemReportsByStopStmt:                   q.getProblemReportsByStopStmt,
 		getProblemReportsByTripStmt:                   q.getProblemReportsByTripStmt,
 		getRouteStmt:                                  q.getRouteStmt,

--- a/gtfsdb/query.sql
+++ b/gtfsdb/query.sql
@@ -484,6 +484,13 @@ WHERE t.route_id = @route_id
 GROUP BY st.stop_id
 ORDER BY MAX(st.stop_sequence);
 
+-- name: GetOrderedStopIDsForTrips :many
+SELECT st.stop_id
+FROM stop_times st
+WHERE st.trip_id IN (sqlc.slice('trip_ids'))
+GROUP BY st.stop_id
+ORDER BY MAX(st.stop_sequence);
+
 -- name: GetScheduleForStop :many
 SELECT
     st.trip_id,

--- a/gtfsdb/query.sql
+++ b/gtfsdb/query.sql
@@ -489,7 +489,7 @@ SELECT st.stop_id
 FROM stop_times st
 WHERE st.trip_id IN (sqlc.slice('trip_ids'))
 GROUP BY st.stop_id
-ORDER BY MAX(st.stop_sequence);
+ORDER BY MAX(st.stop_sequence) ASC;
 
 -- name: GetScheduleForStop :many
 SELECT

--- a/gtfsdb/query.sql.go
+++ b/gtfsdb/query.sql.go
@@ -2331,7 +2331,7 @@ SELECT st.stop_id
 FROM stop_times st
 WHERE st.trip_id IN (/*SLICE:trip_ids*/?)
 GROUP BY st.stop_id
-ORDER BY MAX(st.stop_sequence)
+ORDER BY MAX(st.stop_sequence) ASC
 `
 
 func (q *Queries) GetOrderedStopIDsForTrips(ctx context.Context, tripIds []string) ([]string, error) {

--- a/gtfsdb/query.sql.go
+++ b/gtfsdb/query.sql.go
@@ -2326,6 +2326,47 @@ func (q *Queries) GetOrderedStopIDsForTrip(ctx context.Context, tripID string) (
 	return items, nil
 }
 
+const getOrderedStopIDsForTrips = `-- name: GetOrderedStopIDsForTrips :many
+SELECT st.stop_id
+FROM stop_times st
+WHERE st.trip_id IN (/*SLICE:trip_ids*/?)
+GROUP BY st.stop_id
+ORDER BY MAX(st.stop_sequence)
+`
+
+func (q *Queries) GetOrderedStopIDsForTrips(ctx context.Context, tripIds []string) ([]string, error) {
+	query := getOrderedStopIDsForTrips
+	var queryParams []interface{}
+	if len(tripIds) > 0 {
+		for _, v := range tripIds {
+			queryParams = append(queryParams, v)
+		}
+		query = strings.Replace(query, "/*SLICE:trip_ids*/?", strings.Repeat(",?", len(tripIds))[1:], 1)
+	} else {
+		query = strings.Replace(query, "/*SLICE:trip_ids*/?", "NULL", 1)
+	}
+	rows, err := q.query(ctx, nil, query, queryParams...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []string
+	for rows.Next() {
+		var stop_id string
+		if err := rows.Scan(&stop_id); err != nil {
+			return nil, err
+		}
+		items = append(items, stop_id)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const getProblemReportsByStop = `-- name: GetProblemReportsByStop :many
 SELECT id, stop_id, code, user_comment, user_lat, user_lon, user_location_accuracy, created_at, submitted_at FROM problem_reports_stop
 WHERE stop_id = ?

--- a/internal/restapi/stops_for_route_handler.go
+++ b/internal/restapi/stops_for_route_handler.go
@@ -333,9 +333,16 @@ func orderedStopIDsForGroup(ctx context.Context, api *RestAPI, routeID string, g
 		/*
 			direction_id is NULL in the GTFS data. SQL NULL = NULL evaluates to
 			UNKNOWN, not TRUE, so GetOrderedStopIDsForRouteDirection would return
-			zero rows. Fall back to single-trip ordering instead.
+			zero rows. Fall back to ordering by the group's trips directly, still
+			collecting the union of stops across all of them — otherwise stops
+			served only by trips after the first would be dropped from both the
+			flat stop list and this group.
 		*/
-		return api.GtfsManager.GtfsDB.Queries.GetOrderedStopIDsForTrip(ctx, group.Trips[0].ID)
+		tripIDs := make([]string, len(group.Trips))
+		for i, trip := range group.Trips {
+			tripIDs[i] = trip.ID
+		}
+		return api.GtfsManager.GtfsDB.Queries.GetOrderedStopIDsForTrips(ctx, tripIDs)
 	}
 	return api.GtfsManager.GtfsDB.Queries.GetOrderedStopIDsForRouteDirection(ctx,
 		gtfsdb.GetOrderedStopIDsForRouteDirectionParams{

--- a/internal/restapi/stops_for_route_handler_test.go
+++ b/internal/restapi/stops_for_route_handler_test.go
@@ -273,13 +273,19 @@ func createTestApiWithNullDirectionID(t *testing.T) *RestAPI {
 			"svc1,1,1,1,1,1,1,1,20240101,20991231\n",
 		"stops.txt": "stop_id,stop_name,stop_lat,stop_lon\n" +
 			"stopA1,Stop One,37.7749,-122.4194\n" +
-			"stopA2,Stop Two,37.7849,-122.4094\n",
+			"stopA2,Stop Two,37.7849,-122.4094\n" +
+			"stopA3,Stop Three,37.7949,-122.3994\n",
 		// No direction_id column — all trips will have NULL direction_id in the DB.
+		// tripB shares stopA1 but adds stopA3, which tripA never visits: the union
+		// of both trips' stops must be returned, not just the first trip's.
 		"trips.txt": "route_id,service_id,trip_id,trip_headsign\n" +
-			"routeA,svc1,tripA,Downtown\n",
+			"routeA,svc1,tripA,Downtown\n" +
+			"routeA,svc1,tripB,Downtown\n",
 		"stop_times.txt": "trip_id,arrival_time,departure_time,stop_id,stop_sequence\n" +
 			"tripA,08:00:00,08:00:00,stopA1,1\n" +
-			"tripA,08:10:00,08:10:00,stopA2,2\n",
+			"tripA,08:10:00,08:10:00,stopA2,2\n" +
+			"tripB,09:00:00,09:00:00,stopA1,1\n" +
+			"tripB,09:10:00,09:10:00,stopA3,2\n",
 	}
 
 	for name, content := range files {
@@ -324,9 +330,11 @@ func createTestApiWithNullDirectionID(t *testing.T) *RestAPI {
 }
 
 // TestStopsForRouteNullDirectionID guards against the regression where agencies
-// that omit direction_id in their GTFS feed receive an empty stop list. When
-// direction_id is NULL, the SQL condition `t.direction_id = NULL` evaluates to
-// UNKNOWN (not TRUE), so we fall back to single-trip ordering instead.
+// that omit direction_id in their GTFS feed receive an empty or incomplete stop
+// list. When direction_id is NULL, the SQL condition `t.direction_id = NULL`
+// evaluates to UNKNOWN (not TRUE), so we fall back to ordering by the group's
+// trips directly — collecting the union of stops across every trip, not just the
+// first. The fixture's tripB adds stopA3, which tripA never visits.
 func TestStopsForRouteNullDirectionID(t *testing.T) {
 	api := createTestApiWithNullDirectionID(t)
 
@@ -335,10 +343,13 @@ func TestStopsForRouteNullDirectionID(t *testing.T) {
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 
 	entry := model.Data.Entry
-	assert.NotEmpty(t, entry.StopIds, "stops-for-route must return stops even when direction_id is NULL")
+	wantStops := []string{"agencyA_stopA1", "agencyA_stopA2", "agencyA_stopA3"}
+	assert.ElementsMatch(t, wantStops, entry.StopIds,
+		"flat stopIds must be the union of stops across all trips, not just the first")
 
 	require.Len(t, entry.StopGroupings, 1)
 	stopGroups := entry.StopGroupings[0].StopGroups
 	require.Len(t, stopGroups, 1, "expected one stop group for the single NULL direction_id")
-	assert.Len(t, stopGroups[0].StopIds, 2, "expected both stops to appear in the stop group")
+	assert.ElementsMatch(t, wantStops, stopGroups[0].StopIds,
+		"the group must contain every stop served across all trips")
 }


### PR DESCRIPTION
Fixes: #1248 

`stops-for-route` dropped stops when a feed's trips have no `direction_id`. The
per-direction ordered query returns nothing in that case (`direction_id = NULL`
→ UNKNOWN in SQL), so the handler fell back to ordering a single trip — and
since both the flat `stopIds` and the group's `stopIds` come from that list, any
stop served only by another trip was lost. The reference implementation builds
`stopIds` as the union across every qualifying trip.

**Fix:** add `GetOrderedStopIDsForTrips` (unions + orders stops across a set of
trip IDs, same as the per-direction query) and use it for the NULL-direction
fallback with all of the group's trips.

**Test:** extended the NULL-direction fixture with a second trip visiting a stop
the first doesn't; verified it fails on the old code and passes now.

Scope: minimal completeness fix. Splitting NULL-direction trips into
similarity-based groups remains a follow-up.

