### PR TITLE
Disambiguate nil return in buildTripsForLocationEntries

### DIFF
--- a/internal/restapi/trips_for_location_handler.go
+++ b/internal/restapi/trips_for_location_handler.go
@@ -243,6 +243,9 @@ func (api *RestAPI) getActiveTrips(stopTimes []gtfsdb.StopTime, realTimeVehicles
 }
 
 // buildTripsForLocationEntries builds trip entries from pre-fetched batch data.
+// It returns nil only when an error response has already been sent to the client.
+// Otherwise, it returns a non-nil (possibly empty) slice. The result slice is empty if
+// context cancellation occurs before appending any entry to the result slice.
 func (api *RestAPI) buildTripsForLocationEntries(
 	ctx context.Context,
 	trips []gtfsdb.Trip,
@@ -360,7 +363,7 @@ func (api *RestAPI) buildTripsForLocationEntries(
 		}
 	}
 
-	var result []models.TripsForLocationListEntry
+	result := make([]models.TripsForLocationListEntry, 0)
 
 	for _, tripID := range validVehicleTrips {
 		if ctx.Err() != nil {

--- a/internal/restapi/trips_for_location_handler.go
+++ b/internal/restapi/trips_for_location_handler.go
@@ -244,8 +244,6 @@ func (api *RestAPI) getActiveTrips(stopTimes []gtfsdb.StopTime, realTimeVehicles
 
 // buildTripsForLocationEntries builds trip entries from pre-fetched batch data.
 // It returns nil only when an error response has already been sent to the client.
-// Otherwise, it returns a non-nil (possibly empty) slice. The result slice is empty if
-// context cancellation occurs before appending any entry to the result slice.
 func (api *RestAPI) buildTripsForLocationEntries(
 	ctx context.Context,
 	trips []gtfsdb.Trip,
@@ -363,11 +361,12 @@ func (api *RestAPI) buildTripsForLocationEntries(
 		}
 	}
 
-	result := make([]models.TripsForLocationListEntry, 0)
+	var result []models.TripsForLocationListEntry
 
 	for _, tripID := range validVehicleTrips {
 		if ctx.Err() != nil {
-			return result
+			api.clientCanceledResponse(w, r, ctx.Err())
+			return nil
 		}
 
 		agencyID := tripAgencyMap[tripID]


### PR DESCRIPTION
## Fix nil sentinel ambiguity in `buildTripsForLocationEntries` on early context cancellation

Closes #1324 

### Problem

`buildTripsForLocationEntries` uses a `nil` return value to signal to the caller that a response has already been written (e.g., after `serverErrorResponse`). However, the function also returned a nil `result` when `ctx.Err() != nil` inside the trip-building loop — if cancellation fires before any entries had been appended as`result` is still its zero value: `nil`.

This overloads the nil sentinel with two meanings: "already responded", "no entries yet"

The caller:

```go
result := api.buildTripsForLocationEntries(...)
if result == nil {
    return
}

if ctx.Err() != nil {              // never reached on early cancellation
    api.clientCanceledResponse(w, r, ctx.Err())
    return
}
```

On early cancellation, `result` is `nil`, so the handler assumes a response was already written and returns immediately. The `ctx.Err()` check — which would call `clientCanceledResponse` to properly handle the context error — is never reached, inappropriately sending the client a `200 OK` with an empty body.


### Fix

Call `clientCanceledResponse` directly inside `buildTripsForLocationEntries` when context cancellation is detected, and return `nil`:

```go
// Before
if ctx.Err() != nil {
    return result
}

// After
if ctx.Err() != nil {
    api.clientCanceledResponse(w, r, ctx.Err())
    return nil
}
```

The function's contract now has a single meaning for `nil`: "error response already handled." This is consistent with the existing `serverErrorResponse` + `return nil` pattern already used elsewhere in the same function. The handler-level `ctx.Err()` check is retained as a safety net for cancellations that occur after `buildTripsForLocationEntries` returns.

### Testing

The existing `TestTripsForLocationHandler_ContextCancellation` already validates that the handler correctly handles context cancellation either due to a timeout or explicit client disconnect.

Deterministically testing the specific bug window (context cancelled after the batch queries succeed but before the first `append` in the loop) would require adding scaffolding for an extreme edge case. The fix is a small, localized change with obviously correct semantics: `nil` now consistently means "response already handled," matching the existing error handling pattern in the same function.

Existing tests continue to pass.
