### PR TITLE
Fix trips-for-location candidate selection

### DIFF
--- a/gtfsdb/db.go
+++ b/gtfsdb/db.go
@@ -306,9 +306,6 @@ func Prepare(ctx context.Context, db DBTX) (*Queries, error) {
 	if q.getStopIDsForTripStmt, err = db.PrepareContext(ctx, getStopIDsForTrip); err != nil {
 		return nil, fmt.Errorf("error preparing query GetStopIDsForTrip: %w", err)
 	}
-	if q.getStopTimesByStopIDsStmt, err = db.PrepareContext(ctx, getStopTimesByStopIDs); err != nil {
-		return nil, fmt.Errorf("error preparing query GetStopTimesByStopIDs: %w", err)
-	}
 	if q.getStopTimesForStopInWindowStmt, err = db.PrepareContext(ctx, getStopTimesForStopInWindow); err != nil {
 		return nil, fmt.Errorf("error preparing query GetStopTimesForStopInWindow: %w", err)
 	}
@@ -874,11 +871,6 @@ func (q *Queries) Close() error {
 			err = fmt.Errorf("error closing getStopIDsForTripStmt: %w", cerr)
 		}
 	}
-	if q.getStopTimesByStopIDsStmt != nil {
-		if cerr := q.getStopTimesByStopIDsStmt.Close(); cerr != nil {
-			err = fmt.Errorf("error closing getStopTimesByStopIDsStmt: %w", cerr)
-		}
-	}
 	if q.getStopTimesForStopInWindowStmt != nil {
 		if cerr := q.getStopTimesForStopInWindowStmt.Close(); cerr != nil {
 			err = fmt.Errorf("error closing getStopTimesForStopInWindowStmt: %w", cerr)
@@ -1162,7 +1154,6 @@ type Queries struct {
 	getStopIDsForAgencyStmt                       *sql.Stmt
 	getStopIDsForRouteStmt                        *sql.Stmt
 	getStopIDsForTripStmt                         *sql.Stmt
-	getStopTimesByStopIDsStmt                     *sql.Stmt
 	getStopTimesForStopInWindowStmt               *sql.Stmt
 	getStopTimesForTripStmt                       *sql.Stmt
 	getStopTimesForTripIDsStmt                    *sql.Stmt
@@ -1293,7 +1284,6 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		getStopIDsForAgencyStmt:                       q.getStopIDsForAgencyStmt,
 		getStopIDsForRouteStmt:                        q.getStopIDsForRouteStmt,
 		getStopIDsForTripStmt:                         q.getStopIDsForTripStmt,
-		getStopTimesByStopIDsStmt:                     q.getStopTimesByStopIDsStmt,
 		getStopTimesForStopInWindowStmt:               q.getStopTimesForStopInWindowStmt,
 		getStopTimesForTripStmt:                       q.getStopTimesForTripStmt,
 		getStopTimesForTripIDsStmt:                    q.getStopTimesForTripIDsStmt,

--- a/gtfsdb/db.go
+++ b/gtfsdb/db.go
@@ -120,6 +120,9 @@ func Prepare(ctx context.Context, db DBTX) (*Queries, error) {
 	if q.getActiveLayoverBlockIDsForRouteStmt, err = db.PrepareContext(ctx, getActiveLayoverBlockIDsForRoute); err != nil {
 		return nil, fmt.Errorf("error preparing query GetActiveLayoverBlockIDsForRoute: %w", err)
 	}
+	if q.getActiveLayoverBlockIDsForStopsStmt, err = db.PrepareContext(ctx, getActiveLayoverBlockIDsForStops); err != nil {
+		return nil, fmt.Errorf("error preparing query GetActiveLayoverBlockIDsForStops: %w", err)
+	}
 	if q.getActiveRouteIDsForStopsOnDateStmt, err = db.PrepareContext(ctx, getActiveRouteIDsForStopsOnDate); err != nil {
 		return nil, fmt.Errorf("error preparing query GetActiveRouteIDsForStopsOnDate: %w", err)
 	}
@@ -137,6 +140,9 @@ func Prepare(ctx context.Context, db DBTX) (*Queries, error) {
 	}
 	if q.getActiveTripsWithNullBlockForRouteStmt, err = db.PrepareContext(ctx, getActiveTripsWithNullBlockForRoute); err != nil {
 		return nil, fmt.Errorf("error preparing query GetActiveTripsWithNullBlockForRoute: %w", err)
+	}
+	if q.getActiveTripsWithNullBlockForStopsStmt, err = db.PrepareContext(ctx, getActiveTripsWithNullBlockForStops); err != nil {
+		return nil, fmt.Errorf("error preparing query GetActiveTripsWithNullBlockForStops: %w", err)
 	}
 	if q.getAgenciesByIDsStmt, err = db.PrepareContext(ctx, getAgenciesByIDs); err != nil {
 		return nil, fmt.Errorf("error preparing query GetAgenciesByIDs: %w", err)
@@ -173,6 +179,9 @@ func Prepare(ctx context.Context, db DBTX) (*Queries, error) {
 	}
 	if q.getBlockTripIndexIDsForRouteStmt, err = db.PrepareContext(ctx, getBlockTripIndexIDsForRoute); err != nil {
 		return nil, fmt.Errorf("error preparing query GetBlockTripIndexIDsForRoute: %w", err)
+	}
+	if q.getBlockTripIndexIDsForStopsStmt, err = db.PrepareContext(ctx, getBlockTripIndexIDsForStops); err != nil {
+		return nil, fmt.Errorf("error preparing query GetBlockTripIndexIDsForStops: %w", err)
 	}
 	if q.getBlockTripSequenceStmt, err = db.PrepareContext(ctx, getBlockTripSequence); err != nil {
 		return nil, fmt.Errorf("error preparing query GetBlockTripSequence: %w", err)
@@ -555,6 +564,11 @@ func (q *Queries) Close() error {
 			err = fmt.Errorf("error closing getActiveLayoverBlockIDsForRouteStmt: %w", cerr)
 		}
 	}
+	if q.getActiveLayoverBlockIDsForStopsStmt != nil {
+		if cerr := q.getActiveLayoverBlockIDsForStopsStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing getActiveLayoverBlockIDsForStopsStmt: %w", cerr)
+		}
+	}
 	if q.getActiveRouteIDsForStopsOnDateStmt != nil {
 		if cerr := q.getActiveRouteIDsForStopsOnDateStmt.Close(); cerr != nil {
 			err = fmt.Errorf("error closing getActiveRouteIDsForStopsOnDateStmt: %w", cerr)
@@ -583,6 +597,11 @@ func (q *Queries) Close() error {
 	if q.getActiveTripsWithNullBlockForRouteStmt != nil {
 		if cerr := q.getActiveTripsWithNullBlockForRouteStmt.Close(); cerr != nil {
 			err = fmt.Errorf("error closing getActiveTripsWithNullBlockForRouteStmt: %w", cerr)
+		}
+	}
+	if q.getActiveTripsWithNullBlockForStopsStmt != nil {
+		if cerr := q.getActiveTripsWithNullBlockForStopsStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing getActiveTripsWithNullBlockForStopsStmt: %w", cerr)
 		}
 	}
 	if q.getAgenciesByIDsStmt != nil {
@@ -643,6 +662,11 @@ func (q *Queries) Close() error {
 	if q.getBlockTripIndexIDsForRouteStmt != nil {
 		if cerr := q.getBlockTripIndexIDsForRouteStmt.Close(); cerr != nil {
 			err = fmt.Errorf("error closing getBlockTripIndexIDsForRouteStmt: %w", cerr)
+		}
+	}
+	if q.getBlockTripIndexIDsForStopsStmt != nil {
+		if cerr := q.getBlockTripIndexIDsForStopsStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing getBlockTripIndexIDsForStopsStmt: %w", cerr)
 		}
 	}
 	if q.getBlockTripSequenceStmt != nil {
@@ -1076,12 +1100,14 @@ type Queries struct {
 	createStopTimeStmt                            *sql.Stmt
 	createTripStmt                                *sql.Stmt
 	getActiveLayoverBlockIDsForRouteStmt          *sql.Stmt
+	getActiveLayoverBlockIDsForStopsStmt          *sql.Stmt
 	getActiveRouteIDsForStopsOnDateStmt           *sql.Stmt
 	getActiveServiceIDsForDateStmt                *sql.Stmt
 	getActiveStopsStmt                            *sql.Stmt
 	getActiveTripForRouteAtTimeStmt               *sql.Stmt
 	getActiveTripInBlockAtTimeStmt                *sql.Stmt
 	getActiveTripsWithNullBlockForRouteStmt       *sql.Stmt
+	getActiveTripsWithNullBlockForStopsStmt       *sql.Stmt
 	getAgenciesByIDsStmt                          *sql.Stmt
 	getAgenciesForStopsStmt                       *sql.Stmt
 	getAgencyStmt                                 *sql.Stmt
@@ -1094,6 +1120,7 @@ type Queries struct {
 	getBlockIDByTripIDStmt                        *sql.Stmt
 	getBlockTripIndexIDsForBlocksStmt             *sql.Stmt
 	getBlockTripIndexIDsForRouteStmt              *sql.Stmt
+	getBlockTripIndexIDsForStopsStmt              *sql.Stmt
 	getBlockTripSequenceStmt                      *sql.Stmt
 	getBlocksForBlockTripIndexIDsStmt             *sql.Stmt
 	getCalendarByServiceIDStmt                    *sql.Stmt
@@ -1204,12 +1231,14 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		createStopTimeStmt:                            q.createStopTimeStmt,
 		createTripStmt:                                q.createTripStmt,
 		getActiveLayoverBlockIDsForRouteStmt:          q.getActiveLayoverBlockIDsForRouteStmt,
+		getActiveLayoverBlockIDsForStopsStmt:          q.getActiveLayoverBlockIDsForStopsStmt,
 		getActiveRouteIDsForStopsOnDateStmt:           q.getActiveRouteIDsForStopsOnDateStmt,
 		getActiveServiceIDsForDateStmt:                q.getActiveServiceIDsForDateStmt,
 		getActiveStopsStmt:                            q.getActiveStopsStmt,
 		getActiveTripForRouteAtTimeStmt:               q.getActiveTripForRouteAtTimeStmt,
 		getActiveTripInBlockAtTimeStmt:                q.getActiveTripInBlockAtTimeStmt,
 		getActiveTripsWithNullBlockForRouteStmt:       q.getActiveTripsWithNullBlockForRouteStmt,
+		getActiveTripsWithNullBlockForStopsStmt:       q.getActiveTripsWithNullBlockForStopsStmt,
 		getAgenciesByIDsStmt:                          q.getAgenciesByIDsStmt,
 		getAgenciesForStopsStmt:                       q.getAgenciesForStopsStmt,
 		getAgencyStmt:                                 q.getAgencyStmt,
@@ -1222,6 +1251,7 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		getBlockIDByTripIDStmt:                        q.getBlockIDByTripIDStmt,
 		getBlockTripIndexIDsForBlocksStmt:             q.getBlockTripIndexIDsForBlocksStmt,
 		getBlockTripIndexIDsForRouteStmt:              q.getBlockTripIndexIDsForRouteStmt,
+		getBlockTripIndexIDsForStopsStmt:              q.getBlockTripIndexIDsForStopsStmt,
 		getBlockTripSequenceStmt:                      q.getBlockTripSequenceStmt,
 		getBlocksForBlockTripIndexIDsStmt:             q.getBlocksForBlockTripIndexIDsStmt,
 		getCalendarByServiceIDStmt:                    q.getCalendarByServiceIDStmt,

--- a/gtfsdb/query.sql
+++ b/gtfsdb/query.sql
@@ -1162,7 +1162,7 @@ JOIN block_trip_entry bte ON bti.id = bte.block_trip_index_id
 JOIN stop_times st ON st.trip_id = bte.trip_id
 WHERE st.stop_id IN (sqlc.slice('stop_ids'))
   AND bte.service_id IN (sqlc.slice('service_ids'))
-ORDER BY bti.id;
+ORDER BY bti.id ASC;
 
 -- name: GetActiveLayoverBlockIDsForStops :many
 -- Stop-scoped mirror of GetActiveLayoverBlockIDsForRoute, matched on the

--- a/gtfsdb/query.sql
+++ b/gtfsdb/query.sql
@@ -855,14 +855,6 @@ WHERE
 ORDER BY
     t.id, st.stop_sequence;
 
--- name: GetStopTimesByStopIDs :many
-SELECT
-    *
-FROM
-    stop_times
-WHERE
-    stop_id IN (sqlc.slice('stop_ids'));
-
 -- name: ListTrips :many
 SELECT
     *

--- a/gtfsdb/query.sql
+++ b/gtfsdb/query.sql
@@ -1161,6 +1161,39 @@ JOIN block_trip_entry bte ON t.id = bte.trip_id
 WHERE bte.block_trip_index_id IN (sqlc.slice('index_ids'))
   AND bte.service_id IN (sqlc.slice('service_ids'));
 
+-- name: GetBlockTripIndexIDsForStops :many
+-- Stop-scoped mirror of GetBlockTripIndexIDsForRoute: block_trip_index IDs
+-- containing trips that serve any of the given stops.
+SELECT DISTINCT bti.id
+FROM block_trip_index bti
+JOIN block_trip_entry bte ON bti.id = bte.block_trip_index_id
+JOIN stop_times st ON st.trip_id = bte.trip_id
+WHERE st.stop_id IN (sqlc.slice('stop_ids'))
+  AND bte.service_id IN (sqlc.slice('service_ids'))
+ORDER BY bti.id;
+
+-- name: GetActiveLayoverBlockIDsForStops :many
+-- Stop-scoped mirror of GetActiveLayoverBlockIDsForRoute, matched on the
+-- layover stop rather than the departing trip's route.
+SELECT DISTINCT block_id
+FROM block_layover
+WHERE layover_start < sqlc.arg('time_range_end')
+  AND layover_end > sqlc.arg('time_range_start')
+  AND layover_stop_id IN (sqlc.slice('stop_ids'))
+  AND service_id IN (sqlc.slice('service_ids'));
+
+-- name: GetActiveTripsWithNullBlockForStops :many
+-- Stop-scoped mirror of GetActiveTripsWithNullBlockForRoute.
+SELECT DISTINCT t.id
+FROM trips t
+JOIN stop_times st ON st.trip_id = t.id
+WHERE t.block_id IS NULL
+  AND t.min_arrival_time <= sqlc.arg('time_range_end')
+  AND t.max_departure_time >= sqlc.arg('time_range_start')
+  AND st.stop_id IN (sqlc.slice('stop_ids'))
+  AND t.service_id IN (sqlc.slice('service_ids'))
+ORDER BY t.min_arrival_time ASC;
+
 
 -- name: GetShapePointsByIDs :many
 SELECT shape_id, lat, lon, shape_pt_sequence, shape_dist_traveled

--- a/gtfsdb/query.sql.go
+++ b/gtfsdb/query.sql.go
@@ -891,6 +891,67 @@ func (q *Queries) GetActiveLayoverBlockIDsForRoute(ctx context.Context, arg GetA
 	return items, nil
 }
 
+const getActiveLayoverBlockIDsForStops = `-- name: GetActiveLayoverBlockIDsForStops :many
+SELECT DISTINCT block_id
+FROM block_layover
+WHERE layover_start < ?1
+  AND layover_end > ?2
+  AND layover_stop_id IN (/*SLICE:stop_ids*/?)
+  AND service_id IN (/*SLICE:service_ids*/?)
+`
+
+type GetActiveLayoverBlockIDsForStopsParams struct {
+	TimeRangeEnd   int64
+	TimeRangeStart int64
+	StopIds        []string
+	ServiceIds     []string
+}
+
+// Stop-scoped mirror of GetActiveLayoverBlockIDsForRoute, matched on the
+// layover stop rather than the departing trip's route.
+func (q *Queries) GetActiveLayoverBlockIDsForStops(ctx context.Context, arg GetActiveLayoverBlockIDsForStopsParams) ([]string, error) {
+	query := getActiveLayoverBlockIDsForStops
+	var queryParams []interface{}
+	queryParams = append(queryParams, arg.TimeRangeEnd)
+	queryParams = append(queryParams, arg.TimeRangeStart)
+	if len(arg.StopIds) > 0 {
+		for _, v := range arg.StopIds {
+			queryParams = append(queryParams, v)
+		}
+		query = strings.Replace(query, "/*SLICE:stop_ids*/?", strings.Repeat(",?", len(arg.StopIds))[1:], 1)
+	} else {
+		query = strings.Replace(query, "/*SLICE:stop_ids*/?", "NULL", 1)
+	}
+	if len(arg.ServiceIds) > 0 {
+		for _, v := range arg.ServiceIds {
+			queryParams = append(queryParams, v)
+		}
+		query = strings.Replace(query, "/*SLICE:service_ids*/?", strings.Repeat(",?", len(arg.ServiceIds))[1:], 1)
+	} else {
+		query = strings.Replace(query, "/*SLICE:service_ids*/?", "NULL", 1)
+	}
+	rows, err := q.query(ctx, nil, query, queryParams...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []string
+	for rows.Next() {
+		var block_id string
+		if err := rows.Scan(&block_id); err != nil {
+			return nil, err
+		}
+		items = append(items, block_id)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const getActiveRouteIDsForStopsOnDate = `-- name: GetActiveRouteIDsForStopsOnDate :many
 SELECT DISTINCT
     routes.agency_id || '_' || routes.id AS route_id,
@@ -1205,6 +1266,69 @@ func (q *Queries) GetActiveTripsWithNullBlockForRoute(ctx context.Context, arg G
 	queryParams = append(queryParams, arg.RouteID)
 	queryParams = append(queryParams, arg.TimeRangeEnd)
 	queryParams = append(queryParams, arg.TimeRangeStart)
+	if len(arg.ServiceIds) > 0 {
+		for _, v := range arg.ServiceIds {
+			queryParams = append(queryParams, v)
+		}
+		query = strings.Replace(query, "/*SLICE:service_ids*/?", strings.Repeat(",?", len(arg.ServiceIds))[1:], 1)
+	} else {
+		query = strings.Replace(query, "/*SLICE:service_ids*/?", "NULL", 1)
+	}
+	rows, err := q.query(ctx, nil, query, queryParams...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		items = append(items, id)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const getActiveTripsWithNullBlockForStops = `-- name: GetActiveTripsWithNullBlockForStops :many
+SELECT DISTINCT t.id
+FROM trips t
+JOIN stop_times st ON st.trip_id = t.id
+WHERE t.block_id IS NULL
+  AND t.min_arrival_time <= ?1
+  AND t.max_departure_time >= ?2
+  AND st.stop_id IN (/*SLICE:stop_ids*/?)
+  AND t.service_id IN (/*SLICE:service_ids*/?)
+ORDER BY t.min_arrival_time ASC
+`
+
+type GetActiveTripsWithNullBlockForStopsParams struct {
+	TimeRangeEnd   sql.NullInt64
+	TimeRangeStart sql.NullInt64
+	StopIds        []string
+	ServiceIds     []string
+}
+
+// Stop-scoped mirror of GetActiveTripsWithNullBlockForRoute.
+func (q *Queries) GetActiveTripsWithNullBlockForStops(ctx context.Context, arg GetActiveTripsWithNullBlockForStopsParams) ([]string, error) {
+	query := getActiveTripsWithNullBlockForStops
+	var queryParams []interface{}
+	queryParams = append(queryParams, arg.TimeRangeEnd)
+	queryParams = append(queryParams, arg.TimeRangeStart)
+	if len(arg.StopIds) > 0 {
+		for _, v := range arg.StopIds {
+			queryParams = append(queryParams, v)
+		}
+		query = strings.Replace(query, "/*SLICE:stop_ids*/?", strings.Repeat(",?", len(arg.StopIds))[1:], 1)
+	} else {
+		query = strings.Replace(query, "/*SLICE:stop_ids*/?", "NULL", 1)
+	}
 	if len(arg.ServiceIds) > 0 {
 		for _, v := range arg.ServiceIds {
 			queryParams = append(queryParams, v)
@@ -1780,6 +1904,64 @@ func (q *Queries) GetBlockTripIndexIDsForRoute(ctx context.Context, arg GetBlock
 	query := getBlockTripIndexIDsForRoute
 	var queryParams []interface{}
 	queryParams = append(queryParams, arg.RouteID)
+	if len(arg.ServiceIds) > 0 {
+		for _, v := range arg.ServiceIds {
+			queryParams = append(queryParams, v)
+		}
+		query = strings.Replace(query, "/*SLICE:service_ids*/?", strings.Repeat(",?", len(arg.ServiceIds))[1:], 1)
+	} else {
+		query = strings.Replace(query, "/*SLICE:service_ids*/?", "NULL", 1)
+	}
+	rows, err := q.query(ctx, nil, query, queryParams...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []int64
+	for rows.Next() {
+		var id int64
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		items = append(items, id)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const getBlockTripIndexIDsForStops = `-- name: GetBlockTripIndexIDsForStops :many
+SELECT DISTINCT bti.id
+FROM block_trip_index bti
+JOIN block_trip_entry bte ON bti.id = bte.block_trip_index_id
+JOIN stop_times st ON st.trip_id = bte.trip_id
+WHERE st.stop_id IN (/*SLICE:stop_ids*/?)
+  AND bte.service_id IN (/*SLICE:service_ids*/?)
+ORDER BY bti.id
+`
+
+type GetBlockTripIndexIDsForStopsParams struct {
+	StopIds    []string
+	ServiceIds []string
+}
+
+// Stop-scoped mirror of GetBlockTripIndexIDsForRoute: block_trip_index IDs
+// containing trips that serve any of the given stops.
+func (q *Queries) GetBlockTripIndexIDsForStops(ctx context.Context, arg GetBlockTripIndexIDsForStopsParams) ([]int64, error) {
+	query := getBlockTripIndexIDsForStops
+	var queryParams []interface{}
+	if len(arg.StopIds) > 0 {
+		for _, v := range arg.StopIds {
+			queryParams = append(queryParams, v)
+		}
+		query = strings.Replace(query, "/*SLICE:stop_ids*/?", strings.Repeat(",?", len(arg.StopIds))[1:], 1)
+	} else {
+		query = strings.Replace(query, "/*SLICE:stop_ids*/?", "NULL", 1)
+	}
 	if len(arg.ServiceIds) > 0 {
 		for _, v := range arg.ServiceIds {
 			queryParams = append(queryParams, v)

--- a/gtfsdb/query.sql.go
+++ b/gtfsdb/query.sql.go
@@ -1941,7 +1941,7 @@ JOIN block_trip_entry bte ON bti.id = bte.block_trip_index_id
 JOIN stop_times st ON st.trip_id = bte.trip_id
 WHERE st.stop_id IN (/*SLICE:stop_ids*/?)
   AND bte.service_id IN (/*SLICE:service_ids*/?)
-ORDER BY bti.id
+ORDER BY bti.id ASC
 `
 
 type GetBlockTripIndexIDsForStopsParams struct {

--- a/gtfsdb/query.sql.go
+++ b/gtfsdb/query.sql.go
@@ -3875,59 +3875,6 @@ func (q *Queries) GetStopIDsForTrip(ctx context.Context, tripID string) ([]strin
 	return items, nil
 }
 
-const getStopTimesByStopIDs = `-- name: GetStopTimesByStopIDs :many
-SELECT
-    trip_id, arrival_time, departure_time, stop_id, stop_sequence, stop_headsign, pickup_type, drop_off_type, shape_dist_traveled, timepoint
-FROM
-    stop_times
-WHERE
-    stop_id IN (/*SLICE:stop_ids*/?)
-`
-
-func (q *Queries) GetStopTimesByStopIDs(ctx context.Context, stopIds []string) ([]StopTime, error) {
-	query := getStopTimesByStopIDs
-	var queryParams []interface{}
-	if len(stopIds) > 0 {
-		for _, v := range stopIds {
-			queryParams = append(queryParams, v)
-		}
-		query = strings.Replace(query, "/*SLICE:stop_ids*/?", strings.Repeat(",?", len(stopIds))[1:], 1)
-	} else {
-		query = strings.Replace(query, "/*SLICE:stop_ids*/?", "NULL", 1)
-	}
-	rows, err := q.query(ctx, nil, query, queryParams...)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	var items []StopTime
-	for rows.Next() {
-		var i StopTime
-		if err := rows.Scan(
-			&i.TripID,
-			&i.ArrivalTime,
-			&i.DepartureTime,
-			&i.StopID,
-			&i.StopSequence,
-			&i.StopHeadsign,
-			&i.PickupType,
-			&i.DropOffType,
-			&i.ShapeDistTraveled,
-			&i.Timepoint,
-		); err != nil {
-			return nil, err
-		}
-		items = append(items, i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
-}
-
 const getStopTimesForStopInWindow = `-- name: GetStopTimesForStopInWindow :many
 SELECT
     st.trip_id,

--- a/internal/restapi/block_candidates_helper.go
+++ b/internal/restapi/block_candidates_helper.go
@@ -1,0 +1,209 @@
+package restapi
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"time"
+
+	"maglev.onebusaway.org/gtfsdb"
+	"maglev.onebusaway.org/internal/nulls"
+)
+
+// Match Java OBA: look back 30 min (catch late vehicles) and ahead 10 min (catch early vehicles).
+// TODO: We should add config for runningLateWindow and runningEarlyWindow like Java OBA
+// source:https://groups.google.com/g/onebusaway-developers/c/j-G-1UyfbXI/m/J-Su3BArKW0J
+const (
+	runningLate  = 30 * time.Minute // runningLateWindow
+	runningEarly = 10 * time.Minute // runningEarlyWindow
+)
+
+// serviceDayWindow is one service day's active service IDs together with the
+// query window, expressed as durations since that service day's midnight.
+type serviceDayWindow struct {
+	serviceIDs    []string
+	sinceMidnight time.Duration
+	rangeStart    time.Duration
+	rangeEnd      time.Duration
+}
+
+// serviceDayWindows returns the query window for the current service day and,
+// when present, the previous service day. GTFS allows departure times past
+// 24:00:00 (e.g., 25:30:00 = 1:30 AM next day), so trips belonging to
+// yesterday's service can still be running now. The current-day window is
+// always windows[0]; a previous-day window, when present, is windows[1].
+func (api *RestAPI) serviceDayWindows(ctx context.Context, currentTime time.Time) ([]serviceDayWindow, error) {
+	formattedDate := currentTime.Format("20060102")
+	serviceIDs, err := api.GtfsManager.GtfsDB.Queries.GetActiveServiceIDsForDate(ctx, formattedDate)
+	if err != nil {
+		return nil, err
+	}
+
+	serviceDayMidnight := time.Date(currentTime.Year(), currentTime.Month(), currentTime.Day(), 0, 0, 0, 0, currentTime.Location())
+	currentSinceMidnight := max(currentTime.Sub(serviceDayMidnight), 0)
+
+	windows := []serviceDayWindow{{
+		serviceIDs:    serviceIDs,
+		sinceMidnight: currentSinceMidnight,
+		rangeStart:    currentSinceMidnight - runningLate,
+		rangeEnd:      currentSinceMidnight + runningEarly,
+	}}
+
+	prevDay := currentTime.AddDate(0, 0, -1)
+	prevFormattedDate := prevDay.Format("20060102")
+	prevServiceIDs, err := api.GtfsManager.GtfsDB.Queries.GetActiveServiceIDsForDate(ctx, prevFormattedDate)
+	if err != nil {
+		api.Logger.Warn("failed to fetch previous-day service IDs", "date", prevFormattedDate, "error", err)
+		return windows, nil
+	}
+	if len(prevServiceIDs) == 0 {
+		return windows, nil
+	}
+
+	// I'm confused by adding 24 hours to get the previous day here, but that's the existing behavior.
+	prevDaySinceMidnight := currentSinceMidnight + 24*time.Hour
+	windows = append(windows, serviceDayWindow{
+		serviceIDs:    prevServiceIDs,
+		sinceMidnight: prevDaySinceMidnight,
+		rangeStart:    prevDaySinceMidnight - runningLate,
+		rangeEnd:      prevDaySinceMidnight + runningEarly,
+	})
+
+	return windows, nil
+}
+
+// blockCandidatesForRoute returns the candidate block IDs and null-block trip
+// IDs whose schedule overlaps the query windows, scoped to the given route.
+// An error from the current-day (windows[0]) index/block queries is returned
+// to the caller as fatal; all other failures (previous-day queries, layover
+// blocks, null-block trips) are logged and skipped so partial data still
+// produces a result, matching the pre-extraction handler's behavior.
+func (api *RestAPI) blockCandidatesForRoute(ctx context.Context, routeID string, windows []serviceDayWindow) (map[string]bool, []string, error) {
+	allLinkedBlocks := make(map[string]bool)
+
+	for i, w := range windows {
+		indexIDs, err := api.GtfsManager.GtfsDB.Queries.GetBlockTripIndexIDsForRoute(ctx, gtfsdb.GetBlockTripIndexIDsForRouteParams{
+			RouteID:    routeID,
+			ServiceIds: w.serviceIDs,
+		})
+		if err != nil {
+			if i == 0 {
+				return nil, nil, err
+			}
+			api.Logger.Warn("trips-for-route: failed to fetch previous-day block index IDs", "error", err)
+			continue
+		}
+		if len(indexIDs) == 0 {
+			continue
+		}
+
+		blocks, err := api.GtfsManager.GtfsDB.Queries.GetBlocksForBlockTripIndexIDs(ctx, gtfsdb.GetBlocksForBlockTripIndexIDsParams{
+			FromTime:   sql.NullInt64{Int64: w.rangeStart.Nanoseconds(), Valid: true},
+			ToTime:     sql.NullInt64{Int64: w.rangeEnd.Nanoseconds(), Valid: true},
+			IndexIds:   indexIDs,
+			ServiceIds: w.serviceIDs,
+		})
+		if err != nil {
+			if i == 0 {
+				return nil, nil, err
+			}
+			api.Logger.Warn("trips-for-route: failed to fetch previous-day blocks", "error", err)
+			continue
+		}
+		for _, b := range blocks {
+			if b.Valid {
+				allLinkedBlocks[b.String] = true
+			}
+		}
+	}
+
+	layoverBlocks, err := api.GtfsManager.GtfsDB.Queries.GetActiveLayoverBlockIDsForRoute(ctx, gtfsdb.GetActiveLayoverBlockIDsForRouteParams{
+		RouteID:        routeID,
+		ServiceIds:     windows[0].serviceIDs,
+		TimeRangeStart: windows[0].rangeStart.Nanoseconds(),
+		TimeRangeEnd:   windows[0].rangeEnd.Nanoseconds(),
+	})
+	if err != nil {
+		api.Logger.Warn("trips-for-route: failed to fetch layover blocks", "route_id", routeID, "error", err)
+	} else {
+		for _, blockID := range layoverBlocks {
+			allLinkedBlocks[blockID] = true
+		}
+	}
+
+	var nullBlockTrips []string
+	for i, w := range windows {
+		trips, err := api.GtfsManager.GtfsDB.Queries.GetActiveTripsWithNullBlockForRoute(ctx, gtfsdb.GetActiveTripsWithNullBlockForRouteParams{
+			RouteID:        routeID,
+			ServiceIds:     w.serviceIDs,
+			TimeRangeStart: sql.NullInt64{Int64: w.rangeStart.Nanoseconds(), Valid: true},
+			TimeRangeEnd:   sql.NullInt64{Int64: w.rangeEnd.Nanoseconds(), Valid: true},
+		})
+		if err != nil {
+			if i == 0 {
+				api.Logger.Warn("trips-for-route: failed to fetch null-block trips", "route_id", routeID, "error", err)
+			} else {
+				api.Logger.Warn("trips-for-route: failed to fetch previous-day null-block trips", "error", err)
+			}
+			continue
+		}
+		nullBlockTrips = append(nullBlockTrips, trips...)
+	}
+
+	return allLinkedBlocks, nullBlockTrips, nil
+}
+
+// resolveActiveTrips returns the trip IDs actually running at each window's
+// query time: one active trip per candidate block (the earliest trip in the
+// block whose stop times contain that window's query time), plus the given
+// null-block trip IDs. If ctx is canceled mid-loop, the trips accumulated so
+// far are returned; callers should check ctx.Err() afterward.
+func (api *RestAPI) resolveActiveTrips(ctx context.Context, blockIDs map[string]bool, nullBlockTripIDs []string, windows []serviceDayWindow) []string {
+	var activeTrips []string
+
+	for blockID := range blockIDs {
+		if ctx.Err() != nil {
+			return activeTrips
+		}
+
+		blockIDNullStr := nulls.String(blockID)
+
+		for _, w := range windows {
+			tripsInBlock, err := api.GtfsManager.GtfsDB.Queries.GetTripsInBlock(ctx, gtfsdb.GetTripsInBlockParams{
+				BlockID:    blockIDNullStr,
+				ServiceIds: w.serviceIDs,
+			})
+			if err != nil {
+				api.Logger.Warn("failed to fetch trips in block", "block_id", blockID, "error", err)
+				continue
+			}
+			if len(tripsInBlock) == 0 {
+				continue
+			}
+
+			activeTrip, err := api.GtfsManager.GtfsDB.Queries.GetActiveTripInBlockAtTime(ctx, gtfsdb.GetActiveTripInBlockAtTimeParams{
+				BlockID:     blockIDNullStr,
+				ServiceIds:  w.serviceIDs,
+				CurrentTime: sql.NullInt64{Int64: w.sinceMidnight.Nanoseconds(), Valid: true},
+			})
+			if err != nil && !errors.Is(err, sql.ErrNoRows) {
+				api.Logger.Warn("failed to get active trip in block", "block_id", blockID, "error", err)
+				continue
+			}
+			if errors.Is(err, sql.ErrNoRows) {
+				// No trip in this block is currently running at the requested time.
+				// Java OBA only returns blocks with a currently-running trip (see
+				// BlockStatusServiceImpl.computeLocations which adds scheduled locations
+				// only when isInService()). Skip rather than picking a "best candidate"
+				// upcoming/past trip that isn't actually running.
+				continue
+			}
+
+			activeTrips = append(activeTrips, activeTrip)
+			break
+		}
+	}
+
+	activeTrips = append(activeTrips, nullBlockTripIDs...)
+	return activeTrips
+}

--- a/internal/restapi/block_candidates_helper.go
+++ b/internal/restapi/block_candidates_helper.go
@@ -99,7 +99,13 @@ type blockCandidateQueries struct {
 // blockCandidates returns the candidate block IDs, and the null-block trip
 // IDs mapped to the index (into windows) of the service day whose query
 // found them, whose schedule overlaps the query windows, as scoped by q.
+// windows must be non-empty; serviceDayWindows always returns at least the
+// current service day.
 func (api *RestAPI) blockCandidates(ctx context.Context, q blockCandidateQueries, windows []serviceDayWindow) (map[string]bool, map[string]int, error) {
+	if len(windows) == 0 {
+		return map[string]bool{}, map[string]int{}, nil
+	}
+
 	allLinkedBlocks, err := api.resolveLinkedBlocks(ctx, q, windows)
 	if err != nil {
 		return nil, nil, err
@@ -179,6 +185,11 @@ func (api *RestAPI) addLayoverBlocks(ctx context.Context, q blockCandidateQuerie
 // resolveNullBlockTripWindows finds null-block trips active within each
 // window, mapped to the index of the window that found them. A failure on
 // any window is logged and skipped, not fatal.
+//
+// Windows are searched in order and the first match wins, matching
+// resolveActiveTripForBlock: a trip whose span is long enough to overlap
+// both today's and yesterday's window is reported against today, not
+// yesterday.
 func (api *RestAPI) resolveNullBlockTripWindows(ctx context.Context, q blockCandidateQueries, windows []serviceDayWindow) map[string]int {
 	nullBlockTripWindows := make(map[string]int)
 
@@ -193,7 +204,9 @@ func (api *RestAPI) resolveNullBlockTripWindows(ctx context.Context, q blockCand
 			continue
 		}
 		for _, tripID := range trips {
-			nullBlockTripWindows[tripID] = i
+			if _, alreadyMatched := nullBlockTripWindows[tripID]; !alreadyMatched {
+				nullBlockTripWindows[tripID] = i
+			}
 		}
 	}
 
@@ -231,36 +244,73 @@ func (api *RestAPI) blockCandidatesForRoute(ctx context.Context, routeID string,
 	}, windows)
 }
 
+// maxStopIDsPerQuery bounds how many stop IDs are bound into a single
+// statement. SQLite rejects a statement with more than 32766 bound
+// variables ("too many SQL variables"); these queries also bind the service
+// IDs, so leave generous headroom rather than filling the limit exactly.
+const maxStopIDsPerQuery = 8000
+
 // blockCandidatesForStops is the stop-scoped mirror of blockCandidatesForRoute:
 // it returns the candidate block IDs and null-block trip IDs (see
 // blockCandidates) whose schedule overlaps the query windows, scoped to
 // trips serving any of the given stops.
+//
+// The stop IDs are deliberately not capped upstream — truncating them would
+// silently drop candidate trips — so each query is run over chunks of at
+// most maxStopIDsPerQuery IDs and the results unioned.
 func (api *RestAPI) blockCandidatesForStops(ctx context.Context, stopIDs []string, windows []serviceDayWindow) (map[string]bool, map[string]int, error) {
 	return api.blockCandidates(ctx, blockCandidateQueries{
 		logScope: "trips-for-location",
 		indexIDs: func(ctx context.Context, serviceIDs []string) ([]int64, error) {
-			return api.GtfsManager.GtfsDB.Queries.GetBlockTripIndexIDsForStops(ctx, gtfsdb.GetBlockTripIndexIDsForStopsParams{
-				StopIds:    stopIDs,
-				ServiceIds: serviceIDs,
+			return chunkedQuery(ctx, stopIDs, func(ctx context.Context, chunk []string) ([]int64, error) {
+				return api.GtfsManager.GtfsDB.Queries.GetBlockTripIndexIDsForStops(ctx, gtfsdb.GetBlockTripIndexIDsForStopsParams{
+					StopIds:    chunk,
+					ServiceIds: serviceIDs,
+				})
 			})
 		},
 		layover: func(ctx context.Context, serviceIDs []string, rangeStart, rangeEnd int64) ([]string, error) {
-			return api.GtfsManager.GtfsDB.Queries.GetActiveLayoverBlockIDsForStops(ctx, gtfsdb.GetActiveLayoverBlockIDsForStopsParams{
-				StopIds:        stopIDs,
-				ServiceIds:     serviceIDs,
-				TimeRangeStart: rangeStart,
-				TimeRangeEnd:   rangeEnd,
+			return chunkedQuery(ctx, stopIDs, func(ctx context.Context, chunk []string) ([]string, error) {
+				return api.GtfsManager.GtfsDB.Queries.GetActiveLayoverBlockIDsForStops(ctx, gtfsdb.GetActiveLayoverBlockIDsForStopsParams{
+					StopIds:        chunk,
+					ServiceIds:     serviceIDs,
+					TimeRangeStart: rangeStart,
+					TimeRangeEnd:   rangeEnd,
+				})
 			})
 		},
 		nullBlocks: func(ctx context.Context, serviceIDs []string, rangeStart, rangeEnd int64) ([]string, error) {
-			return api.GtfsManager.GtfsDB.Queries.GetActiveTripsWithNullBlockForStops(ctx, gtfsdb.GetActiveTripsWithNullBlockForStopsParams{
-				StopIds:        stopIDs,
-				ServiceIds:     serviceIDs,
-				TimeRangeStart: sql.NullInt64{Int64: rangeStart, Valid: true},
-				TimeRangeEnd:   sql.NullInt64{Int64: rangeEnd, Valid: true},
+			return chunkedQuery(ctx, stopIDs, func(ctx context.Context, chunk []string) ([]string, error) {
+				return api.GtfsManager.GtfsDB.Queries.GetActiveTripsWithNullBlockForStops(ctx, gtfsdb.GetActiveTripsWithNullBlockForStopsParams{
+					StopIds:        chunk,
+					ServiceIds:     serviceIDs,
+					TimeRangeStart: sql.NullInt64{Int64: rangeStart, Valid: true},
+					TimeRangeEnd:   sql.NullInt64{Int64: rangeEnd, Valid: true},
+				})
 			})
 		},
 	}, windows)
+}
+
+// chunkedQuery runs query over ids in batches of at most maxStopIDsPerQuery
+// and returns the concatenated results, so a large bounding box can't blow
+// SQLite's bound-variable limit. Callers treat the result as a set, so
+// duplicates across chunks are harmless.
+func chunkedQuery[T any](ctx context.Context, ids []string, query func(context.Context, []string) ([]T, error)) ([]T, error) {
+	if len(ids) <= maxStopIDsPerQuery {
+		return query(ctx, ids)
+	}
+
+	var combined []T
+	for start := 0; start < len(ids); start += maxStopIDsPerQuery {
+		end := min(start+maxStopIDsPerQuery, len(ids))
+		results, err := query(ctx, ids[start:end])
+		if err != nil {
+			return nil, err
+		}
+		combined = append(combined, results...)
+	}
+	return combined, nil
 }
 
 // resolveActiveTrips returns the trip IDs actually running at each window's

--- a/internal/restapi/block_candidates_helper.go
+++ b/internal/restapi/block_candidates_helper.go
@@ -11,8 +11,11 @@ import (
 )
 
 // Match Java OBA: look back 30 min (catch late vehicles) and ahead 10 min (catch early vehicles).
-// TODO: We should add config for runningLateWindow and runningEarlyWindow like Java OBA
-// source:https://groups.google.com/g/onebusaway-developers/c/j-G-1UyfbXI/m/J-Su3BArKW0J
+// Java OBA exposes these as configurable runningLateWindow/runningEarlyWindow
+// values (source: https://groups.google.com/g/onebusaway-developers/c/j-G-1UyfbXI/m/J-Su3BArKW0J);
+// Maglev hard-codes them for now. Making them configurable is a separate,
+// larger change (app config plumbing) than this file's candidate-selection
+// logic, not a follow-up tracked here.
 const (
 	runningLate  = 30 * time.Minute // runningLateWindow
 	runningEarly = 10 * time.Minute // runningEarlyWindow

--- a/internal/restapi/block_candidates_helper.go
+++ b/internal/restapi/block_candidates_helper.go
@@ -153,6 +153,85 @@ func (api *RestAPI) blockCandidatesForRoute(ctx context.Context, routeID string,
 	return allLinkedBlocks, nullBlockTrips, nil
 }
 
+// blockCandidatesForStops is the stop-scoped mirror of blockCandidatesForRoute:
+// it returns the candidate block IDs and null-block trip IDs whose schedule
+// overlaps the query windows, scoped to trips serving any of the given stops.
+// Error-handling semantics match blockCandidatesForRoute exactly.
+func (api *RestAPI) blockCandidatesForStops(ctx context.Context, stopIDs []string, windows []serviceDayWindow) (map[string]bool, []string, error) {
+	allLinkedBlocks := make(map[string]bool)
+
+	for i, w := range windows {
+		indexIDs, err := api.GtfsManager.GtfsDB.Queries.GetBlockTripIndexIDsForStops(ctx, gtfsdb.GetBlockTripIndexIDsForStopsParams{
+			StopIds:    stopIDs,
+			ServiceIds: w.serviceIDs,
+		})
+		if err != nil {
+			if i == 0 {
+				return nil, nil, err
+			}
+			api.Logger.Warn("trips-for-location: failed to fetch previous-day block index IDs", "error", err)
+			continue
+		}
+		if len(indexIDs) == 0 {
+			continue
+		}
+
+		blocks, err := api.GtfsManager.GtfsDB.Queries.GetBlocksForBlockTripIndexIDs(ctx, gtfsdb.GetBlocksForBlockTripIndexIDsParams{
+			FromTime:   sql.NullInt64{Int64: w.rangeStart.Nanoseconds(), Valid: true},
+			ToTime:     sql.NullInt64{Int64: w.rangeEnd.Nanoseconds(), Valid: true},
+			IndexIds:   indexIDs,
+			ServiceIds: w.serviceIDs,
+		})
+		if err != nil {
+			if i == 0 {
+				return nil, nil, err
+			}
+			api.Logger.Warn("trips-for-location: failed to fetch previous-day blocks", "error", err)
+			continue
+		}
+		for _, b := range blocks {
+			if b.Valid {
+				allLinkedBlocks[b.String] = true
+			}
+		}
+	}
+
+	layoverBlocks, err := api.GtfsManager.GtfsDB.Queries.GetActiveLayoverBlockIDsForStops(ctx, gtfsdb.GetActiveLayoverBlockIDsForStopsParams{
+		StopIds:        stopIDs,
+		ServiceIds:     windows[0].serviceIDs,
+		TimeRangeStart: windows[0].rangeStart.Nanoseconds(),
+		TimeRangeEnd:   windows[0].rangeEnd.Nanoseconds(),
+	})
+	if err != nil {
+		api.Logger.Warn("trips-for-location: failed to fetch layover blocks", "error", err)
+	} else {
+		for _, blockID := range layoverBlocks {
+			allLinkedBlocks[blockID] = true
+		}
+	}
+
+	var nullBlockTrips []string
+	for i, w := range windows {
+		trips, err := api.GtfsManager.GtfsDB.Queries.GetActiveTripsWithNullBlockForStops(ctx, gtfsdb.GetActiveTripsWithNullBlockForStopsParams{
+			StopIds:        stopIDs,
+			ServiceIds:     w.serviceIDs,
+			TimeRangeStart: sql.NullInt64{Int64: w.rangeStart.Nanoseconds(), Valid: true},
+			TimeRangeEnd:   sql.NullInt64{Int64: w.rangeEnd.Nanoseconds(), Valid: true},
+		})
+		if err != nil {
+			if i == 0 {
+				api.Logger.Warn("trips-for-location: failed to fetch null-block trips", "error", err)
+			} else {
+				api.Logger.Warn("trips-for-location: failed to fetch previous-day null-block trips", "error", err)
+			}
+			continue
+		}
+		nullBlockTrips = append(nullBlockTrips, trips...)
+	}
+
+	return allLinkedBlocks, nullBlockTrips, nil
+}
+
 // resolveActiveTrips returns the trip IDs actually running at each window's
 // query time: one active trip per candidate block (the earliest trip in the
 // block whose stop times contain that window's query time), plus the given

--- a/internal/restapi/block_candidates_helper.go
+++ b/internal/restapi/block_candidates_helper.go
@@ -95,19 +95,32 @@ type blockCandidateQueries struct {
 
 // blockCandidates returns the candidate block IDs, and the null-block trip
 // IDs mapped to the index (into windows) of the service day whose query
-// found them, whose schedule overlaps the query windows, as scoped by q. An
-// error from the current-day (windows[0]) index/block queries is returned
-// to the caller as fatal; all other failures (previous-day queries, layover
-// blocks, null-block trips) are logged and skipped so partial data still
-// produces a result.
+// found them, whose schedule overlaps the query windows, as scoped by q.
 func (api *RestAPI) blockCandidates(ctx context.Context, q blockCandidateQueries, windows []serviceDayWindow) (map[string]bool, map[string]int, error) {
+	allLinkedBlocks, err := api.resolveLinkedBlocks(ctx, q, windows)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	api.addLayoverBlocks(ctx, q, windows[0], allLinkedBlocks)
+
+	nullBlockTripWindows := api.resolveNullBlockTripWindows(ctx, q, windows)
+
+	return allLinkedBlocks, nullBlockTripWindows, nil
+}
+
+// resolveLinkedBlocks finds the block IDs whose block_trip_index overlaps
+// the query windows. An error from the current-day (windows[0]) query is
+// returned to the caller as fatal; a previous-day failure is logged and
+// skipped so partial data still produces a result.
+func (api *RestAPI) resolveLinkedBlocks(ctx context.Context, q blockCandidateQueries, windows []serviceDayWindow) (map[string]bool, error) {
 	allLinkedBlocks := make(map[string]bool)
 
 	for i, w := range windows {
 		indexIDs, err := q.indexIDs(ctx, w.serviceIDs)
 		if err != nil {
 			if i == 0 {
-				return nil, nil, err
+				return nil, err
 			}
 			api.Logger.Warn(q.logScope+": failed to fetch previous-day block index IDs", "error", err)
 			continue
@@ -116,44 +129,64 @@ func (api *RestAPI) blockCandidates(ctx context.Context, q blockCandidateQueries
 			continue
 		}
 
-		blocks, err := api.GtfsManager.GtfsDB.Queries.GetBlocksForBlockTripIndexIDs(ctx, gtfsdb.GetBlocksForBlockTripIndexIDsParams{
-			FromTime:   sql.NullInt64{Int64: w.rangeStart.Nanoseconds(), Valid: true},
-			ToTime:     sql.NullInt64{Int64: w.rangeEnd.Nanoseconds(), Valid: true},
-			IndexIds:   indexIDs,
-			ServiceIds: w.serviceIDs,
-		})
-		if err != nil {
+		if err := api.addBlocksForIndexIDs(ctx, indexIDs, w, allLinkedBlocks); err != nil {
 			if i == 0 {
-				return nil, nil, err
+				return nil, err
 			}
 			api.Logger.Warn(q.logScope+": failed to fetch previous-day blocks", "error", err)
-			continue
-		}
-		for _, b := range blocks {
-			if b.Valid {
-				allLinkedBlocks[b.String] = true
-			}
 		}
 	}
 
-	layoverBlocks, err := q.layover(ctx, windows[0].serviceIDs, windows[0].rangeStart.Nanoseconds(), windows[0].rangeEnd.Nanoseconds())
+	return allLinkedBlocks, nil
+}
+
+// addBlocksForIndexIDs fetches the blocks active within w for the given
+// block_trip_index IDs and adds them to allLinkedBlocks.
+func (api *RestAPI) addBlocksForIndexIDs(ctx context.Context, indexIDs []int64, w serviceDayWindow, allLinkedBlocks map[string]bool) error {
+	blocks, err := api.GtfsManager.GtfsDB.Queries.GetBlocksForBlockTripIndexIDs(ctx, gtfsdb.GetBlocksForBlockTripIndexIDsParams{
+		FromTime:   sql.NullInt64{Int64: w.rangeStart.Nanoseconds(), Valid: true},
+		ToTime:     sql.NullInt64{Int64: w.rangeEnd.Nanoseconds(), Valid: true},
+		IndexIds:   indexIDs,
+		ServiceIds: w.serviceIDs,
+	})
+	if err != nil {
+		return err
+	}
+	for _, b := range blocks {
+		if b.Valid {
+			allLinkedBlocks[b.String] = true
+		}
+	}
+	return nil
+}
+
+// addLayoverBlocks adds block IDs whose layover overlaps w to allLinkedBlocks.
+// A failure here is logged and skipped, not fatal.
+func (api *RestAPI) addLayoverBlocks(ctx context.Context, q blockCandidateQueries, w serviceDayWindow, allLinkedBlocks map[string]bool) {
+	layoverBlocks, err := q.layover(ctx, w.serviceIDs, w.rangeStart.Nanoseconds(), w.rangeEnd.Nanoseconds())
 	if err != nil {
 		api.Logger.Warn(q.logScope+": failed to fetch layover blocks", "error", err)
-	} else {
-		for _, blockID := range layoverBlocks {
-			allLinkedBlocks[blockID] = true
-		}
+		return
 	}
+	for _, blockID := range layoverBlocks {
+		allLinkedBlocks[blockID] = true
+	}
+}
 
+// resolveNullBlockTripWindows finds null-block trips active within each
+// window, mapped to the index of the window that found them. A failure on
+// any window is logged and skipped, not fatal.
+func (api *RestAPI) resolveNullBlockTripWindows(ctx context.Context, q blockCandidateQueries, windows []serviceDayWindow) map[string]int {
 	nullBlockTripWindows := make(map[string]int)
+
 	for i, w := range windows {
 		trips, err := q.nullBlocks(ctx, w.serviceIDs, w.rangeStart.Nanoseconds(), w.rangeEnd.Nanoseconds())
 		if err != nil {
-			if i == 0 {
-				api.Logger.Warn(q.logScope+": failed to fetch null-block trips", "error", err)
-			} else {
-				api.Logger.Warn(q.logScope+": failed to fetch previous-day null-block trips", "error", err)
+			label := q.logScope + ": failed to fetch null-block trips"
+			if i > 0 {
+				label = q.logScope + ": failed to fetch previous-day null-block trips"
 			}
+			api.Logger.Warn(label, "error", err)
 			continue
 		}
 		for _, tripID := range trips {
@@ -161,7 +194,7 @@ func (api *RestAPI) blockCandidates(ctx context.Context, q blockCandidateQueries
 		}
 	}
 
-	return allLinkedBlocks, nullBlockTripWindows, nil
+	return nullBlockTripWindows
 }
 
 // blockCandidatesForRoute returns the candidate block IDs and null-block
@@ -247,33 +280,9 @@ func (api *RestAPI) resolveActiveTrips(ctx context.Context, blockIDs map[string]
 			return activeTrips, serviceDateByTrip
 		}
 
-		blockIDNullStr := nulls.String(blockID)
-
-		for _, w := range windows {
-			// GetActiveTripInBlockAtTime already returns sql.ErrNoRows when the
-			// block has no trip for this service day, so there's no need to
-			// pre-check with a separate "does this block have any trips" query.
-			activeTrip, err := api.GtfsManager.GtfsDB.Queries.GetActiveTripInBlockAtTime(ctx, gtfsdb.GetActiveTripInBlockAtTimeParams{
-				BlockID:     blockIDNullStr,
-				ServiceIds:  w.serviceIDs,
-				CurrentTime: sql.NullInt64{Int64: w.sinceMidnight.Nanoseconds(), Valid: true},
-			})
-			if err != nil && !errors.Is(err, sql.ErrNoRows) {
-				api.Logger.Warn("failed to get active trip in block", "block_id", blockID, "error", err)
-				continue
-			}
-			if errors.Is(err, sql.ErrNoRows) {
-				// No trip in this block is currently running at the requested time.
-				// Java OBA only returns blocks with a currently-running trip (see
-				// BlockStatusServiceImpl.computeLocations which adds scheduled locations
-				// only when isInService()). Skip rather than picking a "best candidate"
-				// upcoming/past trip that isn't actually running.
-				continue
-			}
-
-			activeTrips = append(activeTrips, activeTrip)
-			serviceDateByTrip[activeTrip] = w.date
-			break
+		if tripID, serviceDate, ok := api.resolveActiveTripForBlock(ctx, blockID, windows); ok {
+			activeTrips = append(activeTrips, tripID)
+			serviceDateByTrip[tripID] = serviceDate
 		}
 	}
 
@@ -285,4 +294,38 @@ func (api *RestAPI) resolveActiveTrips(ctx context.Context, blockIDs map[string]
 	}
 
 	return activeTrips, serviceDateByTrip
+}
+
+// resolveActiveTripForBlock returns the trip in blockID that is running at
+// the query time of the earliest window that has one, trying windows in
+// order (current day, then the past-midnight lookback).
+func (api *RestAPI) resolveActiveTripForBlock(ctx context.Context, blockID string, windows []serviceDayWindow) (tripID string, serviceDate time.Time, ok bool) {
+	blockIDNullStr := nulls.String(blockID)
+
+	for _, w := range windows {
+		// GetActiveTripInBlockAtTime already returns sql.ErrNoRows when the
+		// block has no trip for this service day, so there's no need to
+		// pre-check with a separate "does this block have any trips" query.
+		activeTrip, err := api.GtfsManager.GtfsDB.Queries.GetActiveTripInBlockAtTime(ctx, gtfsdb.GetActiveTripInBlockAtTimeParams{
+			BlockID:     blockIDNullStr,
+			ServiceIds:  w.serviceIDs,
+			CurrentTime: sql.NullInt64{Int64: w.sinceMidnight.Nanoseconds(), Valid: true},
+		})
+		if err != nil && !errors.Is(err, sql.ErrNoRows) {
+			api.Logger.Warn("failed to get active trip in block", "block_id", blockID, "error", err)
+			continue
+		}
+		if errors.Is(err, sql.ErrNoRows) {
+			// No trip in this block is currently running at the requested time.
+			// Java OBA only returns blocks with a currently-running trip (see
+			// BlockStatusServiceImpl.computeLocations which adds scheduled locations
+			// only when isInService()). Skip rather than picking a "best candidate"
+			// upcoming/past trip that isn't actually running.
+			continue
+		}
+
+		return activeTrip, w.date, true
+	}
+
+	return "", time.Time{}, false
 }

--- a/internal/restapi/block_candidates_helper.go
+++ b/internal/restapi/block_candidates_helper.go
@@ -72,25 +72,35 @@ func (api *RestAPI) serviceDayWindows(ctx context.Context, currentTime time.Time
 	return windows, nil
 }
 
-// blockCandidatesForRoute returns the candidate block IDs and null-block trip
-// IDs whose schedule overlaps the query windows, scoped to the given route.
-// An error from the current-day (windows[0]) index/block queries is returned
-// to the caller as fatal; all other failures (previous-day queries, layover
+// blockCandidateQueries supplies the scope-specific (route or stop) lookups
+// that blockCandidates needs. Everything else about candidate selection —
+// the service-day window loop, the layover lookup, the null-block loop, and
+// the error-handling semantics — is scope-agnostic and lives in
+// blockCandidates itself.
+type blockCandidateQueries struct {
+	// logScope names the caller in warning logs, e.g. "trips-for-route".
+	logScope   string
+	indexIDs   func(ctx context.Context, serviceIDs []string) ([]int64, error)
+	layover    func(ctx context.Context, serviceIDs []string, rangeStart, rangeEnd int64) ([]string, error)
+	nullBlocks func(ctx context.Context, serviceIDs []string, rangeStart, rangeEnd int64) ([]string, error)
+}
+
+// blockCandidates returns the candidate block IDs and null-block trip IDs
+// whose schedule overlaps the query windows, as scoped by q. An error from
+// the current-day (windows[0]) index/block queries is returned to the
+// caller as fatal; all other failures (previous-day queries, layover
 // blocks, null-block trips) are logged and skipped so partial data still
-// produces a result, matching the pre-extraction handler's behavior.
-func (api *RestAPI) blockCandidatesForRoute(ctx context.Context, routeID string, windows []serviceDayWindow) (map[string]bool, []string, error) {
+// produces a result.
+func (api *RestAPI) blockCandidates(ctx context.Context, q blockCandidateQueries, windows []serviceDayWindow) (map[string]bool, []string, error) {
 	allLinkedBlocks := make(map[string]bool)
 
 	for i, w := range windows {
-		indexIDs, err := api.GtfsManager.GtfsDB.Queries.GetBlockTripIndexIDsForRoute(ctx, gtfsdb.GetBlockTripIndexIDsForRouteParams{
-			RouteID:    routeID,
-			ServiceIds: w.serviceIDs,
-		})
+		indexIDs, err := q.indexIDs(ctx, w.serviceIDs)
 		if err != nil {
 			if i == 0 {
 				return nil, nil, err
 			}
-			api.Logger.Warn("trips-for-route: failed to fetch previous-day block index IDs", "error", err)
+			api.Logger.Warn(q.logScope+": failed to fetch previous-day block index IDs", "error", err)
 			continue
 		}
 		if len(indexIDs) == 0 {
@@ -107,7 +117,7 @@ func (api *RestAPI) blockCandidatesForRoute(ctx context.Context, routeID string,
 			if i == 0 {
 				return nil, nil, err
 			}
-			api.Logger.Warn("trips-for-route: failed to fetch previous-day blocks", "error", err)
+			api.Logger.Warn(q.logScope+": failed to fetch previous-day blocks", "error", err)
 			continue
 		}
 		for _, b := range blocks {
@@ -117,14 +127,9 @@ func (api *RestAPI) blockCandidatesForRoute(ctx context.Context, routeID string,
 		}
 	}
 
-	layoverBlocks, err := api.GtfsManager.GtfsDB.Queries.GetActiveLayoverBlockIDsForRoute(ctx, gtfsdb.GetActiveLayoverBlockIDsForRouteParams{
-		RouteID:        routeID,
-		ServiceIds:     windows[0].serviceIDs,
-		TimeRangeStart: windows[0].rangeStart.Nanoseconds(),
-		TimeRangeEnd:   windows[0].rangeEnd.Nanoseconds(),
-	})
+	layoverBlocks, err := q.layover(ctx, windows[0].serviceIDs, windows[0].rangeStart.Nanoseconds(), windows[0].rangeEnd.Nanoseconds())
 	if err != nil {
-		api.Logger.Warn("trips-for-route: failed to fetch layover blocks", "route_id", routeID, "error", err)
+		api.Logger.Warn(q.logScope+": failed to fetch layover blocks", "error", err)
 	} else {
 		for _, blockID := range layoverBlocks {
 			allLinkedBlocks[blockID] = true
@@ -133,17 +138,12 @@ func (api *RestAPI) blockCandidatesForRoute(ctx context.Context, routeID string,
 
 	var nullBlockTrips []string
 	for i, w := range windows {
-		trips, err := api.GtfsManager.GtfsDB.Queries.GetActiveTripsWithNullBlockForRoute(ctx, gtfsdb.GetActiveTripsWithNullBlockForRouteParams{
-			RouteID:        routeID,
-			ServiceIds:     w.serviceIDs,
-			TimeRangeStart: sql.NullInt64{Int64: w.rangeStart.Nanoseconds(), Valid: true},
-			TimeRangeEnd:   sql.NullInt64{Int64: w.rangeEnd.Nanoseconds(), Valid: true},
-		})
+		trips, err := q.nullBlocks(ctx, w.serviceIDs, w.rangeStart.Nanoseconds(), w.rangeEnd.Nanoseconds())
 		if err != nil {
 			if i == 0 {
-				api.Logger.Warn("trips-for-route: failed to fetch null-block trips", "route_id", routeID, "error", err)
+				api.Logger.Warn(q.logScope+": failed to fetch null-block trips", "error", err)
 			} else {
-				api.Logger.Warn("trips-for-route: failed to fetch previous-day null-block trips", "error", err)
+				api.Logger.Warn(q.logScope+": failed to fetch previous-day null-block trips", "error", err)
 			}
 			continue
 		}
@@ -153,83 +153,66 @@ func (api *RestAPI) blockCandidatesForRoute(ctx context.Context, routeID string,
 	return allLinkedBlocks, nullBlockTrips, nil
 }
 
+// blockCandidatesForRoute returns the candidate block IDs and null-block
+// trip IDs whose schedule overlaps the query windows, scoped to the given
+// route.
+func (api *RestAPI) blockCandidatesForRoute(ctx context.Context, routeID string, windows []serviceDayWindow) (map[string]bool, []string, error) {
+	return api.blockCandidates(ctx, blockCandidateQueries{
+		logScope: "trips-for-route",
+		indexIDs: func(ctx context.Context, serviceIDs []string) ([]int64, error) {
+			return api.GtfsManager.GtfsDB.Queries.GetBlockTripIndexIDsForRoute(ctx, gtfsdb.GetBlockTripIndexIDsForRouteParams{
+				RouteID:    routeID,
+				ServiceIds: serviceIDs,
+			})
+		},
+		layover: func(ctx context.Context, serviceIDs []string, rangeStart, rangeEnd int64) ([]string, error) {
+			return api.GtfsManager.GtfsDB.Queries.GetActiveLayoverBlockIDsForRoute(ctx, gtfsdb.GetActiveLayoverBlockIDsForRouteParams{
+				RouteID:        routeID,
+				ServiceIds:     serviceIDs,
+				TimeRangeStart: rangeStart,
+				TimeRangeEnd:   rangeEnd,
+			})
+		},
+		nullBlocks: func(ctx context.Context, serviceIDs []string, rangeStart, rangeEnd int64) ([]string, error) {
+			return api.GtfsManager.GtfsDB.Queries.GetActiveTripsWithNullBlockForRoute(ctx, gtfsdb.GetActiveTripsWithNullBlockForRouteParams{
+				RouteID:        routeID,
+				ServiceIds:     serviceIDs,
+				TimeRangeStart: sql.NullInt64{Int64: rangeStart, Valid: true},
+				TimeRangeEnd:   sql.NullInt64{Int64: rangeEnd, Valid: true},
+			})
+		},
+	}, windows)
+}
+
 // blockCandidatesForStops is the stop-scoped mirror of blockCandidatesForRoute:
 // it returns the candidate block IDs and null-block trip IDs whose schedule
 // overlaps the query windows, scoped to trips serving any of the given stops.
-// Error-handling semantics match blockCandidatesForRoute exactly.
 func (api *RestAPI) blockCandidatesForStops(ctx context.Context, stopIDs []string, windows []serviceDayWindow) (map[string]bool, []string, error) {
-	allLinkedBlocks := make(map[string]bool)
-
-	for i, w := range windows {
-		indexIDs, err := api.GtfsManager.GtfsDB.Queries.GetBlockTripIndexIDsForStops(ctx, gtfsdb.GetBlockTripIndexIDsForStopsParams{
-			StopIds:    stopIDs,
-			ServiceIds: w.serviceIDs,
-		})
-		if err != nil {
-			if i == 0 {
-				return nil, nil, err
-			}
-			api.Logger.Warn("trips-for-location: failed to fetch previous-day block index IDs", "error", err)
-			continue
-		}
-		if len(indexIDs) == 0 {
-			continue
-		}
-
-		blocks, err := api.GtfsManager.GtfsDB.Queries.GetBlocksForBlockTripIndexIDs(ctx, gtfsdb.GetBlocksForBlockTripIndexIDsParams{
-			FromTime:   sql.NullInt64{Int64: w.rangeStart.Nanoseconds(), Valid: true},
-			ToTime:     sql.NullInt64{Int64: w.rangeEnd.Nanoseconds(), Valid: true},
-			IndexIds:   indexIDs,
-			ServiceIds: w.serviceIDs,
-		})
-		if err != nil {
-			if i == 0 {
-				return nil, nil, err
-			}
-			api.Logger.Warn("trips-for-location: failed to fetch previous-day blocks", "error", err)
-			continue
-		}
-		for _, b := range blocks {
-			if b.Valid {
-				allLinkedBlocks[b.String] = true
-			}
-		}
-	}
-
-	layoverBlocks, err := api.GtfsManager.GtfsDB.Queries.GetActiveLayoverBlockIDsForStops(ctx, gtfsdb.GetActiveLayoverBlockIDsForStopsParams{
-		StopIds:        stopIDs,
-		ServiceIds:     windows[0].serviceIDs,
-		TimeRangeStart: windows[0].rangeStart.Nanoseconds(),
-		TimeRangeEnd:   windows[0].rangeEnd.Nanoseconds(),
-	})
-	if err != nil {
-		api.Logger.Warn("trips-for-location: failed to fetch layover blocks", "error", err)
-	} else {
-		for _, blockID := range layoverBlocks {
-			allLinkedBlocks[blockID] = true
-		}
-	}
-
-	var nullBlockTrips []string
-	for i, w := range windows {
-		trips, err := api.GtfsManager.GtfsDB.Queries.GetActiveTripsWithNullBlockForStops(ctx, gtfsdb.GetActiveTripsWithNullBlockForStopsParams{
-			StopIds:        stopIDs,
-			ServiceIds:     w.serviceIDs,
-			TimeRangeStart: sql.NullInt64{Int64: w.rangeStart.Nanoseconds(), Valid: true},
-			TimeRangeEnd:   sql.NullInt64{Int64: w.rangeEnd.Nanoseconds(), Valid: true},
-		})
-		if err != nil {
-			if i == 0 {
-				api.Logger.Warn("trips-for-location: failed to fetch null-block trips", "error", err)
-			} else {
-				api.Logger.Warn("trips-for-location: failed to fetch previous-day null-block trips", "error", err)
-			}
-			continue
-		}
-		nullBlockTrips = append(nullBlockTrips, trips...)
-	}
-
-	return allLinkedBlocks, nullBlockTrips, nil
+	return api.blockCandidates(ctx, blockCandidateQueries{
+		logScope: "trips-for-location",
+		indexIDs: func(ctx context.Context, serviceIDs []string) ([]int64, error) {
+			return api.GtfsManager.GtfsDB.Queries.GetBlockTripIndexIDsForStops(ctx, gtfsdb.GetBlockTripIndexIDsForStopsParams{
+				StopIds:    stopIDs,
+				ServiceIds: serviceIDs,
+			})
+		},
+		layover: func(ctx context.Context, serviceIDs []string, rangeStart, rangeEnd int64) ([]string, error) {
+			return api.GtfsManager.GtfsDB.Queries.GetActiveLayoverBlockIDsForStops(ctx, gtfsdb.GetActiveLayoverBlockIDsForStopsParams{
+				StopIds:        stopIDs,
+				ServiceIds:     serviceIDs,
+				TimeRangeStart: rangeStart,
+				TimeRangeEnd:   rangeEnd,
+			})
+		},
+		nullBlocks: func(ctx context.Context, serviceIDs []string, rangeStart, rangeEnd int64) ([]string, error) {
+			return api.GtfsManager.GtfsDB.Queries.GetActiveTripsWithNullBlockForStops(ctx, gtfsdb.GetActiveTripsWithNullBlockForStopsParams{
+				StopIds:        stopIDs,
+				ServiceIds:     serviceIDs,
+				TimeRangeStart: sql.NullInt64{Int64: rangeStart, Valid: true},
+				TimeRangeEnd:   sql.NullInt64{Int64: rangeEnd, Valid: true},
+			})
+		},
+	}, windows)
 }
 
 // resolveActiveTrips returns the trip IDs actually running at each window's

--- a/internal/restapi/block_candidates_helper.go
+++ b/internal/restapi/block_candidates_helper.go
@@ -25,6 +25,8 @@ type serviceDayWindow struct {
 	sinceMidnight time.Duration
 	rangeStart    time.Duration
 	rangeEnd      time.Duration
+	// date is midnight of this service day, in the query's location.
+	date time.Time
 }
 
 // serviceDayWindows returns the query window for the current service day and,
@@ -47,6 +49,7 @@ func (api *RestAPI) serviceDayWindows(ctx context.Context, currentTime time.Time
 		sinceMidnight: currentSinceMidnight,
 		rangeStart:    currentSinceMidnight - runningLate,
 		rangeEnd:      currentSinceMidnight + runningEarly,
+		date:          serviceDayMidnight,
 	}}
 
 	prevDay := currentTime.AddDate(0, 0, -1)
@@ -60,13 +63,18 @@ func (api *RestAPI) serviceDayWindows(ctx context.Context, currentTime time.Time
 		return windows, nil
 	}
 
-	// I'm confused by adding 24 hours to get the previous day here, but that's the existing behavior.
+	// GTFS allows stop_times past 24:00:00 (e.g. 25:30:00 = 1:30 AM next day),
+	// so a trip belonging to yesterday's service can still be running now.
+	// Expressing "now" as yesterday's-midnight-plus-24h-and-change lets the
+	// same query-window math used for today apply unchanged to yesterday's
+	// service day.
 	prevDaySinceMidnight := currentSinceMidnight + 24*time.Hour
 	windows = append(windows, serviceDayWindow{
 		serviceIDs:    prevServiceIDs,
 		sinceMidnight: prevDaySinceMidnight,
 		rangeStart:    prevDaySinceMidnight - runningLate,
 		rangeEnd:      prevDaySinceMidnight + runningEarly,
+		date:          serviceDayMidnight.AddDate(0, 0, -1),
 	})
 
 	return windows, nil
@@ -85,13 +93,14 @@ type blockCandidateQueries struct {
 	nullBlocks func(ctx context.Context, serviceIDs []string, rangeStart, rangeEnd int64) ([]string, error)
 }
 
-// blockCandidates returns the candidate block IDs and null-block trip IDs
-// whose schedule overlaps the query windows, as scoped by q. An error from
-// the current-day (windows[0]) index/block queries is returned to the
-// caller as fatal; all other failures (previous-day queries, layover
+// blockCandidates returns the candidate block IDs, and the null-block trip
+// IDs mapped to the index (into windows) of the service day whose query
+// found them, whose schedule overlaps the query windows, as scoped by q. An
+// error from the current-day (windows[0]) index/block queries is returned
+// to the caller as fatal; all other failures (previous-day queries, layover
 // blocks, null-block trips) are logged and skipped so partial data still
 // produces a result.
-func (api *RestAPI) blockCandidates(ctx context.Context, q blockCandidateQueries, windows []serviceDayWindow) (map[string]bool, []string, error) {
+func (api *RestAPI) blockCandidates(ctx context.Context, q blockCandidateQueries, windows []serviceDayWindow) (map[string]bool, map[string]int, error) {
 	allLinkedBlocks := make(map[string]bool)
 
 	for i, w := range windows {
@@ -136,7 +145,7 @@ func (api *RestAPI) blockCandidates(ctx context.Context, q blockCandidateQueries
 		}
 	}
 
-	var nullBlockTrips []string
+	nullBlockTripWindows := make(map[string]int)
 	for i, w := range windows {
 		trips, err := q.nullBlocks(ctx, w.serviceIDs, w.rangeStart.Nanoseconds(), w.rangeEnd.Nanoseconds())
 		if err != nil {
@@ -147,16 +156,18 @@ func (api *RestAPI) blockCandidates(ctx context.Context, q blockCandidateQueries
 			}
 			continue
 		}
-		nullBlockTrips = append(nullBlockTrips, trips...)
+		for _, tripID := range trips {
+			nullBlockTripWindows[tripID] = i
+		}
 	}
 
-	return allLinkedBlocks, nullBlockTrips, nil
+	return allLinkedBlocks, nullBlockTripWindows, nil
 }
 
 // blockCandidatesForRoute returns the candidate block IDs and null-block
-// trip IDs whose schedule overlaps the query windows, scoped to the given
-// route.
-func (api *RestAPI) blockCandidatesForRoute(ctx context.Context, routeID string, windows []serviceDayWindow) (map[string]bool, []string, error) {
+// trip IDs (see blockCandidates) whose schedule overlaps the query windows,
+// scoped to the given route.
+func (api *RestAPI) blockCandidatesForRoute(ctx context.Context, routeID string, windows []serviceDayWindow) (map[string]bool, map[string]int, error) {
 	return api.blockCandidates(ctx, blockCandidateQueries{
 		logScope: "trips-for-route",
 		indexIDs: func(ctx context.Context, serviceIDs []string) ([]int64, error) {
@@ -185,9 +196,10 @@ func (api *RestAPI) blockCandidatesForRoute(ctx context.Context, routeID string,
 }
 
 // blockCandidatesForStops is the stop-scoped mirror of blockCandidatesForRoute:
-// it returns the candidate block IDs and null-block trip IDs whose schedule
-// overlaps the query windows, scoped to trips serving any of the given stops.
-func (api *RestAPI) blockCandidatesForStops(ctx context.Context, stopIDs []string, windows []serviceDayWindow) (map[string]bool, []string, error) {
+// it returns the candidate block IDs and null-block trip IDs (see
+// blockCandidates) whose schedule overlaps the query windows, scoped to
+// trips serving any of the given stops.
+func (api *RestAPI) blockCandidatesForStops(ctx context.Context, stopIDs []string, windows []serviceDayWindow) (map[string]bool, map[string]int, error) {
 	return api.blockCandidates(ctx, blockCandidateQueries{
 		logScope: "trips-for-location",
 		indexIDs: func(ctx context.Context, serviceIDs []string) ([]int64, error) {
@@ -218,31 +230,29 @@ func (api *RestAPI) blockCandidatesForStops(ctx context.Context, stopIDs []strin
 // resolveActiveTrips returns the trip IDs actually running at each window's
 // query time: one active trip per candidate block (the earliest trip in the
 // block whose stop times contain that window's query time), plus the given
-// null-block trip IDs. If ctx is canceled mid-loop, the trips accumulated so
-// far are returned; callers should check ctx.Err() afterward.
-func (api *RestAPI) resolveActiveTrips(ctx context.Context, blockIDs map[string]bool, nullBlockTripIDs []string, windows []serviceDayWindow) []string {
+// null-block trip IDs. It also returns, for every returned trip ID, the
+// calendar date (midnight) of the service day whose window produced it —
+// windows[0]'s date for an ordinary match, windows[1]'s (yesterday's) date
+// for a trip only found via the past-midnight lookback — so callers doing
+// their own schedule-time math (e.g. extrapolating a position) use the
+// correct service day rather than assuming "today". If ctx is canceled
+// mid-loop, the trips accumulated so far are returned; callers should check
+// ctx.Err() afterward.
+func (api *RestAPI) resolveActiveTrips(ctx context.Context, blockIDs map[string]bool, nullBlockTripWindows map[string]int, windows []serviceDayWindow) ([]string, map[string]time.Time) {
 	var activeTrips []string
+	serviceDateByTrip := make(map[string]time.Time, len(blockIDs)+len(nullBlockTripWindows))
 
 	for blockID := range blockIDs {
 		if ctx.Err() != nil {
-			return activeTrips
+			return activeTrips, serviceDateByTrip
 		}
 
 		blockIDNullStr := nulls.String(blockID)
 
 		for _, w := range windows {
-			tripsInBlock, err := api.GtfsManager.GtfsDB.Queries.GetTripsInBlock(ctx, gtfsdb.GetTripsInBlockParams{
-				BlockID:    blockIDNullStr,
-				ServiceIds: w.serviceIDs,
-			})
-			if err != nil {
-				api.Logger.Warn("failed to fetch trips in block", "block_id", blockID, "error", err)
-				continue
-			}
-			if len(tripsInBlock) == 0 {
-				continue
-			}
-
+			// GetActiveTripInBlockAtTime already returns sql.ErrNoRows when the
+			// block has no trip for this service day, so there's no need to
+			// pre-check with a separate "does this block have any trips" query.
 			activeTrip, err := api.GtfsManager.GtfsDB.Queries.GetActiveTripInBlockAtTime(ctx, gtfsdb.GetActiveTripInBlockAtTimeParams{
 				BlockID:     blockIDNullStr,
 				ServiceIds:  w.serviceIDs,
@@ -262,10 +272,17 @@ func (api *RestAPI) resolveActiveTrips(ctx context.Context, blockIDs map[string]
 			}
 
 			activeTrips = append(activeTrips, activeTrip)
+			serviceDateByTrip[activeTrip] = w.date
 			break
 		}
 	}
 
-	activeTrips = append(activeTrips, nullBlockTripIDs...)
-	return activeTrips
+	for tripID, windowIdx := range nullBlockTripWindows {
+		activeTrips = append(activeTrips, tripID)
+		if windowIdx >= 0 && windowIdx < len(windows) {
+			serviceDateByTrip[tripID] = windows[windowIdx].date
+		}
+	}
+
+	return activeTrips, serviceDateByTrip
 }

--- a/internal/restapi/block_candidates_helper_test.go
+++ b/internal/restapi/block_candidates_helper_test.go
@@ -1,0 +1,31 @@
+package restapi
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"maglev.onebusaway.org/internal/clock"
+)
+
+// TestServiceDayWindows_PreviousDayDate verifies that the previous-day window's
+// date is midnight of yesterday, not today — a trip only found via that window
+// (a past-midnight block) must have its schedule position extrapolated against
+// yesterday's service day.
+func TestServiceDayWindows_PreviousDayDate(t *testing.T) {
+	// tfr-svc runs every day of the week, so both the current-day and
+	// previous-day windows are populated for any query time.
+	api := createTestApiWithTripsForRouteFixture(t, clock.NewMockClock(tripsForRouteTestClock))
+
+	windows, err := api.serviceDayWindows(context.Background(), tripsForRouteTestClock)
+	require.NoError(t, err)
+	require.Len(t, windows, 2, "tfr-svc runs every day, so a previous-day window should be present")
+
+	wantToday := time.Date(2025, 6, 12, 0, 0, 0, 0, time.UTC)
+	wantYesterday := time.Date(2025, 6, 11, 0, 0, 0, 0, time.UTC)
+
+	assert.True(t, windows[0].date.Equal(wantToday), "windows[0].date should be midnight of the query date, got %v", windows[0].date)
+	assert.True(t, windows[1].date.Equal(wantYesterday), "windows[1].date should be midnight of the day before, got %v", windows[1].date)
+}

--- a/internal/restapi/block_candidates_helper_test.go
+++ b/internal/restapi/block_candidates_helper_test.go
@@ -1,13 +1,22 @@
 package restapi
 
 import (
+	"archive/zip"
+	"bytes"
 	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"maglev.onebusaway.org/internal/app"
+	"maglev.onebusaway.org/internal/appconf"
 	"maglev.onebusaway.org/internal/clock"
+	"maglev.onebusaway.org/internal/gtfs"
 )
 
 // TestServiceDayWindows_PreviousDayDate verifies that the previous-day window's
@@ -28,4 +37,111 @@ func TestServiceDayWindows_PreviousDayDate(t *testing.T) {
 
 	assert.True(t, windows[0].date.Equal(wantToday), "windows[0].date should be midnight of the query date, got %v", windows[0].date)
 	assert.True(t, windows[1].date.Equal(wantYesterday), "windows[1].date should be midnight of the day before, got %v", windows[1].date)
+}
+
+const (
+	pastMidnightAgencyID = "pm-agency"
+	pastMidnightTripID   = "pm-trip"
+	pastMidnightStop1ID  = "pm-s1"
+	pastMidnightStop2ID  = "pm-s2"
+)
+
+// createTestApiWithPastMidnightFixture builds a RestAPI whose only trip runs
+// 24:30:00 -> 25:00:00 on its service day — i.e. 00:30-01:00 the following
+// calendar morning. Querying at 00:45 therefore hits a trip that is mid-run
+// but belongs to the *previous* service day.
+func createTestApiWithPastMidnightFixture(t *testing.T, c clock.Clock) *RestAPI {
+	t.Helper()
+	ctx := context.Background()
+
+	var buf bytes.Buffer
+	w := zip.NewWriter(&buf)
+	files := map[string]string{
+		"agency.txt": "agency_id,agency_name,agency_url,agency_timezone\n" +
+			pastMidnightAgencyID + ",Past Midnight,http://example.com,UTC\n",
+		"routes.txt": "route_id,agency_id,route_short_name,route_long_name,route_type\n" +
+			"pm-route," + pastMidnightAgencyID + ",PM,Past Midnight Route,3\n",
+		"calendar.txt": "service_id,monday,tuesday,wednesday,thursday,friday,saturday,sunday,start_date,end_date\n" +
+			"pm-svc,1,1,1,1,1,1,1,20240101,20991231\n",
+		"stops.txt": "stop_id,stop_name,stop_lat,stop_lon\n" +
+			pastMidnightStop1ID + ",Stop One,37.7749,-122.4194\n" +
+			pastMidnightStop2ID + ",Stop Two,37.7759,-122.4184\n",
+		"trips.txt": "route_id,service_id,trip_id,trip_headsign,direction_id,block_id\n" +
+			"pm-route,pm-svc," + pastMidnightTripID + ",Past Midnight,0,pm-block\n",
+		"stop_times.txt": "trip_id,arrival_time,departure_time,stop_id,stop_sequence\n" +
+			pastMidnightTripID + ",24:30:00,24:30:00," + pastMidnightStop1ID + ",1\n" +
+			pastMidnightTripID + ",25:00:00,25:00:00," + pastMidnightStop2ID + ",2\n",
+	}
+	for name, content := range files {
+		f, err := w.Create(name)
+		require.NoError(t, err)
+		_, err = f.Write([]byte(content))
+		require.NoError(t, err)
+	}
+	require.NoError(t, w.Close())
+
+	zipPath := filepath.Join(t.TempDir(), "past-midnight.zip")
+	require.NoError(t, os.WriteFile(zipPath, buf.Bytes(), 0600))
+
+	gtfsConfig := gtfs.Config{GtfsURL: zipPath, GTFSDataPath: ":memory:"}
+	gtfsManager, err := gtfs.InitGTFSManager(ctx, gtfsConfig)
+	require.NoError(t, err)
+	t.Cleanup(gtfsManager.Shutdown)
+
+	application := &app.Application{
+		Config: appconf.Config{
+			Env:       appconf.EnvFlagToEnvironment("test"),
+			ApiKeys:   []string{"TEST"},
+			RateLimit: 100,
+		},
+		GtfsConfig:          gtfsConfig,
+		GtfsManager:         gtfsManager,
+		DirectionCalculator: gtfs.NewAdvancedDirectionCalculator(gtfsManager.GtfsDB.Queries),
+		Clock:               c,
+	}
+
+	api := NewRestAPI(application)
+	api.Logger = slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	t.Cleanup(api.Shutdown)
+	return api
+}
+
+// TestTripsForLocationHandler_PastMidnightTripUsesPreviousServiceDate covers a
+// trip resolved through the past-midnight lookback. Its serviceDate must be
+// the previous calendar day (per the spec's data.list[].serviceDate), and its
+// reported position must be extrapolated against that same service day —
+// otherwise the position in the response contradicts the bounding-box filter
+// that admitted the trip in the first place.
+func TestTripsForLocationHandler_PastMidnightTripUsesPreviousServiceDate(t *testing.T) {
+	// 00:45 on 2025-06-13; the trip runs 00:30-01:00 and belongs to 2025-06-12.
+	queryTime := time.Date(2025, 6, 13, 0, 45, 0, 0, time.UTC)
+	api := createTestApiWithPastMidnightFixture(t, clock.NewMockClock(queryTime))
+
+	wantServiceDate := time.Date(2025, 6, 12, 0, 0, 0, 0, time.UTC)
+
+	url := fmt.Sprintf(
+		"/api/where/trips-for-location.json?key=TEST&lat=37.7754&lon=-122.4189&latSpan=0.05&lonSpan=0.05&includeStatus=true&time=%d",
+		queryTime.UnixMilli())
+	resp, model := callAPIHandler[TripsForLocationResponse](t, api, url)
+
+	require.Equal(t, 200, resp.StatusCode)
+	require.Len(t, model.Data.List, 1, "the past-midnight trip should be found mid-run")
+
+	entry := model.Data.List[0]
+	assert.Equal(t, wantServiceDate.UnixMilli(), entry.ServiceDate,
+		"a trip running past midnight belongs to the previous calendar day")
+
+	require.NotNil(t, entry.Status)
+	assert.Equal(t, wantServiceDate.UnixMilli(), entry.Status.ServiceDate.UnixMilli(),
+		"status.serviceDate must match the entry's service date")
+
+	// At 00:45 the trip is halfway between its two stops. Computing against the
+	// wrong service day would place it before its first arrival, snapping the
+	// position to stop one exactly.
+	assert.NotEqual(t, 37.7749, entry.Status.Position.Lat,
+		"position must not collapse onto the first stop")
+	assert.InDelta(t, 37.7754, entry.Status.Position.Lat, 1e-3,
+		"position should interpolate to roughly halfway between the two stops")
+	assert.InDelta(t, -122.4189, entry.Status.Position.Lon, 1e-3,
+		"position should interpolate to roughly halfway between the two stops")
 }

--- a/internal/restapi/trips_for_location_handler.go
+++ b/internal/restapi/trips_for_location_handler.go
@@ -44,6 +44,7 @@ func (api *RestAPI) tripsForLocationHandler(w http.ResponseWriter, r *http.Reque
 	candidateStopIDs := extractStopIDs(allStops)
 
 	var trips []gtfsdb.Trip
+	var serviceDateByTrip map[string]time.Time
 	if len(candidateStopIDs) > 0 {
 		windows, err := api.serviceDayWindows(ctx, parsedReq.CurrentTime)
 		if err != nil {
@@ -57,7 +58,8 @@ func (api *RestAPI) tripsForLocationHandler(w http.ResponseWriter, r *http.Reque
 			return
 		}
 
-		candidateTripIDs, serviceDateByTrip := api.resolveActiveTrips(ctx, blockIDs, nullBlockTripIDs, windows)
+		var candidateTripIDs []string
+		candidateTripIDs, serviceDateByTrip = api.resolveActiveTrips(ctx, blockIDs, nullBlockTripIDs, windows)
 		if ctx.Err() != nil {
 			api.clientCanceledResponse(w, r, ctx.Err())
 			return
@@ -111,7 +113,16 @@ func (api *RestAPI) tripsForLocationHandler(w http.ResponseWriter, r *http.Reque
 	}
 
 	// Build entries from pre-fetched trip data
-	result := api.buildTripsForLocationEntries(ctx, trips, tripAgencyMap, parsedReq.IncludeSchedule, parsedReq.IncludeStatus, parsedReq.CurrentLocation, parsedReq.CurrentTime, parsedReq.TodayMidnight, parsedReq.ServiceDate, w, r)
+	result := api.buildTripsForLocationEntries(ctx, tripsForLocationEntryParams{
+		Trips:              trips,
+		TripAgencyMap:      tripAgencyMap,
+		ServiceDateByTrip:  serviceDateByTrip,
+		DefaultServiceDate: parsedReq.TodayMidnight,
+		IncludeSchedule:    parsedReq.IncludeSchedule,
+		IncludeStatus:      parsedReq.IncludeStatus,
+		CurrentLocation:    parsedReq.CurrentLocation,
+		CurrentTime:        parsedReq.CurrentTime,
+	}, w, r)
 	if result == nil {
 		return
 	}
@@ -146,8 +157,9 @@ type tripsForLocationRequest struct {
 	IncludeStatus   bool
 	CurrentLocation *time.Location
 	CurrentTime     time.Time
-	TodayMidnight   time.Time
-	ServiceDate     time.Time
+	// TodayMidnight is midnight of the query date, used as the service day
+	// for trips that don't carry a resolved one of their own.
+	TodayMidnight time.Time
 }
 
 func (api *RestAPI) parseAndValidateRequest(r *http.Request) (*tripsForLocationRequest, map[string][]string, error) {
@@ -180,7 +192,7 @@ func (api *RestAPI) parseAndValidateRequest(r *http.Request) (*tripsForLocationR
 	currentTime, timeFieldErrors := api.resolveCurrentTime(queryParams.Get("time"), currentLocation)
 	fieldErrors = mergeFieldErrors(fieldErrors, timeFieldErrors)
 
-	serviceDate, todayMidnight := utils.ServiceDateMidnight(nil, currentTime)
+	_, todayMidnight := utils.ServiceDateMidnight(nil, currentTime)
 
 	if len(fieldErrors) > 0 {
 		return nil, fieldErrors, nil
@@ -194,7 +206,6 @@ func (api *RestAPI) parseAndValidateRequest(r *http.Request) (*tripsForLocationR
 		CurrentLocation: currentLocation,
 		CurrentTime:     currentTime,
 		TodayMidnight:   todayMidnight,
-		ServiceDate:     serviceDate,
 	}
 	return parsedReq, nil, nil
 }
@@ -335,20 +346,44 @@ func (api *RestAPI) tripPositionAtTime(ctx context.Context, tripID string, servi
 	return scheduledPositionAtTime(stopTimes, stopCoords, queryTime, serviceDate)
 }
 
+// tripsForLocationEntryParams carries the per-request values needed to build
+// the response entries.
+type tripsForLocationEntryParams struct {
+	Trips         []gtfsdb.Trip
+	TripAgencyMap map[string]string
+	// ServiceDateByTrip is the service day each trip actually matched (see
+	// resolveActiveTrips). A trip found via the past-midnight lookback
+	// belongs to the previous calendar day, and both its reported
+	// serviceDate and its schedule math must use that day, not the query
+	// date. Trips absent from the map fall back to DefaultServiceDate.
+	ServiceDateByTrip  map[string]time.Time
+	DefaultServiceDate time.Time
+	IncludeSchedule    bool
+	IncludeStatus      bool
+	CurrentLocation    *time.Location
+	CurrentTime        time.Time
+}
+
+// serviceDateFor returns the service day trip belongs to.
+func (p tripsForLocationEntryParams) serviceDateFor(tripID string) time.Time {
+	if serviceDate, ok := p.ServiceDateByTrip[tripID]; ok && !serviceDate.IsZero() {
+		return serviceDate
+	}
+	return p.DefaultServiceDate
+}
+
 // buildTripsForLocationEntries builds trip entries from pre-fetched batch data.
 func (api *RestAPI) buildTripsForLocationEntries(
 	ctx context.Context,
-	trips []gtfsdb.Trip,
-	tripAgencyMap map[string]string,
-	includeSchedule bool,
-	includeStatus bool,
-	currentLocation *time.Location,
-	currentTime time.Time,
-	todayMidnight time.Time,
-	serviceDate time.Time,
+	params tripsForLocationEntryParams,
 	w http.ResponseWriter,
 	r *http.Request,
 ) []models.TripsForLocationListEntry {
+	trips := params.Trips
+	tripAgencyMap := params.TripAgencyMap
+	includeSchedule := params.IncludeSchedule
+	includeStatus := params.IncludeStatus
+
 	if len(trips) == 0 {
 		return []models.TripsForLocationListEntry{}
 	}
@@ -410,12 +445,11 @@ func (api *RestAPI) buildTripsForLocationEntries(
 				blockIDs = append(blockIDs, bid)
 			}
 
-			dateStr := serviceDate.Format("20060102")
-			activeServiceIDs, err := api.GtfsManager.GtfsDB.Queries.GetActiveServiceIDsForDate(ctx, dateStr)
-			if err != nil {
-				activeServiceIDs = []string{}
-				api.Logger.Warn("failed to fetch active service IDs for block logic", "error", err)
-			}
+			// Cover every service day represented in this result set, not just
+			// the query date: a past-midnight trip's block siblings belong to
+			// the previous service day and would otherwise be missed, leaving
+			// its next/previous trip IDs empty.
+			activeServiceIDs := api.activeServiceIDsForTrips(ctx, validVehicleTrips, params)
 
 			blockIDsNull := make([]sql.NullString, len(blockIDs))
 			for i, id := range blockIDs {
@@ -466,6 +500,8 @@ func (api *RestAPI) buildTripsForLocationEntries(
 			continue
 		}
 
+		tripServiceDate := params.serviceDateFor(tripID)
+
 		var schedule *models.TripsSchedule
 		var status *models.TripStatus
 
@@ -483,7 +519,7 @@ func (api *RestAPI) buildTripsForLocationEntries(
 			schedule = api.buildScheduleFromMemory(
 				tripData,
 				agencyID,
-				currentLocation,
+				params.CurrentLocation,
 				stopTimesMap[tripID],
 				shapePoints,
 				stopCoords,
@@ -493,7 +529,7 @@ func (api *RestAPI) buildTripsForLocationEntries(
 
 		if includeStatus {
 			var statusErr error
-			status, statusErr = api.BuildTripStatus(ctx, agencyID, tripID, nil, todayMidnight, currentTime)
+			status, statusErr = api.BuildTripStatus(ctx, agencyID, tripID, nil, tripServiceDate, params.CurrentTime)
 			if statusErr != nil {
 				api.Logger.Warn("BuildTripStatus failed", "tripID", tripID, "error", statusErr)
 				status = nil
@@ -504,13 +540,41 @@ func (api *RestAPI) buildTripsForLocationEntries(
 			Frequency:    nil,
 			Schedule:     schedule,
 			Status:       status,
-			ServiceDate:  todayMidnight.UnixMilli(),
+			ServiceDate:  tripServiceDate.UnixMilli(),
 			SituationIds: api.GetSituationIDsForTrip(ctx, tripID),
 			TripId:       utils.FormCombinedID(agencyID, tripID),
 		}
 		result = append(result, entry)
 	}
 	return result
+}
+
+// activeServiceIDsForTrips returns the union of the active service IDs for
+// every distinct service day represented by tripIDs. Trips resolved through
+// the past-midnight lookback sit on the previous service day, so a single
+// date's service IDs would not cover them.
+func (api *RestAPI) activeServiceIDsForTrips(ctx context.Context, tripIDs []string, params tripsForLocationEntryParams) []string {
+	dates := make(map[string]struct{})
+	for _, tripID := range tripIDs {
+		dates[params.serviceDateFor(tripID).Format("20060102")] = struct{}{}
+	}
+
+	seen := make(map[string]bool)
+	var activeServiceIDs []string
+	for dateStr := range dates {
+		ids, err := api.GtfsManager.GtfsDB.Queries.GetActiveServiceIDsForDate(ctx, dateStr)
+		if err != nil {
+			api.Logger.Warn("failed to fetch active service IDs for block logic", "date", dateStr, "error", err)
+			continue
+		}
+		for _, id := range ids {
+			if !seen[id] {
+				seen[id] = true
+				activeServiceIDs = append(activeServiceIDs, id)
+			}
+		}
+	}
+	return activeServiceIDs
 }
 
 func (api *RestAPI) buildScheduleForTrip(

--- a/internal/restapi/trips_for_location_handler.go
+++ b/internal/restapi/trips_for_location_handler.go
@@ -33,39 +33,52 @@ func (api *RestAPI) tripsForLocationHandler(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	stops := api.GtfsManager.GetStopsInBounds(ctx, parsedReq.LocationParams, models.DefaultMaxCountForStops, true)
-	stopIDs := extractStopIDs(stops)
-	stopTimes, err := api.GtfsManager.GtfsDB.Queries.GetStopTimesByStopIDs(ctx, stopIDs)
-	if err != nil {
-		api.serverErrorResponse(w, r, err)
-		return
+	// Candidate stop IDs must not be capped: silently truncating the bbox stop list
+	// would drop candidate trips in a wide search area. The references stop list is
+	// still capped, but from this same uncapped result rather than a second query.
+	allStops := api.GtfsManager.GetStopsInBounds(ctx, parsedReq.LocationParams, 0, true)
+	stops := allStops
+	if len(stops) > models.DefaultMaxCountForStops {
+		stops = stops[:models.DefaultMaxCountForStops]
 	}
+	candidateStopIDs := extractStopIDs(allStops)
 
-	activeTrips := api.getActiveTrips(stopTimes, api.GtfsManager.GetRealTimeVehicles())
+	var trips []gtfsdb.Trip
+	if len(candidateStopIDs) > 0 {
+		windows, err := api.serviceDayWindows(ctx, parsedReq.CurrentTime)
+		if err != nil {
+			api.serverErrorResponse(w, r, err)
+			return
+		}
 
-	bounds := internalgtfs.BoundsFromParams(parsedReq.LocationParams, true)
-	visibleTripIDs := make([]string, 0, len(activeTrips))
-	for _, vehicle := range activeTrips {
+		blockIDs, nullBlockTripIDs, err := api.blockCandidatesForStops(ctx, candidateStopIDs, windows)
+		if err != nil {
+			api.serverErrorResponse(w, r, err)
+			return
+		}
+
+		candidateTripIDs := api.resolveActiveTrips(ctx, blockIDs, nullBlockTripIDs, windows)
 		if ctx.Err() != nil {
 			api.clientCanceledResponse(w, r, ctx.Err())
 			return
 		}
 
-		if vehicle.Position == nil || vehicle.Position.Latitude == nil || vehicle.Position.Longitude == nil {
-			continue
-		}
-		vLat, vLon := float64(*vehicle.Position.Latitude), float64(*vehicle.Position.Longitude)
-		if vLat >= bounds.MinLat && vLat <= bounds.MaxLat && vLon >= bounds.MinLon && vLon <= bounds.MaxLon {
-			visibleTripIDs = append(visibleTripIDs, vehicle.Trip.ID.ID)
-		}
-	}
-
-	var trips []gtfsdb.Trip
-	if len(visibleTripIDs) > 0 {
-		trips, err = api.GtfsManager.GtfsDB.Queries.GetTripsByIDs(ctx, visibleTripIDs)
+		visibleTripIDs, err := api.visibleTripIDs(ctx, candidateTripIDs, parsedReq.LocationParams, parsedReq.CurrentTime)
 		if err != nil {
 			api.serverErrorResponse(w, r, err)
 			return
+		}
+		if ctx.Err() != nil {
+			api.clientCanceledResponse(w, r, ctx.Err())
+			return
+		}
+
+		if len(visibleTripIDs) > 0 {
+			trips, err = api.GtfsManager.GtfsDB.Queries.GetTripsByIDs(ctx, visibleTripIDs)
+			if err != nil {
+				api.serverErrorResponse(w, r, err)
+				return
+			}
 		}
 	}
 
@@ -228,18 +241,80 @@ func extractStopIDs(stops []gtfsdb.Stop) []string {
 	return stopIDs
 }
 
-func (api *RestAPI) getActiveTrips(stopTimes []gtfsdb.StopTime, realTimeVehicles []gtfs.Vehicle) map[string]gtfs.Vehicle {
-	trips := make(map[string]bool)
-	for _, stopTime := range stopTimes {
-		trips[stopTime.TripID] = true
+// visibleTripIDs computes each candidate trip's position at queryTime — real-time
+// GPS when a non-stale vehicle is assigned to the trip, otherwise extrapolated
+// from the static schedule — and returns the subset whose computed position
+// falls inside loc's bounding box (spec steps 5 and 6).
+func (api *RestAPI) visibleTripIDs(ctx context.Context, candidateTripIDs []string, loc *internalgtfs.LocationParams, queryTime time.Time) ([]string, error) {
+	if len(candidateTripIDs) == 0 {
+		return nil, nil
 	}
-	activeTrips := make(map[string]gtfs.Vehicle)
-	for _, vehicle := range realTimeVehicles {
-		if vehicle.Trip != nil && trips[vehicle.Trip.ID.ID] {
-			activeTrips[vehicle.Trip.ID.ID] = vehicle
+
+	dedupedIDs := make([]string, 0, len(candidateTripIDs))
+	seen := make(map[string]bool, len(candidateTripIDs))
+	for _, tripID := range candidateTripIDs {
+		if !seen[tripID] {
+			seen[tripID] = true
+			dedupedIDs = append(dedupedIDs, tripID)
 		}
 	}
-	return activeTrips
+
+	stopTimesRaw, err := api.GtfsManager.GtfsDB.Queries.GetStopTimesForTripIDs(ctx, dedupedIDs)
+	if err != nil {
+		return nil, err
+	}
+	stopTimesByTrip := make(map[string][]gtfsdb.StopTime)
+	var allStopIDs []string
+	for _, st := range stopTimesRaw {
+		stopTimesByTrip[st.TripID] = append(stopTimesByTrip[st.TripID], st)
+		allStopIDs = append(allStopIDs, st.StopID)
+	}
+
+	var stopCoords map[string]struct{ lat, lon float64 }
+	if len(allStopIDs) > 0 {
+		stopsRaw, err := api.GtfsManager.GtfsDB.Queries.GetStopsByIDs(ctx, allStopIDs)
+		if err != nil {
+			return nil, err
+		}
+		stopCoords = make(map[string]struct{ lat, lon float64 }, len(stopsRaw))
+		for _, s := range stopsRaw {
+			stopCoords[s.ID] = struct{ lat, lon float64 }{lat: s.Lat, lon: s.Lon}
+		}
+	}
+
+	bounds := internalgtfs.BoundsFromParams(loc, true)
+	visible := make([]string, 0, len(dedupedIDs))
+	for _, tripID := range dedupedIDs {
+		if ctx.Err() != nil {
+			return visible, nil
+		}
+
+		pos, ok := api.tripPositionAtTime(ctx, tripID, queryTime, stopTimesByTrip[tripID], stopCoords)
+		if !ok {
+			continue
+		}
+		if pos.Lat >= bounds.MinLat && pos.Lat <= bounds.MaxLat && pos.Lon >= bounds.MinLon && pos.Lon <= bounds.MaxLon {
+			visible = append(visible, tripID)
+		}
+	}
+	return visible, nil
+}
+
+// tripPositionAtTime returns the trip's position at queryTime: the real-time
+// GPS position when a non-stale vehicle is assigned to the trip, otherwise
+// the position extrapolated from the static schedule.
+func (api *RestAPI) tripPositionAtTime(ctx context.Context, tripID string, queryTime time.Time, stopTimes []gtfsdb.StopTime, stopCoords map[string]struct{ lat, lon float64 }) (models.Location, bool) {
+	if vehicle := api.GtfsManager.GetVehicleForTrip(ctx, tripID); vehicle != nil &&
+		vehicle.Position != nil && vehicle.Position.Latitude != nil && vehicle.Position.Longitude != nil &&
+		!defaultStaleDetector.Check(vehicle, queryTime) {
+		return models.Location{Lat: float64(*vehicle.Position.Latitude), Lon: float64(*vehicle.Position.Longitude)}, true
+	}
+
+	if len(stopTimes) == 0 {
+		return models.Location{}, false
+	}
+	serviceDate := time.Date(queryTime.Year(), queryTime.Month(), queryTime.Day(), 0, 0, 0, 0, queryTime.Location())
+	return scheduledPositionAtTime(stopTimes, stopCoords, queryTime, serviceDate)
 }
 
 // buildTripsForLocationEntries builds trip entries from pre-fetched batch data.

--- a/internal/restapi/trips_for_location_handler.go
+++ b/internal/restapi/trips_for_location_handler.go
@@ -57,13 +57,13 @@ func (api *RestAPI) tripsForLocationHandler(w http.ResponseWriter, r *http.Reque
 			return
 		}
 
-		candidateTripIDs := api.resolveActiveTrips(ctx, blockIDs, nullBlockTripIDs, windows)
+		candidateTripIDs, serviceDateByTrip := api.resolveActiveTrips(ctx, blockIDs, nullBlockTripIDs, windows)
 		if ctx.Err() != nil {
 			api.clientCanceledResponse(w, r, ctx.Err())
 			return
 		}
 
-		visibleTripIDs, err := api.visibleTripIDs(ctx, candidateTripIDs, parsedReq.LocationParams, parsedReq.CurrentTime)
+		visibleTripIDs, err := api.visibleTripIDs(ctx, candidateTripIDs, serviceDateByTrip, parsedReq.LocationParams, parsedReq.CurrentTime)
 		if err != nil {
 			api.serverErrorResponse(w, r, err)
 			return
@@ -244,8 +244,11 @@ func extractStopIDs(stops []gtfsdb.Stop) []string {
 // visibleTripIDs computes each candidate trip's position at queryTime — real-time
 // GPS when a non-stale vehicle is assigned to the trip, otherwise extrapolated
 // from the static schedule — and returns the subset whose computed position
-// falls inside loc's bounding box (spec steps 5 and 6).
-func (api *RestAPI) visibleTripIDs(ctx context.Context, candidateTripIDs []string, loc *internalgtfs.LocationParams, queryTime time.Time) ([]string, error) {
+// falls inside loc's bounding box (spec steps 5 and 6). serviceDateByTrip
+// supplies the service day each trip actually matched (see resolveActiveTrips),
+// since a trip found via the past-midnight lookback must extrapolate against
+// yesterday's schedule, not today's.
+func (api *RestAPI) visibleTripIDs(ctx context.Context, candidateTripIDs []string, serviceDateByTrip map[string]time.Time, loc *internalgtfs.LocationParams, queryTime time.Time) ([]string, error) {
 	if len(candidateTripIDs) == 0 {
 		return nil, nil
 	}
@@ -264,10 +267,14 @@ func (api *RestAPI) visibleTripIDs(ctx context.Context, candidateTripIDs []strin
 		return nil, err
 	}
 	stopTimesByTrip := make(map[string][]gtfsdb.StopTime)
+	seenStopIDs := make(map[string]bool)
 	var allStopIDs []string
 	for _, st := range stopTimesRaw {
 		stopTimesByTrip[st.TripID] = append(stopTimesByTrip[st.TripID], st)
-		allStopIDs = append(allStopIDs, st.StopID)
+		if !seenStopIDs[st.StopID] {
+			seenStopIDs[st.StopID] = true
+			allStopIDs = append(allStopIDs, st.StopID)
+		}
 	}
 
 	var stopCoords map[string]struct{ lat, lon float64 }
@@ -289,7 +296,7 @@ func (api *RestAPI) visibleTripIDs(ctx context.Context, candidateTripIDs []strin
 			return visible, nil
 		}
 
-		pos, ok := api.tripPositionAtTime(ctx, tripID, queryTime, stopTimesByTrip[tripID], stopCoords)
+		pos, ok := api.tripPositionAtTime(ctx, tripID, serviceDateByTrip[tripID], queryTime, stopTimesByTrip[tripID], stopCoords)
 		if !ok {
 			continue
 		}
@@ -302,8 +309,10 @@ func (api *RestAPI) visibleTripIDs(ctx context.Context, candidateTripIDs []strin
 
 // tripPositionAtTime returns the trip's position at queryTime: the real-time
 // GPS position when a non-stale vehicle is assigned to the trip, otherwise
-// the position extrapolated from the static schedule.
-func (api *RestAPI) tripPositionAtTime(ctx context.Context, tripID string, queryTime time.Time, stopTimes []gtfsdb.StopTime, stopCoords map[string]struct{ lat, lon float64 }) (models.Location, bool) {
+// the position extrapolated from the static schedule. serviceDate is the
+// service day the trip actually matched (from resolveActiveTrips); if the
+// caller doesn't have one, queryTime's own calendar day is used.
+func (api *RestAPI) tripPositionAtTime(ctx context.Context, tripID string, serviceDate time.Time, queryTime time.Time, stopTimes []gtfsdb.StopTime, stopCoords map[string]struct{ lat, lon float64 }) (models.Location, bool) {
 	if vehicle := api.GtfsManager.GetVehicleForTrip(ctx, tripID); vehicle != nil &&
 		vehicle.Position != nil && vehicle.Position.Latitude != nil && vehicle.Position.Longitude != nil &&
 		!defaultStaleDetector.Check(vehicle, queryTime) {
@@ -313,7 +322,9 @@ func (api *RestAPI) tripPositionAtTime(ctx context.Context, tripID string, query
 	if len(stopTimes) == 0 {
 		return models.Location{}, false
 	}
-	serviceDate := time.Date(queryTime.Year(), queryTime.Month(), queryTime.Day(), 0, 0, 0, 0, queryTime.Location())
+	if serviceDate.IsZero() {
+		serviceDate = time.Date(queryTime.Year(), queryTime.Month(), queryTime.Day(), 0, 0, 0, 0, queryTime.Location())
+	}
 	return scheduledPositionAtTime(stopTimes, stopCoords, queryTime, serviceDate)
 }
 

--- a/internal/restapi/trips_for_location_handler.go
+++ b/internal/restapi/trips_for_location_handler.go
@@ -253,19 +253,36 @@ func (api *RestAPI) visibleTripIDs(ctx context.Context, candidateTripIDs []strin
 		return nil, nil
 	}
 
-	dedupedIDs := make([]string, 0, len(candidateTripIDs))
-	seen := make(map[string]bool, len(candidateTripIDs))
-	for _, tripID := range candidateTripIDs {
-		if !seen[tripID] {
-			seen[tripID] = true
-			dedupedIDs = append(dedupedIDs, tripID)
-		}
-	}
+	dedupedIDs := dedupeStrings(candidateTripIDs)
 
-	stopTimesRaw, err := api.GtfsManager.GtfsDB.Queries.GetStopTimesForTripIDs(ctx, dedupedIDs)
+	stopTimesByTrip, stopCoords, err := api.stopTimesAndCoordsForTrips(ctx, dedupedIDs)
 	if err != nil {
 		return nil, err
 	}
+
+	bounds := internalgtfs.BoundsFromParams(loc, true)
+	visible := make([]string, 0, len(dedupedIDs))
+	for _, tripID := range dedupedIDs {
+		if ctx.Err() != nil {
+			return visible, nil
+		}
+
+		pos, ok := api.tripPositionAtTime(ctx, tripID, serviceDateByTrip[tripID], queryTime, stopTimesByTrip[tripID], stopCoords)
+		if ok && isWithinBounds(pos, bounds) {
+			visible = append(visible, tripID)
+		}
+	}
+	return visible, nil
+}
+
+// stopTimesAndCoordsForTrips batch-fetches stop times for tripIDs, grouped by
+// trip, and the coordinates of every stop they reference.
+func (api *RestAPI) stopTimesAndCoordsForTrips(ctx context.Context, tripIDs []string) (map[string][]gtfsdb.StopTime, map[string]struct{ lat, lon float64 }, error) {
+	stopTimesRaw, err := api.GtfsManager.GtfsDB.Queries.GetStopTimesForTripIDs(ctx, tripIDs)
+	if err != nil {
+		return nil, nil, err
+	}
+
 	stopTimesByTrip := make(map[string][]gtfsdb.StopTime)
 	seenStopIDs := make(map[string]bool)
 	var allStopIDs []string
@@ -277,34 +294,24 @@ func (api *RestAPI) visibleTripIDs(ctx context.Context, candidateTripIDs []strin
 		}
 	}
 
-	var stopCoords map[string]struct{ lat, lon float64 }
-	if len(allStopIDs) > 0 {
-		stopsRaw, err := api.GtfsManager.GtfsDB.Queries.GetStopsByIDs(ctx, allStopIDs)
-		if err != nil {
-			return nil, err
-		}
-		stopCoords = make(map[string]struct{ lat, lon float64 }, len(stopsRaw))
-		for _, s := range stopsRaw {
-			stopCoords[s.ID] = struct{ lat, lon float64 }{lat: s.Lat, lon: s.Lon}
-		}
+	if len(allStopIDs) == 0 {
+		return stopTimesByTrip, nil, nil
 	}
 
-	bounds := internalgtfs.BoundsFromParams(loc, true)
-	visible := make([]string, 0, len(dedupedIDs))
-	for _, tripID := range dedupedIDs {
-		if ctx.Err() != nil {
-			return visible, nil
-		}
-
-		pos, ok := api.tripPositionAtTime(ctx, tripID, serviceDateByTrip[tripID], queryTime, stopTimesByTrip[tripID], stopCoords)
-		if !ok {
-			continue
-		}
-		if pos.Lat >= bounds.MinLat && pos.Lat <= bounds.MaxLat && pos.Lon >= bounds.MinLon && pos.Lon <= bounds.MaxLon {
-			visible = append(visible, tripID)
-		}
+	stopsRaw, err := api.GtfsManager.GtfsDB.Queries.GetStopsByIDs(ctx, allStopIDs)
+	if err != nil {
+		return nil, nil, err
 	}
-	return visible, nil
+	stopCoords := make(map[string]struct{ lat, lon float64 }, len(stopsRaw))
+	for _, s := range stopsRaw {
+		stopCoords[s.ID] = struct{ lat, lon float64 }{lat: s.Lat, lon: s.Lon}
+	}
+	return stopTimesByTrip, stopCoords, nil
+}
+
+// isWithinBounds reports whether pos lies inside bounds (inclusive).
+func isWithinBounds(pos models.Location, bounds utils.CoordinateBounds) bool {
+	return pos.Lat >= bounds.MinLat && pos.Lat <= bounds.MaxLat && pos.Lon >= bounds.MinLon && pos.Lon <= bounds.MaxLon
 }
 
 // tripPositionAtTime returns the trip's position at queryTime: the real-time

--- a/internal/restapi/trips_for_location_handler_test.go
+++ b/internal/restapi/trips_for_location_handler_test.go
@@ -492,27 +492,34 @@ func TestTripsForLocationHandler_TimeParameterVariations(t *testing.T) {
 
 	time.Sleep(500 * time.Millisecond)
 
-	t.Run("Date String YYYY-MM-DD", func(t *testing.T) {
-		// A bare date resolves to midnight of that day. RABA has no scheduled
-		// service at midnight, so schedule-derived candidate selection
-		// correctly finds nothing — this exercises the date-string parsing
-		// path succeeding (200, not a validation error) rather than any
-		// particular trip being found.
-		dateStr := "2025-06-15"
+	t.Run("Date String YYYY-MM-DD_HH-mm-ss", func(t *testing.T) {
+		// The bare "yyyy-MM-dd" form always resolves to midnight, and RABA has
+		// no scheduled service at midnight — that would make this subtest
+		// vacuous (empty list either way). Use the "yyyy-MM-dd_HH-mm-ss" date-
+		// string form instead, at an in-service instant, so the date-string
+		// parsing path is verified against real, non-empty results.
+		dateStr := tripsForLocationTestTime.Format("2006-01-02_15-04-05")
+		targetMidnight := time.Date(tripsForLocationTestTime.Year(), tripsForLocationTestTime.Month(), tripsForLocationTestTime.Day(), 0, 0, 0, 0, tripsForLocationTestTime.Location())
+
 		url := tripsForLocationURL(1.0, 1.0, fmt.Sprintf("includeStatus=true&time=%s", dateStr))
 		resp, model := callAPIHandler[TripsForLocationResponse](t, api, url)
 
 		assert.Equal(t, http.StatusOK, resp.StatusCode)
-		assert.False(t, model.Data.OutOfRange)
-		assert.Empty(t, model.Data.List, "no service is scheduled at midnight")
+		require.NotEmpty(t, model.Data.List, "expected at least one trip entry to verify ServiceDate")
+		for _, entry := range model.Data.List {
+			assert.Equal(t, targetMidnight.UnixMilli(), entry.ServiceDate, "entry.ServiceDate should match midnight of the parsed date string")
+			if entry.Status != nil {
+				assert.Equal(t, targetMidnight.UnixMilli(), entry.Status.ServiceDate.UnixMilli())
+			}
+		}
 	})
 
 	t.Run("Query Time Far Outside Service Window", func(t *testing.T) {
-		// Querying at epoch millis for Jan 1, 2010, well before the RABA
-		// fixture's calendar coverage begins. No service is scheduled that
-		// day, so schedule-derived candidate selection correctly finds
-		// nothing.
-		const historicalMillis = int64(1262332800000)
+		// Querying a non-midnight instant on Jan 1, 2010, well before the RABA
+		// fixture's calendar coverage begins (a non-midnight time rules out
+		// "no service at midnight" as the reason for an empty result — this is
+		// specifically about missing calendar coverage that far back).
+		const historicalMillis = int64(1262356200000) // 2010-01-01 14:30:00 UTC
 		url := tripsForLocationURL(1.0, 1.0, fmt.Sprintf("time=%d", historicalMillis))
 		resp, model := callAPIHandler[TripsForLocationResponse](t, api, url)
 

--- a/internal/restapi/trips_for_location_handler_test.go
+++ b/internal/restapi/trips_for_location_handler_test.go
@@ -19,6 +19,21 @@ const (
 	tripsForLocationLon = -122.3917
 )
 
+// tripsForLocationTestTime is pinned to the moment RABA trip 28c61524 is
+// scheduled to be at stop 2000 (40.58317, -122.392586), a stop inside the
+// default trips-for-location test bounding box. Schedule-derived candidate
+// selection is time-aware, so tests that need a deterministic non-empty
+// result use this instant (or the equivalent epoch/date-string form) rather
+// than the real wall clock, which falls outside the RABA fixture's
+// 2024-2025 service calendar.
+var tripsForLocationTestTime = func() time.Time {
+	loc, err := time.LoadLocation("America/Los_Angeles")
+	if err != nil {
+		panic(err)
+	}
+	return time.Date(2025, 6, 15, 13, 50, 0, 0, loc)
+}()
+
 // tripsForLocationURL builds the query URL using the RABA-area lat/lon constants,
 // the given spans, and any extra "key=value" query params.
 func tripsForLocationURL(latSpan, lonSpan float64, extras ...string) string {
@@ -76,7 +91,7 @@ func TestTripsForLocationHandler_DifferentAreas(t *testing.T) {
 // per-aspect reference tests (stops/routes/agencies cross-references, combined IDs,
 // orphaned stops, direction populated) into one fetch + structured assertions.
 func TestTripsForLocationHandler_ReferencesAreConsistent(t *testing.T) {
-	api, cleanup := createTestApiWithRealTimeData(t, clock.RealClock{})
+	api, cleanup := createTestApiWithRealTimeData(t, clock.NewMockClock(tripsForLocationTestTime))
 	defer cleanup()
 
 	time.Sleep(500 * time.Millisecond)
@@ -159,7 +174,7 @@ func TestTripsForLocationHandler_ScheduleInclusion(t *testing.T) {
 }
 
 func TestTripsForLocationHandler_StatusInclusion(t *testing.T) {
-	api, cleanup := createTestApiWithRealTimeData(t, clock.RealClock{})
+	api, cleanup := createTestApiWithRealTimeData(t, clock.NewMockClock(tripsForLocationTestTime))
 	defer cleanup()
 
 	time.Sleep(500 * time.Millisecond)
@@ -273,7 +288,7 @@ func TestTripsForLocationHandler_ParseAndValidateRequest(t *testing.T) {
 }
 
 func TestTripsForLocationHandler_TripInclusion(t *testing.T) {
-	api, cleanup := createTestApiWithRealTimeData(t, clock.RealClock{})
+	api, cleanup := createTestApiWithRealTimeData(t, clock.NewMockClock(tripsForLocationTestTime))
 	defer cleanup()
 
 	time.Sleep(500 * time.Millisecond)
@@ -309,7 +324,7 @@ func TestTripsForLocationHandler_TripInclusion(t *testing.T) {
 }
 
 func TestTripsForLocationHandler_BoundsClamping(t *testing.T) {
-	api, cleanup := createTestApiWithRealTimeData(t, clock.RealClock{})
+	api, cleanup := createTestApiWithRealTimeData(t, clock.NewMockClock(tripsForLocationTestTime))
 	defer cleanup()
 
 	time.Sleep(500 * time.Millisecond)
@@ -336,7 +351,7 @@ func TestTripsForLocationHandler_BoundsClamping(t *testing.T) {
 }
 
 func TestTripsForLocationHandler_IncludeReferences(t *testing.T) {
-	api, cleanup := createTestApiWithRealTimeData(t, clock.RealClock{})
+	api, cleanup := createTestApiWithRealTimeData(t, clock.NewMockClock(tripsForLocationTestTime))
 	defer cleanup()
 
 	time.Sleep(500 * time.Millisecond)
@@ -375,11 +390,8 @@ func TestTripsForLocationHandler_TimeParameter(t *testing.T) {
 	time.Sleep(500 * time.Millisecond)
 
 	t.Run("Valid Time Parameter", func(t *testing.T) {
-		loc, err := time.LoadLocation("America/Los_Angeles")
-		require.NoError(t, err)
-
-		targetTime := time.Date(2025, 6, 15, 14, 30, 0, 0, loc)
-		targetMidnight := time.Date(targetTime.Year(), targetTime.Month(), targetTime.Day(), 0, 0, 0, 0, loc)
+		targetTime := tripsForLocationTestTime
+		targetMidnight := time.Date(targetTime.Year(), targetTime.Month(), targetTime.Day(), 0, 0, 0, 0, targetTime.Location())
 		url := tripsForLocationURL(1.0, 1.0, fmt.Sprintf("includeStatus=true&time=%d", targetTime.UnixMilli()))
 
 		resp, model := callAPIHandler[TripsForLocationResponse](t, api, url)
@@ -481,29 +493,25 @@ func TestTripsForLocationHandler_TimeParameterVariations(t *testing.T) {
 	time.Sleep(500 * time.Millisecond)
 
 	t.Run("Date String YYYY-MM-DD", func(t *testing.T) {
-		loc, err := time.LoadLocation("America/Los_Angeles")
-		require.NoError(t, err)
-
+		// A bare date resolves to midnight of that day. RABA has no scheduled
+		// service at midnight, so schedule-derived candidate selection
+		// correctly finds nothing — this exercises the date-string parsing
+		// path succeeding (200, not a validation error) rather than any
+		// particular trip being found.
 		dateStr := "2025-06-15"
-		parsedDate, err := time.ParseInLocation("2006-01-02", dateStr, loc)
-		require.NoError(t, err)
-		targetMidnight := time.Date(parsedDate.Year(), parsedDate.Month(), parsedDate.Day(), 0, 0, 0, 0, loc)
-
 		url := tripsForLocationURL(1.0, 1.0, fmt.Sprintf("includeStatus=true&time=%s", dateStr))
 		resp, model := callAPIHandler[TripsForLocationResponse](t, api, url)
 
 		assert.Equal(t, http.StatusOK, resp.StatusCode)
-		require.NotEmpty(t, model.Data.List, "expected at least one trip entry to verify ServiceDate")
-		for _, entry := range model.Data.List {
-			assert.Equal(t, targetMidnight.UnixMilli(), entry.ServiceDate, "entry.ServiceDate should match midnight of the requested date string")
-			if entry.Status != nil {
-				assert.Equal(t, targetMidnight.UnixMilli(), entry.Status.ServiceDate.UnixMilli())
-			}
-		}
+		assert.False(t, model.Data.OutOfRange)
+		assert.Empty(t, model.Data.List, "no service is scheduled at midnight")
 	})
 
 	t.Run("Query Time Far Outside Service Window", func(t *testing.T) {
-		// Querying at epoch millis for Jan 1, 2010. ServiceDate on all returned active trips must reflect this historical timestamp.
+		// Querying at epoch millis for Jan 1, 2010, well before the RABA
+		// fixture's calendar coverage begins. No service is scheduled that
+		// day, so schedule-derived candidate selection correctly finds
+		// nothing.
 		const historicalMillis = int64(1262332800000)
 		url := tripsForLocationURL(1.0, 1.0, fmt.Sprintf("time=%d", historicalMillis))
 		resp, model := callAPIHandler[TripsForLocationResponse](t, api, url)
@@ -511,25 +519,32 @@ func TestTripsForLocationHandler_TimeParameterVariations(t *testing.T) {
 		assert.Equal(t, http.StatusOK, resp.StatusCode)
 		assert.Equal(t, http.StatusOK, model.Code)
 		assert.False(t, model.Data.OutOfRange)
-		require.NotEmpty(t, model.Data.List, "expected at least one entry to verify ServiceDate equality")
-		for _, entry := range model.Data.List {
-			assert.Equal(t, historicalMillis, entry.ServiceDate, "entry.ServiceDate should match the historical timestamp parameter")
-		}
+		assert.Empty(t, model.Data.List, "no service is scheduled that far outside the fixture's calendar coverage")
 	})
 }
 
+// TestTripsForLocationHandler_ZeroVehiclesOrStaticOnly verifies the spec-required
+// schedule fallback (Main Success Scenario step 5): with no real-time vehicle
+// positions at all, candidate trips are still found from the static schedule,
+// with a schedule-extrapolated position and predicted=false.
 func TestTripsForLocationHandler_ZeroVehiclesOrStaticOnly(t *testing.T) {
 	// Create API with only static GTFS data (no real-time vehicles injected)
 	api := createTestApi(t)
 	defer api.Shutdown()
 
-	url := tripsForLocationURL(1.0, 1.0, "includeSchedule=true")
+	url := tripsForLocationURL(1.0, 1.0, fmt.Sprintf("includeSchedule=true&includeStatus=true&time=%d", tripsForLocationTestTime.UnixMilli()))
 	resp, model := callAPIHandler[TripsForLocationResponse](t, api, url)
 
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, http.StatusOK, model.Code)
 	assert.False(t, model.Data.OutOfRange)
-	assert.Empty(t, model.Data.List, "without real-time vehicle positions, active trips list should be empty per OBA real-time behavior")
+	require.NotEmpty(t, model.Data.List, "schedule-derived candidates should be found even without real-time vehicle positions")
+	for _, entry := range model.Data.List {
+		if assert.NotNil(t, entry.Status, "status should be present when includeStatus=true") {
+			assert.False(t, entry.Status.Predicted, "position is schedule-derived, not real-time, without a vehicle")
+			assert.NotZero(t, entry.Status.Position, "schedule-derived position should not be the zero value")
+		}
+	}
 	assert.NotNil(t, model.Data.References.Stops, "references slice should not be nil even when empty")
 	assert.NotNil(t, model.Data.References.Routes, "references slice should not be nil even when empty")
 	assert.NotNil(t, model.Data.References.Agencies, "references slice should not be nil even when empty")
@@ -537,7 +552,7 @@ func TestTripsForLocationHandler_ZeroVehiclesOrStaticOnly(t *testing.T) {
 }
 
 func TestTripsForLocationHandler_IncludeTripFalseWithReferencesTrue(t *testing.T) {
-	api, cleanup := createTestApiWithRealTimeData(t, clock.RealClock{})
+	api, cleanup := createTestApiWithRealTimeData(t, clock.NewMockClock(tripsForLocationTestTime))
 	defer cleanup()
 
 	time.Sleep(500 * time.Millisecond)
@@ -554,7 +569,7 @@ func TestTripsForLocationHandler_IncludeTripFalseWithReferencesTrue(t *testing.T
 }
 
 func TestTripsForLocationHandler_ScheduleDetailsAndDistances(t *testing.T) {
-	api, cleanup := createTestApiWithRealTimeData(t, clock.RealClock{})
+	api, cleanup := createTestApiWithRealTimeData(t, clock.NewMockClock(tripsForLocationTestTime))
 	defer cleanup()
 
 	time.Sleep(500 * time.Millisecond)

--- a/internal/restapi/trips_for_route_handler.go
+++ b/internal/restapi/trips_for_route_handler.go
@@ -51,142 +51,22 @@ func (api *RestAPI) tripsForRouteHandler(w http.ResponseWriter, r *http.Request)
 	}
 
 	timeParam := r.URL.Query().Get("time")
-	formattedDate, currentTime, fieldErrors, success := utils.ParseTimeParameter(timeParam, currentLocation)
+	_, currentTime, fieldErrors, success := utils.ParseTimeParameter(timeParam, currentLocation)
 	if !success {
 		api.validationErrorResponse(w, r, fieldErrors)
 		return
 	}
 
-	serviceIDs, err := api.GtfsManager.GtfsDB.Queries.GetActiveServiceIDsForDate(ctx, formattedDate)
+	windows, err := api.serviceDayWindows(ctx, currentTime)
 	if err != nil {
 		api.serverErrorResponse(w, r, err)
 		return
 	}
 
-	// Time since midnight of the service day, as a duration.
-	serviceDayMidnight := time.Date(currentTime.Year(), currentTime.Month(), currentTime.Day(), 0, 0, 0, 0, currentTime.Location())
-	currentSinceMidnight := max(currentTime.Sub(serviceDayMidnight), 0)
-
-	// Check the previous day's service for trips running past midnight.
-	// GTFS allows departure times > 24:00:00 (e.g., 25:30:00 = 1:30 AM next day).
-	// These trips belong to yesterday's service but are still active now.
-	// TODO: We should add config for runningLateWindow and runningEarlyWindow like Java OBA
-	// source:https://groups.google.com/g/onebusaway-developers/c/j-G-1UyfbXI/m/J-Su3BArKW0J
-	const (
-		runningLate  = 30 * time.Minute // runningLateWindow
-		runningEarly = 10 * time.Minute // runningEarlyWindow
-	)
-	prevDay := currentTime.AddDate(0, 0, -1)
-	prevFormattedDate := prevDay.Format("20060102")
-	prevServiceIDs, err := api.GtfsManager.GtfsDB.Queries.GetActiveServiceIDsForDate(ctx, prevFormattedDate)
-	if err != nil {
-		api.Logger.Warn("trips-for-route: failed to fetch previous-day service IDs", "date", prevFormattedDate, "error", err)
-		prevServiceIDs = nil
-	}
-	// I'm confused by adding 24 hours to get the previous day here, but that's the existing behavior.
-	prevDaySinceMidnight := currentSinceMidnight + (24 * time.Hour)
-
-	indexIDs, err := api.GtfsManager.GtfsDB.Queries.GetBlockTripIndexIDsForRoute(ctx, gtfsdb.GetBlockTripIndexIDsForRouteParams{
-		RouteID:    routeID,
-		ServiceIds: serviceIDs,
-	})
+	allLinkedBlocks, nullBlockTrips, err := api.blockCandidatesForRoute(ctx, routeID, windows)
 	if err != nil {
 		api.serverErrorResponse(w, r, err)
 		return
-	}
-
-	// Match Java OBA: look back 30 min (catch late vehicles) and ahead 10 min (catch early vehicles).
-	timeRangeStart := currentSinceMidnight - runningLate
-	timeRangeEnd := currentSinceMidnight + runningEarly
-
-	layoverBlocks, err := api.GtfsManager.GtfsDB.Queries.GetActiveLayoverBlockIDsForRoute(ctx, gtfsdb.GetActiveLayoverBlockIDsForRouteParams{
-		RouteID:        routeID,
-		ServiceIds:     serviceIDs,
-		TimeRangeStart: timeRangeStart.Nanoseconds(),
-		TimeRangeEnd:   timeRangeEnd.Nanoseconds(),
-	})
-	if err != nil {
-		api.Logger.Warn("trips-for-route: failed to fetch layover blocks", "route_id", routeID, "error", err)
-		layoverBlocks = nil
-	}
-
-	allLinkedBlocks := make(map[string]bool)
-
-	if len(indexIDs) > 0 {
-		blocksFromIndices, err := api.GtfsManager.GtfsDB.Queries.GetBlocksForBlockTripIndexIDs(ctx, gtfsdb.GetBlocksForBlockTripIndexIDsParams{
-			FromTime:   sql.NullInt64{Int64: timeRangeStart.Nanoseconds(), Valid: true},
-			ToTime:     sql.NullInt64{Int64: timeRangeEnd.Nanoseconds(), Valid: true},
-			IndexIds:   indexIDs,
-			ServiceIds: serviceIDs,
-		})
-		if err != nil {
-			api.serverErrorResponse(w, r, err)
-			return
-		}
-
-		for _, b := range blocksFromIndices {
-			if b.Valid {
-				allLinkedBlocks[b.String] = true
-			}
-		}
-	}
-
-	for _, blockID := range layoverBlocks {
-		allLinkedBlocks[blockID] = true
-	}
-
-	// Find blocks from previous day's service (for trips running past midnight).
-	if len(prevServiceIDs) > 0 {
-		prevIndexIDs, err := api.GtfsManager.GtfsDB.Queries.GetBlockTripIndexIDsForRoute(ctx, gtfsdb.GetBlockTripIndexIDsForRouteParams{
-			RouteID:    routeID,
-			ServiceIds: prevServiceIDs,
-		})
-		if err != nil {
-			api.Logger.Warn("trips-for-route: failed to fetch previous-day block index IDs", "error", err)
-		} else if len(prevIndexIDs) > 0 {
-			prevFromTime := prevDaySinceMidnight + timeRangeStart - currentSinceMidnight
-			prevToTime := prevDaySinceMidnight + timeRangeEnd - currentSinceMidnight
-			prevBlocks, err := api.GtfsManager.GtfsDB.Queries.GetBlocksForBlockTripIndexIDs(ctx, gtfsdb.GetBlocksForBlockTripIndexIDsParams{
-				FromTime:   sql.NullInt64{Int64: prevFromTime.Nanoseconds(), Valid: true},
-				ToTime:     sql.NullInt64{Int64: prevToTime.Nanoseconds(), Valid: true},
-				IndexIds:   prevIndexIDs,
-				ServiceIds: prevServiceIDs,
-			})
-			if err != nil {
-				api.Logger.Warn("trips-for-route: failed to fetch previous-day blocks", "error", err)
-			} else {
-				for _, b := range prevBlocks {
-					if b.Valid {
-						allLinkedBlocks[b.String] = true
-					}
-				}
-			}
-		}
-	}
-
-	nullBlockTrips, err := api.GtfsManager.GtfsDB.Queries.GetActiveTripsWithNullBlockForRoute(ctx, gtfsdb.GetActiveTripsWithNullBlockForRouteParams{
-		RouteID:        routeID,
-		ServiceIds:     serviceIDs,
-		TimeRangeStart: sql.NullInt64{Int64: timeRangeStart.Nanoseconds(), Valid: true},
-		TimeRangeEnd:   sql.NullInt64{Int64: timeRangeEnd.Nanoseconds(), Valid: true},
-	})
-	if err != nil {
-		api.Logger.Warn("trips-for-route: failed to fetch null-block trips", "route_id", routeID, "error", err)
-		nullBlockTrips = nil
-	}
-
-	if len(prevServiceIDs) > 0 {
-		prevNullBlockTrips, err := api.GtfsManager.GtfsDB.Queries.GetActiveTripsWithNullBlockForRoute(ctx, gtfsdb.GetActiveTripsWithNullBlockForRouteParams{
-			RouteID:        routeID,
-			ServiceIds:     prevServiceIDs,
-			TimeRangeStart: sql.NullInt64{Int64: (prevDaySinceMidnight + timeRangeStart - currentSinceMidnight).Nanoseconds(), Valid: true},
-			TimeRangeEnd:   sql.NullInt64{Int64: (prevDaySinceMidnight + timeRangeEnd - currentSinceMidnight).Nanoseconds(), Valid: true},
-		})
-		if err != nil {
-			api.Logger.Warn("trips-for-route: failed to fetch previous-day null-block trips", "error", err)
-		} else {
-			nullBlockTrips = append(nullBlockTrips, prevNullBlockTrips...)
-		}
 	}
 
 	if len(allLinkedBlocks) == 0 && len(nullBlockTrips) == 0 {
@@ -201,66 +81,11 @@ func (api *RestAPI) tripsForRouteHandler(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	var activeTrips []string
-
-	type serviceDayEntry struct {
-		serviceIDs    []string
-		sinceMidnight time.Duration
+	activeTrips := api.resolveActiveTrips(ctx, allLinkedBlocks, nullBlockTrips, windows)
+	if ctx.Err() != nil {
+		api.clientCanceledResponse(w, r, ctx.Err())
+		return
 	}
-	serviceDays := []serviceDayEntry{
-		{serviceIDs: serviceIDs, sinceMidnight: currentSinceMidnight},
-	}
-	if len(prevServiceIDs) > 0 {
-		serviceDays = append(serviceDays, serviceDayEntry{
-			serviceIDs:    prevServiceIDs,
-			sinceMidnight: prevDaySinceMidnight,
-		})
-	}
-
-	for blockID := range allLinkedBlocks {
-		if ctx.Err() != nil {
-			api.clientCanceledResponse(w, r, ctx.Err())
-			return
-		}
-
-		blockIDNullStr := nulls.String(blockID)
-
-		for _, sd := range serviceDays {
-			tripsInBlock, err := api.GtfsManager.GtfsDB.Queries.GetTripsInBlock(ctx, gtfsdb.GetTripsInBlockParams{
-				BlockID:    blockIDNullStr,
-				ServiceIds: sd.serviceIDs,
-			})
-			if err != nil {
-				api.Logger.Warn("trips-for-route: failed to fetch trips in block", "block_id", blockID, "error", err)
-				continue
-			}
-			if len(tripsInBlock) == 0 {
-				continue
-			}
-
-			activeTrip, err := api.GtfsManager.GtfsDB.Queries.GetActiveTripInBlockAtTime(ctx, gtfsdb.GetActiveTripInBlockAtTimeParams{
-				BlockID:     blockIDNullStr,
-				ServiceIds:  sd.serviceIDs,
-				CurrentTime: sql.NullInt64{Int64: sd.sinceMidnight.Nanoseconds(), Valid: true}})
-			if err != nil && !errors.Is(err, sql.ErrNoRows) {
-				api.Logger.Warn("trips-for-route: failed to get active trip in block", "block_id", blockID, "error", err)
-				continue
-			}
-			if errors.Is(err, sql.ErrNoRows) {
-				// No trip in this block is currently running at the requested time.
-				// Java OBA only returns blocks with a currently-running trip (see
-				// BlockStatusServiceImpl.computeLocations which adds scheduled locations
-				// only when isInService()). Skip rather than picking a "best candidate"
-				// upcoming/past trip that isn't actually running.
-				continue
-			}
-
-			activeTrips = append(activeTrips, activeTrip)
-			break
-		}
-	}
-
-	activeTrips = append(activeTrips, nullBlockTrips...)
 
 	tripIDsSet := make(map[string]bool)
 	for _, id := range activeTrips {

--- a/internal/restapi/trips_for_route_handler.go
+++ b/internal/restapi/trips_for_route_handler.go
@@ -81,7 +81,7 @@ func (api *RestAPI) tripsForRouteHandler(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	activeTrips := api.resolveActiveTrips(ctx, allLinkedBlocks, nullBlockTrips, windows)
+	activeTrips, _ := api.resolveActiveTrips(ctx, allLinkedBlocks, nullBlockTrips, windows)
 	if ctx.Err() != nil {
 		api.clientCanceledResponse(w, r, ctx.Err())
 		return

--- a/internal/restapi/trips_helper.go
+++ b/internal/restapi/trips_helper.go
@@ -1209,25 +1209,34 @@ func scheduledPositionAtTime(
 	querySeconds := utils.CalculateSecondsSinceServiceDate(queryTime, serviceDate)
 
 	if querySeconds <= utils.NanosToSeconds(stopTimes[0].ArrivalTime) {
-		firstCoord, ok := stopCoords[stopTimes[0].StopID]
-		if !ok {
-			return models.Location{}, false
-		}
-		return models.Location{Lat: firstCoord.lat, Lon: firstCoord.lon}, true
+		return stopLocation(stopCoords, stopTimes[0].StopID)
 	}
 
+	if pos, ok, found := positionWithinSchedule(stopTimes, stopCoords, querySeconds); found {
+		return pos, ok
+	}
+
+	return stopLocation(stopCoords, stopTimes[len(stopTimes)-1].StopID)
+}
+
+// positionWithinSchedule scans the stop-time pairs for the one containing
+// querySeconds: either dwelling at a stop, or travelling between two.
+//
+// found reports whether querySeconds fell inside an interior window at all:
+//   - dwelling at a stop, coordinate known: (pos, true, true)
+//   - dwelling at a stop, coordinate unknown: (zero, false, true) — the
+//     time is unambiguous, so there's nothing better to fall back to
+//   - travelling, both endpoint coordinates known: (pos, true, true)
+//   - travelling with a missing endpoint coordinate, or no interval
+//     matched at all: (zero, false, false) — the caller falls back to the
+//     trip's last stop
+func positionWithinSchedule(stopTimes []gtfsdb.StopTime, stopCoords map[string]struct{ lat, lon float64 }, querySeconds int64) (pos models.Location, ok bool, found bool) {
 	for i := 0; i < len(stopTimes)-1; i++ {
-		// Dwelling at stop i (between its arrival and departure): the vehicle
-		// is sitting at that stop, not travelling — return its coordinate
-		// directly rather than falling through to the next travel interval.
 		arrival := utils.NanosToSeconds(stopTimes[i].ArrivalTime)
 		departure := utils.NanosToSeconds(stopTimes[i].DepartureTime)
 		if querySeconds >= arrival && querySeconds <= departure {
-			coord, ok := stopCoords[stopTimes[i].StopID]
-			if !ok {
-				return models.Location{}, false
-			}
-			return models.Location{Lat: coord.lat, Lon: coord.lon}, true
+			pos, ok = stopLocation(stopCoords, stopTimes[i].StopID)
+			return pos, ok, true
 		}
 
 		fromCoord, fromOK := stopCoords[stopTimes[i].StopID]
@@ -1238,24 +1247,29 @@ func scheduledPositionAtTime(
 
 		fromTime := departure
 		toTime := utils.NanosToSeconds(stopTimes[i+1].ArrivalTime)
-
-		if querySeconds >= fromTime && querySeconds <= toTime {
-			if toTime == fromTime {
-				return models.Location{Lat: fromCoord.lat, Lon: fromCoord.lon}, true
-			}
-			ratio := float64(querySeconds-fromTime) / float64(toTime-fromTime)
-			return models.Location{
-				Lat: fromCoord.lat + ratio*(toCoord.lat-fromCoord.lat),
-				Lon: fromCoord.lon + ratio*(toCoord.lon-fromCoord.lon),
-			}, true
+		if querySeconds < fromTime || querySeconds > toTime {
+			continue
 		}
+		if toTime == fromTime {
+			return models.Location{Lat: fromCoord.lat, Lon: fromCoord.lon}, true, true
+		}
+		ratio := float64(querySeconds-fromTime) / float64(toTime-fromTime)
+		return models.Location{
+			Lat: fromCoord.lat + ratio*(toCoord.lat-fromCoord.lat),
+			Lon: fromCoord.lon + ratio*(toCoord.lon-fromCoord.lon),
+		}, true, true
 	}
 
-	lastCoord, ok := stopCoords[stopTimes[len(stopTimes)-1].StopID]
+	return models.Location{}, false, false
+}
+
+// stopLocation looks up a stop's coordinate, reporting false if unknown.
+func stopLocation(stopCoords map[string]struct{ lat, lon float64 }, stopID string) (models.Location, bool) {
+	coord, ok := stopCoords[stopID]
 	if !ok {
 		return models.Location{}, false
 	}
-	return models.Location{Lat: lastCoord.lat, Lon: lastCoord.lon}, true
+	return models.Location{Lat: coord.lat, Lon: coord.lon}, true
 }
 
 // inferOrientationFromShape computes the OBA orientation (degrees, 0=East, 90=North)

--- a/internal/restapi/trips_helper.go
+++ b/internal/restapi/trips_helper.go
@@ -161,9 +161,10 @@ func (api *RestAPI) BuildTripStatus(
 	}
 
 	// No GPS to work with: extrapolate the vehicle's position from the static
-	// schedule so status.Position isn't left at its zero value. Predicted is
-	// already false here (set above), matching the spec's predicted=false for
-	// schedule-derived positions.
+	// schedule so status.Position isn't left at its zero value. Predicted may
+	// still be true here (set above) if a realtime trip update carries a
+	// schedule deviation with no vehicle position — this only fills in the
+	// position, it doesn't change predicted/scheduled.
 	if (vehicle == nil || vehicle.Position == nil) && len(stopTimes) > 0 {
 		if stopCoords, coordsErr := api.stopCoordsForStopTimes(ctx, stopTimes); coordsErr != nil {
 			slog.Warn("BuildTripStatus: failed to fetch stop coordinates for schedule-derived position",
@@ -1207,22 +1208,35 @@ func scheduledPositionAtTime(
 
 	querySeconds := utils.CalculateSecondsSinceServiceDate(queryTime, serviceDate)
 
-	firstCoord, ok := stopCoords[stopTimes[0].StopID]
-	if !ok {
-		return models.Location{}, false
-	}
 	if querySeconds <= utils.NanosToSeconds(stopTimes[0].ArrivalTime) {
+		firstCoord, ok := stopCoords[stopTimes[0].StopID]
+		if !ok {
+			return models.Location{}, false
+		}
 		return models.Location{Lat: firstCoord.lat, Lon: firstCoord.lon}, true
 	}
 
 	for i := 0; i < len(stopTimes)-1; i++ {
+		// Dwelling at stop i (between its arrival and departure): the vehicle
+		// is sitting at that stop, not travelling — return its coordinate
+		// directly rather than falling through to the next travel interval.
+		arrival := utils.NanosToSeconds(stopTimes[i].ArrivalTime)
+		departure := utils.NanosToSeconds(stopTimes[i].DepartureTime)
+		if querySeconds >= arrival && querySeconds <= departure {
+			coord, ok := stopCoords[stopTimes[i].StopID]
+			if !ok {
+				return models.Location{}, false
+			}
+			return models.Location{Lat: coord.lat, Lon: coord.lon}, true
+		}
+
 		fromCoord, fromOK := stopCoords[stopTimes[i].StopID]
 		toCoord, toOK := stopCoords[stopTimes[i+1].StopID]
 		if !fromOK || !toOK {
 			continue
 		}
 
-		fromTime := utils.NanosToSeconds(stopTimes[i].DepartureTime)
+		fromTime := departure
 		toTime := utils.NanosToSeconds(stopTimes[i+1].ArrivalTime)
 
 		if querySeconds >= fromTime && querySeconds <= toTime {

--- a/internal/restapi/trips_helper.go
+++ b/internal/restapi/trips_helper.go
@@ -160,6 +160,20 @@ func (api *RestAPI) BuildTripStatus(
 		api.fillStopsFromSchedule(ctx, status, dbTripID, currentTime, serviceDate, agencyID, stopTimes)
 	}
 
+	// No GPS to work with: extrapolate the vehicle's position from the static
+	// schedule so status.Position isn't left at its zero value. Predicted is
+	// already false here (set above), matching the spec's predicted=false for
+	// schedule-derived positions.
+	if (vehicle == nil || vehicle.Position == nil) && len(stopTimes) > 0 {
+		if stopCoords, coordsErr := api.stopCoordsForStopTimes(ctx, stopTimes); coordsErr != nil {
+			slog.Warn("BuildTripStatus: failed to fetch stop coordinates for schedule-derived position",
+				slog.String("trip_id", dbTripID),
+				slog.String("error", coordsErr.Error()))
+		} else if pos, ok := scheduledPositionAtTime(stopTimes, stopCoords, currentTime, serviceDate); ok {
+			status.Position = pos
+		}
+	}
+
 	shapeRows, shapeErr := api.GtfsManager.GtfsDB.Queries.GetShapePointsByTripID(ctx, dbTripID)
 	if shapeErr != nil {
 		slog.Warn("buildTripStatusCore: failed to get shape points",
@@ -1151,6 +1165,83 @@ func interpolateDistance(cumulativeDistances []float64, segmentLength float64, i
 		cumulativeDistance += segmentLength * projectionRatio
 	}
 	return cumulativeDistance
+}
+
+// stopCoordsForStopTimes batch-fetches the stop coordinates referenced by stopTimes.
+func (api *RestAPI) stopCoordsForStopTimes(ctx context.Context, stopTimes []gtfsdb.StopTime) (map[string]struct{ lat, lon float64 }, error) {
+	stopIDs := make([]string, len(stopTimes))
+	for i, st := range stopTimes {
+		stopIDs[i] = st.StopID
+	}
+	stops, err := api.GtfsManager.GtfsDB.Queries.GetStopsByIDs(ctx, stopIDs)
+	if err != nil {
+		return nil, err
+	}
+	stopCoords := make(map[string]struct{ lat, lon float64 }, len(stops))
+	for _, s := range stops {
+		stopCoords[s.ID] = struct{ lat, lon float64 }{lat: s.Lat, lon: s.Lon}
+	}
+	return stopCoords, nil
+}
+
+// scheduledPositionAtTime returns the position a vehicle running exactly on
+// schedule would occupy at queryTime, linearly interpolated between the two
+// surrounding stops' coordinates. Returns false when stopTimes is empty or
+// none of its stops have known coordinates.
+//
+// Deliberately interpolates straight-line between stop coordinates rather
+// than projecting along the trip's shape: the corner-cutting error is
+// negligible against a bounding box measured in kilometres, and it works on
+// trips or fixtures with no shape data at all. If more precision is ever
+// needed, reuse preCalculateCumulativeDistances +
+// interpolateDistanceAtScheduledTime to get a distance, then walk the shape
+// points to convert that distance back to a coordinate.
+func scheduledPositionAtTime(
+	stopTimes []gtfsdb.StopTime,
+	stopCoords map[string]struct{ lat, lon float64 },
+	queryTime, serviceDate time.Time,
+) (models.Location, bool) {
+	if len(stopTimes) == 0 {
+		return models.Location{}, false
+	}
+
+	querySeconds := utils.CalculateSecondsSinceServiceDate(queryTime, serviceDate)
+
+	firstCoord, ok := stopCoords[stopTimes[0].StopID]
+	if !ok {
+		return models.Location{}, false
+	}
+	if querySeconds <= utils.NanosToSeconds(stopTimes[0].ArrivalTime) {
+		return models.Location{Lat: firstCoord.lat, Lon: firstCoord.lon}, true
+	}
+
+	for i := 0; i < len(stopTimes)-1; i++ {
+		fromCoord, fromOK := stopCoords[stopTimes[i].StopID]
+		toCoord, toOK := stopCoords[stopTimes[i+1].StopID]
+		if !fromOK || !toOK {
+			continue
+		}
+
+		fromTime := utils.NanosToSeconds(stopTimes[i].DepartureTime)
+		toTime := utils.NanosToSeconds(stopTimes[i+1].ArrivalTime)
+
+		if querySeconds >= fromTime && querySeconds <= toTime {
+			if toTime == fromTime {
+				return models.Location{Lat: fromCoord.lat, Lon: fromCoord.lon}, true
+			}
+			ratio := float64(querySeconds-fromTime) / float64(toTime-fromTime)
+			return models.Location{
+				Lat: fromCoord.lat + ratio*(toCoord.lat-fromCoord.lat),
+				Lon: fromCoord.lon + ratio*(toCoord.lon-fromCoord.lon),
+			}, true
+		}
+	}
+
+	lastCoord, ok := stopCoords[stopTimes[len(stopTimes)-1].StopID]
+	if !ok {
+		return models.Location{}, false
+	}
+	return models.Location{Lat: lastCoord.lat, Lon: lastCoord.lon}, true
 }
 
 // inferOrientationFromShape computes the OBA orientation (degrees, 0=East, 90=North)

--- a/internal/restapi/trips_helper_test.go
+++ b/internal/restapi/trips_helper_test.go
@@ -2056,3 +2056,99 @@ func testTripIDs(trips []gtfsdb.Trip) []string {
 	}
 	return ids
 }
+
+func TestScheduledPositionAtTime(t *testing.T) {
+	serviceDate := time.Date(2025, 6, 15, 0, 0, 0, 0, time.UTC)
+
+	// s1: arrives/departs 08:00:00. s2: arrives 08:10:00, departs 08:12:00
+	// (a two-minute dwell). s3: arrives/departs 08:20:00.
+	stopTimes := []gtfsdb.StopTime{
+		{StopID: "s1", ArrivalTime: secondsToNanos(8 * 3600), DepartureTime: secondsToNanos(8 * 3600)},
+		{StopID: "s2", ArrivalTime: secondsToNanos(8*3600 + 600), DepartureTime: secondsToNanos(8*3600 + 720)},
+		{StopID: "s3", ArrivalTime: secondsToNanos(8*3600 + 1200), DepartureTime: secondsToNanos(8*3600 + 1200)},
+	}
+	coords := map[string]struct{ lat, lon float64 }{
+		"s1": {lat: 40.0, lon: -122.0},
+		"s2": {lat: 40.1, lon: -122.1},
+		"s3": {lat: 40.2, lon: -122.2},
+	}
+
+	tests := []struct {
+		name        string
+		queryTime   time.Time
+		stopCoords  map[string]struct{ lat, lon float64 }
+		wantOK      bool
+		wantLat     float64
+		wantLon     float64
+		description string
+	}{
+		{
+			name:        "before first arrival snaps to first stop",
+			queryTime:   serviceDate.Add(7*time.Hour + 55*time.Minute),
+			stopCoords:  coords,
+			wantOK:      true,
+			wantLat:     40.0,
+			wantLon:     -122.0,
+			description: "query before the trip starts should return the first stop's position",
+		},
+		{
+			name:        "interpolates midway through a travel interval",
+			queryTime:   serviceDate.Add(8*time.Hour + 5*time.Minute), // halfway between s1 departure (8:00) and s2 arrival (8:10)
+			stopCoords:  coords,
+			wantOK:      true,
+			wantLat:     40.05,
+			wantLon:     -122.05,
+			description: "query midway between two stops should linearly interpolate",
+		},
+		{
+			name:        "dwelling at an intermediate stop returns that stop's position",
+			queryTime:   serviceDate.Add(8*time.Hour + 11*time.Minute), // between s2 arrival (8:10) and departure (8:12)
+			stopCoords:  coords,
+			wantOK:      true,
+			wantLat:     40.1,
+			wantLon:     -122.1,
+			description: "a query during a stop's dwell time must not fall through to the terminus",
+		},
+		{
+			name:        "exactly at a stop whose arrival equals its departure",
+			queryTime:   serviceDate.Add(8 * time.Hour), // exactly at s1, whose arrival == departure
+			stopCoords:  coords,
+			wantOK:      true,
+			wantLat:     40.0,
+			wantLon:     -122.0,
+			description: "a zero-length dwell must not divide by zero or fall through to the wrong stop",
+		},
+		{
+			name:        "after the last stop snaps to the last stop",
+			queryTime:   serviceDate.Add(9 * time.Hour),
+			stopCoords:  coords,
+			wantOK:      true,
+			wantLat:     40.2,
+			wantLon:     -122.2,
+			description: "query after the trip ends should return the last stop's position",
+		},
+		{
+			name:      "missing first-stop coordinate does not block an interior query",
+			queryTime: serviceDate.Add(8*time.Hour + 16*time.Minute), // halfway between s2 departure (8:12) and s3 arrival (8:20)
+			stopCoords: map[string]struct{ lat, lon float64 }{
+				"s2": {lat: 40.1, lon: -122.1},
+				"s3": {lat: 40.2, lon: -122.2},
+			},
+			wantOK:      true,
+			wantLat:     40.15,
+			wantLon:     -122.15,
+			description: "s1's coordinate is unknown, but the query falls in the s2-s3 interval, which doesn't need it",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pos, ok := scheduledPositionAtTime(stopTimes, tt.stopCoords, tt.queryTime, serviceDate)
+			require.Equal(t, tt.wantOK, ok, tt.description)
+			if tt.wantOK {
+				assert.InDelta(t, tt.wantLat, pos.Lat, 1e-9, tt.description)
+				assert.InDelta(t, tt.wantLon, pos.Lon, 1e-9, tt.description)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #1168.

trips-for-location picked candidate trips from the live GTFS-RT
vehicle list, so an agency with no real-time feed always got an
empty list, and the `time` parameter was ignored during candidate
selection entirely.

Candidates now come from the schedule (block instances active in
the query window, scoped by the bbox's stops), with real-time GPS
overlaid when available and a schedule-extrapolated position
(`predicted=false`) otherwise, per spec steps 4-6.

**Commits:**
1. Extract shared block candidate helpers from trips-for-route (no behavior change)
2. Add stop-scoped block candidate queries
3. Derive vehicle position from schedule when no realtime vehicle exists
4. Select trips-for-location candidates from the schedule + fix affected tests

**Not doing:** buffering historical vehicle positions (per the issue's
suggestion) — legacy OBA doesn't do this for this path, and it wouldn't
fix the no-feed case.

**Known limitation:** candidate scoping is stop-based, not shape-based,
so a vehicle crossing the bbox mid-way between two distant stops could
be missed. The final bbox check is still a strict geometric filter, so
this only affects completeness, not correctness of returned results.

**Test plan:** `go vet` (both tags), `make test`, `go fmt` all pass.