### PR TITLE
Correct route-type truncation comments

### DIFF
--- a/internal/gtfs/gtfs_manager.go
+++ b/internal/gtfs/gtfs_manager.go
@@ -315,7 +315,9 @@ func (manager *Manager) RoutesForAgencyID(ctx context.Context, agencyID string) 
 //
 // GetStopsForLocation is used by the stops-for-location endpoint.
 // BOUNDS mode (no routeTypes): shuffles stops then truncates before route-type filtering.
-// ORDERED_BY_CLOSEST mode (routeTypes present): sorts by distance, filters by route type, then truncates.
+// ORDERED_BY_CLOSEST mode (routeTypes present): sorts by distance and filters by route type.
+// The caller caps results after dropping stops without service on the queried date;
+// limitExceeded is therefore only meaningful for BOUNDS mode.
 func (manager *Manager) GetStopsForLocation(
 	ctx context.Context,
 	loc *LocationParams,
@@ -349,7 +351,8 @@ func (manager *Manager) GetStopsForLocation(
 			stops = stops[:maxCount]
 		}
 	} else {
-		// ORDERED_BY_CLOSEST mode: sort by distance, filter by route type, then truncate.
+		// ORDERED_BY_CLOSEST mode: sort by distance and filter by route type.
+		// The caller caps after filtering inactive stops, so limitExceeded remains false.
 		slices.SortFunc(stops, func(a, b gtfsdb.Stop) int {
 			aDist := utils.Distance(loc.Lat, loc.Lon, a.Lat, a.Lon)
 			bDist := utils.Distance(loc.Lat, loc.Lon, b.Lat, b.Lon)


### PR DESCRIPTION
Correct the stale truncation comments for route-type stop searches.

#1272 moved route-type capping to the handler, after inactive stops are
removed. The manager comments still described the old behavior.

Closes #1322


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how location-based stop results are sorted and filtered.
  * Documented that result limits apply differently depending on the search mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->