### PR TITLE
fix: clamp maxCount above the cap in stops-for-location

### DIFF
--- a/internal/restapi/stops_for_location_handler.go
+++ b/internal/restapi/stops_for_location_handler.go
@@ -21,7 +21,7 @@ func (api *RestAPI) stopsForLocationHandler(w http.ResponseWriter, r *http.Reque
 
 	var fieldErrors map[string][]string
 	loc, fieldErrors := api.parseLocationParams(r, fieldErrors)
-	maxCount, fieldErrors := utils.ParseMaxCount(queryParams, models.DefaultMaxCountForStops, fieldErrors)
+	maxCount, fieldErrors := utils.ParseMaxCountClamped(queryParams, models.DefaultMaxCountForStops, fieldErrors)
 	query := queryParams.Get("query")
 
 	var routeTypes []int

--- a/internal/restapi/stops_for_location_handler_test.go
+++ b/internal/restapi/stops_for_location_handler_test.go
@@ -172,6 +172,18 @@ func TestStopsForLocationHandlerValidatesRadius(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, model.Code)
 }
 
+func TestStopsForLocationHandlerClampsMaxCountAboveCap(t *testing.T) {
+	clock := clock.NewMockClock(time.Date(2025, 12, 26, 14, 0, 0, 0, time.UTC))
+	api := createTestApiWithClock(t, clock)
+
+	resp, model := callAPIHandler[StopsResponse](t, api, "/api/where/stops-for-location.json?key=TEST&lat=40.583321&lon=-122.426966&radius=5000&maxCount=300")
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, http.StatusOK, model.Code)
+	assert.NotEmpty(t, model.Data.List, "clamped request should still return stops")
+	assert.LessOrEqual(t, len(model.Data.List), 250, "results must not exceed the 250 cap")
+}
+
 func TestStopsForLocationHandlerValidatesMaxCount(t *testing.T) {
 	api := createTestApi(t)
 	resp, model := callAPIHandler[StopsResponse](t, api, "/api/where/stops-for-location.json?key=TEST&lat=40.583321&lon=-122.426966&maxCount=invalid")

--- a/internal/utils/api.go
+++ b/internal/utils/api.go
@@ -211,20 +211,28 @@ func ParseTimeParameter(timeParam string, currentLocation *time.Location) (strin
 	return parsedTime.Format("20060102"), parsedTime, nil, true
 }
 
+// maxCountOverflow selects how values above models.MaxAllowedCount are handled.
+type maxCountOverflow int
+
+const (
+	rejectAboveMax maxCountOverflow = iota
+	clampAboveMax
+)
+
 // ParseMaxCount parses the maxCount query parameter with validation.
-// It accepts a default value and enforces a maximum of 250.
-// Returns an error in fieldErrors if the value is <= 0 or > 250.
+// It accepts a default value and enforces models.MaxAllowedCount as the ceiling.
+// Returns an error in fieldErrors if the value is <= 0 or above the ceiling.
 func ParseMaxCount(queryParams url.Values, defaultCount int, fieldErrors map[string][]string) (int, map[string][]string) {
-	return parseMaxCount(queryParams, defaultCount, false, fieldErrors)
+	return parseMaxCount(queryParams, defaultCount, rejectAboveMax, fieldErrors)
 }
 
-// ParseMaxCountClamped silently clamps values above 250 instead of rejecting them.
-// Values <= 0 are still field errors.
+// ParseMaxCountClamped silently clamps values above models.MaxAllowedCount
+// instead of rejecting them. Values <= 0 are still field errors.
 func ParseMaxCountClamped(queryParams url.Values, defaultCount int, fieldErrors map[string][]string) (int, map[string][]string) {
-	return parseMaxCount(queryParams, defaultCount, true, fieldErrors)
+	return parseMaxCount(queryParams, defaultCount, clampAboveMax, fieldErrors)
 }
 
-func parseMaxCount(queryParams url.Values, defaultCount int, clampAboveMax bool, fieldErrors map[string][]string) (int, map[string][]string) {
+func parseMaxCount(queryParams url.Values, defaultCount int, overflow maxCountOverflow, fieldErrors map[string][]string) (int, map[string][]string) {
 	if fieldErrors == nil {
 		fieldErrors = make(map[string][]string)
 	}
@@ -238,10 +246,10 @@ func parseMaxCount(queryParams url.Values, defaultCount int, clampAboveMax bool,
 				fieldErrors["maxCount"] = []string{"must be greater than zero"}
 				maxCount = defaultCount
 			} else if maxCount > models.MaxAllowedCount {
-				if clampAboveMax {
+				if overflow == clampAboveMax {
 					maxCount = models.MaxAllowedCount
 				} else {
-					fieldErrors["maxCount"] = []string{"must not exceed 250"}
+					fieldErrors["maxCount"] = []string{fmt.Sprintf("must not exceed %d", models.MaxAllowedCount)}
 					maxCount = defaultCount
 				}
 			}

--- a/internal/utils/api.go
+++ b/internal/utils/api.go
@@ -212,9 +212,19 @@ func ParseTimeParameter(timeParam string, currentLocation *time.Location) (strin
 }
 
 // ParseMaxCount parses the maxCount query parameter with validation.
-// It accepts a default value and enforces a maximum of 250 (matching Java's MaxCountSupport).
+// It accepts a default value and enforces a maximum of 250.
 // Returns an error in fieldErrors if the value is <= 0 or > 250.
 func ParseMaxCount(queryParams url.Values, defaultCount int, fieldErrors map[string][]string) (int, map[string][]string) {
+	return parseMaxCount(queryParams, defaultCount, false, fieldErrors)
+}
+
+// ParseMaxCountClamped silently clamps values above 250 instead of rejecting them.
+// Values <= 0 are still field errors.
+func ParseMaxCountClamped(queryParams url.Values, defaultCount int, fieldErrors map[string][]string) (int, map[string][]string) {
+	return parseMaxCount(queryParams, defaultCount, true, fieldErrors)
+}
+
+func parseMaxCount(queryParams url.Values, defaultCount int, clampAboveMax bool, fieldErrors map[string][]string) (int, map[string][]string) {
 	if fieldErrors == nil {
 		fieldErrors = make(map[string][]string)
 	}
@@ -228,8 +238,12 @@ func ParseMaxCount(queryParams url.Values, defaultCount int, fieldErrors map[str
 				fieldErrors["maxCount"] = []string{"must be greater than zero"}
 				maxCount = defaultCount
 			} else if maxCount > models.MaxAllowedCount {
-				fieldErrors["maxCount"] = []string{"must not exceed 250"}
-				maxCount = defaultCount
+				if clampAboveMax {
+					maxCount = models.MaxAllowedCount
+				} else {
+					fieldErrors["maxCount"] = []string{"must not exceed 250"}
+					maxCount = defaultCount
+				}
 			}
 		} else {
 			fieldErrors["maxCount"] = []string{"Invalid field value for field \"maxCount\"."}

--- a/internal/utils/api_test.go
+++ b/internal/utils/api_test.go
@@ -632,6 +632,41 @@ func TestParseTimeParameter_DateStringUsesProvidedLocation(t *testing.T) {
 	assert.Equal(t, loc.String(), parsedTime.Location().String())
 }
 
+func TestParseMaxCountClamped(t *testing.T) {
+	tests := []struct {
+		name             string
+		maxCount         string
+		expectedMaxCount int
+		expectError      bool
+	}{
+		{"omitted uses default", "", 100, false},
+		{"within cap unchanged", "10", 10, false},
+		{"at cap unchanged", "250", 250, false},
+		{"above cap clamps", "251", 250, false},
+		{"far above cap clamps", "10000", 250, false},
+		{"zero is an error", "0", 100, true},
+		{"negative is an error", "-1", 100, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			params := url.Values{}
+			if tt.maxCount != "" {
+				params.Set("maxCount", tt.maxCount)
+			}
+
+			maxCount, fieldErrors := ParseMaxCountClamped(params, 100, nil)
+
+			assert.Equal(t, tt.expectedMaxCount, maxCount)
+			if tt.expectError {
+				assert.Contains(t, fieldErrors, "maxCount")
+			} else {
+				assert.NotContains(t, fieldErrors, "maxCount")
+			}
+		})
+	}
+}
+
 func TestParseMaxCount(t *testing.T) {
 	tests := []struct {
 		name             string


### PR DESCRIPTION
Fixes #1238 (sub-issue of the #1235 spec review).

Legacy silently clamps `maxCount` to 250; maglev returned HTTP 400 for anything above the cap. Verified on canonical OBA 2.7.1 (booted via maglev-workspace, KCM):

```
legacy  maxCount=300 -> HTTP 200, list=248, limitExceeded=true   (silently capped)
maglev  maxCount=300 -> HTTP 400  {"fieldErrors":{"maxCount":["must not exceed 250"]}}
```

`maxCount <= 0` already matched legacy (400) and is unchanged.

### Approach

`utils.ParseMaxCount` is shared by three endpoints, so rather than flipping it globally this splits the logic into a private helper and adds `ParseMaxCountClamped`, used only by stops-for-location. `routes-for-location` and `search-stop` keep their current behaviour — they have their own spec review cards, and `search-stop`'s spec says nothing about a cap while it does have a test asserting 400 above it, so there was no evidence to justify changing it here.

### Note for `routes-for-location` (#1225)

While confirming the shared-helper behaviour: the [routes-for-location spec](https://github.com/OneBusAway/maglev/wiki/routes-for-location) says its cap is **50**, not 250 — *"The server silently clamps `maxCount` to 50. No error is returned."* ([`MaxCountSupport.getMaxCount`](https://github.com/OneBusAway/onebusaway-application-modules/blob/095bf1ac3aeb7009b9f78e7f1cb4c65bd38b988a/onebusaway-api-core/src/main/java/org/onebusaway/api/impl/MaxCountSupport.java#L41-L43)). maglev applies the global 250 cap and errors instead of clamping, so that endpoint appears to have two deviations. Deliberately left alone here since it belongs to its own card — flagging it for whoever picks that up.

### Tests

Table-driven `TestParseMaxCountClamped` covering at-cap, above-cap, far-above-cap, zero and negative, plus a handler test asserting `maxCount=300` returns 200 with the list capped. Both were confirmed to fail against the pre-fix implementation.

Verified: full suite in both `sqlite_fts5` and `purego` modes, `go vet` both, race detector on `restapi`/`gtfs`, `gofmt`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Requests for more than 250 nearby stops are now capped at 250 instead of being rejected.
  * Invalid values of zero or less continue to return validation errors.

* **Tests**
  * Added coverage for maximum-count limits, valid values, defaults, and invalid inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->