### PR TITLE
Disambiguate stops-for-route directions sharing a headsign

### DIFF
--- a/internal/restapi/stops_for_route_handler.go
+++ b/internal/restapi/stops_for_route_handler.go
@@ -255,6 +255,8 @@ func processTripGroups(
 		allStopGroups = append(allStopGroups, stopGroup)
 	}
 
+	disambiguateGroupNames(allStopGroups)
+
 	slices.SortFunc(allStopGroups, func(a, b models.StopGroup) int {
 		return cmp.Compare(a.Name.Name, b.Name.Name)
 	})
@@ -343,6 +345,27 @@ func orderedStopIDsForGroup(ctx context.Context, api *RestAPI, routeID string, g
 			DirectionID: group.DirectionID,
 			ServiceIds:  dirServiceIDs,
 		})
+}
+
+// disambiguateGroupNames mirrors the Java reference: when two or more direction
+// groups resolve to the same destination name, every group's name gets its
+// direction id appended ("Shasta Lake" -> "Shasta Lake - 0") so the groups stay
+// distinguishable. It runs only on an actual collision, and appending the id
+// also makes the later name-based group sort deterministic.
+func disambiguateGroupNames(groups []models.StopGroup) {
+	distinctNames := make(map[string]struct{}, len(groups))
+	for _, group := range groups {
+		distinctNames[group.Name.Name] = struct{}{}
+	}
+	if len(distinctNames) == len(groups) {
+		return
+	}
+
+	for i := range groups {
+		disambiguated := groups[i].Name.Name + " - " + groups[i].ID
+		groups[i].Name.Name = disambiguated
+		groups[i].Name.Names = []string{disambiguated}
+	}
 }
 
 // mostCommonHeadsign returns the headsign with the highest count, breaking ties by

--- a/internal/restapi/stops_for_route_handler.go
+++ b/internal/restapi/stops_for_route_handler.go
@@ -347,21 +347,23 @@ func orderedStopIDsForGroup(ctx context.Context, api *RestAPI, routeID string, g
 		})
 }
 
-// disambiguateGroupNames mirrors the Java reference: when two or more direction
-// groups resolve to the same destination name, every group's name gets its
-// direction id appended ("Shasta Lake" -> "Shasta Lake - 0") so the groups stay
-// distinguishable. It runs only on an actual collision, and appending the id
-// also makes the later name-based group sort deterministic.
+// disambiguateGroupNames keeps direction groups distinguishable: when two or
+// more groups resolve to the same destination name, only those colliding groups
+// get their direction id appended ("Shasta Lake" -> "Shasta Lake - 0"); a name
+// that is already unique is left untouched. Suffixing collisions also makes the
+// later name-based group sort deterministic. (The Java reference suffixes every
+// group whenever any collision exists; leaving unique names alone is a
+// deliberate, less noisy divergence.)
 func disambiguateGroupNames(groups []models.StopGroup) {
-	distinctNames := make(map[string]struct{}, len(groups))
+	nameCounts := make(map[string]int, len(groups))
 	for _, group := range groups {
-		distinctNames[group.Name.Name] = struct{}{}
-	}
-	if len(distinctNames) == len(groups) {
-		return
+		nameCounts[group.Name.Name]++
 	}
 
 	for i := range groups {
+		if nameCounts[groups[i].Name.Name] <= 1 {
+			continue
+		}
 		disambiguated := groups[i].Name.Name + " - " + groups[i].ID
 		groups[i].Name.Name = disambiguated
 		groups[i].Name.Names = []string{disambiguated}

--- a/internal/restapi/stops_for_route_handler.go
+++ b/internal/restapi/stops_for_route_handler.go
@@ -347,26 +347,38 @@ func orderedStopIDsForGroup(ctx context.Context, api *RestAPI, routeID string, g
 		})
 }
 
