### PR TITLE
Fix schedule timezone and outOfRange bounds in trips-for-location

### DIFF
--- a/internal/gtfs/location_params.go
+++ b/internal/gtfs/location_params.go
@@ -53,13 +53,17 @@ func BoundsFromParams(loc *LocationParams, clamp ...bool) utils.CoordinateBounds
 
 // CheckIfOutOfBounds returns true if the user's search area is completely
 // outside every agency's region bounds.
-func (manager *Manager) CheckIfOutOfBounds(loc *LocationParams) bool {
+//
+// clamp must match what the caller passed to BoundsFromParams when it ran the
+// search. Reporting on unclamped bounds while searching clamped ones lets an
+// oversized radius overlap a region it never actually searched.
+func (manager *Manager) CheckIfOutOfBounds(loc *LocationParams, clamp ...bool) bool {
 	boundsMap := manager.GetRegionBounds()
 	if len(boundsMap) == 0 {
 		return false
 	}
 
-	innerBounds := BoundsFromParams(loc)
+	innerBounds := BoundsFromParams(loc, clamp...)
 
 	for _, region := range boundsMap {
 		outerBounds := utils.CalculateBoundsFromSpan(region.Lat, region.Lon, region.LatSpan/2, region.LonSpan/2)

--- a/internal/gtfs/location_params_test.go
+++ b/internal/gtfs/location_params_test.go
@@ -154,3 +154,19 @@ func TestCheckIfOutOfBounds(t *testing.T) {
 		assert.False(t, manager.CheckIfOutOfBounds(params))
 	})
 }
+
+func TestCheckIfOutOfBoundsClamping(t *testing.T) {
+	manager := &Manager{
+		regionBounds: map[string]*RegionBounds{
+			"agency1": {Lat: 40.0, Lon: -70.0, LatSpan: 1.0, LonSpan: 1.0},
+		},
+	}
+	// Seattle, with a radius wide enough to reach the east-coast region only if
+	// the radius is left unclamped.
+	params := &LocationParams{Lat: 47.6, Lon: -122.3, Radius: 5_000_000}
+
+	assert.False(t, manager.CheckIfOutOfBounds(params),
+		"unclamped bounds still overlap the distant region")
+	assert.True(t, manager.CheckIfOutOfBounds(params, true),
+		"clamped to 20km the search never reaches the region, so it is out of range")
+}

--- a/internal/gtfs/location_params_test.go
+++ b/internal/gtfs/location_params_test.go
@@ -165,8 +165,25 @@ func TestCheckIfOutOfBoundsClamping(t *testing.T) {
 	// the radius is left unclamped.
 	params := &LocationParams{Lat: 47.6, Lon: -122.3, Radius: 5_000_000}
 
-	assert.False(t, manager.CheckIfOutOfBounds(params),
-		"unclamped bounds still overlap the distant region")
-	assert.True(t, manager.CheckIfOutOfBounds(params, true),
-		"clamped to 20km the search never reaches the region, so it is out of range")
+	tests := []struct {
+		name  string
+		clamp []bool
+		want  bool
+	}{
+		{
+			name: "Unclamped bounds still overlap the distant region",
+			want: false,
+		},
+		{
+			name:  "Clamped to 20km the search never reaches the region",
+			clamp: []bool{true},
+			want:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, manager.CheckIfOutOfBounds(params, tt.clamp...))
+		})
+	}
 }

--- a/internal/restapi/trips_for_location_handler.go
+++ b/internal/restapi/trips_for_location_handler.go
@@ -100,7 +100,7 @@ func (api *RestAPI) tripsForLocationHandler(w http.ResponseWriter, r *http.Reque
 	}
 
 	// Build entries from pre-fetched trip data
-	result, situations := api.buildTripsForLocationEntries(ctx, trips, tripAgencyMap, parsedReq.IncludeSchedule, parsedReq.IncludeStatus, parsedReq.CurrentLocation, parsedReq.CurrentTime, parsedReq.TodayMidnight, parsedReq.ServiceDate, w, r)
+	result, situations := api.buildTripsForLocationEntries(ctx, parsedReq, trips, tripAgencyMap, w, r)
 	if result == nil {
 		return
 	}
