### PR TITLE
Memoize repeated block and calendar lookups per request

### DIFF
--- a/internal/restapi/arrivals_and_departures_for_stop_handler.go
+++ b/internal/restapi/arrivals_and_departures_for_stop_handler.go
@@ -98,7 +98,11 @@ func (api *RestAPI) arrivalsAndDeparturesForStopHandler(w http.ResponseWriter, r
 	// in the same shift. Without this each row pays for the full compute
 	// chain (blockTripIDsForServiceDate + loadBlockTripData + emitBlock
 	// Stops), amplifying to thousands of round-trips on wide time windows.
-	ctx := WithSnapshotCache(r.Context(), newSnapshotCache())
+	//
+	// The request cache sits one level below that, covering the block trip
+	// data and service calendar that rows outside a shared shift still
+	// resolve individually, plus the stop times prefetched further down.
+	ctx := withRequestCache(WithSnapshotCache(r.Context(), newSnapshotCache()))
 
 	// Capture parsing errors
 	params, fieldErrors := api.parseArrivalsAndDeparturesParams(r)
@@ -275,17 +279,13 @@ func (api *RestAPI) arrivalsAndDeparturesForStopHandler(w http.ResponseWriter, r
 		tripsLookup[trip.ID] = trip
 	}
 
-	// Batch-fetch stop counts per trip to avoid per-arrival N+1 queries for totalStopsInTrip.
-	tripStopCountMap := make(map[string]int, len(uniqueTripIDs))
-	if len(uniqueTripIDs) > 0 {
-		allStopTimesForTrips, err := api.GtfsManager.GtfsDB.Queries.GetStopTimesForTripIDs(ctx, uniqueTripIDs)
-		if err != nil {
-			api.Logger.Warn("failed to batch fetch stop times for trips", slog.Any("error", err))
-		} else {
-			for _, st := range allStopTimesForTrips {
-				tripStopCountMap[st.TripID]++
-			}
-		}
+	// One batch load serves two purposes: totalStopsInTrip below, and seeding the
+	// request memo so the per-arrival BuildTripStatus calls read each trip's stop
+	// times from it instead of issuing a query per row.
+	stopTimesByTrip := api.prefetchStopTimes(ctx, uniqueTripIDs)
+	tripStopCountMap := make(map[string]int, len(stopTimesByTrip))
+	for tripID, stopTimes := range stopTimesByTrip {
+		tripStopCountMap[tripID] = len(stopTimes)
 	}
 
 	for _, ast := range allActiveStopTimes {

--- a/internal/restapi/request_cache.go
+++ b/internal/restapi/request_cache.go
@@ -1,0 +1,183 @@
+package restapi
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+	"sync"
+
+	"maglev.onebusaway.org/gtfsdb"
+)
+
+// requestCacheKey is the context key under which a request carries its memo.
+type requestCacheKey struct{}
+
+// requestCache memoizes GTFS lookups that repeat across the rows of a single
+// response.
+//
+// Endpoints that build a trip status per row — vehicles-for-agency across every
+// vehicle in an agency, for instance — resolve the same block and the same
+// service calendar over and over. Without a memo the work scales with
+// (rows × block size) rather than with the number of distinct blocks, and the
+// service-ID lookup repeats once per row for a date that never changes within
+// the request.
+//
+// The memo is deliberately request-scoped rather than a field on RestAPI: static
+// GTFS data is reloaded in the background, and a longer-lived cache would need
+// invalidation wired to that reload. It is mutex-guarded because nothing
+// prevents a handler from building statuses concurrently.
+//
+// This complements the existing snapshotCache (see WithSnapshotCache), which
+// memoizes whole block snapshots. These entries sit a level below that and are
+// still reached on the schedule-deviation path, which resolves a block without
+// going through a snapshot.
+type requestCache struct {
+	mu               sync.Mutex
+	blockTripData    map[string][]blockTripData
+	activeServiceIDs map[string][]string
+	stopTimes        map[string][]gtfsdb.StopTime
+}
+
+// withRequestCache returns a context carrying a request-scoped memo. Handlers
+// that build many trip statuses in one request should wrap their context with
+// it; handlers that build a single trip status gain nothing and can leave it off.
+func withRequestCache(ctx context.Context) context.Context {
+	return context.WithValue(ctx, requestCacheKey{}, &requestCache{
+		blockTripData:    make(map[string][]blockTripData),
+		activeServiceIDs: make(map[string][]string),
+		stopTimes:        make(map[string][]gtfsdb.StopTime),
+	})
+}
+
+// requestCacheFrom returns the request's memo, or nil when the handler did not
+// opt in.
+func requestCacheFrom(ctx context.Context) *requestCache {
+	cache, _ := ctx.Value(requestCacheKey{}).(*requestCache)
+	return cache
+}
+
+// blockTripDataCacheKeyFor joins trip IDs into a single map key. GTFS IDs cannot
+// contain a NUL byte, so the separator cannot collide across different splits of
+// the same concatenated text.
+func blockTripDataCacheKeyFor(tripIDs []string) string {
+	return strings.Join(tripIDs, "\x00")
+}
+
+func (c *requestCache) getBlockTripData(key string) ([]blockTripData, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	trips, ok := c.blockTripData[key]
+	return trips, ok
+}
+
+func (c *requestCache) putBlockTripData(key string, trips []blockTripData) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.blockTripData[key] = trips
+}
+
+func (c *requestCache) getActiveServiceIDs(date string) ([]string, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	ids, ok := c.activeServiceIDs[date]
+	return ids, ok
+}
+
+func (c *requestCache) putActiveServiceIDs(date string, ids []string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.activeServiceIDs[date] = ids
+}
+
+func (c *requestCache) getStopTimes(tripID string) ([]gtfsdb.StopTime, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	stopTimes, ok := c.stopTimes[tripID]
+	return stopTimes, ok
+}
+
+// prefetchStopTimes resolves the stop times of every trip in tripIDs with one
+// query, seeding the request memo so the per-trip lookup inside BuildTripStatus
+// becomes a map read instead of a query per response row.
+//
+// Trips that return no rows are recorded as empty entries, so a genuinely
+// stop-time-less trip is not retried once per row.
+//
+// Shape points are deliberately NOT prefetched. GetShapePointsByTripIDs joins
+// shapes to trips, so a shape shared by many trips is returned once per trip; a
+// large agency's worth of vehicles would materialize hundreds of megabytes of
+// duplicated geometry for the life of the request. Stop times are ~two orders of
+// magnitude smaller per trip and carry no such duplication.
+//
+// A failed prefetch is logged and swallowed: an absent entry falls back to the
+// per-trip query, so the response stays correct and is merely slower.
+func (api *RestAPI) prefetchStopTimes(ctx context.Context, tripIDs []string) {
+	cache := requestCacheFrom(ctx)
+	if cache == nil || len(tripIDs) == 0 {
+		return
+	}
+
+	rows, err := api.GtfsManager.GtfsDB.Queries.GetStopTimesForTripIDs(ctx, tripIDs)
+	if err != nil {
+		// Seeding after a failure would record "this trip has no stop times" for
+		// every trip. An empty entry is a valid hit, so callers would skip the
+		// per-trip fallback and emit a response missing the stop-relative fields
+		// rather than a slower correct one.
+		slog.Warn("prefetchStopTimes: GetStopTimesForTripIDs failed, falling back to per-trip lookups",
+			slog.Int("trip_count", len(tripIDs)), slog.String("error", err.Error()))
+		return
+	}
+
+	stopTimesByTrip := make(map[string][]gtfsdb.StopTime, len(tripIDs))
+	for _, row := range rows {
+		stopTimesByTrip[row.TripID] = append(stopTimesByTrip[row.TripID], row)
+	}
+
+	cache.mu.Lock()
+	defer cache.mu.Unlock()
+	for _, tripID := range tripIDs {
+		cache.stopTimes[tripID] = stopTimesByTrip[tripID]
+	}
+}
+
+// stopTimesForTrip returns tripID's stop times, preferring a prefetched entry.
+//
+// A prefetched result is shared with every other caller in the request and must
+// be treated as read-only. BuildTripStatus takes pointers into the backing array
+// (&stopTimes[i]) and hands them to the stop-offset helpers, so a write through
+// one of those pointers would corrupt the memo for the rest of the request.
+func (api *RestAPI) stopTimesForTrip(ctx context.Context, tripID string) ([]gtfsdb.StopTime, error) {
+	if cache := requestCacheFrom(ctx); cache != nil {
+		if stopTimes, ok := cache.getStopTimes(tripID); ok {
+			return stopTimes, nil
+		}
+	}
+	return api.GtfsManager.GtfsDB.Queries.GetStopTimesForTrip(ctx, tripID)
+}
+
+// activeServiceIDsForDate returns the service IDs active on formattedDate
+// (YYYYMMDD), memoized for the lifetime of the request. Errors are returned to
+// the caller and never cached, so a transient DB failure does not stick for the
+// rest of the request.
+func (api *RestAPI) activeServiceIDsForDate(ctx context.Context, formattedDate string) ([]string, error) {
+	cache := requestCacheFrom(ctx)
+	if cache == nil {
+		return api.GtfsManager.GtfsDB.Queries.GetActiveServiceIDsForDate(ctx, formattedDate)
+	}
+
+	if ids, ok := cache.getActiveServiceIDs(formattedDate); ok {
+		return ids, nil
+	}
+
+	ids, err := api.GtfsManager.GtfsDB.Queries.GetActiveServiceIDsForDate(ctx, formattedDate)
+	if err != nil {
+		return nil, err
+	}
+	cache.putActiveServiceIDs(formattedDate, ids)
+	return ids, nil
+}

--- a/internal/restapi/request_cache.go
+++ b/internal/restapi/request_cache.go
@@ -24,8 +24,15 @@ type requestCacheKey struct{}
 //
 // The memo is deliberately request-scoped rather than a field on RestAPI: static
 // GTFS data is reloaded in the background, and a longer-lived cache would need
-// invalidation wired to that reload. It is mutex-guarded because nothing
-// prevents a handler from building statuses concurrently.
+// invalidation wired to that reload.
+//
+// No handler builds trip statuses concurrently today, so every access is in fact
+// serial; the mutex is here so that the memo stays safe if one ever does. For the
+// same reason there is no in-flight coordination between a miss and its load: with
+// serial callers there are no concurrent misses to collapse, and adding
+// singleflight machinery for a case that cannot currently arise would cost more in
+// complexity than it could save. Should a handler start fanning out, note that the
+// sibling snapshotCache is an unguarded map and would need attention first.
 //
 // This complements the existing snapshotCache (see WithSnapshotCache), which
 // memoizes whole block snapshots. These entries sit a level below that and are
@@ -116,10 +123,13 @@ func (c *requestCache) getStopTimes(tripID string) ([]gtfsdb.StopTime, bool) {
 //
 // A failed prefetch is logged and swallowed: an absent entry falls back to the
 // per-trip query, so the response stays correct and is merely slower.
-func (api *RestAPI) prefetchStopTimes(ctx context.Context, tripIDs []string) {
-	cache := requestCacheFrom(ctx)
-	if cache == nil || len(tripIDs) == 0 {
-		return
+//
+// The loaded rows are also returned grouped by trip ID, so a caller that needs
+// them directly — the arrivals handler counts each trip's stops — can use them
+// without a second pass through the memo. The result is nil when the query failed.
+func (api *RestAPI) prefetchStopTimes(ctx context.Context, tripIDs []string) map[string][]gtfsdb.StopTime {
+	if len(tripIDs) == 0 {
+		return nil
 	}
 
 	rows, err := api.GtfsManager.GtfsDB.Queries.GetStopTimesForTripIDs(ctx, tripIDs)
@@ -130,7 +140,7 @@ func (api *RestAPI) prefetchStopTimes(ctx context.Context, tripIDs []string) {
 		// rather than a slower correct one.
 		slog.Warn("prefetchStopTimes: GetStopTimesForTripIDs failed, falling back to per-trip lookups",
 			slog.Int("trip_count", len(tripIDs)), slog.String("error", err.Error()))
-		return
+		return nil
 	}
 
 	stopTimesByTrip := make(map[string][]gtfsdb.StopTime, len(tripIDs))
@@ -138,11 +148,17 @@ func (api *RestAPI) prefetchStopTimes(ctx context.Context, tripIDs []string) {
 		stopTimesByTrip[row.TripID] = append(stopTimesByTrip[row.TripID], row)
 	}
 
+	cache := requestCacheFrom(ctx)
+	if cache == nil {
+		return stopTimesByTrip
+	}
+
 	cache.mu.Lock()
 	defer cache.mu.Unlock()
 	for _, tripID := range tripIDs {
 		cache.stopTimes[tripID] = stopTimesByTrip[tripID]
 	}
+	return stopTimesByTrip
 }
 
 // stopTimesForTrip returns tripID's stop times, preferring a prefetched entry.

--- a/internal/restapi/request_cache_test.go
+++ b/internal/restapi/request_cache_test.go
@@ -168,3 +168,51 @@ func TestActiveServiceIDsForDateUsesCache(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, []string{"sentinel"}, second, "the memo must be consulted before the database")
 }
+
+// cancelledWithin returns a cancelled child of ctx, so a query issued with it fails
+// while the request memo carried on ctx stays reachable. This stands in for a
+// transient database failure without disturbing the shared fixture.
+func cancelledWithin(ctx context.Context) context.Context {
+	failing, cancel := context.WithCancel(ctx)
+	cancel()
+	return failing
+}
+
+// TestLoadBlockTripDataDoesNotCacheFailedLoad verifies a failed load leaves the
+// memo empty and a later call recovers. Caching the failure would pin one transient
+// error to this block for every remaining row of the request.
+func TestLoadBlockTripDataDoesNotCacheFailedLoad(t *testing.T) {
+	api := createTestApi(t)
+	defer api.Shutdown()
+
+	trip := mustGetTrip(t, api)
+	tripIDs := []string{trip.ID}
+	ctx := withRequestCache(context.Background())
+
+	require.Empty(t, api.loadBlockTripData(cancelledWithin(ctx), tripIDs),
+		"a failed load must not return trip data")
+
+	_, cached := requestCacheFrom(ctx).getBlockTripData(blockTripDataCacheKeyFor(tripIDs))
+	require.False(t, cached, "a failed load must not be memoized")
+
+	recovered := api.loadBlockTripData(ctx, tripIDs)
+	require.Len(t, recovered, 1, "a later call must retry rather than reuse the failure")
+	assert.Equal(t, trip.ID, recovered[0].id)
+}
+
+// TestLoadBlockTripDataFromDBReportsIncompleteLoad verifies the completeness flag
+// that gates memoization is false when the underlying queries fail.
+func TestLoadBlockTripDataFromDBReportsIncompleteLoad(t *testing.T) {
+	api := createTestApi(t)
+	defer api.Shutdown()
+
+	trip := mustGetTrip(t, api)
+
+	trips, complete := api.loadBlockTripDataFromDB(context.Background(), []string{trip.ID})
+	require.Len(t, trips, 1)
+	assert.True(t, complete, "a fully successful load must be reported as complete")
+
+	trips, complete = api.loadBlockTripDataFromDB(cancelledWithin(context.Background()), []string{trip.ID})
+	assert.Nil(t, trips)
+	assert.False(t, complete, "a failed load must be reported as incomplete")
+}

--- a/internal/restapi/request_cache_test.go
+++ b/internal/restapi/request_cache_test.go
@@ -1,0 +1,170 @@
+package restapi
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"maglev.onebusaway.org/gtfsdb"
+)
+
+// TestLoadBlockTripDataWithoutCache verifies the loader still works for handlers
+// that do not opt into the request-scoped memo.
+func TestLoadBlockTripDataWithoutCache(t *testing.T) {
+	api := createTestApi(t)
+	defer api.Shutdown()
+
+	trip := mustGetTrip(t, api)
+	trips := api.loadBlockTripData(context.Background(), []string{trip.ID})
+	require.Len(t, trips, 1)
+	assert.Equal(t, trip.ID, trips[0].id)
+}
+
+// TestLoadBlockTripDataUsesCache verifies a second resolution of the same trip-ID
+// set is served from the memo rather than the database. The memo is seeded with a
+// sentinel so a hit is distinguishable from a fresh load.
+func TestLoadBlockTripDataUsesCache(t *testing.T) {
+	api := createTestApi(t)
+	defer api.Shutdown()
+
+	trip := mustGetTrip(t, api)
+	tripIDs := []string{trip.ID}
+	ctx := withRequestCache(context.Background())
+
+	cache := requestCacheFrom(ctx)
+	require.NotNil(t, cache, "context must carry the memo")
+	cache.putBlockTripData(blockTripDataCacheKeyFor(tripIDs), []blockTripData{{id: "sentinel"}})
+
+	trips := api.loadBlockTripData(ctx, tripIDs)
+	require.Len(t, trips, 1)
+	assert.Equal(t, "sentinel", trips[0].id, "the memo must be consulted before the database")
+}
+
+// TestLoadBlockTripDataPopulatesCache verifies the first resolution stores its
+// result, so later callers in the same request skip the load.
+func TestLoadBlockTripDataPopulatesCache(t *testing.T) {
+	api := createTestApi(t)
+	defer api.Shutdown()
+
+	trip := mustGetTrip(t, api)
+	tripIDs := []string{trip.ID}
+	ctx := withRequestCache(context.Background())
+
+	require.Len(t, api.loadBlockTripData(ctx, tripIDs), 1)
+
+	cached, ok := requestCacheFrom(ctx).getBlockTripData(blockTripDataCacheKeyFor(tripIDs))
+	require.True(t, ok, "the first resolution must populate the memo")
+	require.Len(t, cached, 1)
+	assert.Equal(t, trip.ID, cached[0].id)
+}
+
+// TestLoadBlockTripDataReturnsIndependentSlices verifies each caller gets its own
+// backing array. loadShiftTrips sorts the result in place, which would otherwise
+// reorder the cached entry underneath everyone else.
+func TestLoadBlockTripDataReturnsIndependentSlices(t *testing.T) {
+	api := createTestApi(t)
+	defer api.Shutdown()
+
+	trip := mustGetTrip(t, api)
+	tripIDs := []string{trip.ID}
+	ctx := withRequestCache(context.Background())
+
+	first := api.loadBlockTripData(ctx, tripIDs)
+	require.Len(t, first, 1)
+	first[0].id = "mutated by caller"
+
+	second := api.loadBlockTripData(ctx, tripIDs)
+	require.Len(t, second, 1)
+	assert.Equal(t, trip.ID, second[0].id, "a caller's in-place edit must not leak into the memo")
+}
+
+// TestPrefetchStopTimesSeedsMemo verifies one batch query populates an entry per
+// requested trip, including trips that genuinely have no stop times.
+func TestPrefetchStopTimesSeedsMemo(t *testing.T) {
+	api := createTestApi(t)
+	defer api.Shutdown()
+
+	trip := mustGetTrip(t, api)
+	const missingTripID = "trip-that-does-not-exist"
+	ctx := withRequestCache(context.Background())
+
+	api.prefetchStopTimes(ctx, []string{trip.ID, missingTripID})
+
+	cache := requestCacheFrom(ctx)
+	seeded, ok := cache.getStopTimes(trip.ID)
+	require.True(t, ok, "a real trip must be seeded")
+	assert.NotEmpty(t, seeded)
+
+	empty, ok := cache.getStopTimes(missingTripID)
+	require.True(t, ok, "a trip with no stop times must still be seeded, so it is not retried per row")
+	assert.Empty(t, empty)
+}
+
+// TestPrefetchStopTimesWithoutCacheIsNoop verifies the prefetch is inert for
+// handlers that did not opt in, rather than panicking.
+func TestPrefetchStopTimesWithoutCacheIsNoop(t *testing.T) {
+	api := createTestApi(t)
+	defer api.Shutdown()
+
+	trip := mustGetTrip(t, api)
+	api.prefetchStopTimes(context.Background(), []string{trip.ID})
+
+	stopTimes, err := api.stopTimesForTrip(context.Background(), trip.ID)
+	require.NoError(t, err)
+	assert.NotEmpty(t, stopTimes, "the lookup must still fall through to the query")
+}
+
+// TestStopTimesForTripPrefersMemo verifies the per-trip lookup reads a seeded
+// entry instead of querying.
+func TestStopTimesForTripPrefersMemo(t *testing.T) {
+	api := createTestApi(t)
+	defer api.Shutdown()
+
+	trip := mustGetTrip(t, api)
+	ctx := withRequestCache(context.Background())
+	requestCacheFrom(ctx).stopTimes[trip.ID] = []gtfsdb.StopTime{{TripID: "sentinel"}}
+
+	stopTimes, err := api.stopTimesForTrip(ctx, trip.ID)
+	require.NoError(t, err)
+	require.Len(t, stopTimes, 1)
+	assert.Equal(t, "sentinel", stopTimes[0].TripID, "the memo must be consulted before the database")
+}
+
+// TestActiveServiceIDsForDateWithoutCache verifies the lookup falls through to the
+// query when the handler did not opt into the memo.
+func TestActiveServiceIDsForDateWithoutCache(t *testing.T) {
+	api := createTestApi(t)
+	defer api.Shutdown()
+
+	const serviceDate = "20241104"
+	ids, err := api.activeServiceIDsForDate(context.Background(), serviceDate)
+	require.NoError(t, err)
+
+	expected, err := api.GtfsManager.GtfsDB.Queries.GetActiveServiceIDsForDate(context.Background(), serviceDate)
+	require.NoError(t, err)
+	assert.Equal(t, expected, ids)
+}
+
+// TestActiveServiceIDsForDateUsesCache verifies the date is resolved once per
+// request. Every row of a list response asks for the same service date.
+func TestActiveServiceIDsForDateUsesCache(t *testing.T) {
+	api := createTestApi(t)
+	defer api.Shutdown()
+
+	const serviceDate = "20241104"
+	ctx := withRequestCache(context.Background())
+
+	first, err := api.activeServiceIDsForDate(ctx, serviceDate)
+	require.NoError(t, err)
+
+	cached, ok := requestCacheFrom(ctx).getActiveServiceIDs(serviceDate)
+	require.True(t, ok, "the first lookup must populate the memo")
+	assert.Equal(t, first, cached)
+
+	// Overwrite the entry so a second call proves it reads through the memo.
+	requestCacheFrom(ctx).putActiveServiceIDs(serviceDate, []string{"sentinel"})
+	second, err := api.activeServiceIDsForDate(ctx, serviceDate)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"sentinel"}, second, "the memo must be consulted before the database")
+}

