### PR TITLE
refactor: explicitly track referenced trips in buildTripReferences

### DIFF
--- a/internal/restapi/trips_for_route_handler.go
+++ b/internal/restapi/trips_for_route_handler.go
@@ -704,6 +704,14 @@ func buildTripReferences(
 	presentTrips := make(map[string]models.Trip)
 	presentRoutes := make(map[string]models.Route)
 
+	// referencedTripIDs tracks the trips referenced by the response (entry
+	// tripIds, schedule.nextTripId/previousTripId, status.activeTripId) that
+	// were not part of preFetchedTrips and still need to be fetched, so their
+	// full records are present in references.trips. Encoding this as an
+	// explicit set rather than inferring it from a zero-value ID sentinel makes
+	// it unambiguous which trips are still missing from the references.
+	referencedTripIDs := make(map[string]bool)
+
 	for _, trip := range preFetchedTrips {
 		presentTrips[trip.ID] = models.Trip{
 			ID:            trip.ID,
@@ -722,6 +730,7 @@ func buildTripReferences(
 		_, tripID, _ := utils.ExtractAgencyIDAndCodeID(trip.GetTripId())
 		if _, exists := presentTrips[tripID]; !exists {
 			presentTrips[tripID] = models.Trip{}
+			referencedTripIDs[tripID] = true
 		}
 	}
 
@@ -732,6 +741,7 @@ func buildTripReferences(
 				if err == nil {
 					if _, exists := presentTrips[nextTripID]; !exists {
 						presentTrips[nextTripID] = models.Trip{}
+						referencedTripIDs[nextTripID] = true
 					}
 				}
 			}
@@ -740,6 +750,7 @@ func buildTripReferences(
 				if err == nil {
 					if _, exists := presentTrips[prevTripID]; !exists {
 						presentTrips[prevTripID] = models.Trip{}
+						referencedTripIDs[prevTripID] = true
 					}
 				}
 			}
@@ -750,16 +761,15 @@ func buildTripReferences(
 			if err == nil {
 				if _, exists := presentTrips[activeTripID]; !exists {
 					presentTrips[activeTripID] = models.Trip{}
+					referencedTripIDs[activeTripID] = true
 				}
 			}
 		}
 	}
 
 	var tripIDsToFetch []string
-	for id, t := range presentTrips {
-		if t.ID == "" {
-			tripIDsToFetch = append(tripIDsToFetch, id)
-		}
+	for id := range referencedTripIDs {
+		tripIDsToFetch = append(tripIDsToFetch, id)
 	}
 
 	if len(tripIDsToFetch) > 0 {

--- a/internal/restapi/trips_for_route_handler.go
+++ b/internal/restapi/trips_for_route_handler.go
@@ -560,7 +560,10 @@ func (api *RestAPI) buildBlockTripForRoute(
 		// MinArrivalTime/MaxDepartureTime are NULL for a trip with no
 		// stop_times (see schema.sql); such a trip has no time window to
 		// compare against, so it can't be a nearest-midpoint candidate.
-		if bt.RouteID == routeID && bt.BlockID.Valid && bt.MinArrivalTime.Valid && bt.MaxDepartureTime.Valid {
+		if bt.RouteID == routeID &&
+			bt.BlockID.Valid &&
+			bt.MinArrivalTime.Valid &&
+			bt.MaxDepartureTime.Valid {
 			key := bt.BlockID.String
 			blockTripForRoute[key] = append(blockTripForRoute[key], blockTripEntry{
 				ID:               bt.ID,

--- a/internal/restapi/trips_for_route_handler_test.go
+++ b/internal/restapi/trips_for_route_handler_test.go
@@ -5,11 +5,13 @@ import (
 	"bytes"
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -38,6 +40,10 @@ var afterMidnightClock = time.Date(2025, 6, 13, 0, 30, 0, 0, time.UTC)
 // loopRouteClock is 10:15 UTC on 2025-06-12 — used by the looping-route
 // and gap-case fixtures.
 var loopRouteClock = time.Date(2025, 6, 12, 10, 15, 0, 0, time.UTC)
+
+// blockSequenceClock is 09:50 UTC on 2025-06-12, when the middle trip of the
+// block-sequence fixture (tfr-trip-2, 09:35–10:05) is active.
+var blockSequenceClock = time.Date(2025, 6, 12, 9, 50, 0, 0, time.UTC)
 
 const (
 	tripsForRouteAgencyID = "tfr-agency"
@@ -286,6 +292,35 @@ func crossDayBlockReuseFiles() map[string]string {
 			"tfr-today-a,24:25:00,24:25:00," + tripsForRouteStop2ID + ",2\n" +
 			"tfr-today-b,23:00:00,23:00:00," + tripsForRouteStop1ID + ",1\n" +
 			"tfr-today-b,23:30:00,23:30:00," + tripsForRouteStop2ID + ",2\n",
+	}
+}
+
+// blockSequenceFiles models three trips in one block: tfr-trip-1
+// (09:00–09:30), tfr-trip-2 (09:35–10:05), and tfr-trip-3 (10:10–10:40). At
+// blockSequenceClock only tfr-trip-2 is active; its schedule references the
+// adjacent block trips, which are not part of the handler's fetched trips.
+func blockSequenceFiles() map[string]string {
+	return map[string]string{
+		"agency.txt": "agency_id,agency_name,agency_url,agency_timezone\n" +
+			tripsForRouteAgencyID + ",Test Agency,http://example.com,UTC\n",
+		"routes.txt": "route_id,agency_id,route_short_name,route_long_name,route_type\n" +
+			tripsForRouteRouteID + "," + tripsForRouteAgencyID + ",TR,Test Route,3\n",
+		"calendar.txt": "service_id,monday,tuesday,wednesday,thursday,friday,saturday,sunday,start_date,end_date\n" +
+			"tfr-svc,1,1,1,1,1,1,1,20240101,20991231\n",
+		"stops.txt": "stop_id,stop_name,stop_lat,stop_lon\n" +
+			tripsForRouteStop1ID + ",Stop One,37.7749,-122.4194\n" +
+			tripsForRouteStop2ID + ",Stop Two,37.7849,-122.4094\n",
+		"trips.txt": "route_id,service_id,trip_id,trip_headsign,direction_id,block_id\n" +
+			tripsForRouteRouteID + ",tfr-svc,tfr-trip-1,Headsign 1,0,tfr-seq-block\n" +
+			tripsForRouteRouteID + ",tfr-svc,tfr-trip-2,Headsign 2,0,tfr-seq-block\n" +
+			tripsForRouteRouteID + ",tfr-svc,tfr-trip-3,Headsign 3,0,tfr-seq-block\n",
+		"stop_times.txt": "trip_id,arrival_time,departure_time,stop_id,stop_sequence\n" +
+			"tfr-trip-1,09:00:00,09:00:00," + tripsForRouteStop1ID + ",1\n" +
+			"tfr-trip-1,09:30:00,09:30:00," + tripsForRouteStop2ID + ",2\n" +
+			"tfr-trip-2,09:35:00,09:35:00," + tripsForRouteStop1ID + ",1\n" +
+			"tfr-trip-2,10:05:00,10:05:00," + tripsForRouteStop2ID + ",2\n" +
+			"tfr-trip-3,10:10:00,10:10:00," + tripsForRouteStop1ID + ",1\n" +
+			"tfr-trip-3,10:40:00,10:40:00," + tripsForRouteStop2ID + ",2\n",
 	}
 }
 
@@ -1111,4 +1146,164 @@ func TestResolveInterlinedEntryTripID_NoCandidateInBlock(t *testing.T) {
 		map[string][]blockTripEntry{}, map[string]string{})
 
 	assert.False(t, resolved)
+}
+
+// TestTripsForRouteHandler_BlockSequence_AdjacentTripReferences verifies that
+// schedule.previousTripId and schedule.nextTripId trips — which are not part
+// of the handler's fetched trips — are fully populated in references.trips
+// (routeId, headsign, blockId, serviceId), not emitted as empty objects.
+func TestTripsForRouteHandler_BlockSequence_AdjacentTripReferences(t *testing.T) {
+	api := createTestApiWithGTFSFixture(t, clock.NewMockClock(blockSequenceClock),
+		"trips-for-route-block-seq.zip", blockSequenceFiles())
+	combinedRouteID := utils.FormCombinedID(tripsForRouteAgencyID, tripsForRouteRouteID)
+	timeMs := blockSequenceClock.UnixMilli()
+	url := fmt.Sprintf("/api/where/trips-for-route/%s.json?key=TEST&includeSchedule=true&includeTrip=true&time=%d",
+		combinedRouteID, timeMs)
+
+	resp, model := callAPIHandler[TripsForRouteResponse](t, api, url)
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Equal(t, http.StatusOK, model.Code)
+	require.Len(t, model.Data.List, 1)
+
+	entry := model.Data.List[0]
+	assert.Equal(t, utils.FormCombinedID(tripsForRouteAgencyID, "tfr-trip-2"), entry.TripId)
+	require.NotNil(t, entry.Schedule)
+	assert.Equal(t, utils.FormCombinedID(tripsForRouteAgencyID, "tfr-trip-1"), entry.Schedule.PreviousTripId)
+	assert.Equal(t, utils.FormCombinedID(tripsForRouteAgencyID, "tfr-trip-3"), entry.Schedule.NextTripId)
+
+	refTrips := make(map[string]models.Trip)
+	for _, ref := range model.Data.References.Trips {
+		refTrips[ref.ID] = ref
+	}
+
+	// The adjacent block trips are not part of the handler's fetched trips, but
+	// their full records must still be present in the references.
+	expectedRouteID := utils.FormCombinedID(tripsForRouteAgencyID, tripsForRouteRouteID)
+	expectedBlockID := utils.FormCombinedID(tripsForRouteAgencyID, "tfr-seq-block")
+	expectedServiceID := utils.FormCombinedID(tripsForRouteAgencyID, "tfr-svc")
+	for i, tripID := range []string{"tfr-trip-1", "tfr-trip-3"} {
+		ref, ok := refTrips[utils.FormCombinedID(tripsForRouteAgencyID, tripID)]
+		require.Truef(t, ok, "references must include adjacent trip %s", tripID)
+		assert.Equalf(t, expectedRouteID, ref.RouteID, "adjacent trip %s must carry a routeId", tripID)
+		assert.NotEmptyf(t, ref.TripHeadsign, "adjacent trip %s must carry a headsign", tripID)
+		assert.Equalf(t, expectedBlockID, ref.BlockID, "adjacent trip %s must carry its blockId", tripID)
+		assert.Equalf(t, expectedServiceID, ref.ServiceID, "adjacent trip %s must carry its serviceId", tripID)
+		assert.Truef(t,
+			i == 0 ||
+				ref.TripHeadsign != refTrips[utils.FormCombinedID(tripsForRouteAgencyID, "tfr-trip-1")].TripHeadsign,
+			"adjacent trips must not both be the same record")
+	}
+}
+
+// TestBuildTripReferences_FetchesUnprefetchedTrips verifies that trips
+// referenced by entry TripId or Status.ActiveTripID are fetched and fully
+// populated in references.trips when not pre-fetched.
+func TestBuildTripReferences_FetchesUnprefetchedTrips(t *testing.T) {
+	api := createTestApiWithGTFSFixture(t, clock.NewMockClock(blockSequenceClock),
+		"trips-for-route-block-seq.zip", blockSequenceFiles())
+	ctx := context.Background()
+
+	// Only tfr-trip-2 is pre-fetched; tfr-trip-1 (referenced by an entry
+	// TripId) and tfr-trip-3 (referenced by Status.ActiveTripID) are not.
+	preFetchedTrip, err := api.GtfsManager.GtfsDB.Queries.GetTrip(ctx, "tfr-trip-2")
+	require.NoError(t, err)
+
+	entries := []models.TripsForRouteListEntry{
+		{TripId: utils.FormCombinedID(tripsForRouteAgencyID, "tfr-trip-1")},
+		{
+			TripId: utils.FormCombinedID(tripsForRouteAgencyID, "tfr-trip-2"),
+			Status: &models.TripStatus{ActiveTripID: utils.FormCombinedID(tripsForRouteAgencyID, "tfr-trip-3")},
+		},
+	}
+
+	references := buildTripReferences(api, ctx, true, entries, nil, []gtfsdb.Trip{preFetchedTrip}, nil)
+
+	refTrips := make(map[string]models.Trip)
+	for _, ref := range references.Trips {
+		refTrips[ref.ID] = ref
+	}
+
+	expectedRouteID := utils.FormCombinedID(tripsForRouteAgencyID, tripsForRouteRouteID)
+	expectedBlockID := utils.FormCombinedID(tripsForRouteAgencyID, "tfr-seq-block")
+	expectedServiceID := utils.FormCombinedID(tripsForRouteAgencyID, "tfr-svc")
+
+	for _, tc := range []struct {
+		name   string
+		tripID string
+	}{
+		{name: "entry TripId", tripID: "tfr-trip-1"},
+		{name: "status ActiveTripID", tripID: "tfr-trip-3"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ref, ok := refTrips[utils.FormCombinedID(tripsForRouteAgencyID, tc.tripID)]
+			require.Truef(t, ok, "references must include the trip referenced by %s", tc.name)
+			assert.Equal(t, expectedRouteID, ref.RouteID)
+			assert.NotEmpty(t, ref.TripHeadsign)
+			assert.Equal(t, expectedBlockID, ref.BlockID)
+			assert.Equal(t, expectedServiceID, ref.ServiceID)
+		})
+	}
+}
+
+// tripFetchFailureDB wraps the GTFS DB and fails GetTripsByIDs lookups that
+// query any trip ID in failWhenArgsContain. The handler's active-trip fetch
+// never queries those IDs, so only the buildTripReferences lookup fails.
+type tripFetchFailureDB struct {
+	gtfsdb.DBTX
+	failWith            error
+	failWhenArgsContain []string
+}
+
+func (f *tripFetchFailureDB) QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error) {
+	if strings.Contains(query, "-- name: GetTripsByIDs") {
+		for _, arg := range args {
+			tripID, ok := arg.(string)
+			if !ok {
+				continue
+			}
+			for _, failID := range f.failWhenArgsContain {
+				if tripID == failID {
+					return nil, f.failWith
+				}
+			}
+		}
+	}
+	return f.DBTX.QueryContext(ctx, query, args...)
+}
+
+// TestTripsForRouteHandler_ReferenceLookupFailureDegradesGracefully verifies
+// that a failure to fetch a referenced trip degrades gracefully: the handler
+// logs and continues, still returning a 200 with the other references intact,
+// rather than failing the whole response.
+func TestTripsForRouteHandler_ReferenceLookupFailureDegradesGracefully(t *testing.T) {
+	api := createTestApiWithGTFSFixture(t, clock.NewMockClock(blockSequenceClock),
+		"trips-for-route-block-seq.zip", blockSequenceFiles())
+
+	// Block-adjacent trips are referenced by tfr-trip-2's schedule but are
+	// not part of the handler's fetched trips.
+	api.GtfsManager.GtfsDB.Queries = gtfsdb.New(&tripFetchFailureDB{
+		DBTX:                api.GtfsManager.GtfsDB.DB,
+		failWith:            errors.New("forced lookup failure"),
+		failWhenArgsContain: []string{"tfr-trip-1", "tfr-trip-3"},
+	})
+
+	combinedRouteID := utils.FormCombinedID(tripsForRouteAgencyID, tripsForRouteRouteID)
+	url := fmt.Sprintf("/api/where/trips-for-route/%s.json?key=TEST&includeSchedule=true&includeTrip=true&time=%d",
+		combinedRouteID, blockSequenceClock.UnixMilli())
+
+	resp, model := callAPIHandler[TripsForRouteResponse](t, api, url)
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Equal(t, http.StatusOK, model.Code)
+	require.Len(t, model.Data.List, 1)
+
+	refTrips := make(map[string]models.Trip)
+	for _, ref := range model.Data.References.Trips {
+		refTrips[ref.ID] = ref
+	}
+	require.Contains(t, refTrips, utils.FormCombinedID(tripsForRouteAgencyID, "tfr-trip-2"),
+		"the pre-fetched entry trip must still be referenced despite the lookup failure")
+	require.NotContains(t, refTrips, utils.FormCombinedID(tripsForRouteAgencyID, "tfr-trip-1"),
+		"the unfetchable adjacent trip must not appear in references")
 }


### PR DESCRIPTION
### Description

This PR refactors `buildTripReferences` to explicitly track which placeholder trips need to be fetched, replacing the implicit zero-value ID sentinel heuristic (`t.ID == ""`). 

Encoding the required fetches as an actual set (`referencedTripIDs`) makes the code's intent unambiguous and improves overall readability. This is a behavior-neutral change.

### Changes Made

* **Explicit Tracking:** Replaced the `t.ID == ""` check with a `referencedTripIDs` set to explicitly track trips that need to be fetched.
* **Graceful Degradation:** Fetch failures continue to follow the handler's established `log-and-continue` posture, ensuring the response remains a successful 200 OK without escalating to 404/500 errors.

### Testing

Added a three-trip block fixture and three new tests to ensure robust coverage:
* `TestTripsForRouteHandler_BlockSequence_AdjacentTripReferences`: Verifies that `schedule.previousTripId` and `nextTripId` trips are fully populated in `references.trips`.
* `TestBuildTripReferences_FetchesUnprefetchedTrips`: Verifies that explicit tracking correctly fetches trips referenced by the entry `TripId` and `status.activeTripId`.
* `TestTripsForRouteHandler_ReferenceLookupFailureDegradesGracefully`: Verifies that a referenced-trip lookup failure degrades gracefully (logs the error and continues, maintaining a 200 OK response with the remaining references intact).

Closes: #1287 
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

- Fixed trip reference data so related trips are fully populated when viewing route details.
- Improved consistency of adjacent trip information, including route, destination, block, and service details.
- Improved resilience when some trip reference lookups fail, allowing successfully retrieved references to remain available.
- Ensured route details continue loading successfully even when individual related-trip lookups cannot be completed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->