### PR TITLE
Disable commit attribution and auto-load CONTRIBUTING.md

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,5 @@
+{
+  "attribution": {
+    "commit": ""
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,7 +93,9 @@ Then connect from GoLand IDE or other Delve-compatible debugger.
 
 ## Contributing
 
-Read [CONTRIBUTING.md](CONTRIBUTING.md) in full before making or even proposing any code changes in this repo — its guidelines on size, scope, commit hygiene, testing, code reuse, and complexity should shape the code as it's written, not just get checked afterward.
+@CONTRIBUTING.md
+
+Follow these guidelines in full before making or even proposing any code changes in this repo — its guidelines on size, scope, commit hygiene, testing, code reuse, and complexity should shape the code as it's written, not just get checked afterward.
 
 ## Architecture Overview
 


### PR DESCRIPTION
## Summary
- Set `attribution.commit` to an empty string in `.claude/settings.json` so Claude Code no longer appends a `Co-Authored-By` trailer to commits it creates, per CONTRIBUTING.md's rule against attributing commits to a coding agent.
- Replace the markdown link to `CONTRIBUTING.md` in `CLAUDE.md` with an `@`-import so its guidelines load into context automatically every session instead of relying on the agent to decide to go read it.

## Test plan
- N/A — config/tooling-only change, no application code affected.