### PR TITLE
## Fix: schedule stops are now present in `data.references.stops`

### DIFF
--- a/internal/restapi/trip_for_vehicle_handler.go
+++ b/internal/restapi/trip_for_vehicle_handler.go
@@ -130,26 +130,12 @@ func (api *RestAPI) tripForVehicleHandler(w http.ResponseWriter, r *http.Request
 
 	agencyModel := models.AgencyReferenceFromDatabase(&agency)
 
-	stopIDs := []string{}
-
-	if status != nil {
-		if status.ClosestStop != "" {
-			_, closestStopID, err := utils.ExtractAgencyIDAndCodeID(status.ClosestStop)
-			if err != nil {
-				api.serverErrorResponse(w, r, err)
-				return
-			}
-			stopIDs = append(stopIDs, closestStopID)
-		}
-		if status.NextStop != "" {
-			_, nextStopID, err := utils.ExtractAgencyIDAndCodeID(status.NextStop)
-			if err != nil {
-				api.serverErrorResponse(w, r, err)
-				return
-			}
-			stopIDs = append(stopIDs, nextStopID)
-		}
+	stopIDs, err := referencedStopIDs(status, schedule)
+	if err != nil {
+		api.serverErrorResponse(w, r, err)
+		return
 	}
+
 	stops, uniqueRouteMap, err := BuildStopReferencesAndRouteIDsForStops(api, ctx, agencyID, stopIDs)
 	if err != nil {
 		api.serverErrorResponse(w, r, err)
@@ -191,4 +177,36 @@ func (api *RestAPI) tripForVehicleHandler(w http.ResponseWriter, r *http.Request
 
 	response := models.NewEntryResponse(entry, *references, api.Clock)
 	api.sendResponse(w, r, response)
+}
+
+// referencedStopIDs returns the bare stop IDs that the entry refers to and so
+// need dereferencing in the response: the status block's closest and next stops,
+// plus every stop the schedule block lists. Both blocks carry combined
+// {agencyID}_{stopID} identifiers; the reference builders take bare ones.
+func referencedStopIDs(status *models.TripStatus, schedule *models.Schedule) ([]string, error) {
+	var combinedIDs []string
+
+	if status != nil {
+		combinedIDs = append(combinedIDs, status.ClosestStop, status.NextStop)
+	}
+	if schedule != nil {
+		for _, stopTime := range schedule.StopTimes {
+			combinedIDs = append(combinedIDs, stopTime.StopID)
+		}
+	}
+
+	stopIDs := make([]string, 0, len(combinedIDs))
+	for _, combinedID := range combinedIDs {
+		if combinedID == "" {
+			continue
+		}
+
+		_, stopID, err := utils.ExtractAgencyIDAndCodeID(combinedID)
+		if err != nil {
+			return nil, err
+		}
+		stopIDs = append(stopIDs, stopID)
+	}
+
+	return stopIDs, nil
 }

--- a/internal/restapi/trip_for_vehicle_handler_test.go
+++ b/internal/restapi/trip_for_vehicle_handler_test.go
@@ -174,6 +174,19 @@ func TestTripForVehicleHandler_IncludeToggles(t *testing.T) {
 
 		assert.Equal(t, http.StatusOK, resp.StatusCode)
 		assert.NotEmpty(t, model.Data.Entry.TripID)
+
+		schedule := model.Data.Entry.Schedule
+		require.NotNil(t, schedule, "schedule should be present when includeSchedule=true")
+		require.NotEmpty(t, schedule.StopTimes, "the fixture trip should have stop times")
+
+		referencedStops := make(map[string]struct{}, len(model.Data.References.Stops))
+		for _, stop := range model.Data.References.Stops {
+			referencedStops[stop.ID] = struct{}{}
+		}
+		for _, stopTime := range schedule.StopTimes {
+			assert.Contains(t, referencedStops, stopTime.StopID,
+				"every schedule stop must be dereferenceable in references.stops")
+		}
 	})
 
 	t.Run("all-false strips schedule/status/trip refs", func(t *testing.T) {

--- a/internal/restapi/trip_for_vehicle_handler_test.go
+++ b/internal/restapi/trip_for_vehicle_handler_test.go
@@ -305,3 +305,77 @@ func TestParseTripForVehicleParams_Unit(t *testing.T) {
 		assert.Equal(t, "must be a valid Unix timestamp in milliseconds or a date in yyyy-MM-dd format", errs["serviceDate"][0])
 	})
 }
+
+// TestReferencedStopIDs_Unit covers the stop IDs collected for the references
+// block: which entry fields contribute, that absent stops are skipped, and that
+// an unparseable combined ID surfaces an error for the handler to report.
+func TestReferencedStopIDs_Unit(t *testing.T) {
+	combined := func(stopID string) string {
+		return utils.FormCombinedID(testdata.Raba.ID, stopID)
+	}
+
+	tests := []struct {
+		name     string
+		status   *models.TripStatus
+		schedule *models.Schedule
+		want     []string
+		wantErr  bool
+	}{
+		{
+			name: "no status or schedule yields no stops",
+			want: []string{},
+		},
+		{
+			name:   "closest and next stops are collected",
+			status: &models.TripStatus{ClosestStop: combined("1"), NextStop: combined("2")},
+			want:   []string{"1", "2"},
+		},
+		{
+			name:   "absent status stops are skipped",
+			status: &models.TripStatus{ClosestStop: "", NextStop: combined("2")},
+			want:   []string{"2"},
+		},
+		{
+			name:   "schedule stops are collected alongside status stops",
+			status: &models.TripStatus{ClosestStop: combined("1")},
+			schedule: &models.Schedule{StopTimes: []models.StopTime{
+				{StopID: combined("2")}, {StopID: combined("3")},
+			}},
+			want: []string{"1", "2", "3"},
+		},
+		{
+			name: "absent schedule stop IDs are skipped",
+			schedule: &models.Schedule{StopTimes: []models.StopTime{
+				{StopID: ""}, {StopID: combined("2")},
+			}},
+			want: []string{"2"},
+		},
+		{
+			name:    "malformed status stop ID returns an error",
+			status:  &models.TripStatus{ClosestStop: "missing-separator"},
+			wantErr: true,
+		},
+		{
+			name: "malformed schedule stop ID returns an error",
+			schedule: &models.Schedule{StopTimes: []models.StopTime{
+				{StopID: "missing-separator"},
+			}},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := referencedStopIDs(tt.status, tt.schedule)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Nil(t, got, "no stop IDs should be returned alongside an error")
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
Fixes: #1278

### Description

The `trip-for-vehicle` endpoint did not follow the specification when `includeSchedule=true` was used.

According to **Extension 4c**:

> The `schedule` block is populated with the active trip's stop times, its timezone, and (when applicable) IDs for the preceding and following trips in the same block. Each stop in the schedule is added to `data.references.stops`.

Maglev collected only the two stops named by the `status` block — `closestStop` and `nextStop` — and passed those to the reference builder:

- `trip_for_vehicle_handler.go:133-152`

Every `stopId` in `schedule.stopTimes` was therefore undereferenceable: the client received a stop ID with no matching entry in `data.references.stops`.
Extension 4c requires every stop in the schedule block to appear in data.references.stops. Only the status block's closest and next stops were collected, so with includeSchedule=true each stopId in schedule.stopTimes was undereferenceable: the reference server returns 42 stops and 14 routes for the same request where Maglev returned 2 and 5.

Collect the referenced stop IDs in one place instead of extracting them inline per status field, and include the schedule's stops. The existing reference builder already dedupes and batches the lookups, so the extra IDs cost one widened query rather than a query per stop.
### Current behavior

Request:

```text
includeSchedule=true
```

The schedule block returns 43 stop times.

| Implementation | Stops in `data.references` | Routes in `data.references` |
| -------------- | -------------------------- | --------------------------- |
| Java           | ✅ 42 | ✅ 14 |
| Maglev         | ❌ 2  | ❌ 5  |

### Java verification

Verified against the live reference server, which runs the same static GTFS bundle and the same GTFS-RT feed as the local config.

### Changes

- The stops named in `schedule.stopTimes` are now collected alongside the status block's `closestStop` and `nextStop`.
- The two inline extractions are replaced by a single `referencedStopIDs` helper, which converts the entry's combined `{agencyID}_{stopID}` identifiers into the bare IDs the reference builders expect.

`BuildStopReferencesAndRouteIDsForStops` already deduplicates its input and batches the underlying lookups via `GetStopsByIDs` / `GetRoutesForStops`, so the additional IDs widen one query rather than adding a query per stop.

Route references improve as a side effect: they are derived from the stops, so the routes serving the schedule's stops now appear too.

### Resulting behavior

| Request | Schedule stops dereferenceable |
| ------- | ------------------------------ |
| `includeSchedule=true` | ✅ all |
| `includeSchedule=false` (default) | ✅ n/a, no schedule block |





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Trip responses now include references for all stops listed in the schedule, including stops beyond the current trip status.
  * Stop references are normalized consistently, and invalid stop identifiers are handled correctly.

* **Tests**
  * Added coverage confirming scheduled stops include corresponding stop-time and reference data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->