@@ -317,17 +317,13 @@ func (api *RestAPI) getActiveTrips(candidateTripIDs []string, realTimeVehicles [
 // returning the entries alongside the situations they reference.
 func (api *RestAPI) buildTripsForLocationEntries(
 	ctx context.Context,
+	req *tripsForLocationRequest,
 	trips []gtfsdb.Trip,
 	tripAgencyMap map[string]string,
-	includeSchedule bool,
-	includeStatus bool,
-	currentLocation *time.Location,
-	currentTime time.Time,
-	todayMidnight time.Time,
-	serviceDate time.Time,
 	w http.ResponseWriter,
 	r *http.Request,
 ) ([]models.TripsForLocationListEntry, []situationRef) {
+	includeSchedule := req.IncludeSchedule
 	if len(trips) == 0 {
 		return []models.TripsForLocationListEntry{}, nil
 	}
@@ -389,7 +385,7 @@ func (api *RestAPI) buildTripsForLocationEntries(
 				blockIDs = append(blockIDs, bid)
 			}
 
-			dateStr := serviceDate.Format("20060102")
+			dateStr := req.ServiceDate.Format("20060102")
 			activeServiceIDs, err := api.GtfsManager.GtfsDB.Queries.GetActiveServiceIDsForDate(ctx, dateStr)
 			if err != nil {
 				activeServiceIDs = []string{}
@@ -463,7 +459,7 @@ func (api *RestAPI) buildTripsForLocationEntries(
 			schedule = api.buildScheduleFromMemory(
 				tripData,
 				agencyID,
-				currentLocation,
+				req.CurrentLocation,
 				stopTimesMap[tripID],
 				shapePoints,
 				stopCoords,
@@ -471,9 +467,9 @@ func (api *RestAPI) buildTripsForLocationEntries(
 			)
 		}
 
-		if includeStatus {
+		if req.IncludeStatus {
 			var statusErr error
-			status, _, statusErr = api.BuildTripStatus(ctx, agencyID, tripID, nil, todayMidnight, currentTime)
+			status, _, statusErr = api.BuildTripStatus(ctx, agencyID, tripID, nil, req.TodayMidnight, req.CurrentTime)
 			if statusErr != nil {
 				api.Logger.Warn("BuildTripStatus failed", "tripID", tripID, "error", statusErr)
 				status = nil
@@ -490,7 +486,7 @@ func (api *RestAPI) buildTripsForLocationEntries(
 			Frequency:    nil,
 			Schedule:     schedule,
 			Status:       status,
-			ServiceDate:  todayMidnight.UnixMilli(),
+			ServiceDate:  req.TodayMidnight.UnixMilli(),
 			SituationIds: situations.add(alerts, agencyID),
 			TripId:       utils.FormCombinedID(agencyID, tripID),
 		}

--- a/internal/restapi/trips_for_location_handler.go
+++ b/internal/restapi/trips_for_location_handler.go
@@ -130,7 +130,8 @@ func (api *RestAPI) tripsForLocationHandler(w http.ResponseWriter, r *http.Reque
 		})
 	}
 
-	response := models.NewListResponseWithRange(result, references, api.GtfsManager.CheckIfOutOfBounds(parsedReq.LocationParams), api.Clock, false)
+	outOfRange := api.GtfsManager.CheckIfOutOfBounds(parsedReq.LocationParams, true)
+	response := models.NewListResponseWithRange(result, references, outOfRange, api.Clock, false)
 	api.sendResponse(w, r, response)
 }
 

--- a/internal/restapi/trips_for_location_handler.go
+++ b/internal/restapi/trips_for_location_handler.go
@@ -143,9 +143,35 @@ type tripsForLocationRequest struct {
 	IncludeSchedule bool
 	IncludeStatus   bool
 	CurrentLocation *time.Location
+	// AgencyLocations maps agency ID to that agency's timezone, so a trip's
+	// schedule reports its own agency's zone rather than the first agency's.
+	AgencyLocations map[string]*time.Location
 	CurrentTime     time.Time
 	TodayMidnight   time.Time
 	ServiceDate     time.Time
+}
+
+// scheduleLocation returns the timezone to report for a trip belonging to
+// agencyID, falling back to the query timezone for an agency that was not in
+// the agency table when the request was parsed.
+func (req *tripsForLocationRequest) scheduleLocation(agencyID string) *time.Location {
+	if location, ok := req.AgencyLocations[agencyID]; ok {
+		return location
+	}
+	return req.CurrentLocation
+}
+
+// agencyLocations resolves every agency's timezone once per request.
+func agencyLocations(agencies []gtfsdb.Agency) (map[string]*time.Location, error) {
+	locations := make(map[string]*time.Location, len(agencies))
+	for _, agency := range agencies {
+		location, err := loadAgencyLocation(agency.ID, agency.Timezone)
+		if err != nil {
+			return nil, err
+		}
+		locations[agency.ID] = location
+	}
+	return locations, nil
 }
 
 func (api *RestAPI) parseAndValidateRequest(r *http.Request) (*tripsForLocationRequest, map[string][]string, error) {
@@ -169,11 +195,14 @@ func (api *RestAPI) parseAndValidateRequest(r *http.Request) (*tripsForLocationR
 		return nil, nil, errors.New("no agencies configured in GTFS manager")
 	}
 
-	currentAgency := agencies[0]
-	currentLocation, serverErr := loadAgencyLocation(currentAgency.ID, currentAgency.Timezone)
+	locations, serverErr := agencyLocations(agencies)
 	if serverErr != nil {
 		return nil, nil, serverErr
 	}
+
+	// The query time is interpreted in the first agency's zone; only the
+	// per-trip schedule timezone varies by agency.
+	currentLocation := locations[agencies[0].ID]
 
 	currentTime, timeFieldErrors := api.resolveCurrentTime(queryParams.Get("time"), currentLocation)
 	fieldErrors = mergeFieldErrors(fieldErrors, timeFieldErrors)
@@ -190,6 +219,7 @@ func (api *RestAPI) parseAndValidateRequest(r *http.Request) (*tripsForLocationR
 		IncludeSchedule: includeSchedule,
 		IncludeStatus:   includeStatus,
 		CurrentLocation: currentLocation,
+		AgencyLocations: locations,
 		CurrentTime:     currentTime,
 		TodayMidnight:   todayMidnight,
 		ServiceDate:     serviceDate,
@@ -459,7 +489,7 @@ func (api *RestAPI) buildTripsForLocationEntries(
 			schedule = api.buildScheduleFromMemory(
 				tripData,
 				agencyID,
-				req.CurrentLocation,
+				req.scheduleLocation(agencyID),
 				stopTimesMap[tripID],
 				shapePoints,
 				stopCoords,

--- a/internal/restapi/trips_for_location_handler_test.go
+++ b/internal/restapi/trips_for_location_handler_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/OneBusAway/go-gtfs"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"maglev.onebusaway.org/gtfsdb"
 	"maglev.onebusaway.org/internal/clock"
 	internalgtfs "maglev.onebusaway.org/internal/gtfs"
 	"maglev.onebusaway.org/internal/models"
@@ -838,4 +839,53 @@ func uniqueStrings(values []string) []string {
 		unique = append(unique, value)
 	}
 	return unique
+}
+
+func TestTripsForLocationRequest_ScheduleLocation(t *testing.T) {
+	losAngeles, err := time.LoadLocation("America/Los_Angeles")
+	require.NoError(t, err)
+	chicago, err := time.LoadLocation("America/Chicago")
+	require.NoError(t, err)
+
+	req := &tripsForLocationRequest{
+		CurrentLocation: losAngeles,
+		AgencyLocations: map[string]*time.Location{"1": losAngeles, "2": chicago},
+	}
+
+	tests := []struct {
+		name     string
+		agencyID string
+		want     *time.Location
+	}{
+		{name: "First agency", agencyID: "1", want: losAngeles},
+		{name: "Agency in a different zone", agencyID: "2", want: chicago},
+		{name: "Unknown agency falls back to the query zone", agencyID: "99", want: losAngeles},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, req.scheduleLocation(tt.agencyID))
+		})
+	}
+}
+
+func TestAgencyLocations(t *testing.T) {
+	t.Run("Resolves each agency's zone", func(t *testing.T) {
+		locations, err := agencyLocations([]gtfsdb.Agency{
+			{ID: "1", Timezone: "America/Los_Angeles"},
+			{ID: "2", Timezone: "America/Chicago"},
+		})
+
+		require.NoError(t, err)
+		require.Len(t, locations, 2)
+		assert.Equal(t, "America/Los_Angeles", locations["1"].String())
+		assert.Equal(t, "America/Chicago", locations["2"].String())
+	})
+
+	t.Run("Reports an unparseable zone", func(t *testing.T) {
+		_, err := agencyLocations([]gtfsdb.Agency{{ID: "1", Timezone: "Not/A_Zone"}})
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), `invalid timezone for agency "1"`)
+	})
 }


### PR DESCRIPTION
Closes #1310.

Depends on #1314 (and transitively #1313) and includes their commits; merge those first.

Two correctness bugs in the same handler path:

- `schedule.timeZone` came from `agencies[0]` and was stamped onto every trip, so on a feed spanning timezones most trips reported the wrong one.
- `outOfRange` was computed from unclamped bounds while the search clamped to 20 km, so `radius=5000000` reported `outOfRange: false` from anywhere on earth.

## Changes

- Resolve every agency's timezone once per request and look up the trip's own agency when building its schedule. The query `time` is still interpreted in the first agency's zone.
- Give `CheckIfOutOfBounds` the same variadic `clamp` flag `BoundsFromParams` has, and pass `true` from trips-for-location. `routes-for-location` and `stops-for-location` do not clamp their searches, so they keep unclamped behaviour and stay self-consistent.
- Pass the parsed request struct into `buildTripsForLocationEntries` instead of eleven positional parameters, five of which were unpacked from it at the single call site. No behaviour change; it is what keeps the timezone map from becoming a twelfth.

## Verification

Live: LA with `radius=2000000` now reports `outOfRange: true`, previously `false`.

The timezone fix is covered by unit tests rather than the fixture — King County is single-agency, so it cannot exercise a multi-timezone feed. `TestCheckIfOutOfBoundsClamping`, `TestTripsForLocationRequest_ScheduleLocation`, `TestAgencyLocations`.

`go vet` (both tag sets) and `make test` pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved location-based trip searches by consistently applying search boundary limits.
  * Corrected out-of-range indicators for large-radius searches, preventing misleading results when searches overlap distant areas.
  * Added coverage to verify behavior with both clamped and unclamped search bounds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->