### PR TITLE
Fix multi-timezone trip service dates

### DIFF
--- a/internal/restapi/trips_for_location_handler.go
+++ b/internal/restapi/trips_for_location_handler.go
@@ -98,7 +98,7 @@ func (api *RestAPI) tripsForLocationHandler(w http.ResponseWriter, r *http.Reque
 	}
 
 	// Build entries from pre-fetched trip data
-	result := api.buildTripsForLocationEntries(ctx, trips, tripAgencyMap, parsedReq, w, r)
+	result := api.buildTripsForLocationEntries(ctx, trips, tripAgencyMap, routeAgencyMap, parsedReq, w, r)
 	if result == nil {
 		return
 	}
@@ -245,6 +245,7 @@ func (api *RestAPI) buildTripsForLocationEntries(
 	ctx context.Context,
 	trips []gtfsdb.Trip,
 	tripAgencyMap map[string]string,
+	routeAgencyMap map[string]string,
 	request *tripsForLocationRequest,
 	w http.ResponseWriter,
 	r *http.Request,
@@ -330,8 +331,24 @@ func (api *RestAPI) buildTripsForLocationEntries(
 
 			blockTripsRaw, err := api.GtfsManager.GtfsDB.Queries.GetTripsByBlockIDs(ctx, params)
 			if err == nil {
+				missingRouteIDs := make([]string, 0)
 				for _, bt := range blockTripsRaw {
-					if bt.BlockID.Valid {
+					if _, found := routeAgencyMap[bt.RouteID]; !found {
+						missingRouteIDs = append(missingRouteIDs, bt.RouteID)
+					}
+				}
+				if len(missingRouteIDs) > 0 {
+					routes, routeErr := api.GtfsManager.GtfsDB.Queries.GetRoutesByIDs(ctx, missingRouteIDs)
+					if routeErr != nil {
+						api.Logger.Warn("failed to fetch block trip routes", "agency_id", agencyID, "error", routeErr)
+						continue
+					}
+					for _, route := range routes {
+						routeAgencyMap[route.ID] = route.AgencyID
+					}
+				}
+				for _, bt := range blockTripsRaw {
+					if bt.BlockID.Valid && routeAgencyMap[bt.RouteID] == agencyID {
 						key := blockTripsKey{agencyID: agencyID, blockID: bt.BlockID.String}
 						blockTripsMap[key] = append(blockTripsMap[key], bt)
 					}

--- a/internal/restapi/trips_for_location_handler.go
+++ b/internal/restapi/trips_for_location_handler.go
@@ -98,7 +98,7 @@ func (api *RestAPI) tripsForLocationHandler(w http.ResponseWriter, r *http.Reque
 	}
 
 	// Build entries from pre-fetched trip data
-	result := api.buildTripsForLocationEntries(ctx, trips, tripAgencyMap, parsedReq.IncludeSchedule, parsedReq.IncludeStatus, parsedReq.CurrentLocation, parsedReq.CurrentTime, parsedReq.TodayMidnight, parsedReq.ServiceDate, w, r)
+	result := api.buildTripsForLocationEntries(ctx, trips, tripAgencyMap, parsedReq, w, r)
 	if result == nil {
 		return
 	}
@@ -131,10 +131,8 @@ type tripsForLocationRequest struct {
 	IncludeTrip     bool
 	IncludeSchedule bool
 	IncludeStatus   bool
-	CurrentLocation *time.Location
 	CurrentTime     time.Time
-	TodayMidnight   time.Time
-	ServiceDate     time.Time
+	AgencyLocations map[string]*time.Location
 }
 
 func (api *RestAPI) parseAndValidateRequest(r *http.Request) (*tripsForLocationRequest, map[string][]string, error) {
@@ -158,16 +156,18 @@ func (api *RestAPI) parseAndValidateRequest(r *http.Request) (*tripsForLocationR
 		return nil, nil, errors.New("no agencies configured in GTFS manager")
 	}
 
-	currentAgency := agencies[0]
-	currentLocation, serverErr := loadAgencyLocation(currentAgency.ID, currentAgency.Timezone)
-	if serverErr != nil {
-		return nil, nil, serverErr
+	agencyLocations := make(map[string]*time.Location, len(agencies))
+	for _, agency := range agencies {
+		location, locationErr := loadAgencyLocation(agency.ID, agency.Timezone)
+		if locationErr != nil {
+			return nil, nil, locationErr
+		}
+		agencyLocations[agency.ID] = location
 	}
+	currentLocation := agencyLocations[agencies[0].ID]
 
 	currentTime, timeFieldErrors := api.resolveCurrentTime(queryParams.Get("time"), currentLocation)
 	fieldErrors = mergeFieldErrors(fieldErrors, timeFieldErrors)
-
-	serviceDate, todayMidnight := utils.ServiceDateMidnight(nil, currentTime)
 
 	if len(fieldErrors) > 0 {
 		return nil, fieldErrors, nil
@@ -178,10 +178,8 @@ func (api *RestAPI) parseAndValidateRequest(r *http.Request) (*tripsForLocationR
 		IncludeTrip:     includeTrip,
 		IncludeSchedule: includeSchedule,
 		IncludeStatus:   includeStatus,
-		CurrentLocation: currentLocation,
 		CurrentTime:     currentTime,
-		TodayMidnight:   todayMidnight,
-		ServiceDate:     serviceDate,
+		AgencyLocations: agencyLocations,
 	}
 	return parsedReq, nil, nil
 }
@@ -247,12 +245,7 @@ func (api *RestAPI) buildTripsForLocationEntries(
 	ctx context.Context,
 	trips []gtfsdb.Trip,
 	tripAgencyMap map[string]string,
-	includeSchedule bool,
-	includeStatus bool,
-	currentLocation *time.Location,
-	currentTime time.Time,
-	todayMidnight time.Time,
-	serviceDate time.Time,
+	request *tripsForLocationRequest,
 	w http.ResponseWriter,
 	r *http.Request,
 ) []models.TripsForLocationListEntry {
@@ -262,7 +255,7 @@ func (api *RestAPI) buildTripsForLocationEntries(
 
 	tripsMap := make(map[string]gtfsdb.Trip)
 	var shapeIDs []string
-	uniqueBlockIDs := make(map[string]struct{})
+	blockIDsByAgency := make(map[string]map[string]struct{})
 	var validVehicleTrips []string
 
 	for _, trip := range trips {
@@ -276,7 +269,12 @@ func (api *RestAPI) buildTripsForLocationEntries(
 			shapeIDs = append(shapeIDs, trip.ShapeID.String)
 		}
 		if trip.BlockID.Valid {
-			uniqueBlockIDs[trip.BlockID.String] = struct{}{}
+			agencyBlockIDs := blockIDsByAgency[tripAgencyMap[trip.ID]]
+			if agencyBlockIDs == nil {
+				agencyBlockIDs = make(map[string]struct{})
+				blockIDsByAgency[tripAgencyMap[trip.ID]] = agencyBlockIDs
+			}
+			agencyBlockIDs[trip.BlockID.String] = struct{}{}
 		}
 	}
 
@@ -297,10 +295,10 @@ func (api *RestAPI) buildTripsForLocationEntries(
 	}
 
 	stopTimesMap := make(map[string][]gtfsdb.StopTime)
-	blockTripsMap := make(map[string][]gtfsdb.GetTripsByBlockIDsRow)
+	blockTripsMap := make(map[blockTripsKey][]gtfsdb.GetTripsByBlockIDsRow)
 	var allStopIDs []string
 
-	if includeSchedule {
+	if request.IncludeSchedule {
 		stopTimesRaw, err := api.GtfsManager.GtfsDB.Queries.GetStopTimesForTripIDs(ctx, validVehicleTrips)
 		if err != nil {
 			api.serverErrorResponse(w, r, err)
@@ -311,22 +309,18 @@ func (api *RestAPI) buildTripsForLocationEntries(
 			allStopIDs = append(allStopIDs, st.StopID)
 		}
 
-		if len(uniqueBlockIDs) > 0 {
-			var blockIDs []string
-			for bid := range uniqueBlockIDs {
-				blockIDs = append(blockIDs, bid)
-			}
-
-			dateStr := serviceDate.Format("20060102")
+		for agencyID, agencyBlockIDs := range blockIDsByAgency {
+			agencyLocation := request.AgencyLocations[agencyID]
+			dateStr := serviceDateMidnight(request.CurrentTime, agencyLocation).Format("20060102")
 			activeServiceIDs, err := api.GtfsManager.GtfsDB.Queries.GetActiveServiceIDsForDate(ctx, dateStr)
 			if err != nil {
 				activeServiceIDs = []string{}
-				api.Logger.Warn("failed to fetch active service IDs for block logic", "error", err)
+				api.Logger.Warn("failed to fetch active service IDs for block logic", "agency_id", agencyID, "error", err)
 			}
 
-			blockIDsNull := make([]sql.NullString, len(blockIDs))
-			for i, id := range blockIDs {
-				blockIDsNull[i] = nulls.String(id)
+			blockIDsNull := make([]sql.NullString, 0, len(agencyBlockIDs))
+			for id := range agencyBlockIDs {
+				blockIDsNull = append(blockIDsNull, nulls.String(id))
 			}
 
 			params := gtfsdb.GetTripsByBlockIDsParams{
@@ -338,12 +332,12 @@ func (api *RestAPI) buildTripsForLocationEntries(
 			if err == nil {
 				for _, bt := range blockTripsRaw {
 					if bt.BlockID.Valid {
-						bid := bt.BlockID.String
-						blockTripsMap[bid] = append(blockTripsMap[bid], bt)
+						key := blockTripsKey{agencyID: agencyID, blockID: bt.BlockID.String}
+						blockTripsMap[key] = append(blockTripsMap[key], bt)
 					}
 				}
 			} else {
-				api.Logger.Warn("failed to bulk fetch block trips", "error", err)
+				api.Logger.Warn("failed to bulk fetch block trips", "agency_id", agencyID, "error", err)
 			}
 		}
 	}
@@ -372,11 +366,17 @@ func (api *RestAPI) buildTripsForLocationEntries(
 		if !tripFound {
 			continue
 		}
+		agencyLocation, locationFound := request.AgencyLocations[agencyID]
+		if !locationFound {
+			api.Logger.Warn("missing timezone for trip agency", "trip_id", tripID, "agency_id", agencyID)
+			continue
+		}
+		tripMidnight := serviceDateMidnight(request.CurrentTime, agencyLocation)
 
 		var schedule *models.TripsSchedule
 		var status *models.TripStatus
 
-		if includeSchedule {
+		if request.IncludeSchedule {
 			var shapePoints []gtfs.ShapePoint
 			if tripData.ShapeID.Valid {
 				shapePoints = shapesMap[tripData.ShapeID.String]
@@ -384,13 +384,13 @@ func (api *RestAPI) buildTripsForLocationEntries(
 
 			var blockTrips []gtfsdb.GetTripsByBlockIDsRow
 			if tripData.BlockID.Valid {
-				blockTrips = blockTripsMap[tripData.BlockID.String]
+				blockTrips = blockTripsMap[blockTripsKey{agencyID: agencyID, blockID: tripData.BlockID.String}]
 			}
 
 			schedule = api.buildScheduleFromMemory(
 				tripData,
 				agencyID,
-				currentLocation,
+				agencyLocation,
 				stopTimesMap[tripID],
 				shapePoints,
 				stopCoords,
@@ -398,9 +398,9 @@ func (api *RestAPI) buildTripsForLocationEntries(
 			)
 		}
 
-		if includeStatus {
+		if request.IncludeStatus {
 			var statusErr error
-			status, _, statusErr = api.BuildTripStatus(ctx, agencyID, tripID, nil, todayMidnight, currentTime)
+			status, _, statusErr = api.BuildTripStatus(ctx, agencyID, tripID, nil, tripMidnight, request.CurrentTime)
 			if statusErr != nil {
 				api.Logger.Warn("BuildTripStatus failed", "tripID", tripID, "error", statusErr)
 				status = nil
@@ -411,13 +411,24 @@ func (api *RestAPI) buildTripsForLocationEntries(
 			Frequency:    nil,
 			Schedule:     schedule,
 			Status:       status,
-			ServiceDate:  todayMidnight.UnixMilli(),
+			ServiceDate:  tripMidnight.UnixMilli(),
 			SituationIds: api.GetSituationIDsForTrip(ctx, tripID),
 			TripId:       utils.FormCombinedID(agencyID, tripID),
 		}
 		result = append(result, entry)
 	}
 	return result
+}
+
+type blockTripsKey struct {
+	agencyID string
+	blockID  string
+}
+
+// serviceDateMidnight returns the start of the service day in an agency's timezone.
+func serviceDateMidnight(currentTime time.Time, agencyLocation *time.Location) time.Time {
+	_, midnight := utils.ServiceDateMidnight(nil, currentTime.In(agencyLocation))
+	return midnight
 }
 
 func (api *RestAPI) buildScheduleForTrip(

--- a/internal/restapi/trips_for_location_handler_test.go
+++ b/internal/restapi/trips_for_location_handler_test.go
@@ -72,6 +72,24 @@ func TestTripsForLocationHandler_DifferentAreas(t *testing.T) {
 	}
 }
 
+func TestTripsForLocationServiceDateUsesTripAgencyTimezone(t *testing.T) {
+	currentTime := time.Date(2026, 8, 10, 13, 0, 0, 0, time.UTC)
+	losAngeles, err := time.LoadLocation("America/Los_Angeles")
+	require.NoError(t, err)
+	chicago, err := time.LoadLocation("America/Chicago")
+	require.NoError(t, err)
+
+	assert.Equal(t,
+		time.Date(2026, 8, 10, 0, 0, 0, 0, losAngeles),
+		serviceDateMidnight(currentTime, losAngeles))
+	assert.Equal(t,
+		time.Date(2026, 8, 10, 0, 0, 0, 0, chicago),
+		serviceDateMidnight(currentTime, chicago))
+	assert.Equal(t, 2*time.Hour,
+		serviceDateMidnight(currentTime, losAngeles).Sub(serviceDateMidnight(currentTime, chicago)),
+		"a Chicago trip must not use Los Angeles midnight")
+}
+
 // TestTripsForLocationHandler_ReferencesAreConsistent consolidates the previous
 // per-aspect reference tests (stops/routes/agencies cross-references, combined IDs,
 // orphaned stops, direction populated) into one fetch + structured assertions.

--- a/internal/restapi/trips_for_location_handler_test.go
+++ b/internal/restapi/trips_for_location_handler_test.go
@@ -8,9 +8,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/OneBusAway/go-gtfs"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"maglev.onebusaway.org/internal/clock"
+	internalgtfs "maglev.onebusaway.org/internal/gtfs"
 	"maglev.onebusaway.org/internal/models"
 )
 
@@ -88,6 +90,89 @@ func TestTripsForLocationServiceDateUsesTripAgencyTimezone(t *testing.T) {
 	assert.Equal(t, 2*time.Hour,
 		serviceDateMidnight(currentTime, losAngeles).Sub(serviceDateMidnight(currentTime, chicago)),
 		"a Chicago trip must not use Los Angeles midnight")
+}
+
+func TestTripsForLocationHandler_UsesEachTripAgencyTimezone(t *testing.T) {
+	currentTime := time.Date(2026, 8, 10, 13, 0, 0, 0, time.UTC)
+	api := createTestApiWithGTFSFixture(t, clock.NewMockClock(currentTime),
+		"trips-for-location-multi-timezone.zip", multiTimezoneTripsForLocationFiles())
+	t.Cleanup(api.GtfsManager.MockResetRealTimeData)
+
+	latitude := float32(tripsForLocationLat)
+	longitude := float32(tripsForLocationLon)
+	for _, trip := range []struct {
+		tripID  string
+		routeID string
+	}{
+		{tripID: "la-trip", routeID: "la-route"},
+		{tripID: "chicago-trip", routeID: "chicago-route"},
+	} {
+		api.GtfsManager.MockAddVehicleWithOptions("vehicle-"+trip.tripID, trip.tripID, trip.routeID,
+			internalgtfs.MockVehicleOptions{
+				Timestamp: &currentTime,
+				Position: &gtfs.Position{
+					Latitude:  &latitude,
+					Longitude: &longitude,
+				},
+			})
+	}
+
+	url := tripsForLocationURL(0.1, 0.1,
+		"includeSchedule=true",
+		"includeStatus=true",
+		fmt.Sprintf("time=%d", currentTime.UnixMilli()))
+	resp, model := callAPIHandler[TripsForLocationResponse](t, api, url)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Len(t, model.Data.List, 2)
+
+	losAngeles, err := time.LoadLocation("America/Los_Angeles")
+	require.NoError(t, err)
+	chicago, err := time.LoadLocation("America/Chicago")
+	require.NoError(t, err)
+	expectedMidnights := map[string]time.Time{
+		"la_la-trip":           serviceDateMidnight(currentTime, losAngeles),
+		"chicago_chicago-trip": serviceDateMidnight(currentTime, chicago),
+	}
+	expectedTimezones := map[string]string{
+		"la_la-trip":           losAngeles.String(),
+		"chicago_chicago-trip": chicago.String(),
+	}
+
+	for _, entry := range model.Data.List {
+		expectedMidnight, found := expectedMidnights[entry.TripId]
+		require.True(t, found, "unexpected trip %q", entry.TripId)
+		assert.Equal(t, expectedMidnight.UnixMilli(), entry.ServiceDate)
+		require.NotNil(t, entry.Schedule)
+		assert.Equal(t, expectedTimezones[entry.TripId], entry.Schedule.TimeZone)
+		assert.Empty(t, entry.Schedule.NextTripId,
+			"trips with a shared block ID must remain isolated by agency")
+		assert.Empty(t, entry.Schedule.PreviousTripId,
+			"trips with a shared block ID must remain isolated by agency")
+		require.NotNil(t, entry.Status)
+		assert.Equal(t, expectedMidnight.UnixMilli(), entry.Status.ServiceDate.UnixMilli())
+	}
+}
+
+func multiTimezoneTripsForLocationFiles() map[string]string {
+	return map[string]string{
+		"agency.txt": "agency_id,agency_name,agency_url,agency_timezone\n" +
+			"la,Los Angeles Transit,http://example.com/la,America/Los_Angeles\n" +
+			"chicago,Chicago Transit,http://example.com/chicago,America/Chicago\n",
+		"routes.txt": "route_id,agency_id,route_short_name,route_long_name,route_type\n" +
+			"la-route,la,LA,Los Angeles Route,3\n" +
+			"chicago-route,chicago,CH,Chicago Route,3\n",
+		"calendar.txt": "service_id,monday,tuesday,wednesday,thursday,friday,saturday,sunday,start_date,end_date\n" +
+			"shared-service,1,1,1,1,1,1,1,20240101,20991231\n",
+		"stops.txt": "stop_id,stop_name,stop_lat,stop_lon\n" +
+			"la-stop,Los Angeles Stop,40.5865,-122.3917\n" +
+			"chicago-stop,Chicago Stop,40.5865,-122.3917\n",
+		"trips.txt": "route_id,service_id,trip_id,trip_headsign,block_id\n" +
+			"la-route,shared-service,la-trip,Los Angeles,shared-block\n" +
+			"chicago-route,shared-service,chicago-trip,Chicago,shared-block\n",
+		"stop_times.txt": "trip_id,arrival_time,departure_time,stop_id,stop_sequence\n" +
+			"la-trip,05:00:00,05:00:00,la-stop,1\n" +
+			"chicago-trip,07:00:00,07:00:00,chicago-stop,1\n",
+	}
 }
 
 // TestTripsForLocationHandler_ReferencesAreConsistent consolidates the previous


### PR DESCRIPTION
## Summary
- resolve each trips-for-location trip in its agency timezone
- align schedule.timeZone, serviceDate, trip status, and block lookups
- add a Los Angeles/Chicago regression test

## Context
PR #1315 fixes schedule.timeZone but remains open. This PR also aligns serviceDate with the returned trip's agency timezone, preventing clients from displaying incorrect scheduled times in multi-timezone feeds.

## Validation
- go vet -tags "sqlite_fts5 sqlite_math_functions" ./...
- go vet -tags "purego" ./...
- make test

Closes #1325

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved trip schedules and statuses for locations served by agencies in different time zones.
  * Ensured each trip uses its agency’s local service-day midnight and correct service date.
  * Improved time-based request handling across multiple agency time zones.
  * Prevented block-trip data from being mixed between agencies.
  * Trips are now omitted when the agency’s time zone cannot be determined.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->