### PR TITLE
Fix scheduledDistanceAlongTrip when scheduleDeviation is zero

### DIFF
--- a/internal/restapi/trips_helper.go
+++ b/internal/restapi/trips_helper.go
@@ -194,13 +194,14 @@ func (api *RestAPI) BuildTripStatus(
 				}
 			}
 
-			if scheduleDeviation != 0 && len(stopTimes) > 0 {
-				scheduledDistance := api.calculateEffectiveDistanceAlongTrip(
-					ctx, actualDistance, scheduleDeviation, currentTime, serviceDate,
-					stopTimes, shapePoints, cumulativeDistances,
-				)
-				status.ScheduledDistanceAlongTrip = scheduledDistance
-			}
+			// Called unconditionally: an on-time vehicle's scheduled distance is its
+			// actual distance, not zero, and calculateEffectiveDistanceAlongTrip
+			// already falls back to actualDistance when there is no deviation to
+			// project away from and when the trip has no stop times.
+			status.ScheduledDistanceAlongTrip = api.calculateEffectiveDistanceAlongTrip(
+				ctx, actualDistance, scheduleDeviation, currentTime, serviceDate,
+				stopTimes, shapePoints, cumulativeDistances,
+			)
 		}
 	}
 

--- a/internal/restapi/trips_helper_test.go
+++ b/internal/restapi/trips_helper_test.go
@@ -560,6 +560,13 @@ func TestBuildTripStatus_ShapeData_ComputesDistanceAlongTrip(t *testing.T) {
 	assert.Greater(t, status.TotalDistanceAlongTrip, float64(0), "TotalDistanceAlongTrip should be > 0 with shape data")
 	assert.Greater(t, status.DistanceAlongTrip, float64(0), "DistanceAlongTrip should be > 0 for a vehicle mid-route")
 	assert.Less(t, status.DistanceAlongTrip, status.TotalDistanceAlongTrip, "DistanceAlongTrip should be less than total for a mid-route vehicle")
+
+	// No trip update is mocked, so the vehicle is on time. There is no deviation
+	// to project away from, which makes the scheduled distance the actual one —
+	// not zero, which is what a guard on a non-zero deviation used to produce.
+	require.Zero(t, status.ScheduleDeviation, "an unmocked trip update leaves the vehicle on time")
+	assert.Equal(t, status.DistanceAlongTrip, status.ScheduledDistanceAlongTrip,
+		"an on-time vehicle's scheduled distance is its actual distance")
 }
 
 func TestBuildTripStatus_VehicleIDFormat(t *testing.T) {


### PR DESCRIPTION
Fixes: #1282 

## Summary

This PR fixes the computation of `scheduledDistanceAlongTrip` for on-time vehicles.

Previously, the value was only calculated when `scheduleDeviation != 0`, causing vehicles with no schedule deviation to incorrectly report:

```json id="g1m8qa"
"scheduledDistanceAlongTrip": 0
```

instead of a value equal to `distanceAlongTrip`.

This behavior differs from the Java reference implementation, which reports:

```text id="k4n2pw"
scheduledDistanceAlongTrip == distanceAlongTrip
```

whenever `scheduleDeviation == 0`.

## Changes

* Remove the `scheduleDeviation != 0` guard when computing `scheduledDistanceAlongTrip`.
* Ensure on-time vehicles report `scheduledDistanceAlongTrip` equal to `distanceAlongTrip`.
* Add a test covering the zero schedule deviation case.

## Result

`scheduledDistanceAlongTrip` now matches the Java implementation and the API specification for both delayed/early and on-time vehicles.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved trip status accuracy for vehicles with valid GPS and route data.
  * Scheduled distance now reflects actual distance when a vehicle is on time, even when stop-time or schedule-deviation data is unavailable.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->