### PR TITLE
Add oba-workspace skill; resolve /workspace as a repo tier

### DIFF
--- a/.claude/skills/lib/resolve-oba-repo.sh
+++ b/.claude/skills/lib/resolve-oba-repo.sh
@@ -10,16 +10,29 @@
 #
 # Resolution order:
 #   1. $OBA_WORKSPACE/<repo>        - explicit override, if set
-#   2. <maglev-root>/../<repo>      - sibling checkout, if this maglev
+#   2. /workspace/<repo>            - deterministic default, if $OBA_WORKSPACE
+#                                      is unset and /workspace exists (the
+#                                      conventional bind-mount point in
+#                                      sandboxed VMs, so checkouts land
+#                                      somewhere that can be mounted back to
+#                                      the host)
+#   3. <maglev-root>/../<repo>      - sibling checkout, if this maglev
 #                                      checkout lives in a multi-repo workspace
-#   3. cache dir, cloning if absent - fallback for a maglev-only checkout
+#   4. cache dir, cloning if absent - final fallback for a maglev-only
+#                                      checkout with no /workspace available
 #
-# Repos found via (1) or (2) were checked out independently of this script,
-# so it never mutates them - it only does a read-only freshness check
-# (fetch + compare, no reset/pull) and prints a warning to stderr if the
-# checkout looks behind its own upstream. Repos in the cache dir (3) *are*
-# managed by this script, so those are kept up to date automatically
-# instead of just flagged.
+# Tiers 1-3 are places a human might be editing directly (that's the whole
+# point of $OBA_WORKSPACE and /workspace - e.g. to push changes to
+# maglev.wiki from the host), so this script only ever clones into them if
+# the repo isn't there yet; once a checkout exists there, it's never
+# mutated - no fetch+reset, no pull. The only thing done to an existing
+# checkout in tiers 1-3 is a read-only freshness check (fetch + compare)
+# that prints a warning to stderr if it looks behind its own upstream.
+#
+# Tier 4 (the cache dir) is fully owned by this script - nothing else is
+# expected to edit it - so it's kept up to date automatically: cloned on
+# first use, then fetched and hard-reset to match its upstream branch on
+# every later run.
 #
 # Only the resolved path is printed to stdout; all progress/diagnostic
 # output goes to stderr, so this is safe to use as:
@@ -51,9 +64,9 @@ case "$REPO" in
     ;;
 esac
 
