### PR TITLE
test: add coverage for boundary state (zero stop-times) in agencies-with-coverage

### DIFF
--- a/internal/restapi/agencies_with_coverage_handler_test.go
+++ b/internal/restapi/agencies_with_coverage_handler_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"maglev.onebusaway.org/internal/models"
 	"maglev.onebusaway.org/internal/restapi/testdata"
 )
@@ -93,11 +94,14 @@ func TestAgenciesWithCoverageHandlerZeroStopTimes(t *testing.T) {
 
 	// Insert a mock agency with exactly zero stop-times to the test data.
 	_, err := api.GtfsManager.GtfsDB.DB.Exec("INSERT INTO agencies (id, name, url, timezone) VALUES ('MOCK_ZERO', 'Mock Agency', 'http://mock.agency', 'America/Los_Angeles')")
-	assert.NoError(t, err)
+
+	require.NoError(t, err)
 
 	// Clean up after test
 	t.Cleanup(func() {
-		_, _ = api.GtfsManager.GtfsDB.DB.Exec("DELETE FROM agencies WHERE id = 'MOCK_ZERO'")
+		if _, err := api.GtfsManager.GtfsDB.DB.Exec("DELETE FROM agencies WHERE id = 'MOCK_ZERO'"); err != nil {
+			t.Errorf("failed to clean up MOCK_ZERO agency: %v", err)
+		}
 	})
 
 	resp, model := callAPIHandler[CoverageResponse](t, api, "/api/where/agencies-with-coverage.json?key=TEST")
@@ -114,7 +118,7 @@ func TestAgenciesWithCoverageHandlerZeroStopTimes(t *testing.T) {
 		}
 	}
 
-	assert.NotNil(t, mockAgency, "mock agency should be in the returned list")
+	require.NotNil(t, mockAgency, "mock agency should be in the returned list")
 
 	// The spec mandates that latSpan and lonSpan must evaluate exactly to 0
 	// if an agency contains no stop records.

--- a/internal/restapi/agencies_with_coverage_handler_test.go
+++ b/internal/restapi/agencies_with_coverage_handler_test.go
@@ -86,3 +86,40 @@ func TestAgenciesWithCoverageHandlerIncludeReferencesFalse(t *testing.T) {
 	assert.Empty(t, model.Data.References.Stops)
 	assert.Empty(t, model.Data.References.Trips)
 }
+
+func TestAgenciesWithCoverageHandlerZeroStopTimes(t *testing.T) {
+	api := createTestApi(t)
+	defer api.Shutdown()
+
+	// Insert a mock agency with exactly zero stop-times to the test data.
+	_, err := api.GtfsManager.GtfsDB.DB.Exec("INSERT INTO agencies (id, name, url, timezone) VALUES ('MOCK_ZERO', 'Mock Agency', 'http://mock.agency', 'America/Los_Angeles')")
+	assert.NoError(t, err)
+
+	// Clean up after test
+	t.Cleanup(func() {
+		_, _ = api.GtfsManager.GtfsDB.DB.Exec("DELETE FROM agencies WHERE id = 'MOCK_ZERO'")
+	})
+
+	resp, model := callAPIHandler[CoverageResponse](t, api, "/api/where/agencies-with-coverage.json?key=TEST")
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, http.StatusOK, model.Code)
+	assert.Equal(t, "OK", model.Text)
+
+	var mockAgency *models.AgencyCoverage
+	for i, agency := range model.Data.List {
+		if agency.AgencyID == "MOCK_ZERO" {
+			mockAgency = &model.Data.List[i]
+			break
+		}
+	}
+
+	assert.NotNil(t, mockAgency, "mock agency should be in the returned list")
+
+	// The spec mandates that latSpan and lonSpan must evaluate exactly to 0
+	// if an agency contains no stop records.
+	assert.Equal(t, 0.0, mockAgency.Lat)
+	assert.Equal(t, 0.0, mockAgency.Lon)
+	assert.Equal(t, 0.0, mockAgency.LatSpan)
+	assert.Equal(t, 0.0, mockAgency.LonSpan)
+}


### PR DESCRIPTION
### Description

It introduces a mock agency (`MOCK_ZERO`) into the SQLite database during the test execution. Because this mock agency bypassed the startup `regionBounds` computation (as it possesses no `stop_times` records), it naturally falls back to an empty `RegionBounds` map. 

The test explicitly asserts that the endpoint successfully processes this state and defaults the geographic metrics (`lat`, `lon`, `latSpan`, `lonSpan`) to exactly `0.0`, fulfilling the mandated OBA specification.

### Related Issues
Fixes #1213

### Testing
- [x] Added `TestAgenciesWithCoverageHandlerZeroStopTimes`
- [x] Verified that tests pass locally (`go test -tags "sqlite_fts5 sqlite_math_functions" ./internal/restapi`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a new test case covering agencies that have no stop records.
  * Verified the `/api/where/agencies-with-coverage.json?key=TEST` response still includes the agency, with zero-valued `Lat`/`Lon` and `LatSpan`/`LonSpan` boundaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->