-// disambiguateGroupNames keeps direction groups distinguishable: when two or
-// more groups resolve to the same destination name, only those colliding groups
-// get their direction id appended ("Shasta Lake" -> "Shasta Lake - 0"); a name
-// that is already unique is left untouched. Suffixing collisions also makes the
-// later name-based group sort deterministic. (The Java reference suffixes every
-// group whenever any collision exists; leaving unique names alone is a
-// deliberate, less noisy divergence.)
+// disambiguateGroupNames keeps direction groups distinguishable: any group whose
+// name is shared with another group has its direction id appended
+// ("Shasta Lake" -> "Shasta Lake - 0"), while a name that is already unique is
+// left untouched. The check is repeated against the *resulting* names, so a
+// suffixed name that happens to equal an originally-unique name (e.g. a literal
+// "A - 0" headsign) is disambiguated further rather than left duplicated.
+// Direction ids are unique, so two colliding groups always separate on the next
+// pass and the loop is bounded by the group count; the final names are a
+// function of the groups alone, independent of input order, which also makes the
+// later name-based sort deterministic. (The Java reference suffixes every group
+// whenever any collision exists; leaving unique names alone is a deliberate,
+// less noisy divergence.)
 func disambiguateGroupNames(groups []models.StopGroup) {
-	nameCounts := make(map[string]int, len(groups))
-	for _, group := range groups {
-		nameCounts[group.Name.Name]++
-	}
-
-	for i := range groups {
-		if nameCounts[groups[i].Name.Name] <= 1 {
-			continue
+	for range groups {
+		nameCounts := make(map[string]int, len(groups))
+		for _, group := range groups {
+			nameCounts[group.Name.Name]++
 		}
-		disambiguated := groups[i].Name.Name + " - " + groups[i].ID
-		groups[i].Name.Name = disambiguated
-		groups[i].Name.Names = []string{disambiguated}
+
+		collision := false
+		for i := range groups {
+			if nameCounts[groups[i].Name.Name] <= 1 {
+				continue
+			}
+			collision = true
+			disambiguated := groups[i].Name.Name + " - " + groups[i].ID
+			groups[i].Name.Name = disambiguated
+			groups[i].Name.Names = []string{disambiguated}
+		}
+		if !collision {
+			return
+		}
 	}
 }
 

--- a/internal/restapi/stops_for_route_handler_test.go
+++ b/internal/restapi/stops_for_route_handler_test.go
@@ -367,9 +367,9 @@ func TestDisambiguateGroupNames(t *testing.T) {
 			wantNames: []string{"Shasta Lake - 0", "Shasta Lake - 1"},
 		},
 		{
-			name:      "any collision disambiguates every group",
+			name:      "only colliding groups are suffixed, unique name is left alone",
 			groups:    []models.StopGroup{group("0", "Loop"), group("1", "Loop"), group("2", "Express")},
-			wantNames: []string{"Loop - 0", "Loop - 1", "Express - 2"},
+			wantNames: []string{"Loop - 0", "Loop - 1", "Express"},
 		},
 	}
 

--- a/internal/restapi/stops_for_route_handler_test.go
+++ b/internal/restapi/stops_for_route_handler_test.go
@@ -51,11 +51,13 @@ func TestStopsForRouteHandlerEndToEnd(t *testing.T) {
 
 	require.Len(t, grouping.StopGroups, 2)
 
+	// Both RABA directions share the headsign "Shasta Lake", so each group's
+	// name is disambiguated with its direction id (and the sort is deterministic).
 	outbound := grouping.StopGroups[0]
 	assert.Equal(t, "0", outbound.ID)
-	assert.Equal(t, "Shasta Lake", outbound.Name.Name)
+	assert.Equal(t, "Shasta Lake - 0", outbound.Name.Name)
 	assert.Equal(t, "destination", outbound.Name.Type)
-	assert.Equal(t, []string{"Shasta Lake"}, outbound.Name.Names)
+	assert.Equal(t, []string{"Shasta Lake - 0"}, outbound.Name.Names)
 	assert.Len(t, outbound.StopIds, 21)
 	// Direction-0 shape retraces two of its own edges, splitting into 3 polylines.
 	require.Len(t, outbound.Polylines, 3)
@@ -66,8 +68,9 @@ func TestStopsForRouteHandlerEndToEnd(t *testing.T) {
 
 	inbound := grouping.StopGroups[1]
 	assert.Equal(t, "1", inbound.ID)
-	assert.Equal(t, "Shasta Lake", inbound.Name.Name)
+	assert.Equal(t, "Shasta Lake - 1", inbound.Name.Name)
 	assert.Equal(t, "destination", inbound.Name.Type)
+	assert.Equal(t, []string{"Shasta Lake - 1"}, inbound.Name.Names)
 	assert.Len(t, inbound.StopIds, 22)
 	// Direction-1 shape retraces one of its own edges, splitting into 2 polylines.
 	require.Len(t, inbound.Polylines, 2)
@@ -341,4 +344,42 @@ func TestStopsForRouteNullDirectionID(t *testing.T) {
 	stopGroups := entry.StopGroupings[0].StopGroups
 	require.Len(t, stopGroups, 1, "expected one stop group for the single NULL direction_id")
 	assert.Len(t, stopGroups[0].StopIds, 2, "expected both stops to appear in the stop group")
+}
+
+func TestDisambiguateGroupNames(t *testing.T) {
+	group := func(id, name string) models.StopGroup {
+		return models.StopGroup{ID: id, Name: models.StopGroupName{Name: name, Names: []string{name}}}
+	}
+
+	tests := []struct {
+		name      string
+		groups    []models.StopGroup
+		wantNames []string
+	}{
+		{
+			name:      "distinct names are left untouched",
+			groups:    []models.StopGroup{group("0", "Downtown"), group("1", "Airport")},
+			wantNames: []string{"Downtown", "Airport"},
+		},
+		{
+			name:      "shared name is disambiguated with the direction id",
+			groups:    []models.StopGroup{group("0", "Shasta Lake"), group("1", "Shasta Lake")},
+			wantNames: []string{"Shasta Lake - 0", "Shasta Lake - 1"},
+		},
+		{
+			name:      "any collision disambiguates every group",
+			groups:    []models.StopGroup{group("0", "Loop"), group("1", "Loop"), group("2", "Express")},
+			wantNames: []string{"Loop - 0", "Loop - 1", "Express - 2"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			disambiguateGroupNames(tt.groups)
+			for i, want := range tt.wantNames {
+				assert.Equal(t, want, tt.groups[i].Name.Name)
+				assert.Equal(t, []string{want}, tt.groups[i].Name.Names)
+			}
+		})
+	}
 }

--- a/internal/restapi/stops_for_route_handler_test.go
+++ b/internal/restapi/stops_for_route_handler_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -382,4 +383,45 @@ func TestDisambiguateGroupNames(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestDisambiguateGroupNamesCollidesWithUniqueName covers the case where suffixing
+// a duplicated name produces a string that already exists as another group's
+// unique name ("A", "A", "A - 0"): the generated "A - 0" must be pushed further
+// so every final name stays unique. It also asserts the outcome is independent of
+// input order, which is what makes the later name-based sort stable.
+func TestDisambiguateGroupNamesCollidesWithUniqueName(t *testing.T) {
+	newGroups := func() []models.StopGroup {
+		mk := func(id, name string) models.StopGroup {
+			return models.StopGroup{ID: id, Name: models.StopGroupName{Name: name, Names: []string{name}}}
+		}
+		return []models.StopGroup{mk("0", "A"), mk("1", "A"), mk("2", "A - 0")}
+	}
+
+	// Final name per direction id, regardless of the order groups arrive in.
+	wantByID := map[string]string{
+		"0": "A - 0 - 0",
+		"1": "A - 1",
+		"2": "A - 0 - 2",
+	}
+
+	assertResolved := func(t *testing.T, groups []models.StopGroup) {
+		seen := make(map[string]bool)
+		for _, g := range groups {
+			assert.Equal(t, wantByID[g.ID], g.Name.Name, "group %s", g.ID)
+			assert.Equal(t, []string{wantByID[g.ID]}, g.Name.Names, "group %s names", g.ID)
+			assert.False(t, seen[g.Name.Name], "duplicate final name %q", g.Name.Name)
+			seen[g.Name.Name] = true
+		}
+	}
+
+	ordered := newGroups()
+	disambiguateGroupNames(ordered)
+	assertResolved(t, ordered)
+
+	// Reversed input must yield the same per-group names (order independence).
+	reversed := newGroups()
+	slices.Reverse(reversed)
+	disambiguateGroupNames(reversed)
+	assertResolved(t, reversed)
 }


### PR DESCRIPTION
Fixes: #1250 

When two direction groups resolved to the same most-common headsign,
both were emitted with identical name.names, and the name-based group
sort left their order nondeterministic. The reference implementation
appends a direction disambiguator whenever directions collide.

Append " - <direction id>" to every group's name on a collision, before
the sort so ordering is deterministic. Update the RABA end-to-end test
(both directions are "Shasta Lake") and add a unit test for the
collision and no-collision paths.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stop-group (destination) naming when a route has multiple directions with the same headsign.
  * Added deterministic disambiguation to prevent duplicate stop-group names and ensure consistent ordering.
  * Updated end-to-end behavior so outbound/inbound stop-group names and their display name lists reflect collision-free, direction-suffixed values.
* **Tests**
  * Added unit tests covering normal cases, duplicate collisions, and order-independent results for stop-group name disambiguation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->