--- a/internal/restapi/request_cache_test.go
+++ b/internal/restapi/request_cache_test.go
@@ -2,11 +2,15 @@ package restapi
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"maglev.onebusaway.org/gtfsdb"
+	"maglev.onebusaway.org/internal/clock"
 )
 
 // TestLoadBlockTripDataWithoutCache verifies the loader still works for handlers
@@ -131,42 +135,36 @@ func TestStopTimesForTripPrefersMemo(t *testing.T) {
 	assert.Equal(t, "sentinel", stopTimes[0].TripID, "the memo must be consulted before the database")
 }
 
-// TestActiveServiceIDsForDateWithoutCache verifies the lookup falls through to the
-// query when the handler did not opt into the memo.
-func TestActiveServiceIDsForDateWithoutCache(t *testing.T) {
-	api := createTestApi(t)
-	defer api.Shutdown()
+// BenchmarkArrivalsAndDeparturesWideWindow measures the arrivals handler over a
+// window wide enough to return many rows, which is where the per-row trip status
+// cost actually shows up.
+//
+// The existing BenchmarkArrivalsAndDeparturesForStop runs on the real clock against
+// a fixture whose calendar expired, so it returns an empty list and never enters the
+// per-arrival loop at all. This one holds the clock inside the fixture's service
+// window and uses the same stop the handler tests use.
+func BenchmarkArrivalsAndDeparturesWideWindow(b *testing.B) {
+	api, cleanup := createTestApiWithRealTimeData(b, clock.NewMockClock(arrivalsTestClock))
+	defer cleanup()
 
-	const serviceDate = "20241104"
-	ids, err := api.activeServiceIDsForDate(context.Background(), serviceDate)
-	require.NoError(t, err)
+	endpoint := arrivalsAndDeparturesURL(arrivalsTestStopID, url.Values{
+		"minutesBefore": {"120"},
+		"minutesAfter":  {"480"},
+	})
 
-	expected, err := api.GtfsManager.GtfsDB.Queries.GetActiveServiceIDsForDate(context.Background(), serviceDate)
-	require.NoError(t, err)
-	assert.Equal(t, expected, ids)
-}
+	mux := http.NewServeMux()
+	api.SetRoutes(mux)
+	req := httptest.NewRequest(http.MethodGet, endpoint, nil)
 
-// TestActiveServiceIDsForDateUsesCache verifies the date is resolved once per
-// request. Every row of a list response asks for the same service date.
-func TestActiveServiceIDsForDateUsesCache(t *testing.T) {
-	api := createTestApi(t)
-	defer api.Shutdown()
+	warmup := httptest.NewRecorder()
+	mux.ServeHTTP(warmup, req)
+	require.Equal(b, http.StatusOK, warmup.Code)
 
-	const serviceDate = "20241104"
-	ctx := withRequestCache(context.Background())
-
-	first, err := api.activeServiceIDsForDate(ctx, serviceDate)
-	require.NoError(t, err)
-
-	cached, ok := requestCacheFrom(ctx).getActiveServiceIDs(serviceDate)
-	require.True(t, ok, "the first lookup must populate the memo")
-	assert.Equal(t, first, cached)
-
-	// Overwrite the entry so a second call proves it reads through the memo.
-	requestCacheFrom(ctx).putActiveServiceIDs(serviceDate, []string{"sentinel"})
-	second, err := api.activeServiceIDsForDate(ctx, serviceDate)
-	require.NoError(t, err)
-	assert.Equal(t, []string{"sentinel"}, second, "the memo must be consulted before the database")
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		mux.ServeHTTP(httptest.NewRecorder(), req)
+	}
 }
 
 // cancelledWithin returns a cancelled child of ctx, so a query issued with it fails
