### PR TITLE
Reference only the stops trips-for-location points at

### DIFF
--- a/gtfsdb/db.go
+++ b/gtfsdb/db.go
@@ -300,9 +300,6 @@ func Prepare(ctx context.Context, db DBTX) (*Queries, error) {
 	if q.getStopIDsForTripStmt, err = db.PrepareContext(ctx, getStopIDsForTrip); err != nil {
 		return nil, fmt.Errorf("error preparing query GetStopIDsForTrip: %w", err)
 	}
-	if q.getStopTimesByStopIDsStmt, err = db.PrepareContext(ctx, getStopTimesByStopIDs); err != nil {
-		return nil, fmt.Errorf("error preparing query GetStopTimesByStopIDs: %w", err)
-	}
 	if q.getStopTimesForStopInWindowStmt, err = db.PrepareContext(ctx, getStopTimesForStopInWindow); err != nil {
 		return nil, fmt.Errorf("error preparing query GetStopTimesForStopInWindow: %w", err)
 	}
@@ -338,6 +335,9 @@ func Prepare(ctx context.Context, db DBTX) (*Queries, error) {
 	}
 	if q.getTripStmt, err = db.PrepareContext(ctx, getTrip); err != nil {
 		return nil, fmt.Errorf("error preparing query GetTrip: %w", err)
+	}
+	if q.getTripIDsForStopsStmt, err = db.PrepareContext(ctx, getTripIDsForStops); err != nil {
+		return nil, fmt.Errorf("error preparing query GetTripIDsForStops: %w", err)
 	}
 	if q.getTripTimeBoundsByIDsStmt, err = db.PrepareContext(ctx, getTripTimeBoundsByIDs); err != nil {
 		return nil, fmt.Errorf("error preparing query GetTripTimeBoundsByIDs: %w", err)
@@ -864,11 +864,6 @@ func (q *Queries) Close() error {
 			err = fmt.Errorf("error closing getStopIDsForTripStmt: %w", cerr)
 		}
 	}
-	if q.getStopTimesByStopIDsStmt != nil {
-		if cerr := q.getStopTimesByStopIDsStmt.Close(); cerr != nil {
-			err = fmt.Errorf("error closing getStopTimesByStopIDsStmt: %w", cerr)
-		}
-	}
 	if q.getStopTimesForStopInWindowStmt != nil {
 		if cerr := q.getStopTimesForStopInWindowStmt.Close(); cerr != nil {
 			err = fmt.Errorf("error closing getStopTimesForStopInWindowStmt: %w", cerr)
@@ -927,6 +922,11 @@ func (q *Queries) Close() error {
 	if q.getTripStmt != nil {
 		if cerr := q.getTripStmt.Close(); cerr != nil {
 			err = fmt.Errorf("error closing getTripStmt: %w", cerr)
+		}
+	}
+	if q.getTripIDsForStopsStmt != nil {
+		if cerr := q.getTripIDsForStopsStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing getTripIDsForStopsStmt: %w", cerr)
 		}
 	}
 	if q.getTripTimeBoundsByIDsStmt != nil {
@@ -1160,7 +1160,6 @@ type Queries struct {
 	getStopIDsForAgencyStmt                       *sql.Stmt
 	getStopIDsForRouteStmt                        *sql.Stmt
 	getStopIDsForTripStmt                         *sql.Stmt
-	getStopTimesByStopIDsStmt                     *sql.Stmt
 	getStopTimesForStopInWindowStmt               *sql.Stmt
 	getStopTimesForTripStmt                       *sql.Stmt
 	getStopTimesForTripIDsStmt                    *sql.Stmt
@@ -1173,6 +1172,7 @@ type Queries struct {
 	getTargetStopTimeWithTotalStopsStmt           *sql.Stmt
 	getTargetStopTimeWithTotalStopsBySequenceStmt *sql.Stmt
 	getTripStmt                                   *sql.Stmt
+	getTripIDsForStopsStmt                        *sql.Stmt
 	getTripTimeBoundsByIDsStmt                    *sql.Stmt
 	getTripsByBlockIDStmt                         *sql.Stmt
 	getTripsByBlockIDOrderedStmt                  *sql.Stmt
@@ -1291,7 +1291,6 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		getStopIDsForAgencyStmt:                       q.getStopIDsForAgencyStmt,
 		getStopIDsForRouteStmt:                        q.getStopIDsForRouteStmt,
 		getStopIDsForTripStmt:                         q.getStopIDsForTripStmt,
-		getStopTimesByStopIDsStmt:                     q.getStopTimesByStopIDsStmt,
 		getStopTimesForStopInWindowStmt:               q.getStopTimesForStopInWindowStmt,
 		getStopTimesForTripStmt:                       q.getStopTimesForTripStmt,
 		getStopTimesForTripIDsStmt:                    q.getStopTimesForTripIDsStmt,
@@ -1304,6 +1303,7 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		getTargetStopTimeWithTotalStopsStmt:           q.getTargetStopTimeWithTotalStopsStmt,
 		getTargetStopTimeWithTotalStopsBySequenceStmt: q.getTargetStopTimeWithTotalStopsBySequenceStmt,
 		getTripStmt:                                   q.getTripStmt,
+		getTripIDsForStopsStmt:                        q.getTripIDsForStopsStmt,
 		getTripTimeBoundsByIDsStmt:                    q.getTripTimeBoundsByIDsStmt,
 		getTripsByBlockIDStmt:                         q.getTripsByBlockIDStmt,
 		getTripsByBlockIDOrderedStmt:                  q.getTripsByBlockIDOrderedStmt,

--- a/gtfsdb/query.sql
+++ b/gtfsdb/query.sql
@@ -884,9 +884,10 @@ ORDER BY
     t.id, st.stop_sequence;
 
 -- name: GetTripIDsForStops :many
--- DISTINCT on trip_id alone so the existing (stop_id, trip_id) index covers
--- this: the caller only needs to know which trips touch these stops, and the
--- stop set can be every stop inside a 20 km box.
+-- GetTripIDsForStops returns the IDs of the trips serving any of these stops.
+-- DISTINCT on trip_id alone so the existing (stop_id, trip_id) index covers it:
+-- the caller only needs to know which trips touch these stops, and the stop set
+-- can be every stop inside a 20 km box.
 SELECT DISTINCT
     trip_id
 FROM

--- a/gtfsdb/query.sql
+++ b/gtfsdb/query.sql
@@ -883,9 +883,12 @@ WHERE
 ORDER BY
     t.id, st.stop_sequence;
 
--- name: GetStopTimesByStopIDs :many
-SELECT
-    *
+-- name: GetTripIDsForStops :many
+-- DISTINCT on trip_id alone so the existing (stop_id, trip_id) index covers
+-- this: the caller only needs to know which trips touch these stops, and the
+-- stop set can be every stop inside a 20 km box.
+SELECT DISTINCT
+    trip_id
 FROM
     stop_times
 WHERE

--- a/gtfsdb/query.sql.go
+++ b/gtfsdb/query.sql.go
@@ -3762,59 +3762,6 @@ func (q *Queries) GetStopIDsForTrip(ctx context.Context, tripID string) ([]strin
 	return items, nil
 }
 
-const getStopTimesByStopIDs = `-- name: GetStopTimesByStopIDs :many
-SELECT
-    trip_id, arrival_time, departure_time, stop_id, stop_sequence, stop_headsign, pickup_type, drop_off_type, shape_dist_traveled, timepoint
-FROM
-    stop_times
-WHERE
-    stop_id IN (/*SLICE:stop_ids*/?)
-`
-
-func (q *Queries) GetStopTimesByStopIDs(ctx context.Context, stopIds []string) ([]StopTime, error) {
-	query := getStopTimesByStopIDs
-	var queryParams []interface{}
-	if len(stopIds) > 0 {
-		for _, v := range stopIds {
-			queryParams = append(queryParams, v)
-		}
-		query = strings.Replace(query, "/*SLICE:stop_ids*/?", strings.Repeat(",?", len(stopIds))[1:], 1)
-	} else {
-		query = strings.Replace(query, "/*SLICE:stop_ids*/?", "NULL", 1)
-	}
-	rows, err := q.query(ctx, nil, query, queryParams...)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	var items []StopTime
-	for rows.Next() {
-		var i StopTime
-		if err := rows.Scan(
-			&i.TripID,
-			&i.ArrivalTime,
-			&i.DepartureTime,
-			&i.StopID,
-			&i.StopSequence,
-			&i.StopHeadsign,
-			&i.PickupType,
-			&i.DropOffType,
-			&i.ShapeDistTraveled,
-			&i.Timepoint,
-		); err != nil {
-			return nil, err
-		}
-		items = append(items, i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
-}
-
 const getStopTimesForStopInWindow = `-- name: GetStopTimesForStopInWindow :many
 SELECT
     st.trip_id,
@@ -4503,6 +4450,51 @@ func (q *Queries) GetTrip(ctx context.Context, id string) (Trip, error) {
 		&i.MaxDepartureTime,
 	)
 	return i, err
+}
+
+const getTripIDsForStops = `-- name: GetTripIDsForStops :many
+SELECT DISTINCT
+    trip_id
+FROM
+    stop_times
+WHERE
+    stop_id IN (/*SLICE:stop_ids*/?)
+`
+
+// DISTINCT on trip_id alone so the existing (stop_id, trip_id) index covers
+// this: the caller only needs to know which trips touch these stops, and the
+// stop set can be every stop inside a 20 km box.
+func (q *Queries) GetTripIDsForStops(ctx context.Context, stopIds []string) ([]string, error) {
+	query := getTripIDsForStops
+	var queryParams []interface{}
+	if len(stopIds) > 0 {
+		for _, v := range stopIds {
+			queryParams = append(queryParams, v)
+		}
+		query = strings.Replace(query, "/*SLICE:stop_ids*/?", strings.Repeat(",?", len(stopIds))[1:], 1)
+	} else {
+		query = strings.Replace(query, "/*SLICE:stop_ids*/?", "NULL", 1)
+	}
+	rows, err := q.query(ctx, nil, query, queryParams...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []string
+	for rows.Next() {
+		var trip_id string
+		if err := rows.Scan(&trip_id); err != nil {
+			return nil, err
+		}
+		items = append(items, trip_id)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
 }
 
 const getTripTimeBoundsByIDs = `-- name: GetTripTimeBoundsByIDs :many

--- a/gtfsdb/query.sql.go
+++ b/gtfsdb/query.sql.go
@@ -4461,9 +4461,10 @@ WHERE
     stop_id IN (/*SLICE:stop_ids*/?)
 `
 
-// DISTINCT on trip_id alone so the existing (stop_id, trip_id) index covers
-// this: the caller only needs to know which trips touch these stops, and the
-// stop set can be every stop inside a 20 km box.
+// GetTripIDsForStops returns the IDs of the trips serving any of these stops.
+// DISTINCT on trip_id alone so the existing (stop_id, trip_id) index covers it:
+// the caller only needs to know which trips touch these stops, and the stop set
+// can be every stop inside a 20 km box.
 func (q *Queries) GetTripIDsForStops(ctx context.Context, stopIds []string) ([]string, error) {
 	query := getTripIDsForStops
 	var queryParams []interface{}

--- a/internal/restapi/reference_utils.go
+++ b/internal/restapi/reference_utils.go
@@ -452,6 +452,71 @@ func (api *RestAPI) buildStopModel(ctx context.Context, agencyID string, stop gt
 	}
 }
 
+// stopReferences builds the stop reference block for a set of list entries,
+// labelling each stop with the combined ID the entries actually referred to it
+// by — the referring trip's agency need not own the stop's first route. A stop
+// whose routes do not resolve still gets a reference, with an empty route list,
+// so every stop ID an entry emits resolves in the block.
+//
+// The routes each stop serves are returned alongside the references, for callers
+// that collect route references from them.
+func (api *RestAPI) stopReferences(ctx context.Context, stops []gtfsdb.Stop, idsByBareID map[string]string) ([]models.Stop, map[string][]string) {
+	routeIDsByStop := api.routeIDsForStops(ctx, stops)
+
+	stopList := make([]models.Stop, 0, len(stops))
+	for _, stop := range stops {
+		routeIDs := routeIDsByStop[stop.ID]
+		if routeIDs == nil {
+			routeIDs = []string{}
+		}
+
+		direction := api.DirectionCalculator.CalculateStopDirection(ctx, stop.ID, stop.Direction)
+		if direction == "" {
+			direction = models.UnknownValue
+		}
+
+		stopList = append(stopList, models.Stop{
+			Code:               nulls.StringOrEmpty(stop.Code),
+			Direction:          direction,
+			ID:                 idsByBareID[stop.ID],
+			Lat:                stop.Lat,
+			Lon:                stop.Lon,
+			LocationType:       0,
+			Name:               nulls.StringOrEmpty(stop.Name),
+			Parent:             "",
+			RouteIDs:           routeIDs,
+			StaticRouteIDs:     routeIDs,
+			WheelchairBoarding: utils.MapWheelchairBoarding(nulls.WheelchairBoardingOrUnknown(stop.WheelchairBoarding)),
+		})
+	}
+	return stopList, routeIDsByStop
+}
+
+// routeIDsForStops maps each stop to the combined IDs of the routes serving it.
+func (api *RestAPI) routeIDsForStops(ctx context.Context, stops []gtfsdb.Stop) map[string][]string {
+	routeIDsByStop := make(map[string][]string)
+	if len(stops) == 0 {
+		return routeIDsByStop
+	}
+
+	stopIDs := make([]string, len(stops))
+	for i, stop := range stops {
+		stopIDs[i] = stop.ID
+	}
+
+	rows, err := api.GtfsManager.GtfsDB.Queries.GetRouteIDsForStops(ctx, stopIDs)
+	if err != nil {
+		logging.LogError(api.Logger, "failed to fetch routes for stop references", err)
+		return routeIDsByStop
+	}
+	for _, row := range rows {
+		if routeID, ok := row.RouteID.(string); ok {
+			routeIDsByStop[row.StopID] = append(routeIDsByStop[row.StopID], routeID)
+		}
+	}
+	return routeIDsByStop
+}
+
 // Situation references
 //
 // An entry's situationIds and the response's references.situations must use the

--- a/internal/restapi/reference_utils.go
+++ b/internal/restapi/reference_utils.go
@@ -452,6 +452,28 @@ func (api *RestAPI) buildStopModel(ctx context.Context, agencyID string, stop gt
 	}
 }
 
+// idsPerBatchedQuery bounds how many IDs go into one IN (...) list. SQLite
+// rejects a statement carrying more bind variables than it allows rather than
+// truncating it, and these ID sets are only bounded by how much the request
+// matched. Kept well under the oldest limit (999) so the batch size does not
+// depend on which SQLite the build links against.
+const idsPerBatchedQuery = 900
+
+// queryInBatches runs query over ids in batches small enough to stay under the
+// bind variable limit, concatenating the results.
+func queryInBatches[T any](ctx context.Context, ids []string, query func(context.Context, []string) ([]T, error)) ([]T, error) {
+	results := make([]T, 0, len(ids))
+	for start := 0; start < len(ids); start += idsPerBatchedQuery {
+		end := min(start+idsPerBatchedQuery, len(ids))
+		batch, err := query(ctx, ids[start:end])
+		if err != nil {
+			return nil, err
+		}
+		results = append(results, batch...)
+	}
+	return results, nil
+}
+
 // stopReferences builds the stop reference block for a set of list entries,
 // labelling each stop with the combined ID the entries actually referred to it
 // by — the referring trip's agency need not own the stop's first route. A stop
@@ -504,7 +526,7 @@ func (api *RestAPI) routeIDsForStops(ctx context.Context, stops []gtfsdb.Stop) m
 		stopIDs[i] = stop.ID
 	}
 
-	rows, err := api.GtfsManager.GtfsDB.Queries.GetRouteIDsForStops(ctx, stopIDs)
+	rows, err := queryInBatches(ctx, stopIDs, api.GtfsManager.GtfsDB.Queries.GetRouteIDsForStops)
 	if err != nil {
 		logging.LogError(api.Logger, "failed to fetch routes for stop references", err)
 		return routeIDsByStop

--- a/internal/restapi/reference_utils_test.go
+++ b/internal/restapi/reference_utils_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/OneBusAway/go-gtfs"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"maglev.onebusaway.org/gtfsdb"
 	"maglev.onebusaway.org/internal/utils"
 )
 
@@ -156,6 +157,35 @@ func TestBuildStopReferencesAndRouteIDsForStops(t *testing.T) {
 			assert.True(t, ok, "route %q referenced by stop should be present in routeMap", rid)
 		}
 	}
+}
+
+func TestStopReferences(t *testing.T) {
+	api := createTestApi(t)
+	ctx := context.Background()
+
+	servedStopID := firstRabaStopIDs(t, api, 1)[0]
+	servedStop, err := api.GtfsManager.GtfsDB.Queries.GetStop(ctx, servedStopID)
+	require.NoError(t, err)
+
+	// No stop_times point at this stop, so no route resolves for it.
+	routelessStop := gtfsdb.Stop{ID: "stop-served-by-no-route", Lat: 40.5, Lon: -122.3}
+
+	referringIDs := map[string]string{
+		servedStopID:     utils.FormCombinedID("referring-agency", servedStopID),
+		routelessStop.ID: utils.FormCombinedID("referring-agency", routelessStop.ID),
+	}
+
+	refs, routeIDsByStop := api.stopReferences(ctx, []gtfsdb.Stop{servedStop, routelessStop}, referringIDs)
+	require.Len(t, refs, 2, "a stop with no resolvable routes still gets a reference")
+
+	assert.Equal(t, referringIDs[servedStopID], refs[0].ID, "the referring entry's ID labels the reference")
+	assert.NotEmpty(t, refs[0].RouteIDs)
+	assert.Equal(t, routeIDsByStop[servedStopID], refs[0].RouteIDs)
+
+	assert.Equal(t, referringIDs[routelessStop.ID], refs[1].ID)
+	assert.Empty(t, refs[1].RouteIDs)
+	assert.NotNil(t, refs[1].RouteIDs, "an unresolved route list is empty, not null")
+	assert.Equal(t, refs[1].RouteIDs, refs[1].StaticRouteIDs)
 }
 
 func TestBuildStopReferencesAndRouteIDsForStops_DeduplicatesStopIDs(t *testing.T) {

--- a/internal/restapi/reference_utils_test.go
+++ b/internal/restapi/reference_utils_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"maglev.onebusaway.org/gtfsdb"
+	"maglev.onebusaway.org/internal/models"
 	"maglev.onebusaway.org/internal/utils"
 )
 
@@ -186,6 +187,8 @@ func TestStopReferences(t *testing.T) {
 	assert.Empty(t, refs[1].RouteIDs)
 	assert.NotNil(t, refs[1].RouteIDs, "an unresolved route list is empty, not null")
 	assert.Equal(t, refs[1].RouteIDs, refs[1].StaticRouteIDs)
+	// No stop_times and no shape, so nothing supports a direction.
+	assert.Equal(t, models.UnknownValue, refs[1].Direction)
 }
 
 func TestBuildStopReferencesAndRouteIDsForStops_DeduplicatesStopIDs(t *testing.T) {

--- a/internal/restapi/reference_utils_test.go
+++ b/internal/restapi/reference_utils_test.go
@@ -2,6 +2,7 @@ package restapi
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"slices"
@@ -158,6 +159,34 @@ func TestBuildStopReferencesAndRouteIDsForStops(t *testing.T) {
 			assert.True(t, ok, "route %q referenced by stop should be present in routeMap", rid)
 		}
 	}
+}
+
+func TestQueryInBatches(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("An empty ID set runs no query", func(t *testing.T) {
+		queried := false
+		results, err := queryInBatches(ctx, nil, func(context.Context, []string) ([]string, error) {
+			queried = true
+			return nil, nil
+		})
+
+		require.NoError(t, err)
+		assert.Empty(t, results)
+		assert.False(t, queried, "there is nothing to look up")
+	})
+
+	t.Run("A failing batch stops the run", func(t *testing.T) {
+		batches := 0
+		_, err := queryInBatches(ctx, make([]string, idsPerBatchedQuery+1),
+			func(context.Context, []string) ([]string, error) {
+				batches++
+				return nil, errors.New("query failed")
+			})
+
+		require.Error(t, err)
+		assert.Equal(t, 1, batches, "the remaining batches must not run once one fails")
+	})
 }
 
 func TestStopReferences(t *testing.T) {

--- a/internal/restapi/trips_for_location_handler.go
+++ b/internal/restapi/trips_for_location_handler.go
@@ -33,7 +33,9 @@ func (api *RestAPI) tripsForLocationHandler(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	stopsInBounds := api.GtfsManager.GetStopsInBounds(ctx, parsedReq.LocationParams, models.DefaultMaxCountForStops, true)
+	// Uncapped: this stop set only narrows the candidate trips, and a cap here
+	// silently drops trips the spec says should all be returned.
+	stopsInBounds := api.GtfsManager.GetStopsInBounds(ctx, parsedReq.LocationParams, 0, true)
 	stopIDs := extractStopIDs(stopsInBounds)
 	stopTimes, err := api.GtfsManager.GtfsDB.Queries.GetStopTimesByStopIDs(ctx, stopIDs)
 	if err != nil {

--- a/internal/restapi/trips_for_location_handler.go
+++ b/internal/restapi/trips_for_location_handler.go
@@ -673,81 +673,22 @@ func (rb *referenceBuilder) collectTripIDs(trips []models.TripsForLocationListEn
 	}
 }
 
+// buildStopList emits the stop references and registers the routes serving them.
+// A stop referred to by more than one agency still gets a single reference — the
+// first ID seen wins, and the other stays dangling.
 func (rb *referenceBuilder) buildStopList(stops []gtfsdb.Stop, stopIDsByBareID map[string]string) {
-	rb.stopList = make([]models.Stop, 0, len(stops))
-	if len(stops) == 0 {
-		return
-	}
+	stopList, routeIDsByStop := rb.api.stopReferences(rb.ctx, stops, stopIDsByBareID)
+	rb.stopList = stopList
 
-	stopIDs := make([]string, 0, len(stops))
-	for _, stop := range stops {
-		stopIDs = append(stopIDs, stop.ID)
-	}
-
-	routesForStops, err := rb.api.GtfsManager.GtfsDB.Queries.GetRouteIDsForStops(rb.ctx, stopIDs)
-	if err != nil {
-		logging.LogError(rb.api.Logger, "failed to batch fetch routes for stops", err)
-		return
-	}
-
-	// Build in-memory map: stopID → []combinedRouteID (e.g. "40_100479").
-	// Also register the raw route ID (e.g. "100479") in presentRoutes so that
-	// collectAgenciesAndRoutes can fetch full route details via GetRoutesByIDs,
-	// which queries WHERE routes.id IN (?), using raw IDs — not combined ones.
-	stopRouteMap := make(map[string][]string)
-	for _, r := range routesForStops {
-		combinedID, ok := r.RouteID.(string)
-		if !ok {
-			continue
-		}
-		stopRouteMap[r.StopID] = append(stopRouteMap[r.StopID], combinedID)
-		if rawID, err := utils.ExtractCodeID(combinedID); err == nil {
-			rb.presentRoutes[rawID] = models.Route{}
-		}
-	}
-
-	for _, stop := range stops {
-		if rb.ctx.Err() != nil {
-			return
-		}
-		combinedRouteIDs := stopRouteMap[stop.ID]
-		if len(combinedRouteIDs) == 0 {
-			continue
-		}
-		rb.stopList = append(rb.stopList, rb.createStop(stop, combinedRouteIDs, stopIDsByBareID[stop.ID]))
-	}
-}
-
-// createStop builds one stop reference. referredID is the combined ID an entry
-// pointed at this stop by; it is preferred over deriving one from the stop's
-// first route, whose agency need not be the agency of the trip that referred to
-// it. A stop referred to by more than one agency still gets a single reference —
-// the first ID seen wins, and the other stays dangling.
-func (rb *referenceBuilder) createStop(stop gtfsdb.Stop, routeIds []string, referredID string) models.Stop {
-	if referredID == "" {
-		agencyID := ""
-		if len(routeIds) > 0 {
-			if id, err := utils.ExtractAgencyID(routeIds[0]); err == nil {
-				agencyID = id
+	// Register the raw route ID (e.g. "100479") rather than the combined one, so
+	// that collectAgenciesAndRoutes can fetch full route details via
+	// GetRoutesByIDs, which queries WHERE routes.id IN (?) using raw IDs.
+	for _, combinedRouteIDs := range routeIDsByStop {
+		for _, combinedID := range combinedRouteIDs {
+			if rawID, err := utils.ExtractCodeID(combinedID); err == nil {
+				rb.presentRoutes[rawID] = models.Route{}
 			}
 		}
-		referredID = utils.FormCombinedID(agencyID, stop.ID)
-	}
-
-	direction := rb.api.DirectionCalculator.CalculateStopDirection(rb.ctx, stop.ID, stop.Direction)
-
-	return models.Stop{
-		Code:               nulls.StringOrEmpty(stop.Code),
-		Direction:          direction,
-		ID:                 referredID,
-		Lat:                stop.Lat,
-		Lon:                stop.Lon,
-		LocationType:       0,
-		Name:               nulls.StringOrEmpty(stop.Name),
-		Parent:             "",
-		RouteIDs:           routeIds,
-		StaticRouteIDs:     routeIds,
-		WheelchairBoarding: utils.MapWheelchairBoarding(nulls.WheelchairBoardingOrUnknown(stop.WheelchairBoarding)),
 	}
 }
 

--- a/internal/restapi/trips_for_location_handler.go
+++ b/internal/restapi/trips_for_location_handler.go
@@ -37,13 +37,13 @@ func (api *RestAPI) tripsForLocationHandler(w http.ResponseWriter, r *http.Reque
 	// silently drops trips the spec says should all be returned.
 	stopsInBounds := api.GtfsManager.GetStopsInBounds(ctx, parsedReq.LocationParams, 0, true)
 	stopIDs := extractStopIDs(stopsInBounds)
-	stopTimes, err := api.GtfsManager.GtfsDB.Queries.GetStopTimesByStopIDs(ctx, stopIDs)
+	candidateTripIDs, err := api.GtfsManager.GtfsDB.Queries.GetTripIDsForStops(ctx, stopIDs)
 	if err != nil {
 		api.serverErrorResponse(w, r, err)
 		return
 	}
 
-	activeTrips := api.getActiveTrips(stopTimes, api.GtfsManager.GetRealTimeVehicles())
+	activeTrips := api.getActiveTrips(candidateTripIDs, api.GtfsManager.GetRealTimeVehicles())
 
 	bounds := internalgtfs.BoundsFromParams(parsedReq.LocationParams, true)
 	visibleTripIDs := make([]string, 0, len(activeTrips))
@@ -115,17 +115,18 @@ func (api *RestAPI) tripsForLocationHandler(w http.ResponseWriter, r *http.Reque
 	includeReferences := ShouldIncludeReferences(r)
 
 	if includeReferences {
-		referencedStops, stopsErr := api.stopsReferencedByEntries(ctx, result)
+		referencedStops, stopIDsByBareID, stopsErr := api.stopsReferencedByEntries(ctx, result)
 		if stopsErr != nil {
 			api.serverErrorResponse(w, r, stopsErr)
 			return
 		}
 
 		references = api.BuildReference(w, r, ctx, ReferenceParams{
-			IncludeTrip: parsedReq.IncludeTrip,
-			Stops:       referencedStops,
-			Trips:       result,
-			Situations:  situations,
+			IncludeTrip:     parsedReq.IncludeTrip,
+			Stops:           referencedStops,
+			StopIDsByBareID: stopIDsByBareID,
+			Trips:           result,
+			Situations:      situations,
 		})
 	}
 
@@ -234,7 +235,7 @@ func mergeFieldErrors(dst, src map[string][]string) map[string][]string {
 // The in-bounds stop set is deliberately not included — it is a candidate-trip
 // selection detail, and stops on it that no returned trip serves have nothing in
 // the response pointing at them.
-func (api *RestAPI) stopsReferencedByEntries(ctx context.Context, entries []models.TripsForLocationListEntry) ([]gtfsdb.Stop, error) {
+func (api *RestAPI) stopsReferencedByEntries(ctx context.Context, entries []models.TripsForLocationListEntry) ([]gtfsdb.Stop, map[string]string, error) {
 	stopIDsByBareID := make(map[string]string)
 
 	for _, entry := range entries {
@@ -254,7 +255,7 @@ func (api *RestAPI) stopsReferencedByEntries(ctx context.Context, entries []mode
 	}
 
 	if len(stopIDsByBareID) == 0 {
-		return nil, nil
+		return nil, nil, nil
 	}
 
 	bareIDs := make([]string, 0, len(stopIDsByBareID))
@@ -262,7 +263,8 @@ func (api *RestAPI) stopsReferencedByEntries(ctx context.Context, entries []mode
 		bareIDs = append(bareIDs, bareID)
 	}
 
-	return api.GtfsManager.GtfsDB.Queries.GetStopsByIDs(ctx, bareIDs)
+	stops, err := api.GtfsManager.GtfsDB.Queries.GetStopsByIDs(ctx, bareIDs)
+	return stops, stopIDsByBareID, err
 }
 
 func extractStopIDs(stops []gtfsdb.Stop) []string {
@@ -273,10 +275,10 @@ func extractStopIDs(stops []gtfsdb.Stop) []string {
 	return stopIDs
 }
 
-func (api *RestAPI) getActiveTrips(stopTimes []gtfsdb.StopTime, realTimeVehicles []gtfs.Vehicle) map[string]gtfs.Vehicle {
-	trips := make(map[string]bool)
-	for _, stopTime := range stopTimes {
-		trips[stopTime.TripID] = true
+func (api *RestAPI) getActiveTrips(candidateTripIDs []string, realTimeVehicles []gtfs.Vehicle) map[string]gtfs.Vehicle {
+	trips := make(map[string]bool, len(candidateTripIDs))
+	for _, tripID := range candidateTripIDs {
+		trips[tripID] = true
 	}
 	activeTrips := make(map[string]gtfs.Vehicle)
 	for _, vehicle := range realTimeVehicles {
@@ -538,8 +540,11 @@ func buildStopTimesList(api *RestAPI, ctx context.Context, stopTimes []gtfsdb.St
 type ReferenceParams struct {
 	IncludeTrip bool
 	Stops       []gtfsdb.Stop
-	Trips       []models.TripsForLocationListEntry
-	Situations  []situationRef
+	// StopIDsByBareID maps each stop's bare ID to the combined ID the entries
+	// referred to it by, so a reference is published under the ID pointing at it.
+	StopIDsByBareID map[string]string
+	Trips           []models.TripsForLocationListEntry
+	Situations      []situationRef
 }
 
 func (api *RestAPI) BuildReference(w http.ResponseWriter, r *http.Request, ctx context.Context, params ReferenceParams) models.ReferencesModel {
@@ -572,7 +577,7 @@ type referenceBuilder struct {
 func (rb *referenceBuilder) build(params ReferenceParams) error {
 	rb.situations = params.Situations
 	rb.collectTripIDs(params.Trips)
-	rb.buildStopList(params.Stops)
+	rb.buildStopList(params.Stops, params.StopIDsByBareID)
 
 	rb.enrichTripsData()
 
@@ -614,7 +619,7 @@ func (rb *referenceBuilder) collectTripIDs(trips []models.TripsForLocationListEn
 	}
 }
 
-func (rb *referenceBuilder) buildStopList(stops []gtfsdb.Stop) {
+func (rb *referenceBuilder) buildStopList(stops []gtfsdb.Stop, stopIDsByBareID map[string]string) {
 	rb.stopList = make([]models.Stop, 0, len(stops))
 	if len(stops) == 0 {
 		return
@@ -655,16 +660,24 @@ func (rb *referenceBuilder) buildStopList(stops []gtfsdb.Stop) {
 		if len(combinedRouteIDs) == 0 {
 			continue
 		}
-		rb.stopList = append(rb.stopList, rb.createStop(stop, combinedRouteIDs))
+		rb.stopList = append(rb.stopList, rb.createStop(stop, combinedRouteIDs, stopIDsByBareID[stop.ID]))
 	}
 }
 
-func (rb *referenceBuilder) createStop(stop gtfsdb.Stop, routeIds []string) models.Stop {
-	agencyID := ""
-	if len(routeIds) > 0 {
-		if id, err := utils.ExtractAgencyID(routeIds[0]); err == nil {
-			agencyID = id
+// createStop builds one stop reference. referredID is the combined ID an entry
+// pointed at this stop by; it is preferred over deriving one from the stop's
+// first route, whose agency need not be the agency of the trip that referred to
+// it. A stop referred to by more than one agency still gets a single reference —
+// the first ID seen wins, and the other stays dangling.
+func (rb *referenceBuilder) createStop(stop gtfsdb.Stop, routeIds []string, referredID string) models.Stop {
+	if referredID == "" {
+		agencyID := ""
+		if len(routeIds) > 0 {
+			if id, err := utils.ExtractAgencyID(routeIds[0]); err == nil {
+				agencyID = id
+			}
 		}
+		referredID = utils.FormCombinedID(agencyID, stop.ID)
 	}
 
 	direction := rb.api.DirectionCalculator.CalculateStopDirection(rb.ctx, stop.ID, stop.Direction)
@@ -672,7 +685,7 @@ func (rb *referenceBuilder) createStop(stop gtfsdb.Stop, routeIds []string) mode
 	return models.Stop{
 		Code:               nulls.StringOrEmpty(stop.Code),
 		Direction:          direction,
-		ID:                 utils.FormCombinedID(agencyID, stop.ID),
+		ID:                 referredID,
 		Lat:                stop.Lat,
 		Lon:                stop.Lon,
 		LocationType:       0,

--- a/internal/restapi/trips_for_location_handler.go
+++ b/internal/restapi/trips_for_location_handler.go
@@ -33,8 +33,8 @@ func (api *RestAPI) tripsForLocationHandler(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	stops := api.GtfsManager.GetStopsInBounds(ctx, parsedReq.LocationParams, models.DefaultMaxCountForStops, true)
-	stopIDs := extractStopIDs(stops)
+	stopsInBounds := api.GtfsManager.GetStopsInBounds(ctx, parsedReq.LocationParams, models.DefaultMaxCountForStops, true)
+	stopIDs := extractStopIDs(stopsInBounds)
 	stopTimes, err := api.GtfsManager.GtfsDB.Queries.GetStopTimesByStopIDs(ctx, stopIDs)
 	if err != nil {
 		api.serverErrorResponse(w, r, err)
@@ -113,9 +113,15 @@ func (api *RestAPI) tripsForLocationHandler(w http.ResponseWriter, r *http.Reque
 	includeReferences := ShouldIncludeReferences(r)
 
 	if includeReferences {
+		referencedStops, stopsErr := api.stopsReferencedByEntries(ctx, result)
+		if stopsErr != nil {
+			api.serverErrorResponse(w, r, stopsErr)
+			return
+		}
+
 		references = api.BuildReference(w, r, ctx, ReferenceParams{
 			IncludeTrip: parsedReq.IncludeTrip,
-			Stops:       stops,
+			Stops:       referencedStops,
 			Trips:       result,
 			Situations:  situations,
 		})
@@ -219,6 +225,42 @@ func mergeFieldErrors(dst, src map[string][]string) map[string][]string {
 		dst[k] = append(dst[k], v...)
 	}
 	return dst
+}
+
+// stopsReferencedByEntries fetches the stops the response actually refers to:
+// those on each entry's schedule, plus the closest and next stops on its status.
+// The in-bounds stop set is deliberately not included — it is a candidate-trip
+// selection detail, and stops on it that no returned trip serves have nothing in
+// the response pointing at them.
+func (api *RestAPI) stopsReferencedByEntries(ctx context.Context, entries []models.TripsForLocationListEntry) ([]gtfsdb.Stop, error) {
+	stopIDsByBareID := make(map[string]string)
+
+	for _, entry := range entries {
+		collectStopIDsFromSchedule(entry.Schedule, stopIDsByBareID)
+		if entry.Status == nil {
+			continue
+		}
+		for _, combinedID := range []string{entry.Status.ClosestStop, entry.Status.NextStop} {
+			_, bareID, err := utils.ExtractAgencyIDAndCodeID(combinedID)
+			if err != nil {
+				continue
+			}
+			if _, exists := stopIDsByBareID[bareID]; !exists {
+				stopIDsByBareID[bareID] = combinedID
+			}
+		}
+	}
+
+	if len(stopIDsByBareID) == 0 {
+		return nil, nil
+	}
+
+	bareIDs := make([]string, 0, len(stopIDsByBareID))
+	for bareID := range stopIDsByBareID {
+		bareIDs = append(bareIDs, bareID)
+	}
+
+	return api.GtfsManager.GtfsDB.Queries.GetStopsByIDs(ctx, bareIDs)
 }
 
 func extractStopIDs(stops []gtfsdb.Stop) []string {

--- a/internal/restapi/trips_for_location_handler.go
+++ b/internal/restapi/trips_for_location_handler.go
@@ -261,31 +261,14 @@ func (api *RestAPI) stopsReferencedByEntries(ctx context.Context, entries []mode
 		bareIDs = append(bareIDs, bareID)
 	}
 
-	stops, err := api.GtfsManager.GtfsDB.Queries.GetStopsByIDs(ctx, bareIDs)
+	stops, err := queryInBatches(ctx, bareIDs, api.GtfsManager.GtfsDB.Queries.GetStopsByIDs)
 	return stops, stopIDsByBareID, err
 }
 
-// stopIDsPerTripIDQuery bounds how many stop IDs go into one IN (...) list.
-// The candidate stop set is uncapped, and SQLite rejects a statement carrying
-// more bind variables than it allows rather than truncating it. Kept well under
-// the oldest limit (999) so the batch size does not depend on which SQLite the
-// build links against.
-const stopIDsPerTripIDQuery = 900
-
 // candidateTripIDsForStops returns the IDs of the trips serving any of these
-// stops, in batches so an uncapped stop set cannot overflow the bind variable
-// limit. IDs may repeat across batches; the caller sets them.
+// stops. IDs may repeat across batches; the caller sets them.
 func (api *RestAPI) candidateTripIDsForStops(ctx context.Context, stopIDs []string) ([]string, error) {
-	tripIDs := make([]string, 0, len(stopIDs))
-	for start := 0; start < len(stopIDs); start += stopIDsPerTripIDQuery {
-		end := min(start+stopIDsPerTripIDQuery, len(stopIDs))
-		batch, err := api.GtfsManager.GtfsDB.Queries.GetTripIDsForStops(ctx, stopIDs[start:end])
-		if err != nil {
-			return nil, err
-		}
-		tripIDs = append(tripIDs, batch...)
-	}
-	return tripIDs, nil
+	return queryInBatches(ctx, stopIDs, api.GtfsManager.GtfsDB.Queries.GetTripIDsForStops)
 }
 
 func extractStopIDs(stops []gtfsdb.Stop) []string {

--- a/internal/restapi/trips_for_location_handler.go
+++ b/internal/restapi/trips_for_location_handler.go
@@ -37,7 +37,7 @@ func (api *RestAPI) tripsForLocationHandler(w http.ResponseWriter, r *http.Reque
 	// silently drops trips the spec says should all be returned.
 	stopsInBounds := api.GtfsManager.GetStopsInBounds(ctx, parsedReq.LocationParams, 0, true)
 	stopIDs := extractStopIDs(stopsInBounds)
-	candidateTripIDs, err := api.GtfsManager.GtfsDB.Queries.GetTripIDsForStops(ctx, stopIDs)
+	candidateTripIDs, err := api.candidateTripIDsForStops(ctx, stopIDs)
 	if err != nil {
 		api.serverErrorResponse(w, r, err)
 		return
@@ -265,6 +265,29 @@ func (api *RestAPI) stopsReferencedByEntries(ctx context.Context, entries []mode
 
 	stops, err := api.GtfsManager.GtfsDB.Queries.GetStopsByIDs(ctx, bareIDs)
 	return stops, stopIDsByBareID, err
+}
+
+// stopIDsPerTripIDQuery bounds how many stop IDs go into one IN (...) list.
+// The candidate stop set is uncapped, and SQLite rejects a statement carrying
+// more bind variables than it allows rather than truncating it. Kept well under
+// the oldest limit (999) so the batch size does not depend on which SQLite the
+// build links against.
+const stopIDsPerTripIDQuery = 900
+
+// candidateTripIDsForStops returns the IDs of the trips serving any of these
+// stops, in batches so an uncapped stop set cannot overflow the bind variable
+// limit. IDs may repeat across batches; the caller sets them.
+func (api *RestAPI) candidateTripIDsForStops(ctx context.Context, stopIDs []string) ([]string, error) {
+	tripIDs := make([]string, 0, len(stopIDs))
+	for start := 0; start < len(stopIDs); start += stopIDsPerTripIDQuery {
+		end := min(start+stopIDsPerTripIDQuery, len(stopIDs))
+		batch, err := api.GtfsManager.GtfsDB.Queries.GetTripIDsForStops(ctx, stopIDs[start:end])
+		if err != nil {
+			return nil, err
+		}
+		tripIDs = append(tripIDs, batch...)
+	}
+	return tripIDs, nil
 }
 
 func extractStopIDs(stops []gtfsdb.Stop) []string {

--- a/internal/restapi/trips_for_location_handler_test.go
+++ b/internal/restapi/trips_for_location_handler_test.go
@@ -669,7 +669,11 @@ func TestTripsForLocationHandler_ScheduleStopsAreReferenced(t *testing.T) {
 	api, cleanup := createTestApiWithRealTimeData(t, clock.RealClock{})
 	defer cleanup()
 
-	time.Sleep(500 * time.Millisecond)
+	// createTestApiWithRealTimeData returns before the first feed poll lands, and
+	// this endpoint selects trips from live vehicles, so wait for one to arrive.
+	require.Eventually(t, func() bool {
+		return len(api.GtfsManager.GetRealTimeVehicles()) > 0
+	}, 10*time.Second, 20*time.Millisecond, "real-time vehicles never loaded")
 
 	url := tripsForLocationURL(2.0, 3.0, "includeSchedule=true", "includeStatus=true")
 
@@ -683,16 +687,29 @@ func TestTripsForLocationHandler_ScheduleStopsAreReferenced(t *testing.T) {
 		referenced[stop.ID] = true
 	}
 
+	pointedAt := make(map[string]bool)
 	sawStopTime := false
 	for _, entry := range model.Data.List {
 		require.NotNil(t, entry.Schedule, "includeSchedule=true should populate the schedule")
+		if entry.Status != nil {
+			pointedAt[entry.Status.ClosestStop] = true
+			pointedAt[entry.Status.NextStop] = true
+		}
 		for _, stopTime := range entry.Schedule.StopTimes {
+			pointedAt[stopTime.StopID] = true
 			sawStopTime = true
 			assert.True(t, referenced[stopTime.StopID],
 				"stop %q named by trip %q must appear in references.stops", stopTime.StopID, entry.TripId)
 		}
 	}
 	require.True(t, sawStopTime, "expected at least one scheduled stop time to assert against")
+
+	// And nothing extra: a reference stamped with an ID no entry used would
+	// resolve for no one.
+	for _, stop := range model.Data.References.Stops {
+		assert.True(t, pointedAt[stop.ID],
+			"reference %q is not the ID any entry referred to that stop by", stop.ID)
+	}
 }
 
 // TestTripsForLocationHandler_UnreferencedStopsAreOmitted verifies that stops
@@ -702,7 +719,11 @@ func TestTripsForLocationHandler_UnreferencedStopsAreOmitted(t *testing.T) {
 	api, cleanup := createTestApiWithRealTimeData(t, clock.RealClock{})
 	defer cleanup()
 
-	time.Sleep(500 * time.Millisecond)
+	// createTestApiWithRealTimeData returns before the first feed poll lands, and
+	// this endpoint selects trips from live vehicles, so wait for one to arrive.
+	require.Eventually(t, func() bool {
+		return len(api.GtfsManager.GetRealTimeVehicles()) > 0
+	}, 10*time.Second, 20*time.Millisecond, "real-time vehicles never loaded")
 
 	url := tripsForLocationURL(2.0, 3.0, "includeSchedule=false", "includeStatus=false")
 
@@ -721,7 +742,11 @@ func TestTripsForLocationHandler_CandidateStopsAreNotCapped(t *testing.T) {
 	api, cleanup := createTestApiWithRealTimeData(t, clock.RealClock{})
 	defer cleanup()
 
-	time.Sleep(500 * time.Millisecond)
+	// createTestApiWithRealTimeData returns before the first feed poll lands, and
+	// this endpoint selects trips from live vehicles, so wait for one to arrive.
+	require.Eventually(t, func() bool {
+		return len(api.GtfsManager.GetRealTimeVehicles()) > 0
+	}, 10*time.Second, 20*time.Millisecond, "real-time vehicles never loaded")
 
 	params := &internalgtfs.LocationParams{
 		Lat:     tripsForLocationLat,

--- a/internal/restapi/trips_for_location_handler_test.go
+++ b/internal/restapi/trips_for_location_handler_test.go
@@ -660,3 +660,54 @@ func TestTripsForLocationHandler_SituationReferences(t *testing.T) {
 	require.Contains(t, emitted, "25_test-alert-trips-for-location",
 		"expected the seeded alert to surface as a situationId")
 }
+
+// TestTripsForLocationHandler_ScheduleStopsAreReferenced verifies that every
+// stop named by an entry's schedule resolves to an entry in references.stops.
+func TestTripsForLocationHandler_ScheduleStopsAreReferenced(t *testing.T) {
+	api, cleanup := createTestApiWithRealTimeData(t, clock.RealClock{})
+	defer cleanup()
+
+	time.Sleep(500 * time.Millisecond)
+
+	url := tripsForLocationURL(2.0, 3.0, "includeSchedule=true", "includeStatus=true")
+
+	resp, model := callAPIHandler[TripsForLocationResponse](t, api, url)
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NotEmpty(t, model.Data.List, "expected trips so stop references can be asserted")
+
+	referenced := make(map[string]bool, len(model.Data.References.Stops))
+	for _, stop := range model.Data.References.Stops {
+		referenced[stop.ID] = true
+	}
+
+	sawStopTime := false
+	for _, entry := range model.Data.List {
+		require.NotNil(t, entry.Schedule, "includeSchedule=true should populate the schedule")
+		for _, stopTime := range entry.Schedule.StopTimes {
+			sawStopTime = true
+			assert.True(t, referenced[stopTime.StopID],
+				"stop %q named by trip %q must appear in references.stops", stopTime.StopID, entry.TripId)
+		}
+	}
+	require.True(t, sawStopTime, "expected at least one scheduled stop time to assert against")
+}
+
+// TestTripsForLocationHandler_UnreferencedStopsAreOmitted verifies that stops
+// merely inside the search bounds are not emitted as references when nothing in
+// the response points at them.
+func TestTripsForLocationHandler_UnreferencedStopsAreOmitted(t *testing.T) {
+	api, cleanup := createTestApiWithRealTimeData(t, clock.RealClock{})
+	defer cleanup()
+
+	time.Sleep(500 * time.Millisecond)
+
+	url := tripsForLocationURL(2.0, 3.0, "includeSchedule=false", "includeStatus=false")
+
+	resp, model := callAPIHandler[TripsForLocationResponse](t, api, url)
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NotEmpty(t, model.Data.List, "expected trips so the reference set is meaningful")
+	assert.Empty(t, model.Data.References.Stops,
+		"no schedule or status means nothing in the response refers to a stop")
+}

--- a/internal/restapi/trips_for_location_handler_test.go
+++ b/internal/restapi/trips_for_location_handler_test.go
@@ -813,6 +813,48 @@ func TestTripsForLocationHandler_ScheduleStopsAreReferenced(t *testing.T) {
 	}
 }
 
+// TestTripsForLocationHandler_StatusStopsAreReferenced covers the path where a
+// status is the only thing naming a stop: with includeSchedule=false there are
+// no stop times to collect, so closestStop and nextStop are the whole of what
+// references.stops has to resolve.
+func TestTripsForLocationHandler_StatusStopsAreReferenced(t *testing.T) {
+	api, cleanup := createTestApiWithRealTimeData(t, clock.RealClock{})
+	defer cleanup()
+
+	require.Eventually(t, func() bool {
+		return len(api.GtfsManager.GetRealTimeVehicles()) > 0
+	}, 10*time.Second, 20*time.Millisecond, "real-time vehicles never loaded")
+
+	url := tripsForLocationURL(2.0, 3.0, "includeSchedule=false", "includeStatus=true")
+
+	resp, model := callAPIHandler[TripsForLocationResponse](t, api, url)
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NotEmpty(t, model.Data.List, "expected trips so status stop references can be asserted")
+
+	referenced := make(map[string]bool, len(model.Data.References.Stops))
+	for _, stop := range model.Data.References.Stops {
+		referenced[stop.ID] = true
+	}
+
+	sawStatusStop := false
+	for _, entry := range model.Data.List {
+		require.Nil(t, entry.Schedule, "includeSchedule=false should leave the schedule out")
+		if entry.Status == nil {
+			continue
+		}
+		for _, stopID := range []string{entry.Status.ClosestStop, entry.Status.NextStop} {
+			if stopID == "" {
+				continue
+			}
+			sawStatusStop = true
+			assert.True(t, referenced[stopID],
+				"stop %q named by trip %q's status must appear in references.stops", stopID, entry.TripId)
+		}
+	}
+	require.True(t, sawStatusStop, "expected at least one status stop to assert against")
+}
+
 // TestTripsForLocationHandler_UnreferencedStopsAreOmitted verifies that stops
 // merely inside the search bounds are not emitted as references when nothing in
 // the response points at them.
@@ -910,13 +952,13 @@ func TestCandidateTripIDsForStops_BatchesLargeStopSets(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, stops)
 
-	stopIDs := make([]string, 0, stopIDsPerTripIDQuery+len(stops))
-	for len(stopIDs) <= stopIDsPerTripIDQuery {
+	stopIDs := make([]string, 0, idsPerBatchedQuery+len(stops))
+	for len(stopIDs) <= idsPerBatchedQuery {
 		for _, stop := range stops {
 			stopIDs = append(stopIDs, stop.ID)
 		}
 	}
-	require.Greater(t, len(stopIDs), stopIDsPerTripIDQuery,
+	require.Greater(t, len(stopIDs), idsPerBatchedQuery,
 		"the input must span more than one batch for this test to mean anything")
 
 	batched, err := api.candidateTripIDsForStops(ctx, stopIDs)

--- a/internal/restapi/trips_for_location_handler_test.go
+++ b/internal/restapi/trips_for_location_handler_test.go
@@ -12,7 +12,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"maglev.onebusaway.org/internal/clock"
+	internalgtfs "maglev.onebusaway.org/internal/gtfs"
 	"maglev.onebusaway.org/internal/models"
+	"maglev.onebusaway.org/internal/utils"
 )
 
 const (
@@ -710,4 +712,63 @@ func TestTripsForLocationHandler_UnreferencedStopsAreOmitted(t *testing.T) {
 	require.NotEmpty(t, model.Data.List, "expected trips so the reference set is meaningful")
 	assert.Empty(t, model.Data.References.Stops,
 		"no schedule or status means nothing in the response refers to a stop")
+}
+
+// TestTripsForLocationHandler_CandidateStopsAreNotCapped verifies that the
+// candidate stop set is not truncated, which previously dropped trips serving
+// only stops beyond the cap.
+func TestTripsForLocationHandler_CandidateStopsAreNotCapped(t *testing.T) {
+	api, cleanup := createTestApiWithRealTimeData(t, clock.RealClock{})
+	defer cleanup()
+
+	time.Sleep(500 * time.Millisecond)
+
+	params := &internalgtfs.LocationParams{
+		Lat:     tripsForLocationLat,
+		Lon:     tripsForLocationLon,
+		LatSpan: 2.0,
+		LonSpan: 3.0,
+	}
+
+	uncapped := api.GtfsManager.GetStopsInBounds(context.Background(), params, 0, true)
+	require.Greater(t, len(uncapped), models.DefaultMaxCountForStops,
+		"fixture must hold more in-bounds stops than the old cap for this test to mean anything")
+
+	bounds := internalgtfs.BoundsFromParams(params, true)
+
+	resp, model := callAPIHandler[TripsForLocationResponse](t, api, tripsForLocationURL(2.0, 3.0))
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	returned := make(map[string]bool, len(model.Data.List))
+	for _, entry := range model.Data.List {
+		_, tripID, err := utils.ExtractAgencyIDAndCodeID(entry.TripId)
+		require.NoError(t, err)
+		returned[tripID] = true
+	}
+
+	// Every real-time vehicle positioned inside the bounds must be represented.
+	// The RABA fixture's vehicles all happen to serve stops early in the
+	// in-bounds ordering, so this guards the invariant rather than reproducing
+	// a truncation the fixture cannot produce.
+	assertedAnyVehicle := false
+	for _, vehicle := range api.GtfsManager.GetRealTimeVehicles() {
+		if vehicle.Trip == nil || vehicle.Position == nil ||
+			vehicle.Position.Latitude == nil || vehicle.Position.Longitude == nil {
+			continue
+		}
+		lat, lon := float64(*vehicle.Position.Latitude), float64(*vehicle.Position.Longitude)
+		if lat < bounds.MinLat || lat > bounds.MaxLat || lon < bounds.MinLon || lon > bounds.MaxLon {
+			continue
+		}
+
+		tripID := vehicle.Trip.ID.ID
+		stopTimes, err := api.GtfsManager.GtfsDB.Queries.GetStopTimesForTrip(context.Background(), tripID)
+		if err != nil || len(stopTimes) == 0 {
+			continue
+		}
+
+		assertedAnyVehicle = true
+		assert.True(t, returned[tripID], "in-bounds vehicle's trip %q must be returned", tripID)
+	}
+	require.True(t, assertedAnyVehicle, "expected at least one in-bounds vehicle to assert against")
 }

--- a/internal/restapi/trips_for_location_handler_test.go
+++ b/internal/restapi/trips_for_location_handler_test.go
@@ -797,3 +797,45 @@ func TestTripsForLocationHandler_CandidateStopsAreNotCapped(t *testing.T) {
 	}
 	require.True(t, assertedAnyVehicle, "expected at least one in-bounds vehicle to assert against")
 }
+
+// TestCandidateTripIDsForStops_BatchesLargeStopSets covers the uncapped stop
+// set exceeding one query's bind variable budget: the batches together must
+// return what a single query would.
+func TestCandidateTripIDsForStops_BatchesLargeStopSets(t *testing.T) {
+	api := createTestApi(t)
+	ctx := context.Background()
+
+	stops, err := api.GtfsManager.GtfsDB.Queries.ListStops(ctx)
+	require.NoError(t, err)
+	require.NotEmpty(t, stops)
+
+	stopIDs := make([]string, 0, stopIDsPerTripIDQuery+len(stops))
+	for len(stopIDs) <= stopIDsPerTripIDQuery {
+		for _, stop := range stops {
+			stopIDs = append(stopIDs, stop.ID)
+		}
+	}
+	require.Greater(t, len(stopIDs), stopIDsPerTripIDQuery,
+		"the input must span more than one batch for this test to mean anything")
+
+	batched, err := api.candidateTripIDsForStops(ctx, stopIDs)
+	require.NoError(t, err)
+
+	singleQuery, err := api.GtfsManager.GtfsDB.Queries.GetTripIDsForStops(ctx, stopIDs[:len(stops)])
+	require.NoError(t, err)
+
+	assert.ElementsMatch(t, singleQuery, uniqueStrings(batched))
+}
+
+func uniqueStrings(values []string) []string {
+	seen := make(map[string]struct{}, len(values))
+	unique := make([]string, 0, len(values))
+	for _, value := range values {
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		unique = append(unique, value)
+	}
+	return unique
+}

--- a/internal/restapi/trips_for_route_handler.go
+++ b/internal/restapi/trips_for_route_handler.go
@@ -745,7 +745,7 @@ func (api *RestAPI) buildTripReferences(ctx context.Context, params tripReferenc
 	references := models.NewEmptyReferences()
 	references.Agencies = utils.MapValues(sets.agencies)
 	references.Routes = sets.routeList()
-	references.Stops = api.stopReferenceList(ctx, params.Stops, params.StopIDMap)
+	references.Stops, _ = api.stopReferences(ctx, params.Stops, params.StopIDMap)
 	references.Trips = sets.tripReferenceList(params.IncludeTrip)
 	references.Situations = api.situationReferences(params.Situations)
 	return *references
@@ -902,64 +902,6 @@ func (api *RestAPI) addAgencyReference(ctx context.Context, sets *tripReferenceS
 	if agency != nil {
 		sets.agencies[agency.ID] = models.AgencyReferenceFromDatabase(agency)
 	}
-}
-
-// stopReferenceList builds the stop references, labelling each with the combined
-// ID the list entries used for it.
-func (api *RestAPI) stopReferenceList(ctx context.Context, stops []gtfsdb.Stop, stopIDMap map[string]string) []models.Stop {
-	routeIDsByStop := api.routeIDsForStops(ctx, stops)
-
-	stopList := make([]models.Stop, 0, len(stops))
-	for _, stop := range stops {
-		routeIDs := routeIDsByStop[stop.ID]
-		if routeIDs == nil {
-			routeIDs = []string{}
-		}
-
-		direction := models.UnknownValue
-		if stop.Direction.Valid && stop.Direction.String != "" {
-			direction = stop.Direction.String
-		}
-
-		stopList = append(stopList, models.Stop{
-			Code:               nulls.StringOrEmpty(stop.Code),
-			Direction:          direction,
-			ID:                 stopIDMap[stop.ID],
-			Lat:                stop.Lat,
-			Lon:                stop.Lon,
-			LocationType:       0,
-			Name:               nulls.StringOrEmpty(stop.Name),
-			Parent:             "",
-			RouteIDs:           routeIDs,
-			StaticRouteIDs:     routeIDs,
-			WheelchairBoarding: utils.MapWheelchairBoarding(nulls.WheelchairBoardingOrUnknown(stop.WheelchairBoarding)),
-		})
-	}
-	return stopList
-}
-
-func (api *RestAPI) routeIDsForStops(ctx context.Context, stops []gtfsdb.Stop) map[string][]string {
-	routeIDsByStop := make(map[string][]string)
-	if len(stops) == 0 {
-		return routeIDsByStop
-	}
-
-	stopIDs := make([]string, len(stops))
-	for i, stop := range stops {
-		stopIDs[i] = stop.ID
-	}
-
-	rows, err := api.GtfsManager.GtfsDB.Queries.GetRouteIDsForStops(ctx, stopIDs)
-	if err != nil {
-		logging.LogError(api.Logger, "failed to fetch routes for stop references", err)
-		return routeIDsByStop
-	}
-	for _, row := range rows {
-		if routeID, ok := row.RouteID.(string); ok {
-			routeIDsByStop[row.StopID] = append(routeIDsByStop[row.StopID], routeID)
-		}
-	}
-	return routeIDsByStop
 }
 
 // tripReferenceList emits the collected trips in combined-ID form. A trip whose

--- a/internal/restapi/trips_for_route_handler.go
+++ b/internal/restapi/trips_for_route_handler.go
@@ -513,7 +513,7 @@ func (api *RestAPI) tripsForRouteHandler(w http.ResponseWriter, r *http.Request)
 				bareIDs = append(bareIDs, bareID)
 			}
 			var err error
-			stops, err = api.GtfsManager.GtfsDB.Queries.GetStopsByIDs(ctx, bareIDs)
+			stops, err = queryInBatches(ctx, bareIDs, api.GtfsManager.GtfsDB.Queries.GetStopsByIDs)
 			if err != nil {
 				api.Logger.Warn("failed to fetch stops for references", "error", err, "count", len(bareIDs))
 				stops = []gtfsdb.Stop{}


### PR DESCRIPTION
Closes #1308. Closes #1309.

Depends on #1313 and includes its commits; merge that first.

The in-bounds stop query was doing double duty as both the candidate-trip source and the stop reference list, which broke it in two ways: stops named by an entry's schedule or status but outside the search box were missing from `references.stops`, while in-bounds stops no returned trip serves were included with nothing pointing at them. That same set was capped at 100, silently dropping trips with `limitExceeded` still `false`.

## Changes

- Build `references.stops` from the response — the stops on each entry's schedule plus the closest and next stops on its status. Reuses `collectStopIDsFromSchedule`.
- Publish each stop reference under the combined ID an entry referred to it by, rather than deriving one from the stop's first route, whose agency need not be the referring trip's.
- Drop the cap on the candidate stop query, now that it no longer doubles as reference-payload control.
- Replace `GetStopTimesByStopIDs` with `GetTripIDsForStops` (`SELECT DISTINCT trip_id`). The caller reads nothing but the trip ID, and the existing `(stop_id, trip_id)` index covers the query, so the uncapped stop set no longer implies materializing whole `stop_times` rows.

Both issues in one PR because they rewrite the same stop set and are not separable line-for-line.

## Behaviour change

With `includeSchedule=false` and `includeStatus=false` (both defaults), `references.stops` is now empty — nothing in the response refers to a stop.

## Verification

Live against the King County feed, downtown Seattle, `radius=2000&includeSchedule=true`: unresolvable schedule stops went from 1369 of 1438 to 20, and `references.stops` from exactly 100 (the cap) to 1605.

The remaining 20 are a limitation this cannot fully close: a stop referred to under two agencies in one response gets a single reference, and the first referring ID wins.

`go vet` and `make test` pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved trip, route, vehicle, and stop responses so service alerts consistently include valid situation IDs and references.
  - Preserved relevant stop and route references while omitting unrelated stops.
  - Improved handling of large stop sets, preventing truncated results and request failures.
  - Added more reliable alert resolution, including agency-specific and interlined-trip scenarios.
  - Prevented duplicate trip results when stops serve the same trips.

- **Tests**
  - Added coverage for situation references, stop references, large stop sets, batching, and deduplication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->