### PR TITLE
test: add activeTripId and phase assertions to includeStatus coverage

### DIFF
--- a/internal/restapi/trips_for_route_handler_test.go
+++ b/internal/restapi/trips_for_route_handler_test.go
@@ -695,6 +695,9 @@ func TestTripsForRouteHandler_BoolParamParsing(t *testing.T) {
 			for i, entry := range model.Data.List {
 				if want {
 					require.NotNil(t, entry.Status, "list[%d].status should be present", i)
+					assert.NotEmpty(t, entry.Status.ActiveTripID, "list[%d].status.activeTripId should be set", i)
+					assert.Contains(t, []string{"scheduled", "in_progress", "completed"}, entry.Status.Phase,
+						"list[%d].status.phase should be a known value", i)
 				} else {
 					assert.Nil(t, entry.Status, "list[%d].status should be omitted", i)
 				}


### PR DESCRIPTION
This is a small follow-up PR for #1293. 

While the core `includeStatus` test coverage was already added to `main` via `TestTripsForRouteHandler_BoolParamParsing`, this PR folds two specific assertions into the new `assertFlag` helper to make the coverage even stronger:
- Asserts that `entry.Status.ActiveTripID` is populated.
- Asserts that `entry.Status.Phase` is a known valid value (`scheduled`, `in_progress`, or `completed`).

Updates: #1292

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added validation ensuring returned trip statuses include a non-empty active trip identifier.
  * Added checks that trip statuses report a recognized trip phase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->