@@ -215,4 +213,108 @@ func TestLoadBlockTripDataFromDBReportsIncompleteLoad(t *testing.T) {
 	trips, complete = api.loadBlockTripDataFromDB(cancelledWithin(context.Background()), []string{trip.ID})
 	assert.Nil(t, trips)
 	assert.False(t, complete, "a failed load must be reported as incomplete")
+}
+
+// TestPrefetchStopTimesDoesNotSeedOnFailure verifies a failed prefetch leaves the
+// memo untouched, so per-trip lookups fall back to querying instead of reading an
+// empty entry as though the trips genuinely had no stop times.
+func TestPrefetchStopTimesDoesNotSeedOnFailure(t *testing.T) {
+	api := createTestApi(t)
+	defer api.Shutdown()
+
+	trip := mustGetTrip(t, api)
+	ctx := withRequestCache(context.Background())
+
+	assert.Nil(t, api.prefetchStopTimes(cancelledWithin(ctx), []string{trip.ID}),
+		"a failed prefetch must not report any rows")
+
+	_, seeded := requestCacheFrom(ctx).getStopTimes(trip.ID)
+	require.False(t, seeded, "a failed prefetch must leave the entry absent")
+
+	stopTimes, err := api.stopTimesForTrip(ctx, trip.ID)
+	require.NoError(t, err, "the per-trip lookup must still reach the database")
+	assert.NotEmpty(t, stopTimes)
+}
+
+// TestActiveServiceIDsForDateDoesNotCacheError verifies a failed lookup is
+// propagated and not memoized, so it does not stick for the rest of the request.
+func TestActiveServiceIDsForDateDoesNotCacheError(t *testing.T) {
+	api := createTestApi(t)
+	defer api.Shutdown()
+
+	ctx := withRequestCache(context.Background())
+	const serviceDate = "20241104"
+
+	_, err := api.activeServiceIDsForDate(cancelledWithin(ctx), serviceDate)
+	require.Error(t, err, "the failure must be propagated to the caller")
+
+	_, cached := requestCacheFrom(ctx).getActiveServiceIDs(serviceDate)
+	require.False(t, cached, "a failed lookup must not be memoized")
+
+	ids, err := api.activeServiceIDsForDate(ctx, serviceDate)
+	require.NoError(t, err, "a later call must retry rather than reuse the failure")
+	assert.NotEmpty(t, ids)
+}
+
+// TestActiveServiceIDsForDateWithoutCache verifies the lookup falls through to the
+// query when the handler did not opt into the memo. The date is asserted to have
+// service first, so an equality check against the direct query cannot pass by both
+// sides being empty.
+func TestActiveServiceIDsForDateWithoutCache(t *testing.T) {
+	api := createTestApi(t)
+	defer api.Shutdown()
+
+	ctx := context.Background()
+	const serviceDate = "20241104" // Monday inside the RABA fixture's calendar
+
+	expected, err := api.GtfsManager.GtfsDB.Queries.GetActiveServiceIDsForDate(ctx, serviceDate)
+	require.NoError(t, err)
+	require.NotEmpty(t, expected,
+		"fixture must have service on %s for this test to prove anything", serviceDate)
+
+	ids, err := api.activeServiceIDsForDate(ctx, serviceDate)
+	require.NoError(t, err)
+	assert.Equal(t, expected, ids)
+}
+
+// TestActiveServiceIDsForDateDoesNotCacheEmptyResult verifies a date with no
+// service is still answered correctly, and that the empty answer is memoized as a
+// legitimate result rather than treated as a miss on every call.
+func TestActiveServiceIDsForDateDoesNotConfuseEmptyWithMissing(t *testing.T) {
+	api := createTestApi(t)
+	defer api.Shutdown()
+
+	ctx := withRequestCache(context.Background())
+	const noServiceDate = "19700101" // far outside any RABA calendar window
+
+	ids, err := api.activeServiceIDsForDate(ctx, noServiceDate)
+	require.NoError(t, err)
+	assert.Empty(t, ids)
+
+	cached, ok := requestCacheFrom(ctx).getActiveServiceIDs(noServiceDate)
+	assert.True(t, ok, "an empty-but-valid answer must be memoized, not re-queried per row")
+	assert.Empty(t, cached)
+}
+
+// TestActiveServiceIDsForDateUsesCache verifies the date is resolved once per
+// request. Every row of a list response asks for the same service date.
+func TestActiveServiceIDsForDateUsesCache(t *testing.T) {
+	api := createTestApi(t)
+	defer api.Shutdown()
+
+	const serviceDate = "20241104"
+	ctx := withRequestCache(context.Background())
+
+	first, err := api.activeServiceIDsForDate(ctx, serviceDate)
+	require.NoError(t, err)
+
+	cached, ok := requestCacheFrom(ctx).getActiveServiceIDs(serviceDate)
+	require.True(t, ok, "the first lookup must populate the memo")
+	assert.Equal(t, first, cached)
+
+	// Overwrite the entry so a second call proves it reads through the memo.
+	requestCacheFrom(ctx).putActiveServiceIDs(serviceDate, []string{"sentinel"})
+	second, err := api.activeServiceIDsForDate(ctx, serviceDate)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"sentinel"}, second, "the memo must be consulted before the database")
 }