-# Read-only staleness check for a checkout this script does not manage
-# (found via OBA_WORKSPACE or as a sibling). Fetches the current branch's
-# upstream and compares - never resets/pulls/mutates the working tree.
+# Read-only staleness check for an existing checkout. Fetches the current
+# branch's upstream and compares - never resets/pulls/mutates the working
+# tree or local branch.
 warn_if_stale() {
   local path="$1"
   local branch upstream_ref local_rev remote_rev behind last_date
@@ -80,22 +93,45 @@ warn_if_stale() {
     behind="$(git -C "$path" rev-list --count "HEAD..$upstream_ref" 2>/dev/null || echo "?")"
     if [[ "$behind" != "0" ]]; then
       last_date="$(git -C "$path" log -1 --format=%ad --date=short)"
-      echo "Warning: $REPO at $path (branch $branch) is $behind commit(s) behind origin/$branch (last local commit: $last_date). This checkout was found independently, not cloned by this script, so it was not updated automatically - results below may reflect stale code. Run 'git -C $path pull' to update it, or unset OBA_WORKSPACE / move it aside to let this script manage a fresh copy in its cache instead." >&2
+      echo "Warning: $REPO at $path (branch $branch) is $behind commit(s) behind origin/$branch (last local commit: $last_date). This script never mutates an existing checkout, so it was not updated automatically - results below may reflect stale code. Run 'git -C $path pull' to update it yourself." >&2
     fi
   fi
 }
 
+# Clones $URL into $1 if it isn't already a git checkout there; otherwise
+# just runs the read-only staleness check. Never mutates an existing
+# checkout.
+resolve_target() {
+  local target="$1"
+  if [[ -d "$target/.git" ]]; then
+    warn_if_stale "$target"
+  else
+    echo "Cloning $REPO into $target (first use)..." >&2
+    mkdir -p "$(dirname "$target")"
+    git clone --depth 1 "$URL" "$target" >&2
+  fi
+  echo "$target"
+}
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-# 1. Explicit workspace override
-if [[ -n "${OBA_WORKSPACE:-}" && -d "$OBA_WORKSPACE/$REPO" ]]; then
-  warn_if_stale "$OBA_WORKSPACE/$REPO"
-  echo "$OBA_WORKSPACE/$REPO"
+# 1. Explicit workspace override - clone into it if the repo isn't there yet,
+#    otherwise read-only.
+if [[ -n "${OBA_WORKSPACE:-}" ]]; then
+  resolve_target "$OBA_WORKSPACE/$REPO"
   exit 0
 fi
 
-# 2. Sibling of the maglev checkout this script lives in (script is at
-#    <maglev-root>/.claude/skills/lib/resolve-oba-repo.sh)
+# 2. Deterministic default: /workspace, if present. Same clone-if-absent /
+#    read-only-otherwise handling as (1).
+if [[ -d /workspace ]]; then
+  resolve_target "/workspace/$REPO"
+  exit 0
+fi
+
+# 3. Sibling of the maglev checkout this script lives in (script is at
+#    <maglev-root>/.claude/skills/lib/resolve-oba-repo.sh). Read-only only -
+#    a sibling that doesn't exist isn't a sibling, so this tier never clones.
 MAGLEV_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
 SIBLING="$(dirname "$MAGLEV_ROOT")/$REPO"
 if [[ -d "$SIBLING/.git" ]]; then
@@ -104,7 +140,9 @@ if [[ -d "$SIBLING/.git" ]]; then
   exit 0
 fi
 
-# 3. Cache dir - clone on first use, best-effort refresh on later runs
+# 4. Cache dir - final fallback, fully managed by this script: cloned on
+#    first use, then kept up to date automatically (fetch + reset --hard)
+#    on every later run, since nothing else is expected to edit it.
 CACHE_ROOT="${OBA_SKILL_CACHE:-$HOME/.cache/oba-api-review}/repos"
 TARGET="$CACHE_ROOT/$REPO"
 

--- a/.claude/skills/oba-api-client-impact/SKILL.md
+++ b/.claude/skills/oba-api-client-impact/SKILL.md
@@ -11,7 +11,7 @@ Typically invoked by `oba-api-review`. Can be called directly when you want to i
 
 ## Workspace layout
 
-Each client repo is resolved on demand with `.claude/skills/lib/resolve-oba-repo.sh <repo-name>`, which prints the repo's local path — cloning it to a local cache on first use if it isn't already checked out as a sibling of `maglev`. Paths below are relative to that resolved root:
+Each client repo is resolved via the `oba-workspace` skill, which prints each repo's local path. Paths below are relative to that resolved root:
 
 - **JS SDK resource** (repo: `js-sdk`): `src/resources/<endpoint>.ts`, `src/resources/shared.ts`
 - **Wayfinder API route** (repo: `wayfinder`): `src/routes/api/oba/<endpoint>/+server.js` (if it exists) — note `.js`, not `.ts`. If the endpoint takes a path parameter, the file lives one level deeper under a bracketed folder named for that parameter, e.g. `src/routes/api/oba/stops-for-route/[routeId]/+server.js` — the bracket name varies per endpoint (`[id]`, `[stopId]`, `[tripId]`, …), so list the endpoint's directory rather than guessing the exact folder name.
@@ -21,9 +21,7 @@ Each client repo is resolved on demand with `.claude/skills/lib/resolve-oba-repo
 - **Android response models** (repo: `onebusaway-android`): `onebusaway-android/src/main/java/org/onebusaway/android/api/contract/ObaApiModels.kt` — a single file with one `kotlinx.serialization` `data class` per response shape, named to match (e.g. `StopsForRoute`).
 - **Android data/adapter layer** (repo: `onebusaway-android`, secondary): `onebusaway-android/src/main/java/org/onebusaway/android/api/data/` (per-feature `*DataSource.kt`, e.g. `RouteStopsDataSource.kt`) and `.../api/adapters/` (per-domain `*Adapters.kt`, e.g. `RouteAdapters.kt`) hold business logic and DTO-to-app-model mapping. These aren't named 1:1 per endpoint — grep for the endpoint's Retrofit method name or response model class name to find the consuming files.
 
-This skill always needs all four client repos, so resolve `js-sdk`, `wayfinder`, `onebusaway-ios`, and `onebusaway-android` up front, before starting step 2. First use may take a minute to clone; later runs just refresh the cache.
-
-If a repo was found as a sibling checkout or via `OBA_WORKSPACE` rather than cloned into the cache, the resolver does not update it automatically and instead prints a `Warning: ... commit(s) behind ...` to stderr if it's stale. Watch for these — if one appears, note it as a caveat in the final report (the analysis for that client may be based on out-of-date source) rather than silently proceeding as if the checkout were current.
+This skill always needs all four client repos, so invoke `oba-workspace` once up front with all four repo names (`js-sdk wayfinder onebusaway-ios onebusaway-android`), before starting step 2, rather than resolving them one at a time. First use may take a minute to clone. Include any caveats `oba-workspace` reports in the final report (the analysis for that client may be based on out-of-date or locally-modified source) rather than silently proceeding as if the checkouts were unremarkable.
 
 ## Steps
 

--- a/.claude/skills/oba-api-review/README.md
+++ b/.claude/skills/oba-api-review/README.md
@@ -36,10 +36,13 @@ That said, nothing here is specific to that project. Point `oba-api-review` at a
 
 ## How cross-repo resolution works
 
-`oba-api-client-impact` and `oba-api-spec-check` need source from `wayfinder`, `js-sdk`, `onebusaway-ios`, `onebusaway-android`, and `maglev.wiki` — none of which need to be checked out ahead of time. `.claude/skills/lib/resolve-oba-repo.sh <repo-name>` finds each one automatically:
+`oba-api-client-impact` and `oba-api-spec-check` need source from `wayfinder`, `js-sdk`, `onebusaway-ios`, `onebusaway-android`, and `maglev.wiki` — none of which need to be checked out ahead of time. They resolve each one through the `oba-workspace` skill, which in turn calls `.claude/skills/lib/resolve-oba-repo.sh <repo-name>`:
 
-1. `$OBA_WORKSPACE/<repo>`, if you've set that env var to point at a directory containing your own checkout.
-2. A sibling directory of your `maglev` checkout (i.e. `../<repo>`), if you happen to have the other repos checked out that way already.
-3. Otherwise, it's cloned into a local cache (`~/.cache/oba-api-review` by default, override with `OBA_SKILL_CACHE`) the first time it's needed, and kept up to date automatically on later runs.
+1. `$OBA_WORKSPACE/<repo>`, if you've set that env var to point at a directory containing your own checkout — cloned in if not already there.
+2. `/workspace/<repo>`, if `$OBA_WORKSPACE` isn't set and `/workspace` exists — the conventional bind-mount point in sandboxed VMs, so a checkout here can be mounted back to the host. Same clone-if-missing behavior as (1).
+3. A sibling directory of your `maglev` checkout (i.e. `../<repo>`), if you happen to have the other repos checked out that way already. Only used if it already exists — never cloned.
+4. Otherwise, it's cloned into a local cache (`~/.cache/oba-api-review` by default, override with `OBA_SKILL_CACHE`) the first time it's needed, and kept up to date automatically on later runs.
 
-Repos found via (1) or (2) aren't managed by this script, so they're never modified — instead, each is checked (read-only) against its upstream, and a skill's output will flag it if the checkout looks stale enough that the analysis might be based on outdated code.
+Repos found via (1), (2) or (3) are places you might be editing directly (e.g. to push changes to `maglev.wiki` from the host), so this script never modifies an existing checkout there — each is only checked (read-only) against its upstream. Repos in (4) are fully owned by this script and kept fresh automatically instead.
+
+`oba-workspace` sits in front of the script for all of this: it resolves repos on behalf of the other skills, and if any resolved checkout is stale or in an odd state (not on `main`/`master`, staged changes, uncommitted or untracked files), it stops and asks you how to proceed before the calling skill continues. You can also invoke `oba-workspace status` directly at any time to see where all five repos currently resolve to and whether any look off.

--- a/.claude/skills/oba-api-review/SKILL.md
+++ b/.claude/skills/oba-api-review/SKILL.md
@@ -2,7 +2,7 @@
 
 Entry point for reviewing a change to the OBA API. Determines which analyses are relevant and runs them.
 
-Lives inside the `maglev` repo and is meant to be usable with only `maglev` checked out. `oba-api-client-impact` and `oba-api-spec-check` need source from `wayfinder`, `js-sdk`, `onebusaway-ios`, `onebusaway-android`, and `maglev.wiki` — they resolve those automatically via `.claude/skills/lib/resolve-oba-repo.sh` (see that script's header for details). First use clones what's missing into a local cache (`~/.cache/oba-api-review` by default), so it needs `git` and network access; later runs reuse and refresh the cache. If you already have some of these repos checked out elsewhere, set `OBA_WORKSPACE` to the parent directory and they'll be used directly instead of being cloned.
+Lives inside the `maglev` repo and is meant to be usable with only `maglev` checked out. `oba-api-client-impact` and `oba-api-spec-check` need source from `wayfinder`, `js-sdk`, `onebusaway-ios`, `onebusaway-android`, and `maglev.wiki` — they resolve those automatically via the `oba-workspace` skill, which needs `git` and (on first use) network access. See `oba-workspace` for how repos are located and how it handles stale or locally-modified checkouts.
 
 Run this skill with the current working directory set to the root of your `maglev` checkout.
 

--- a/.claude/skills/oba-api-spec-check/SKILL.md
+++ b/.claude/skills/oba-api-spec-check/SKILL.md
@@ -13,14 +13,14 @@ Typically invoked by `oba-api-review`. Can be called directly when you want to i
 
 ## Workspace layout
 
-- **Spec**: `<endpoint>.md` in the `maglev.wiki` repo — resolve the repo's local path with `.claude/skills/lib/resolve-oba-repo.sh maglev.wiki` (clones it to a local cache on first use if it isn't already checked out as a sibling of `maglev`).
+- **Spec**: `<endpoint>.md` in the `maglev.wiki` repo — resolve the repo's local path via the `oba-workspace` skill (argument: `maglev.wiki`).
 - **Maglev handler**: `internal/restapi/<endpoint>_handler.go` (relative to the `maglev` repo root) — handler filenames use underscores throughout, e.g. `stops-for-route` → `stops_for_route_handler.go`, so convert every hyphen in the endpoint name to an underscore before looking for the file.
 
 ## Steps
 
 ### 1. Read the spec in full
 
-Run `.claude/skills/lib/resolve-oba-repo.sh maglev.wiki` to get the wiki repo's local path. If it was found as a sibling checkout or via `OBA_WORKSPACE` rather than cloned into the cache, the resolver doesn't update it automatically and will print a `Warning: ... commit(s) behind ...` to stderr if it's stale — if that happens, note it as a caveat in the final report, since the spec being read may be out of date. Then read `<path>/<endpoint>.md` entirely. Note:
+Get the wiki repo's local path from `oba-workspace` (see Workspace layout above); include any caveats it reports in the final report, since the spec being read may be out of date. Then read `<path>/<endpoint>.md` entirely. Note:
 - The specified behaviour for each request parameter, response field, and error case.
 - The **Suspected Defects** section — known divergences from ideal behaviour in the legacy implementation.
 - The **Implementation Decisions** section — deliberate deviations Maglev has chosen to make, with rationale.

--- a/.claude/skills/oba-api-verify/SKILL.md
+++ b/.claude/skills/oba-api-verify/SKILL.md
@@ -11,7 +11,7 @@ Typically invoked by `oba-api-review`. Can be called directly when you have a sp
 
 ## Workspace layout
 
-- **Spec**: `<endpoint>.md` in the `maglev.wiki` repo — resolve the repo's local path with `.claude/skills/lib/resolve-oba-repo.sh maglev.wiki` (clones it to a local cache on first use if it isn't already checked out as a sibling of `maglev`).
+- **Spec**: `<endpoint>.md` in the `maglev.wiki` repo — resolve the repo's local path via the `oba-workspace` skill (argument: `maglev.wiki`).
 - **Maglev handler**: `internal/restapi/<endpoint>_handler.go` (relative to the `maglev` repo root) — handler filenames use underscores throughout, e.g. `stops-for-route` → `stops_for_route_handler.go`, so convert every hyphen in the endpoint name to an underscore before looking for the file.
 - **Maglev tests**: `internal/restapi/<endpoint>_handler_test.go` (relative to the `maglev` repo root, same hyphen-to-underscore conversion).
 
@@ -23,7 +23,7 @@ Extract the endpoint name and the specific behaviours, fields, parameters, or er
 
 ### 2. Read the relevant spec section
 
-Run `.claude/skills/lib/resolve-oba-repo.sh maglev.wiki` to get the wiki repo's local path. If it was found as a sibling checkout or via `OBA_WORKSPACE` rather than cloned into the cache, the resolver doesn't update it automatically and will print a `Warning: ... commit(s) behind ...` to stderr if it's stale — if that happens, note it as a caveat in the final report, since the spec being read may be out of date. Then read the section(s) of `<path>/<endpoint>.md` that correspond to the stated goal. Confirm what correct behaviour looks like according to the spec.
+Get the wiki repo's local path from `oba-workspace` (see Workspace layout above); include any caveats it reports in the final report, since the spec being read may be out of date. Then read the section(s) of `<path>/<endpoint>.md` that correspond to the stated goal. Confirm what correct behaviour looks like according to the spec.
 
 ### 3. Get the diff
 

--- a/.claude/skills/oba-workspace/SKILL.md
+++ b/.claude/skills/oba-workspace/SKILL.md
@@ -1,0 +1,55 @@
+# OBA Workspace
+
+Resolves local checkout paths for the OBA companion repos (`wayfinder`, `js-sdk`, `onebusaway-ios`, `onebusaway-android`, `maglev.wiki`) and checks their state. `oba-api-review`, `oba-api-client-impact`, `oba-api-spec-check`, and `oba-api-verify` all resolve repos through this skill rather than calling `.claude/skills/lib/resolve-oba-repo.sh` directly, so resolution and anomaly handling live in one place instead of being repeated in each.
+
+## Arguments
+
+One of:
+- One or more repo names, e.g. `maglev.wiki` or `wayfinder js-sdk onebusaway-ios onebusaway-android` — resolve these for an upcoming task.
+- `status` — report on all five known repos without resolving for any specific task (see [Status mode](#status-mode)).
+
+## Known repos
+
+`wayfinder`, `js-sdk`, `onebusaway-ios`, `onebusaway-android`, `maglev.wiki`
+
+## Steps (resolving specific repos)
+
+### 1. Resolve each requested repo
+
+For each repo name given, run:
+```bash
+.claude/skills/lib/resolve-oba-repo.sh <repo>
+```
+capturing stdout (the resolved path) and stderr separately.
+
+### 2. Check each resolved path for anomalies
+
+- **Staleness**: a `Warning: ... commit(s) behind ...` line on the stderr captured above. Only tiers 1-3 (explicit `OBA_WORKSPACE`, `/workspace`, sibling checkout) can produce this — the cache-dir tier is fetched and hard-reset on every run, so it's never stale.
+- **Odd repo state**: run `git -C <path> rev-parse --abbrev-ref HEAD` and `git -C <path> status --porcelain` on the resolved path and flag any of:
+  - Current branch is not `main` or `master` (or `HEAD`, i.e. detached)
+  - Staged changes not yet committed
+  - Unstaged modifications or untracked files
+
+### 3. If any repo in this batch has anomalies
+
+Present one consolidated summary covering every affected repo (list each anomaly found, per repo) — do not ask separately per repo. Then use the `AskUserQuestion` tool to ask how to proceed, with exactly these two options:
+
+- **Continue anyway** — proceed with the checkouts as-is. Every anomaly listed must be folded into the calling skill's final report as a caveat.
+- **Stop here** — halt the calling skill entirely without proceeding to its analysis steps, so the user can fix things (`git pull`, commit, or stash) and re-run.
+
+### 4. Return to the caller
+
+- No anomalies: just the resolved path(s).
+- "Continue anyway": the resolved path(s) plus the full anomaly list, to be included in the caller's final report.
+- "Stop here": tell the calling skill to stop immediately — do not proceed to its own analysis.
+
+## Status mode
+
+Invoked with `status` instead of specific repo names: resolve all five known repos (steps 1-2 above, for all of them — this clones any that aren't yet checked out anywhere) and present a table, no prompting:
+
+| Repo | Path | Resolved via | Anomalies |
+|------|------|--------------|-----------|
+
+"Resolved via" — infer from the path: under `$OBA_WORKSPACE` if that env var is set, under `/workspace`, a sibling of the `maglev` checkout, or the cache dir (whichever prefix matches).
+
+This mode is read/report-only — it never prompts, since it isn't a precondition for anything else proceeding.


### PR DESCRIPTION
Adds a /workspace bind-mount tier to resolve-oba-repo.sh (between
OBA_WORKSPACE and the sibling-checkout tier) so companion-repo clones
land somewhere that can be mounted back to the host in sandboxed VMs,
and lets tiers 1-2 clone on first use instead of only being usable
when already present.

Introduces the oba-workspace skill as a single place to resolve repos
and handle anomalies (staleness, wrong branch, dirty checkout) with a
consistent prompt, and repoints oba-api-review, oba-api-client-impact,
oba-api-spec-check, and oba-api-verify to go through it instead of
calling resolve-oba-repo.sh and handling anomalies individually.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/OneBusAway/codesmith/maglev/pr/1259"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787957617&installation_model_id=429412&pr_number=1259&repository=OneBusAway%2Fmaglev&return_to=https%3A%2F%2Fgithub.com%2FOneBusAway%2Fmaglev%2Fpull%2F1259&signature=9f62329c6e68ebfd73f6c86e53281ba9c8eac05f4f688102cdd4eb4d650b2258"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added standardized workspace resolution for companion repositories across supported local and cached locations.
  * Added checks for stale, incorrect, or locally modified repositories before analysis.
  * Added a workspace status mode showing repository locations and detected issues.
  * Added prompts to continue or stop when repository anomalies are found.

* **Documentation**
  * Updated API review, verification, specification, and impact-analysis guidance to use the standardized workspace workflow.
  * Documented repository resolution options, caveats, and status reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->