### PR TITLE
fix: thread api.Clock into ParseTimeParameter and add coverage for time edges

### DIFF
--- a/internal/restapi/stops_for_route_handler.go
+++ b/internal/restapi/stops_for_route_handler.go
@@ -48,7 +48,7 @@ func (api *RestAPI) stopsForRouteHandler(w http.ResponseWriter, r *http.Request)
 
 	var serviceIDs []string
 	if filterByDate {
-		formattedDate, _, fieldErrors, success := utils.ParseTimeParameter(timeParam, currentLocation)
+		formattedDate, _, fieldErrors, success := utils.ParseTimeParameter(timeParam, currentLocation, api.Clock)
 		if !success {
 			api.validationErrorResponse(w, r, fieldErrors)
 			return

--- a/internal/restapi/trips_for_location_handler.go
+++ b/internal/restapi/trips_for_location_handler.go
@@ -202,7 +202,7 @@ func (api *RestAPI) resolveCurrentTime(timeParam string, currentLocation *time.L
 	if timeParam == "" {
 		return api.Clock.Now().In(currentLocation), nil
 	}
-	_, currentTime, timeFieldErrors, _ := utils.ParseTimeParameter(timeParam, currentLocation)
+	_, currentTime, timeFieldErrors, _ := utils.ParseTimeParameter(timeParam, currentLocation, api.Clock)
 	return currentTime, timeFieldErrors
 }
 

--- a/internal/restapi/trips_for_route_handler.go
+++ b/internal/restapi/trips_for_route_handler.go
@@ -53,7 +53,7 @@ func (api *RestAPI) tripsForRouteHandler(w http.ResponseWriter, r *http.Request)
 	}
 
 	timeParam := r.URL.Query().Get("time")
-	formattedDate, currentTime, fieldErrors, success := utils.ParseTimeParameter(timeParam, currentLocation)
+	formattedDate, currentTime, fieldErrors, success := utils.ParseTimeParameter(timeParam, currentLocation, api.Clock)
 	if !success {
 		api.validationErrorResponse(w, r, fieldErrors)
 		return

--- a/internal/restapi/trips_for_route_handler_test.go
+++ b/internal/restapi/trips_for_route_handler_test.go
@@ -337,8 +337,7 @@ func TestTripsForRouteHandler_DifferentRoutes(t *testing.T) {
 		},
 	}
 
-	// ParseTimeParameter ignores api.Clock when no time= is given, so pass it explicitly
-	// to pin the handler's time window to our fixture.
+	// Pass time explicitly to pin the handler's time window to our fixture.
 	timeMs := tripsForRouteTestClock.UnixMilli()
 
 	for _, tt := range tests {
@@ -419,7 +418,7 @@ func TestTripsForRouteHandler_DifferentRoutes(t *testing.T) {
 // TestTripsForRouteHandler_TimeOmitted verifies that omitting the time parameter
 // correctly falls back to the injected api.Clock to resolve active trips.
 func TestTripsForRouteHandler_TimeOmitted(t *testing.T) {
-	api := createTestApiWithTripsForRouteFixture(t, clock.NewMockClock(tripsForRouteTestClock))
+	api := createTestApiWithGTFSFixture(t, clock.NewMockClock(tripsForRouteTestClock), "trips-for-route.zip", basicTripsForRouteFiles())
 	combinedRouteID := utils.FormCombinedID(tripsForRouteAgencyID, tripsForRouteRouteID)
 	url := fmt.Sprintf("/api/where/trips-for-route/%s.json?key=TEST&includeSchedule=true", combinedRouteID)
 
@@ -444,7 +443,7 @@ func TestTripsForRouteHandler_TimeOmitted(t *testing.T) {
 // TestTripsForRouteHandler_InvalidTimeParameter verifies that malformed time
 // parameter values correctly trigger a 400 Bad Request validation error.
 func TestTripsForRouteHandler_InvalidTimeParameter(t *testing.T) {
-	api := createTestApiWithTripsForRouteFixture(t, clock.NewMockClock(tripsForRouteTestClock))
+	api := createTestApiWithGTFSFixture(t, clock.NewMockClock(tripsForRouteTestClock), "trips-for-route.zip", basicTripsForRouteFiles())
 	combinedRouteID := utils.FormCombinedID(tripsForRouteAgencyID, tripsForRouteRouteID)
 
 	tests := []struct {

--- a/internal/restapi/trips_for_route_handler_test.go
+++ b/internal/restapi/trips_for_route_handler_test.go
@@ -416,8 +416,8 @@ func TestTripsForRouteHandler_DifferentRoutes(t *testing.T) {
 	}
 }
 
-// TestTripsForRouteHandler_TimeOmitted verifies that the handler defaults to the
-// current time and returns a 200 OK response when the time parameter is omitted.
+// TestTripsForRouteHandler_TimeOmitted verifies that omitting the time parameter
+// correctly falls back to the injected api.Clock to resolve active trips.
 func TestTripsForRouteHandler_TimeOmitted(t *testing.T) {
 	api := createTestApiWithTripsForRouteFixture(t, clock.NewMockClock(tripsForRouteTestClock))
 	combinedRouteID := utils.FormCombinedID(tripsForRouteAgencyID, tripsForRouteRouteID)
@@ -429,12 +429,16 @@ func TestTripsForRouteHandler_TimeOmitted(t *testing.T) {
 	assert.Equal(t, http.StatusOK, model.Code)
 	assert.Equal(t, "OK", model.Text)
 	assert.Equal(t, 2, model.Version)
-	// currentTime comes from the API clock, unlike the request's time= param.
+	// currentTime comes from the API clock, as does the omitted time= lookup.
 	assert.Equal(t, tripsForRouteTestClock.UnixMilli(), model.CurrentTime)
 	assert.False(t, model.Data.LimitExceeded)
 	assert.False(t, model.Data.OutOfRange)
 	assert.Empty(t, model.Data.FieldErrors)
-	assert.NotNil(t, model.Data.List)
+
+	require.Len(t, model.Data.List, 1, "the fixture trip must be active at the pinned clock time")
+	expectedTripID := utils.FormCombinedID(tripsForRouteAgencyID, tripsForRouteTripID)
+	assert.Equal(t, expectedTripID, model.Data.List[0].TripId)
+	assert.NotZero(t, model.Data.List[0].ServiceDate)
 }
 
 // TestTripsForRouteHandler_InvalidTimeParameter verifies that malformed time

--- a/internal/restapi/trips_for_route_handler_test.go
+++ b/internal/restapi/trips_for_route_handler_test.go
@@ -416,6 +416,59 @@ func TestTripsForRouteHandler_DifferentRoutes(t *testing.T) {
 	}
 }
 
+// TestTripsForRouteHandler_TimeOmitted verifies that the handler defaults to the
+// current time and returns a 200 OK response when the time parameter is omitted.
+func TestTripsForRouteHandler_TimeOmitted(t *testing.T) {
+	api := createTestApiWithTripsForRouteFixture(t, clock.NewMockClock(tripsForRouteTestClock))
+	combinedRouteID := utils.FormCombinedID(tripsForRouteAgencyID, tripsForRouteRouteID)
+	url := fmt.Sprintf("/api/where/trips-for-route/%s.json?key=TEST&includeSchedule=true", combinedRouteID)
+
+	resp, model := callAPIHandler[TripsForRouteResponse](t, api, url)
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, http.StatusOK, model.Code)
+	assert.Equal(t, "OK", model.Text)
+	assert.Equal(t, 2, model.Version)
+	// currentTime comes from the API clock, unlike the request's time= param.
+	assert.Equal(t, tripsForRouteTestClock.UnixMilli(), model.CurrentTime)
+	assert.False(t, model.Data.LimitExceeded)
+	assert.False(t, model.Data.OutOfRange)
+	assert.Empty(t, model.Data.FieldErrors)
+	assert.NotNil(t, model.Data.List)
+}
+
+// TestTripsForRouteHandler_InvalidTimeParameter verifies that malformed time
+// parameter values correctly trigger a 400 Bad Request validation error.
+func TestTripsForRouteHandler_InvalidTimeParameter(t *testing.T) {
+	api := createTestApiWithTripsForRouteFixture(t, clock.NewMockClock(tripsForRouteTestClock))
+	combinedRouteID := utils.FormCombinedID(tripsForRouteAgencyID, tripsForRouteRouteID)
+
+	tests := []struct {
+		name string
+		time string
+	}{
+		{name: "Garbage String", time: "garbage"},
+		{name: "Overflowing Epoch", time: "99999999999999999999"},
+		{name: "Invalid Calendar Date", time: "2024-13-45"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			url := fmt.Sprintf("/api/where/trips-for-route/%s.json?key=TEST&includeSchedule=true&time=%s",
+				combinedRouteID, tt.time)
+
+			resp, model := callAPIHandler[TripsForRouteResponse](t, api, url)
+
+			assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+			assert.Equal(t, http.StatusBadRequest, model.Code)
+			assert.Equal(t, "Invalid field value for field \"time\".", model.Text)
+			assert.Equal(t, 2, model.Version)
+			require.Contains(t, model.Data.FieldErrors, "time")
+			assert.Equal(t, []string{"Invalid field value for field \"time\"."}, model.Data.FieldErrors["time"])
+		})
+	}
+}
+
 func TestTripsForRouteHandler_ScheduleInclusion(t *testing.T) {
 	api := createTestApiWithGTFSFixture(t, clock.NewMockClock(tripsForRouteTestClock), "trips-for-route.zip", basicTripsForRouteFiles())
 	combinedRouteID := utils.FormCombinedID(tripsForRouteAgencyID, tripsForRouteRouteID)

--- a/internal/restapi/vehicles_for_agency_handler.go
+++ b/internal/restapi/vehicles_for_agency_handler.go
@@ -40,7 +40,7 @@ func (api *RestAPI) vehiclesForAgencyHandler(w http.ResponseWriter, r *http.Requ
 	}
 	referenceTime := api.Clock.Now().In(loc)
 	if timeParam := r.URL.Query().Get("time"); timeParam != "" {
-		_, parsedTime, fieldErrors, ok := utils.ParseTimeParameter(timeParam, loc)
+		_, parsedTime, fieldErrors, ok := utils.ParseTimeParameter(timeParam, loc, api.Clock)
 		if !ok {
 			api.validationErrorResponse(w, r, fieldErrors)
 			return

--- a/internal/utils/api.go
+++ b/internal/utils/api.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/OneBusAway/go-gtfs"
+	"maglev.onebusaway.org/internal/clock"
 	"maglev.onebusaway.org/internal/models"
 )
 
@@ -169,10 +170,10 @@ func ParseRequiredFloatParam(params url.Values, key string, fieldErrors map[stri
 
 }
 
-func ParseTimeParameter(timeParam string, currentLocation *time.Location) (string, time.Time, map[string][]string, bool) {
+func ParseTimeParameter(timeParam string, currentLocation *time.Location, c clock.Clock) (string, time.Time, map[string][]string, bool) {
 	if timeParam == "" {
-		// No time parameter, use current date
-		now := time.Now().In(currentLocation)
+		// No time parameter, use the provided clock's current time
+		now := c.Now().In(currentLocation)
 		return now.Format("20060102"), now, nil, true
 	}
 

--- a/internal/utils/api_test.go
+++ b/internal/utils/api_test.go
@@ -449,8 +449,9 @@ func TestParseTimeParameter(t *testing.T) {
 	loc, err := time.LoadLocation("America/Los_Angeles")
 	require.NoError(t, err)
 
-	// Get current time for testing
-	now := time.Now().In(loc)
+	// Use a fixed time for deterministic testing
+	now := time.Date(2025, 6, 12, 12, 0, 0, 0, loc)
+	testClock := clock.NewMockClock(now)
 	todayFormatted := now.Format("20060102")
 
 	// Calculate yesterday
@@ -563,7 +564,7 @@ func TestParseTimeParameter(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			dateStr, parsedTime, fieldErrors, valid := ParseTimeParameter(tt.timeParam, loc, clock.RealClock{})
+			dateStr, parsedTime, fieldErrors, valid := ParseTimeParameter(tt.timeParam, loc, testClock)
 
 			if tt.expectError {
 				assert.False(t, valid)

--- a/internal/utils/api_test.go
+++ b/internal/utils/api_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/OneBusAway/go-gtfs"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"maglev.onebusaway.org/internal/clock"
 	"maglev.onebusaway.org/internal/models"
 )
 
@@ -562,7 +563,7 @@ func TestParseTimeParameter(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			dateStr, parsedTime, fieldErrors, valid := ParseTimeParameter(tt.timeParam, loc)
+			dateStr, parsedTime, fieldErrors, valid := ParseTimeParameter(tt.timeParam, loc, clock.RealClock{})
 
 			if tt.expectError {
 				assert.False(t, valid)
@@ -590,7 +591,7 @@ func TestParseTimeParameter_EdgeCases(t *testing.T) {
 		todayMidnight := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, loc)
 		todayDateStr := todayMidnight.Format("2006-01-02")
 
-		dateStr, parsedTime, fieldErrors, valid := ParseTimeParameter(todayDateStr, loc)
+		dateStr, parsedTime, fieldErrors, valid := ParseTimeParameter(todayDateStr, loc, clock.RealClock{})
 
 		assert.True(t, valid)
 		assert.Nil(t, fieldErrors)
@@ -601,7 +602,7 @@ func TestParseTimeParameter_EdgeCases(t *testing.T) {
 	})
 
 	t.Run("Malformed YYYY-MM-DD", func(t *testing.T) {
-		_, _, fieldErrors, valid := ParseTimeParameter("2024-13-45", loc)
+		_, _, fieldErrors, valid := ParseTimeParameter("2024-13-45", loc, clock.RealClock{})
 
 		assert.False(t, valid)
 		assert.NotNil(t, fieldErrors)
@@ -609,7 +610,7 @@ func TestParseTimeParameter_EdgeCases(t *testing.T) {
 	})
 
 	t.Run("Non-numeric epoch", func(t *testing.T) {
-		_, _, fieldErrors, valid := ParseTimeParameter("not-a-number", loc)
+		_, _, fieldErrors, valid := ParseTimeParameter("not-a-number", loc, clock.RealClock{})
 
 		assert.False(t, valid)
 		assert.NotNil(t, fieldErrors)
@@ -621,7 +622,7 @@ func TestParseTimeParameter_DateStringUsesProvidedLocation(t *testing.T) {
 	loc, err := time.LoadLocation("America/Los_Angeles")
 	require.NoError(t, err)
 
-	dateStr, parsedTime, fieldErrors, valid := ParseTimeParameter("2026-03-12", loc)
+	dateStr, parsedTime, fieldErrors, valid := ParseTimeParameter("2026-03-12", loc, clock.RealClock{})
 
 	require.True(t, valid)
 	require.Nil(t, fieldErrors)


### PR DESCRIPTION
### Description
This PR addresses the missing test coverage for edge cases regarding the `time` query parameter in the `trips-for-route` handler. 

### Changes Made
- **Added `TestTripsForRouteHandler_TimeOmitted`:** Verifies that when the `time` parameter is not provided, the handler correctly defaults to the current clock time and returns a `200 OK` response.
- **Added `TestTripsForRouteHandler_InvalidTimeParameter`:** Asserts that passing malformed time values (e.g., garbage strings, overflowing epochs, or invalid calendar dates) correctly triggers a validation error, returning a `400 Bad Request`.

Closes: #1295 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of optional time parameters across trip, stop, and vehicle endpoints.
  * Requests without a specified time now consistently use the API’s configured current time.
  * Malformed, overflowing, or invalid-date time values now return HTTP 400 responses with the expected error details.

* **Tests**
  * Added coverage for default-time behavior and invalid time parameter responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->