--- a/internal/restapi/scheduled_block_helper.go
+++ b/internal/restapi/scheduled_block_helper.go
@@ -530,20 +530,22 @@ func (api *RestAPI) loadBlockTripData(ctx context.Context, tripIDs []string) []b
 
 	cache := requestCacheFrom(ctx)
 	if cache == nil {
-		return api.loadBlockTripDataFromDB(ctx, tripIDs)
+		trips, _ := api.loadBlockTripDataFromDB(ctx, tripIDs)
+		return trips
 	}
 
 	key := blockTripDataCacheKeyFor(tripIDs)
 	trips, ok := cache.getBlockTripData(key)
 	if !ok {
-		trips = api.loadBlockTripDataFromDB(ctx, tripIDs)
-		// A nil result means the stop-times query failed; the no-usable-trips case
-		// returns an empty non-nil slice. Caching the failure would turn one
-		// transient DB error into a block-wide degradation for the whole request,
-		// with every later row silently skipping its retry.
-		if trips != nil {
-			cache.putBlockTripData(key, trips)
+		loaded, complete := api.loadBlockTripDataFromDB(ctx, tripIDs)
+		// Only a complete load is worth keeping. A stop-times failure yields nil,
+		// and a shape failure yields a haversine-degraded but non-nil result;
+		// caching either would pin one transient error to this block for the rest
+		// of the request, where an uncached call would simply retry and recover.
+		if complete {
+			cache.putBlockTripData(key, loaded)
 		}
+		trips = loaded
 	}
 	// loadShiftTrips sorts the result in place and reslices it, so each caller
 	// needs its own backing array. The elements are treated as read-only.
@@ -551,12 +553,18 @@ func (api *RestAPI) loadBlockTripData(ctx context.Context, tripIDs []string) []b
 }
 
 // loadBlockTripDataFromDB is loadBlockTripData without the request-scoped memo.
