### PR TITLE
Add optional --output flag to oba-api-review skill

### DIFF
--- a/.claude/skills/oba-api-review/README.md
+++ b/.claude/skills/oba-api-review/README.md
@@ -34,6 +34,15 @@ That said, nothing here is specific to that project. Point `oba-api-review` at a
 /oba-api-review "remove situationIds from stops-for-route"   # a proposed change, described in English
 ```
 
+Add `--output` to also save the report as markdown, in addition to printing it inline:
+
+```
+/oba-api-review 123 --output                          # saves to tmp/oba-api-review/pr-123-<timestamp>.md
+/oba-api-review fix/route-ids-paging --output notes/review.md   # saves to a specific path
+```
+
+Without `--output`, the report is only printed inline, as before.
+
 ## How cross-repo resolution works
 
 `oba-api-client-impact` needs source from `wayfinder`, `js-sdk`, `onebusaway-ios`, and `onebusaway-android`; `oba-api-spec-check` and `oba-api-verify` need `maglev.wiki` — none of which need to be checked out ahead of time. They resolve each one through the `oba-workspace` skill, which in turn calls `.claude/skills/lib/resolve-oba-repo.sh <repo-name>`:

--- a/.claude/skills/oba-api-review/SKILL.md
+++ b/.claude/skills/oba-api-review/SKILL.md
@@ -8,7 +8,7 @@ Run this skill with the current working directory set to the root of your `magle
 
 ## Argument
 
-One of four forms:
+The source is one of four forms, optionally followed by a `--output [path]` flag:
 
 | Form | Detection | Example |
 |------|-----------|---------|
@@ -16,6 +16,8 @@ One of four forms:
 | Branch name | Single token, no spaces, not numeric | `fix/route-ids-paging` |
 | Description | Contains spaces | `remove the situationIds field from stops-for-route` |
 | *(empty)* | No argument | *(none)* → current working tree |
+
+Strip a trailing `--output` or `--output <path>` token from the argument before applying the detection rules above — it's a modifier, not part of the source. Its presence means: also save the final report to a file (step 7). Its absence means the report is only printed inline, as before. If `--output` is given without a path, use the default path described in step 7.
 
 ## Steps
 
@@ -116,3 +118,27 @@ Combine the sub-skill outputs into a single report:
 A short plain-English summary of what the analysis found. Note anything that is incomplete, incorrect, or that the change touches beyond its stated scope. Do not prescribe what should happen — that is the reader's decision.
 
 ---
+
+### 7. Save the report to a file (only if `--output` was given)
+
+Skip this step entirely if the `--output` flag wasn't present in the argument — the report printed in step 6 is the only output.
+
+If `--output <path>` was given, write the exact report content from step 6 to `<path>` verbatim (no truncation or reformatting), creating parent directories if needed.
+
+If `--output` was given with no path, write it to `tmp/oba-api-review/<slug>-<timestamp>.md` instead (this directory is already covered by the repo's `.gitignore`, so nothing here gets committed by accident):
+
+```bash
+mkdir -p tmp/oba-api-review
+```
+
+- `<timestamp>` is `date +%Y%m%d-%H%M%S`
+- `<slug>` depends on the resolved source:
+
+| Source | Slug |
+|--------|------|
+| PR | `pr-<NNN>` |
+| Branch | the branch name with `/` replaced by `-` |
+| Working tree | `working-tree-<current-branch-name-with-/-replaced-by-->` |
+| Description | a short kebab-case slug derived from the description (e.g. `remove-situationids-from-stops-for-route`) |
+
+After writing, tell the user the file path so they can open, share, or diff it against a previous run.


### PR DESCRIPTION
## Summary
- The `oba-api-review` Claude Code skill previously only printed its report inline, making it hard to save, diff, or share a review afterward.
- Adds an opt-in `--output [path]` flag: when present, the same report is also written to a file (a default path under `tmp/oba-api-review/` if no path is given, or the caller-supplied path) in addition to being printed inline.
- Default behavior (no flag) is unchanged.

## Test plan
- [x] Read through `SKILL.md` end-to-end to confirm the new step 7 is only triggered when `--output` is present and doesn't affect the existing argument-detection or report-synthesis steps.
- [x] Exercised the skill directly (`/oba-api-review 1223 --output`) against a real PR and confirmed the report was both printed inline and saved to `tmp/oba-api-review/pr-1223-<timestamp>.md`, which `.gitignore`'s `tmp/` pattern already excludes from version control.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for an optional `--output` option when generating API review reports.
  * Reports can now be saved to a custom path or a timestamped default location.
  * Parent directories are created automatically when needed.
  * Without `--output`, reports continue to appear inline only.

* **Documentation**
  * Updated usage guidance for the new report output options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->