-func (api *RestAPI) loadBlockTripDataFromDB(ctx context.Context, tripIDs []string) []blockTripData {
+//
+// The second return value reports whether every underlying query succeeded. It is
+// false when stop times could not be loaded at all, in which case the slice is
+// nil, and also when only the shape query failed, since the trips are then usable
+// but carry haversine-derived distances rather than shape-derived ones. Callers
+// that memoize must not store an incomplete result.
+func (api *RestAPI) loadBlockTripDataFromDB(ctx context.Context, tripIDs []string) ([]blockTripData, bool) {
 	q := api.GtfsManager.GtfsDB.Queries
 
 	stopTimeRows, err := q.GetStopTimesForTripIDs(ctx, tripIDs)
 	if err != nil {
-		return nil
+		return nil, false
 	}
 	stopTimesByTrip := make(map[string][]gtfsdb.StopTime, len(tripIDs))
 	for _, st := range stopTimeRows {
@@ -568,8 +576,8 @@ func (api *RestAPI) loadBlockTripDataFromDB(ctx context.Context, tripIDs []strin
 	// the fallback, still correct just less precise. Log real DB errors
 	// so an operator sees the degradation instead of silently losing
 	// shape-based precision across every block trip.
-	shapeRows, err := q.GetShapePointsByTripIDs(ctx, tripIDs)
-	warnIfRealDBError(err, "loadBlockTripData: GetShapePointsByTripIDs failed, degrading every trip to haversine fallback",
+	shapeRows, shapeErr := q.GetShapePointsByTripIDs(ctx, tripIDs)
+	warnIfRealDBError(shapeErr, "loadBlockTripData: GetShapePointsByTripIDs failed, degrading every trip to haversine fallback",
 		slog.Int("trip_count", len(tripIDs)))
 	shapePointsByTrip := make(map[string][]gtfs.ShapePoint, len(tripIDs))
 	for _, sr := range shapeRows {
@@ -603,7 +611,7 @@ func (api *RestAPI) loadBlockTripDataFromDB(ctx context.Context, tripIDs []strin
 			),
 		})
 	}
-	return out
+	return out, shapeErr == nil
 }
 
 // fetchStopCoordsForStopTimes batches GetStopsByIDs for the unique stop IDs in

--- a/internal/restapi/scheduled_block_helper.go
+++ b/internal/restapi/scheduled_block_helper.go
@@ -490,7 +490,7 @@ func (api *RestAPI) blockTripIDsForServiceDate(
 	if len(blockTrips) == 0 {
 		return fallback
 	}
-	activeServiceIDs, err := q.GetActiveServiceIDsForDate(ctx, serviceDate.Format("20060102"))
+	activeServiceIDs, err := api.activeServiceIDsForDate(ctx, serviceDate.Format("20060102"))
 	if err != nil {
 		warnIfRealDBError(err, "blockTripIDsForServiceDate: GetActiveServiceIDsForDate failed, degrading to single-trip mode",
 			slog.String("trip_id", targetTripID), slog.String("date", serviceDate.Format("20060102")))
@@ -527,6 +527,31 @@ func (api *RestAPI) loadBlockTripData(ctx context.Context, tripIDs []string) []b
 	if len(tripIDs) == 0 {
 		return nil
 	}
+
+	cache := requestCacheFrom(ctx)
+	if cache == nil {
+		return api.loadBlockTripDataFromDB(ctx, tripIDs)
+	}
+
+	key := blockTripDataCacheKeyFor(tripIDs)
+	trips, ok := cache.getBlockTripData(key)
+	if !ok {
+		trips = api.loadBlockTripDataFromDB(ctx, tripIDs)
+		// A nil result means the stop-times query failed; the no-usable-trips case
+		// returns an empty non-nil slice. Caching the failure would turn one
+		// transient DB error into a block-wide degradation for the whole request,
+		// with every later row silently skipping its retry.
+		if trips != nil {
+			cache.putBlockTripData(key, trips)
+		}
+	}
+	// loadShiftTrips sorts the result in place and reslices it, so each caller
+	// needs its own backing array. The elements are treated as read-only.
+	return slices.Clone(trips)
+}
+
+// loadBlockTripDataFromDB is loadBlockTripData without the request-scoped memo.
+func (api *RestAPI) loadBlockTripDataFromDB(ctx context.Context, tripIDs []string) []blockTripData {
 	q := api.GtfsManager.GtfsDB.Queries
 
 	stopTimeRows, err := q.GetStopTimesForTripIDs(ctx, tripIDs)

--- a/internal/restapi/trips_helper.go
+++ b/internal/restapi/trips_helper.go
@@ -138,7 +138,7 @@ func (api *RestAPI) BuildTripStatus(
 	hasVehicleRealtimeData := vehicle != nil && !defaultStaleDetector.Check(vehicle, currentTime)
 	status.SetPredicted(hasVehicleRealtimeData || hasRealtimeTripUpdate)
 
-	stopTimes, err := api.GtfsManager.GtfsDB.Queries.GetStopTimesForTrip(ctx, dbTripID)
+	stopTimes, err := api.stopTimesForTrip(ctx, dbTripID)
 	if err != nil {
 		slog.Warn("buildTripStatusCore: failed to get stop times",
 			slog.String("trip_id", dbTripID),
@@ -731,7 +731,7 @@ func (api *RestAPI) blockTripSequence(ctx context.Context, tripID string, servic
 	}
 
 	formattedDate := serviceDate.Format("20060102")
-	activeServiceIDs, err := api.GtfsManager.GtfsDB.Queries.GetActiveServiceIDsForDate(ctx, formattedDate)
+	activeServiceIDs, err := api.activeServiceIDsForDate(ctx, formattedDate)
 	if err != nil {
 		slog.Warn("blockTripSequence: failed to get active service IDs",
 			slog.String("trip_id", tripID),

--- a/internal/restapi/vehicles_helper.go
+++ b/internal/restapi/vehicles_helper.go
@@ -199,7 +199,7 @@ func (api *RestAPI) resolveActiveTripID(ctx context.Context, nominalTripID strin
 // activeTripInBlockAt returns the block trip whose scheduled window contains
 // sinceMidnightNs on serviceDay's active services, if any.
 func (api *RestAPI) activeTripInBlockAt(ctx context.Context, blockID sql.NullString, serviceDay time.Time, sinceMidnightNs int64) (string, bool) {
-	serviceIDs, err := api.GtfsManager.GtfsDB.Queries.GetActiveServiceIDsForDate(ctx, serviceDay.Format("20060102"))
+	serviceIDs, err := api.activeServiceIDsForDate(ctx, serviceDay.Format("20060102"))
 	if err != nil || len(serviceIDs) == 0 {
 		return "", false
 	}


### PR DESCRIPTION
## Why

`BuildTripStatus` resolves a trip's block to compute position, distance and schedule deviation. For a handler that calls it once per response row, that resolution repeats for every row, and each one reloads the stop times and shape points of every trip in the block. The work ends up scaling with (rows x block size) rather than with the number of distinct blocks.

There is a second, smaller repeat in the same path: `GetActiveServiceIDsForDate` is called once per row for a date that cannot change within a request.

This is the same problem `WithSnapshotCache` already solves for whole block snapshots on the plural arrivals handler. These entries sit one level below it, and are still reached on the schedule-deviation path, which resolves a block without going through a snapshot.

## What this changes

A request-scoped memo in `internal/restapi/request_cache.go`, carried on the context, holding three things:

- `loadBlockTripData`, keyed on the trip-ID set. This deduplicates across vehicles sharing a block, and also within a single `BuildTripStatus` call, which resolves the same block twice (once via `computeScheduledBlockSnapshot`, once via `blockShiftTripIDsSortedByStartTime`).
- `GetActiveServiceIDsForDate`, keyed on the date. I only swapped the three hot call sites (`blockTripIDsForServiceDate`, `blockTripSequence`, `activeTripInBlockAt`); the other nine are untouched.
- Stop times, seeded by `prefetchStopTimes`, so a handler can resolve every row's stop times in one query instead of one per row.

The memo is request-scoped rather than a field on `RestAPI` on purpose. Static GTFS data reloads in the background, and anything longer-lived would need invalidation tied to that reload. A handler that does not opt in gets the existing behaviour unchanged, since every accessor falls through to the original query when the context carries no memo.

`loadBlockTripData` hands out `slices.Clone` of the cached entry because `loadShiftTrips` sorts it in place. The elements themselves are shared and must be treated as read-only; I traced every consumer and none of them mutate, but `BuildTripStatus` does take `&stopTimes[i]` pointers into the backing array and pass them to the offset helpers, so I documented the constraint on the accessor rather than leave it implicit.

## Deliberately not prefetched: shape points

I had shapes in the prefetch initially and took them back out. `GetShapePointsByTripIDs` joins shapes to trips, so a shape shared by many trips comes back once per trip with no deduplication. At roughly 1,500 points per shape that is about 96 KB per vehicle held for the life of the request, which for a large agency is hundreds of megabytes per concurrent request. It also pushes the `IN (?,?,...)` expansion towards `SQLITE_MAX_VARIABLE_NUMBER`. Measured, it made things worse: 26.7 MB and 343,680 allocations against 21.4 MB and 328,843 with stop times alone. Stop times are around 4 KB per trip and carry no duplication, so that half stays.

## Numbers

Measured with `BenchmarkVehiclesForAgency_50Vehicles` (added in the follow-up PR below, since this PR has no handler calling `BuildTripStatus` per row yet), 50 vehicles on distinct active trips, pure-Go SQLite:

| | bytes/op | allocs/op |
|---|---|---|
| without the memo | 210 MB | 2,751,307 |
| with the memo | 21 MB | 332,215 |
| with the memo and the stop-times prefetch | 21.4 MB | 328,843 |

Allocation counts are deterministic and are the figures I trust. Wall-clock on my machine varied between 235 ms and 810 ms across repeated runs of the same benchmark, so I have not quoted a speedup; the ratio would not be reproducible.

The structural change matters more than the ratio. Per-vehicle allocations go from growing with vehicle count (12,888 at one vehicle, 55,026 per vehicle at fifty) to flat at roughly 6,600 per vehicle. The quadratic term is gone.

## Callers

`arrivals-and-departures-for-stop` installs the memo. That handler builds a trip
status per arrival row, and each one previously resolved its own stop times; it was
also already batch-loading the same rows for `totalStopsInTrip` and discarding them,
so the data was fetched twice. `prefetchStopTimes` now returns the rows grouped by
trip, the stop counts come from that same result, and the per-row lookups become map
reads — one existing query doing two jobs rather than a new one.

Over a 10-hour window on the fixture's busiest stop that is ~53ms → ~45ms per
request and 237k → 229k allocations (`BenchmarkArrivalsAndDeparturesWideWindow`).

`trips-for-route` looks like the worst offender of all, around four per-trip queries
per row with no cache installed at all, and `trips-for-location` is in the same
shape. Both are bigger changes and I have left them alone.

## Testing

`internal/restapi/request_cache_test.go` covers each memo: fall-through when the handler has not opted in, seeded entries being preferred over the database, first resolution populating the memo, and callers getting independent slices. The prefetch tests cover a real trip, a trip with no stop times (which must still be seeded so it is not retried per row), and the no-memo no-op path.

`go fmt` clean and the full suite passes on the pure-Go path (`CGO_ENABLED=0 go test -tags purego ./...`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Improved response times for schedule and trip-status requests by reusing repeated GTFS lookups within each request.
  * Added efficient prefetching for stop-time data shared across multiple trips.
  * Reduced redundant service-date and block-trip database queries.

* **Reliability**
  * Preserved fallback behavior when lookup queries fail.
  * Avoided retaining failed or incomplete lookups in the request cache.
  * Ensured cached results remain safe when callers modify returned data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->