### PR TITLE
Build vehicles-for-agency tripStatus from the shared builder

### DIFF
--- a/internal/restapi/request_cache.go
+++ b/internal/restapi/request_cache.go
@@ -1,0 +1,183 @@
+package restapi
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+	"sync"
+
+	"maglev.onebusaway.org/gtfsdb"
+)
+
+// requestCacheKey is the context key under which a request carries its memo.
+type requestCacheKey struct{}
+
+// requestCache memoizes GTFS lookups that repeat across the rows of a single
+// response.
+//
+// Endpoints that build a trip status per row — vehicles-for-agency across every
+// vehicle in an agency, for instance — resolve the same block and the same
+// service calendar over and over. Without a memo the work scales with
+// (rows × block size) rather than with the number of distinct blocks, and the
+// service-ID lookup repeats once per row for a date that never changes within
+// the request.
+//
+// The memo is deliberately request-scoped rather than a field on RestAPI: static
+// GTFS data is reloaded in the background, and a longer-lived cache would need
+// invalidation wired to that reload. It is mutex-guarded because nothing
+// prevents a handler from building statuses concurrently.
+//
+// This complements the existing snapshotCache (see WithSnapshotCache), which
+// memoizes whole block snapshots. These entries sit a level below that and are
+// still reached on the schedule-deviation path, which resolves a block without
+// going through a snapshot.
+type requestCache struct {
+	mu               sync.Mutex
+	blockTripData    map[string][]blockTripData
+	activeServiceIDs map[string][]string
+	stopTimes        map[string][]gtfsdb.StopTime
+}
+
+// withRequestCache returns a context carrying a request-scoped memo. Handlers
+// that build many trip statuses in one request should wrap their context with
+// it; handlers that build a single trip status gain nothing and can leave it off.
+func withRequestCache(ctx context.Context) context.Context {
+	return context.WithValue(ctx, requestCacheKey{}, &requestCache{
+		blockTripData:    make(map[string][]blockTripData),
+		activeServiceIDs: make(map[string][]string),
+		stopTimes:        make(map[string][]gtfsdb.StopTime),
+	})
+}
+
+// requestCacheFrom returns the request's memo, or nil when the handler did not
+// opt in.
+func requestCacheFrom(ctx context.Context) *requestCache {
+	cache, _ := ctx.Value(requestCacheKey{}).(*requestCache)
+	return cache
+}
+
+// blockTripDataCacheKeyFor joins trip IDs into a single map key. GTFS IDs cannot
+// contain a NUL byte, so the separator cannot collide across different splits of
+// the same concatenated text.
+func blockTripDataCacheKeyFor(tripIDs []string) string {
+	return strings.Join(tripIDs, "\x00")
+}
+
+func (c *requestCache) getBlockTripData(key string) ([]blockTripData, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	trips, ok := c.blockTripData[key]
+	return trips, ok
+}
+
+func (c *requestCache) putBlockTripData(key string, trips []blockTripData) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.blockTripData[key] = trips
+}
+
+func (c *requestCache) getActiveServiceIDs(date string) ([]string, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	ids, ok := c.activeServiceIDs[date]
+	return ids, ok
+}
+
+func (c *requestCache) putActiveServiceIDs(date string, ids []string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.activeServiceIDs[date] = ids
+}
+
+func (c *requestCache) getStopTimes(tripID string) ([]gtfsdb.StopTime, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	stopTimes, ok := c.stopTimes[tripID]
+	return stopTimes, ok
+}
+
+// prefetchStopTimes resolves the stop times of every trip in tripIDs with one
+// query, seeding the request memo so the per-trip lookup inside BuildTripStatus
+// becomes a map read instead of a query per response row.
+//
+// Trips that return no rows are recorded as empty entries, so a genuinely
+// stop-time-less trip is not retried once per row.
+//
+// Shape points are deliberately NOT prefetched. GetShapePointsByTripIDs joins
+// shapes to trips, so a shape shared by many trips is returned once per trip; a
+// large agency's worth of vehicles would materialize hundreds of megabytes of
+// duplicated geometry for the life of the request. Stop times are ~two orders of
+// magnitude smaller per trip and carry no such duplication.
+//
+// A failed prefetch is logged and swallowed: an absent entry falls back to the
+// per-trip query, so the response stays correct and is merely slower.
+func (api *RestAPI) prefetchStopTimes(ctx context.Context, tripIDs []string) {
+	cache := requestCacheFrom(ctx)
+	if cache == nil || len(tripIDs) == 0 {
+		return
+	}
+
+	rows, err := api.GtfsManager.GtfsDB.Queries.GetStopTimesForTripIDs(ctx, tripIDs)
+	if err != nil {
+		// Seeding after a failure would record "this trip has no stop times" for
+		// every trip. An empty entry is a valid hit, so callers would skip the
+		// per-trip fallback and emit a response missing the stop-relative fields
+		// rather than a slower correct one.
+		slog.Warn("prefetchStopTimes: GetStopTimesForTripIDs failed, falling back to per-trip lookups",
+			slog.Int("trip_count", len(tripIDs)), slog.String("error", err.Error()))
+		return
+	}
+
+	stopTimesByTrip := make(map[string][]gtfsdb.StopTime, len(tripIDs))
+	for _, row := range rows {
+		stopTimesByTrip[row.TripID] = append(stopTimesByTrip[row.TripID], row)
+	}
+
+	cache.mu.Lock()
+	defer cache.mu.Unlock()
+	for _, tripID := range tripIDs {
+		cache.stopTimes[tripID] = stopTimesByTrip[tripID]
+	}
+}
+
+// stopTimesForTrip returns tripID's stop times, preferring a prefetched entry.
+//
+// A prefetched result is shared with every other caller in the request and must
+// be treated as read-only. BuildTripStatus takes pointers into the backing array
+// (&stopTimes[i]) and hands them to the stop-offset helpers, so a write through
+// one of those pointers would corrupt the memo for the rest of the request.
+func (api *RestAPI) stopTimesForTrip(ctx context.Context, tripID string) ([]gtfsdb.StopTime, error) {
+	if cache := requestCacheFrom(ctx); cache != nil {
+		if stopTimes, ok := cache.getStopTimes(tripID); ok {
+			return stopTimes, nil
+		}
+	}
+	return api.GtfsManager.GtfsDB.Queries.GetStopTimesForTrip(ctx, tripID)
+}
+
+// activeServiceIDsForDate returns the service IDs active on formattedDate
+// (YYYYMMDD), memoized for the lifetime of the request. Errors are returned to
+// the caller and never cached, so a transient DB failure does not stick for the
+// rest of the request.
+func (api *RestAPI) activeServiceIDsForDate(ctx context.Context, formattedDate string) ([]string, error) {
+	cache := requestCacheFrom(ctx)
+	if cache == nil {
+		return api.GtfsManager.GtfsDB.Queries.GetActiveServiceIDsForDate(ctx, formattedDate)
+	}
+
+	if ids, ok := cache.getActiveServiceIDs(formattedDate); ok {
+		return ids, nil
+	}
+
+	ids, err := api.GtfsManager.GtfsDB.Queries.GetActiveServiceIDsForDate(ctx, formattedDate)
+	if err != nil {
+		return nil, err
+	}
+	cache.putActiveServiceIDs(formattedDate, ids)
+	return ids, nil
+}

--- a/internal/restapi/request_cache_test.go
+++ b/internal/restapi/request_cache_test.go
@@ -1,0 +1,170 @@
+package restapi
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"maglev.onebusaway.org/gtfsdb"
+)
+
+// TestLoadBlockTripDataWithoutCache verifies the loader still works for handlers
+// that do not opt into the request-scoped memo.
+func TestLoadBlockTripDataWithoutCache(t *testing.T) {
+	api := createTestApi(t)
+	defer api.Shutdown()
+
+	trip := mustGetTrip(t, api)
+	trips := api.loadBlockTripData(context.Background(), []string{trip.ID})
+	require.Len(t, trips, 1)
+	assert.Equal(t, trip.ID, trips[0].id)
+}
+
+// TestLoadBlockTripDataUsesCache verifies a second resolution of the same trip-ID
+// set is served from the memo rather than the database. The memo is seeded with a
+// sentinel so a hit is distinguishable from a fresh load.
+func TestLoadBlockTripDataUsesCache(t *testing.T) {
+	api := createTestApi(t)
+	defer api.Shutdown()
+
+	trip := mustGetTrip(t, api)
+	tripIDs := []string{trip.ID}
+	ctx := withRequestCache(context.Background())
+
+	cache := requestCacheFrom(ctx)
+	require.NotNil(t, cache, "context must carry the memo")
+	cache.putBlockTripData(blockTripDataCacheKeyFor(tripIDs), []blockTripData{{id: "sentinel"}})
+
+	trips := api.loadBlockTripData(ctx, tripIDs)
+	require.Len(t, trips, 1)
+	assert.Equal(t, "sentinel", trips[0].id, "the memo must be consulted before the database")
+}
+
+// TestLoadBlockTripDataPopulatesCache verifies the first resolution stores its
+// result, so later callers in the same request skip the load.
+func TestLoadBlockTripDataPopulatesCache(t *testing.T) {
+	api := createTestApi(t)
+	defer api.Shutdown()
+
+	trip := mustGetTrip(t, api)
+	tripIDs := []string{trip.ID}
+	ctx := withRequestCache(context.Background())
+
+	require.Len(t, api.loadBlockTripData(ctx, tripIDs), 1)
+
+	cached, ok := requestCacheFrom(ctx).getBlockTripData(blockTripDataCacheKeyFor(tripIDs))
+	require.True(t, ok, "the first resolution must populate the memo")
+	require.Len(t, cached, 1)
+	assert.Equal(t, trip.ID, cached[0].id)
+}
+
+// TestLoadBlockTripDataReturnsIndependentSlices verifies each caller gets its own
+// backing array. loadShiftTrips sorts the result in place, which would otherwise
+// reorder the cached entry underneath everyone else.
+func TestLoadBlockTripDataReturnsIndependentSlices(t *testing.T) {
+	api := createTestApi(t)
+	defer api.Shutdown()
+
+	trip := mustGetTrip(t, api)
+	tripIDs := []string{trip.ID}
+	ctx := withRequestCache(context.Background())
+
+	first := api.loadBlockTripData(ctx, tripIDs)
+	require.Len(t, first, 1)
+	first[0].id = "mutated by caller"
+
+	second := api.loadBlockTripData(ctx, tripIDs)
+	require.Len(t, second, 1)
+	assert.Equal(t, trip.ID, second[0].id, "a caller's in-place edit must not leak into the memo")
+}
+
+// TestPrefetchStopTimesSeedsMemo verifies one batch query populates an entry per
+// requested trip, including trips that genuinely have no stop times.
+func TestPrefetchStopTimesSeedsMemo(t *testing.T) {
+	api := createTestApi(t)
+	defer api.Shutdown()
+
+	trip := mustGetTrip(t, api)
+	const missingTripID = "trip-that-does-not-exist"
+	ctx := withRequestCache(context.Background())
+
+	api.prefetchStopTimes(ctx, []string{trip.ID, missingTripID})
+
+	cache := requestCacheFrom(ctx)
+	seeded, ok := cache.getStopTimes(trip.ID)
+	require.True(t, ok, "a real trip must be seeded")
+	assert.NotEmpty(t, seeded)
+
+	empty, ok := cache.getStopTimes(missingTripID)
+	require.True(t, ok, "a trip with no stop times must still be seeded, so it is not retried per row")
+	assert.Empty(t, empty)
+}
+
+// TestPrefetchStopTimesWithoutCacheIsNoop verifies the prefetch is inert for
+// handlers that did not opt in, rather than panicking.
+func TestPrefetchStopTimesWithoutCacheIsNoop(t *testing.T) {
+	api := createTestApi(t)
+	defer api.Shutdown()
+
+	trip := mustGetTrip(t, api)
+	api.prefetchStopTimes(context.Background(), []string{trip.ID})
+
+	stopTimes, err := api.stopTimesForTrip(context.Background(), trip.ID)
+	require.NoError(t, err)
+	assert.NotEmpty(t, stopTimes, "the lookup must still fall through to the query")
+}
+
+// TestStopTimesForTripPrefersMemo verifies the per-trip lookup reads a seeded
+// entry instead of querying.
+func TestStopTimesForTripPrefersMemo(t *testing.T) {
+	api := createTestApi(t)
+	defer api.Shutdown()
+
+	trip := mustGetTrip(t, api)
+	ctx := withRequestCache(context.Background())
+	requestCacheFrom(ctx).stopTimes[trip.ID] = []gtfsdb.StopTime{{TripID: "sentinel"}}
+
+	stopTimes, err := api.stopTimesForTrip(ctx, trip.ID)
+	require.NoError(t, err)
+	require.Len(t, stopTimes, 1)
+	assert.Equal(t, "sentinel", stopTimes[0].TripID, "the memo must be consulted before the database")
+}
+
+// TestActiveServiceIDsForDateWithoutCache verifies the lookup falls through to the
+// query when the handler did not opt into the memo.
+func TestActiveServiceIDsForDateWithoutCache(t *testing.T) {
+	api := createTestApi(t)
+	defer api.Shutdown()
+
+	const serviceDate = "20241104"
+	ids, err := api.activeServiceIDsForDate(context.Background(), serviceDate)
+	require.NoError(t, err)
+
+	expected, err := api.GtfsManager.GtfsDB.Queries.GetActiveServiceIDsForDate(context.Background(), serviceDate)
+	require.NoError(t, err)
+	assert.Equal(t, expected, ids)
+}
+
+// TestActiveServiceIDsForDateUsesCache verifies the date is resolved once per
+// request. Every row of a list response asks for the same service date.
+func TestActiveServiceIDsForDateUsesCache(t *testing.T) {
+	api := createTestApi(t)
+	defer api.Shutdown()
+
+	const serviceDate = "20241104"
+	ctx := withRequestCache(context.Background())
+
+	first, err := api.activeServiceIDsForDate(ctx, serviceDate)
+	require.NoError(t, err)
+
+	cached, ok := requestCacheFrom(ctx).getActiveServiceIDs(serviceDate)
+	require.True(t, ok, "the first lookup must populate the memo")
+	assert.Equal(t, first, cached)
+
+	// Overwrite the entry so a second call proves it reads through the memo.
+	requestCacheFrom(ctx).putActiveServiceIDs(serviceDate, []string{"sentinel"})
+	second, err := api.activeServiceIDsForDate(ctx, serviceDate)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"sentinel"}, second, "the memo must be consulted before the database")
+}

--- a/internal/restapi/scheduled_block_helper.go
+++ b/internal/restapi/scheduled_block_helper.go
@@ -490,7 +490,7 @@ func (api *RestAPI) blockTripIDsForServiceDate(
 	if len(blockTrips) == 0 {
 		return fallback
 	}
-	activeServiceIDs, err := q.GetActiveServiceIDsForDate(ctx, serviceDate.Format("20060102"))
+	activeServiceIDs, err := api.activeServiceIDsForDate(ctx, serviceDate.Format("20060102"))
 	if err != nil {
 		warnIfRealDBError(err, "blockTripIDsForServiceDate: GetActiveServiceIDsForDate failed, degrading to single-trip mode",
 			slog.String("trip_id", targetTripID), slog.String("date", serviceDate.Format("20060102")))
@@ -527,6 +527,31 @@ func (api *RestAPI) loadBlockTripData(ctx context.Context, tripIDs []string) []b
 	if len(tripIDs) == 0 {
 		return nil
 	}
+
+	cache := requestCacheFrom(ctx)
+	if cache == nil {
+		return api.loadBlockTripDataFromDB(ctx, tripIDs)
+	}
+
+	key := blockTripDataCacheKeyFor(tripIDs)
+	trips, ok := cache.getBlockTripData(key)
+	if !ok {
+		trips = api.loadBlockTripDataFromDB(ctx, tripIDs)
+		// A nil result means the stop-times query failed; the no-usable-trips case
+		// returns an empty non-nil slice. Caching the failure would turn one
+		// transient DB error into a block-wide degradation for the whole request,
+		// with every later row silently skipping its retry.
+		if trips != nil {
+			cache.putBlockTripData(key, trips)
+		}
+	}
+	// loadShiftTrips sorts the result in place and reslices it, so each caller
+	// needs its own backing array. The elements are treated as read-only.
+	return slices.Clone(trips)
+}
+
+// loadBlockTripDataFromDB is loadBlockTripData without the request-scoped memo.
+func (api *RestAPI) loadBlockTripDataFromDB(ctx context.Context, tripIDs []string) []blockTripData {
 	q := api.GtfsManager.GtfsDB.Queries
 
 	stopTimeRows, err := q.GetStopTimesForTripIDs(ctx, tripIDs)

--- a/internal/restapi/trips_helper.go
+++ b/internal/restapi/trips_helper.go
@@ -138,7 +138,7 @@ func (api *RestAPI) BuildTripStatus(
 	hasVehicleRealtimeData := vehicle != nil && !defaultStaleDetector.Check(vehicle, currentTime)
 	status.SetPredicted(hasVehicleRealtimeData || hasRealtimeTripUpdate)
 
-	stopTimes, err := api.GtfsManager.GtfsDB.Queries.GetStopTimesForTrip(ctx, dbTripID)
+	stopTimes, err := api.stopTimesForTrip(ctx, dbTripID)
 	if err != nil {
 		slog.Warn("buildTripStatusCore: failed to get stop times",
 			slog.String("trip_id", dbTripID),
@@ -731,7 +731,7 @@ func (api *RestAPI) blockTripSequence(ctx context.Context, tripID string, servic
 	}
 
 	formattedDate := serviceDate.Format("20060102")
-	activeServiceIDs, err := api.GtfsManager.GtfsDB.Queries.GetActiveServiceIDsForDate(ctx, formattedDate)
+	activeServiceIDs, err := api.activeServiceIDsForDate(ctx, formattedDate)
 	if err != nil {
 		slog.Warn("blockTripSequence: failed to get active service IDs",
 			slog.String("trip_id", tripID),

--- a/internal/restapi/vehicles_for_agency_handler.go
+++ b/internal/restapi/vehicles_for_agency_handler.go
@@ -1,10 +1,12 @@
 package restapi
 
 import (
+	"context"
 	"net/http"
 	"strconv"
 	"time"
 
+	"github.com/OneBusAway/go-gtfs"
 	"maglev.onebusaway.org/gtfsdb"
 	"maglev.onebusaway.org/internal/models"
 	"maglev.onebusaway.org/internal/nulls"
@@ -18,7 +20,12 @@ func (api *RestAPI) vehiclesForAgencyHandler(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	ctx := r.Context()
+	// This endpoint builds a trip status per vehicle, so vehicles sharing a block
+	// would otherwise recompute that block's snapshot and reload its trip data once
+	// per vehicle. The plural arrivals handler installs the snapshot cache for the
+	// same reason; the trip-data memo additionally covers the schedule-deviation
+	// path, which resolves the same block without going through a snapshot.
+	ctx := withRequestCache(WithSnapshotCache(r.Context(), newSnapshotCache()))
 
 	agency, err := api.GtfsManager.FindAgency(ctx, id)
 	if err != nil {
@@ -49,7 +56,7 @@ func (api *RestAPI) vehiclesForAgencyHandler(w http.ResponseWriter, r *http.Requ
 	}
 
 	// Service date is midnight of the reference date in the agency timezone.
-	serviceDate := models.NewModelTime(utils.CalculateServiceDate(referenceTime))
+	serviceDate := utils.CalculateServiceDate(referenceTime)
 
 	vehiclesForAgency, err := api.GtfsManager.VehiclesForAgencyID(ctx, id)
 	if err != nil {
@@ -74,17 +81,28 @@ func (api *RestAPI) vehiclesForAgencyHandler(w http.ResponseWriter, r *http.Requ
 
 	vehiclesList := make([]models.VehicleStatus, 0, len(vehiclesForAgency))
 
-	// Collect unique route IDs and batch-fetch routes
+	// Collect unique route and trip IDs, then batch-fetch what every vehicle needs.
 	routeIDSet := make(map[string]struct{})
+	tripIDSet := make(map[string]struct{})
 	for _, vehicle := range vehiclesForAgency {
 		if vehicle.Trip != nil {
 			routeIDSet[vehicle.Trip.ID.RouteID] = struct{}{}
+			tripIDSet[vehicle.Trip.ID.ID] = struct{}{}
 		}
 	}
 	routeIDs := make([]string, 0, len(routeIDSet))
 	for routeID := range routeIDSet {
 		routeIDs = append(routeIDs, routeID)
 	}
+
+	// Resolve every vehicle's stop times in one query, so the trip status built
+	// for each one reads them from the request memo rather than issuing its own.
+	tripIDs := make([]string, 0, len(tripIDSet))
+	for tripID := range tripIDSet {
+		tripIDs = append(tripIDs, tripID)
+	}
+	api.prefetchStopTimes(ctx, tripIDs)
+
 	routes, err := api.GtfsManager.GtfsDB.Queries.GetRoutesByIDs(ctx, routeIDs)
 	if err != nil {
 		api.serverErrorResponse(w, r, err)
@@ -136,55 +154,26 @@ func (api *RestAPI) vehiclesForAgencyHandler(w http.ResponseWriter, r *http.Requ
 		if vehicle.Trip != nil {
 			vehicleStatus.TripID = utils.FormCombinedID(id, vehicle.Trip.ID.ID)
 
-			tripStatus := models.NewTripStatus()
 			// Resolve the executing trip; may differ from the nominal trip when interlining.
 			activeTripID := api.resolveActiveTripID(ctx, vehicle.Trip.ID.ID, referenceTime)
-			tripStatus.ActiveTripID = utils.FormCombinedID(id, activeTripID)
-			// Resolve the block trip sequence for the active (not nominal) trip,
-			// so it reflects the position of the trip actually being executed.
-			if seq, ok := api.blockTripSequence(ctx, activeTripID, referenceTime); ok {
-				tripStatus.BlockTripSequence = seq
-			} else {
-				tripStatus.BlockTripSequence = -1
-			}
-			tripStatus.Phase = vehicleStatus.Phase
-			tripStatus.Status = vehicleStatus.Status
 
-			// Add position information to trip status
-			if vehicle.Position != nil && vehicle.Position.Latitude != nil && vehicle.Position.Longitude != nil {
-				tripStatus.Position = models.Location{
-					Lat: float64(*vehicle.Position.Latitude),
-					Lon: float64(*vehicle.Position.Longitude),
-				}
-			}
+			tripStatus := api.buildVehicleTripStatus(ctx, &vehicle, vehicleTripStatusParams{
+				AgencyID:               id,
+				ActiveTripID:           activeTripID,
+				ServiceDate:            serviceDate,
+				ReferenceTime:          referenceTime,
+				Status:                 vehicleStatus.Status,
+				Phase:                  vehicleStatus.Phase,
+				LastUpdateTime:         vehicleStatus.LastUpdateTime,
+				LastLocationUpdateTime: vehicleStatus.LastLocationUpdateTime,
+			})
 
-			// Add orientation if available (convert from GTFS bearing to OBA orientation)
-			if vehicle.Position != nil && vehicle.Position.Bearing != nil {
-				// Convert from GTFS bearing (0° = North, 90° = East) to OBA orientation (0° = East, 90° = North)
-				// OBA orientation = (90 - GTFS bearing) mod 360
-				obaOrientation := (90 - *vehicle.Position.Bearing)
-				if obaOrientation < 0 {
-					obaOrientation += 360
-				}
-				tripStatus.Orientation = float64(obaOrientation)
-			}
-
-			// Trip status update times default to 0 when no real update exists.
-			if vehicle.Timestamp != nil {
-				ts := models.NewModelTime(*vehicle.Timestamp)
-				tripStatus.LastUpdateTime = ts
-				tripStatus.LastLocationUpdateTime = ts
-			}
-
-			tripStatus.ServiceDate = serviceDate
-
-			// Propagate occupancy status from GTFS-RT to both TripStatus and VehicleStatus.
+			// Propagate occupancy status from GTFS-RT to the vehicle-level field as well;
+			// BuildTripStatus already sets it on the trip status.
 			// There is no source for occupancyCapacity or occupancyCount anywhere in maglev — not in the SQLite DB,
 			// not in GTFS-RT. Those fields will remain omitted.
 			if vehicle.OccupancyStatus != nil {
-				occupancy := vehicle.OccupancyStatus.String()
-				tripStatus.OccupancyStatus = occupancy
-				vehicleStatus.OccupancyStatus = occupancy
+				vehicleStatus.OccupancyStatus = vehicle.OccupancyStatus.String()
 			}
 
 			vehicleStatus.TripStatus = tripStatus
@@ -256,6 +245,89 @@ func (api *RestAPI) vehiclesForAgencyHandler(w http.ResponseWriter, r *http.Requ
 	// Spec: this endpoint returns all matching vehicles, so limitExceeded is always false.
 	response := models.NewListResponse(vehiclesList, *references, false, api.Clock)
 	api.sendResponse(w, r, response)
+}
+
+// vehicleTripStatusParams carries the per-request values buildVehicleTripStatus needs
+// alongside the vehicle itself.
+type vehicleTripStatusParams struct {
+	AgencyID string
+	// ActiveTripID is the trip actually executing at ReferenceTime, which differs
+	// from the vehicle's nominal trip when interlining is in play.
+	ActiveTripID  string
+	ServiceDate   time.Time
+	ReferenceTime time.Time
+	// Status, Phase and the update times are the enclosing vehicleStatus values,
+	// mirrored onto the trip status so the two never disagree within a single list
+	// entry. BuildTripStatus derives its own equivalents from vehicle freshness and
+	// position, which would otherwise make the nested object contradict the outer one.
+	Status                 string
+	Phase                  string
+	LastUpdateTime         models.ModelTime
+	LastLocationUpdateTime models.ModelTime
+}
+
+// buildVehicleTripStatus builds the tripStatus for one vehicles-for-agency entry.
+//
+// It delegates to the shared api.BuildTripStatus so this endpoint reports the same
+// stop-relative, schedule-deviation, distance-along-trip, predicted and situation
+// fields as the other real-time endpoints, then re-applies the two behaviours that
+// are specific to this endpoint: the active trip is resolved against the request's
+// reference time, and an unresolvable block sequence is reported as -1 rather than 0.
+func (api *RestAPI) buildVehicleTripStatus(ctx context.Context, vehicle *gtfs.Vehicle, params vehicleTripStatusParams) *models.TripStatus {
+	tripStatus, _, err := api.BuildTripStatus(
+		ctx, params.AgencyID, vehicle.Trip.ID.ID, vehicle, params.ServiceDate, params.ReferenceTime,
+	)
+	if err != nil {
+		api.Logger.Warn("vehicles-for-agency: failed to build trip status",
+			"tripID", vehicle.Trip.ID.ID, "error", err)
+	}
+	if tripStatus == nil {
+		tripStatus = models.NewTripStatus()
+	}
+
+	tripStatus.ActiveTripID = utils.FormCombinedID(params.AgencyID, params.ActiveTripID)
+
+	// Resolve the block trip sequence for the active (not nominal) trip, so it
+	// reflects the position of the trip actually being executed.
+	if seq, ok := api.blockTripSequence(ctx, params.ActiveTripID, params.ReferenceTime); ok {
+		tripStatus.BlockTripSequence = seq
+	} else {
+		tripStatus.BlockTripSequence = -1
+	}
+
+	tripStatus.Status = params.Status
+	tripStatus.Phase = params.Phase
+	tripStatus.LastUpdateTime = params.LastUpdateTime
+	tripStatus.LastLocationUpdateTime = params.LastLocationUpdateTime
+	applyRawVehiclePosition(tripStatus, vehicle)
+
+	return tripStatus
+}
+
+// applyRawVehiclePosition fills position and orientation from the vehicle's own
+// GPS when BuildTripStatus left them unset.
+//
+// BuildTripStatus reports nothing for a vehicle it considers stale, and a
+// requested `time` more than the staleness window away from the feed timestamp
+// makes every vehicle stale. Without this the entry would carry a real
+// vehicle-level location next to a tripStatus sitting at (0, 0). This endpoint
+// has always published the raw position regardless of freshness.
+func applyRawVehiclePosition(tripStatus *models.TripStatus, vehicle *gtfs.Vehicle) {
+	if vehicle.Position == nil {
+		return
+	}
+
+	hasCoordinates := vehicle.Position.Latitude != nil && vehicle.Position.Longitude != nil
+	if hasCoordinates && tripStatus.Position == (models.Location{}) {
+		tripStatus.Position = models.Location{
+			Lat: float64(*vehicle.Position.Latitude),
+			Lon: float64(*vehicle.Position.Longitude),
+		}
+	}
+
+	if vehicle.Position.Bearing != nil && tripStatus.Orientation == 0 {
+		tripStatus.Orientation = OrientationFromGTFSBearing(*vehicle.Position.Bearing)
+	}
 }
 
 // addRouteReference inserts a route reference keyed by its combined agencyID_routeID.

--- a/internal/restapi/vehicles_for_agency_handler_test.go
+++ b/internal/restapi/vehicles_for_agency_handler_test.go
@@ -25,6 +25,7 @@ import (
 	"maglev.onebusaway.org/internal/models"
 	"maglev.onebusaway.org/internal/nulls"
 	"maglev.onebusaway.org/internal/restapi/testdata"
+	"maglev.onebusaway.org/internal/utils"
 )
 
 // vehiclesForAgencyURL builds the /vehicles-for-agency URL with key=TEST baked in.
@@ -1040,6 +1041,206 @@ func TestVehiclesForAgencyHandler_InterliningActiveTrip(t *testing.T) {
 	}
 	assert.True(t, refRouteIDs[expectedNominalRoute], "nominal route must be in references.routes")
 	assert.True(t, refRouteIDs[expectedActiveRoute], "active route must be in references.routes")
+}
+
+// findTripActiveWithStopTimes returns a trip whose block is active on serviceDate
+// and which has at least minStopTimes stop times, together with those stop times.
+func findTripActiveWithStopTimes(t testing.TB, api *RestAPI, ctx context.Context, serviceDate time.Time, minStopTimes int) (gtfsdb.Trip, []gtfsdb.StopTime) {
+	t.Helper()
+	trip := findTripWithBlock(t, api, ctx, func(row gtfsdb.Trip) bool {
+		if _, ok := api.blockTripSequence(ctx, row.ID, serviceDate); !ok {
+			return false
+		}
+		stopTimes, err := api.GtfsManager.GtfsDB.Queries.GetStopTimesForTrip(ctx, row.ID)
+		return err == nil && len(stopTimes) >= minStopTimes
+	})
+	require.NotEmpty(t, trip.ID, "need a trip with >= %d stop times active on %s",
+		minStopTimes, serviceDate.Format("2006-01-02"))
+
+	stopTimes, err := api.GtfsManager.GtfsDB.Queries.GetStopTimesForTrip(ctx, trip.ID)
+	require.NoError(t, err)
+	return trip, stopTimes
+}
+
+// TestVehiclesForAgencyHandler_TripStatusSpecFields verifies that tripStatus carries
+// the stop-relative, distance and prediction fields the spec defines, rather than
+// leaving them at their zero values. These are computed by the shared
+// api.BuildTripStatus that the other real-time endpoints already use.
+func TestVehiclesForAgencyHandler_TripStatusSpecFields(t *testing.T) {
+	loc, err := time.LoadLocation(testdata.Raba.Timezone)
+	require.NoError(t, err)
+	// Monday within the RABA dataset's active service period.
+	serviceDate := time.Date(2024, 11, 4, 0, 0, 0, 0, loc)
+
+	api := createTestApiWithClock(t, clock.NewMockClock(serviceDate.Add(12*time.Hour)))
+	defer api.Shutdown()
+	t.Cleanup(api.GtfsManager.MockResetRealTimeData)
+
+	ctx := context.Background()
+	trip, stopTimes := findTripActiveWithStopTimes(t, api, ctx, serviceDate, 3)
+
+	// Park the vehicle at the trip's second stop, at that stop's scheduled arrival,
+	// so both closestStop and nextStop resolve against real schedule data.
+	target := stopTimes[1]
+	stop, err := api.GtfsManager.GtfsDB.Queries.GetStop(ctx, target.StopID)
+	require.NoError(t, err)
+
+	referenceTime := serviceDate.Add(time.Duration(target.ArrivalTime))
+	lat, lon := float32(stop.Lat), float32(stop.Lon)
+	stoppedAt := gogtfs.CurrentStatus(1)
+	stopID := target.StopID
+
+	const vehicleID = "v_trip_status_fields"
+	api.GtfsManager.MockAddVehicleWithOptions(vehicleID, trip.ID, trip.RouteID, gtfs.MockVehicleOptions{
+		Position:      &gogtfs.Position{Latitude: &lat, Longitude: &lon},
+		StopID:        &stopID,
+		CurrentStatus: &stoppedAt,
+		Timestamp:     &referenceTime,
+	})
+
+	params := url.Values{"time": {strconv.FormatInt(referenceTime.UnixMilli(), 10)}}
+	_, model := callAPIHandler[VehiclesForAgencyResponse](t, api, vehiclesForAgencyURL(testdata.Raba.ID, params))
+	entry := findVehicleStatusByID(model.Data.List, vehicleID)
+	require.NotNil(t, entry, "mock vehicle not returned by VehiclesForAgencyID")
+	require.NotNil(t, entry.TripStatus)
+
+	status := entry.TripStatus
+	assert.Equal(t, utils.FormCombinedID(testdata.Raba.ID, target.StopID), status.ClosestStop,
+		"closestStop must resolve to the stop the vehicle is stopped at")
+	assert.NotEmpty(t, status.NextStop, "nextStop must be populated")
+	assert.True(t, status.Predicted, "predicted must be true for a fresh real-time vehicle")
+	assert.False(t, status.Scheduled, "scheduled must be the inverse of predicted")
+	assert.Greater(t, status.TotalDistanceAlongTrip, float64(0),
+		"totalDistanceAlongTrip must be populated from the trip's shape")
+	assert.NotNil(t, status.SituationIDs, "situationIds must never be null")
+}
+
+// TestVehiclesForAgencyHandler_StaleVehicleKeepsPosition verifies a vehicle whose
+// last update predates the staleness window still reports its GPS position and
+// orientation on tripStatus, matching the vehicle-level location on the same entry.
+// The shared BuildTripStatus reports nothing for a stale vehicle, and any `time`
+// far enough from the feed timestamp makes every vehicle stale — without the
+// fallback the entry would pair a real location with a tripStatus at (0, 0).
+func TestVehiclesForAgencyHandler_StaleVehicleKeepsPosition(t *testing.T) {
+	loc, err := time.LoadLocation(testdata.Raba.Timezone)
+	require.NoError(t, err)
+	referenceTime := time.Date(2024, 11, 4, 12, 0, 0, 0, loc)
+
+	api := createTestApiWithClock(t, clock.NewMockClock(referenceTime))
+	defer api.Shutdown()
+	t.Cleanup(api.GtfsManager.MockResetRealTimeData)
+
+	trip := mustGetTrip(t, api)
+	lat, lon, bearing := float32(40.5865), float32(-122.3917), float32(90)
+	staleTimestamp := referenceTime.Add(-1 * time.Hour)
+
+	const vehicleID = "v_stale_position"
+	api.GtfsManager.MockAddVehicleWithOptions(vehicleID, trip.ID, trip.RouteID, gtfs.MockVehicleOptions{
+		Position:  &gogtfs.Position{Latitude: &lat, Longitude: &lon, Bearing: &bearing},
+		Timestamp: &staleTimestamp,
+	})
+
+	params := url.Values{"time": {strconv.FormatInt(referenceTime.UnixMilli(), 10)}}
+	_, model := callAPIHandler[VehiclesForAgencyResponse](t, api, vehiclesForAgencyURL(testdata.Raba.ID, params))
+	entry := findVehicleStatusByID(model.Data.List, vehicleID)
+	require.NotNil(t, entry, "mock vehicle not returned by VehiclesForAgencyID")
+	require.NotNil(t, entry.TripStatus)
+	require.NotNil(t, entry.Location)
+
+	assert.InDelta(t, entry.Location.Lat, entry.TripStatus.Position.Lat, 0.0001,
+		"tripStatus.position.lat must match the vehicle-level location")
+	assert.InDelta(t, entry.Location.Lon, entry.TripStatus.Position.Lon, 0.0001,
+		"tripStatus.position.lon must match the vehicle-level location")
+	assert.Equal(t, OrientationFromGTFSBearing(bearing), entry.TripStatus.Orientation,
+		"tripStatus.orientation must be derived from the reported bearing")
+}
+
+// findTripsActiveWithStopTimes returns up to limit trips whose block is active on
+// serviceDate and which have at least three stop times.
+func findTripsActiveWithStopTimes(t testing.TB, api *RestAPI, ctx context.Context, serviceDate time.Time, limit int) []gtfsdb.Trip {
+	t.Helper()
+	candidates, err := api.GtfsManager.GetTrips(ctx, 2000)
+	require.NoError(t, err)
+
+	matches := make([]gtfsdb.Trip, 0, limit)
+	for _, trip := range candidates {
+		if len(matches) == limit {
+			break
+		}
+		if !trip.BlockID.Valid || trip.BlockID.String == "" {
+			continue
+		}
+		if _, ok := api.blockTripSequence(ctx, trip.ID, serviceDate); !ok {
+			continue
+		}
+		stopTimes, err := api.GtfsManager.GtfsDB.Queries.GetStopTimesForTrip(ctx, trip.ID)
+		if err != nil || len(stopTimes) < 3 {
+			continue
+		}
+		matches = append(matches, trip)
+	}
+	require.NotEmpty(t, matches, "need trips with stop times active on %s", serviceDate.Format("2006-01-02"))
+	return matches
+}
+
+// benchmarkVehiclesForAgencyWithVehicles serves vehicles-for-agency with vehicleCount
+// live vehicles parked on distinct active trips. Unlike BenchmarkVehiclesForAgency,
+// which runs against the single-vehicle RABA fixture whose positions go stale, this
+// holds the clock still so the per-vehicle tripStatus cost is what actually scales.
+func benchmarkVehiclesForAgencyWithVehicles(b *testing.B, vehicleCount int) {
+	loc, err := time.LoadLocation(testdata.Raba.Timezone)
+	require.NoError(b, err)
+	serviceDate := time.Date(2024, 11, 4, 0, 0, 0, 0, loc)
+	referenceTime := serviceDate.Add(12 * time.Hour)
+
+	api := createTestApiWithClock(b, clock.NewMockClock(referenceTime))
+	defer api.Shutdown()
+	b.Cleanup(api.GtfsManager.MockResetRealTimeData)
+
+	ctx := context.Background()
+	trips := findTripsActiveWithStopTimes(b, api, ctx, serviceDate, vehicleCount)
+
+	for i, trip := range trips {
+		stopTimes, err := api.GtfsManager.GtfsDB.Queries.GetStopTimesForTrip(ctx, trip.ID)
+		require.NoError(b, err)
+		target := stopTimes[len(stopTimes)/2]
+		stop, err := api.GtfsManager.GtfsDB.Queries.GetStop(ctx, target.StopID)
+		require.NoError(b, err)
+
+		lat, lon := float32(stop.Lat), float32(stop.Lon)
+		stoppedAt := gogtfs.CurrentStatus(1)
+		stopID := target.StopID
+		timestamp := referenceTime
+		api.GtfsManager.MockAddVehicleWithOptions(
+			"bench_vehicle_"+strconv.Itoa(i), trip.ID, trip.RouteID, gtfs.MockVehicleOptions{
+				Position:      &gogtfs.Position{Latitude: &lat, Longitude: &lon},
+				StopID:        &stopID,
+				CurrentStatus: &stoppedAt,
+				Timestamp:     &timestamp,
+			})
+	}
+
+	mux := http.NewServeMux()
+	api.SetRoutes(mux)
+	req := httptest.NewRequest(http.MethodGet, vehiclesForAgencyURL(testdata.Raba.ID), nil)
+
+	warmup := httptest.NewRecorder()
+	mux.ServeHTTP(warmup, req)
+	require.Equal(b, http.StatusOK, warmup.Code)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		mux.ServeHTTP(httptest.NewRecorder(), req)
+	}
+}
+
+func BenchmarkVehiclesForAgency_1Vehicle(b *testing.B) {
+	benchmarkVehiclesForAgencyWithVehicles(b, 1)
+}
+
+func BenchmarkVehiclesForAgency_50Vehicles(b *testing.B) {
+	benchmarkVehiclesForAgencyWithVehicles(b, 50)
 }
 
 // TestAddRouteReference verifies a gtfsdb.Route is keyed by its combined

--- a/internal/restapi/vehicles_helper.go
+++ b/internal/restapi/vehicles_helper.go
@@ -134,12 +134,9 @@ func (api *RestAPI) BuildVehicleStatus(
 	}
 
 	if vehicle.Position != nil && vehicle.Position.Bearing != nil {
-		obaOrientation := (90 - *vehicle.Position.Bearing)
-		if obaOrientation < 0 {
-			obaOrientation += 360
-		}
-		status.Orientation = float64(obaOrientation)
-		status.LastKnownOrientation = float64(obaOrientation)
+		orientation := OrientationFromGTFSBearing(*vehicle.Position.Bearing)
+		status.Orientation = orientation
+		status.LastKnownOrientation = orientation
 	}
 
 	status.Status, status.Phase = GetVehicleStatusAndPhase(vehicle)
@@ -149,6 +146,16 @@ func (api *RestAPI) BuildVehicleStatus(
 	} else {
 		status.ActiveTripID = utils.FormCombinedID(agencyID, tripID)
 	}
+}
+
+// OrientationFromGTFSBearing converts a GTFS-RT bearing (0° = North, increasing
+// clockwise) to an OBA orientation (0° = East, increasing counter-clockwise).
+func OrientationFromGTFSBearing(bearing float32) float64 {
+	orientation := 90 - bearing
+	if orientation < 0 {
+		orientation += 360
+	}
+	return float64(orientation)
 }
 
 func GetVehicleActiveTripID(vehicle *gtfs.Vehicle) string {

--- a/internal/restapi/vehicles_helper.go
+++ b/internal/restapi/vehicles_helper.go
@@ -199,7 +199,7 @@ func (api *RestAPI) resolveActiveTripID(ctx context.Context, nominalTripID strin
 // activeTripInBlockAt returns the block trip whose scheduled window contains
 // sinceMidnightNs on serviceDay's active services, if any.
 func (api *RestAPI) activeTripInBlockAt(ctx context.Context, blockID sql.NullString, serviceDay time.Time, sinceMidnightNs int64) (string, bool) {
-	serviceIDs, err := api.GtfsManager.GtfsDB.Queries.GetActiveServiceIDsForDate(ctx, serviceDay.Format("20060102"))
+	serviceIDs, err := api.activeServiceIDsForDate(ctx, serviceDay.Format("20060102"))
 	if err != nil || len(serviceIDs) == 0 {
 		return "", false
 	}


### PR DESCRIPTION
Fixes #1195.

> **Depends on #1331.** This branch is stacked on that one, so its diff includes that commit as well. Please review/merge that first; GitHub will drop it from this diff once it lands.

## Why

`vehicles-for-agency` builds its `tripStatus` inline, and only fills a subset of the fields the spec defines. Missing today: `closestStop` and `closestStopTimeOffset`, `nextStop` and `nextStopTimeOffset`, `scheduleDeviation`, `scheduledDistanceAlongTrip`, `totalDistanceAlongTrip`, `distanceAlongTrip`, `predicted` (always false) and `situationIds` (always empty).

All of it is already computed by `api.BuildTripStatus`, which every other real-time endpoint uses: trip-details, trip-for-vehicle, trips-for-route, and both arrivals endpoints. This handler was the odd one out, carrying a reduced copy of the same logic.

## What this changes

The inline block is replaced by a call to the shared builder, wrapped in `buildVehicleTripStatus`. Roughly fifty lines of duplicated field assignment come out.

Three behaviours specific to this endpoint are re-applied on top, because changing them is outside the scope of this issue:

1. `activeTripId` still comes from `resolveActiveTripID`, resolved against the request's `time` parameter, and `blockTripSequence` still reports -1 when it cannot be resolved rather than the builder's 0. Both are pinned by existing tests.
2. `status`, `phase` and the two update timestamps are mirrored from the enclosing `vehicleStatus`, so the nested object cannot contradict the outer one within a single entry.
3. Raw GPS position and orientation are restored when the builder leaves them unset. More on that below.

## The stale-vehicle case

Worth calling out, because I nearly shipped it as a regression. `BuildVehicleStatus` returns early for a vehicle it considers stale, leaving position at (0, 0) and orientation at 0. The old inline code set both unconditionally. `StaleDetector` compares an absolute difference, so any `time` parameter more than fifteen minutes from the feed timestamp makes every vehicle stale, not just genuinely old ones.

The result was an entry carrying a real `location` at the top level next to a `tripStatus.position` of (0, 0), which is Null Island in the middle of the Atlantic. `applyRawVehiclePosition` restores the reported position and bearing when the builder has not set them. There is a regression test for it.

While in there I pulled the GTFS-bearing-to-OBA-orientation conversion out into `OrientationFromGTFSBearing` rather than have a second copy of it.

## Discrepancies worth flagging

Two things I did not change but that a reviewer should probably rule on:

**`lastLocationUpdateTime` semantics differ between handlers.** `BuildVehicleStatus` only sets it when the vehicle has a position; this endpoint has always set it from the vehicle timestamp regardless. Adopting the shared behaviour breaks `TestVehiclesForAgencyHandler_UpdateTimesPresentWhenSet`. I preserved the existing behaviour rather than flip it inside this PR. If the shared semantics are the correct ones, I will file it separately.

**`activeTripId` can now describe a different trip than the distance fields.** The override in point 1 above picks the active trip by time window, while `scheduledDistanceAlongTrip`, `totalDistanceAlongTrip` and `distanceAlongTrip` were computed by the builder against its own distance-along-block choice. On an interlined block at a trip transition those two disagree, and the response reports one trip's ID with another trip's distances. This is a pre-existing tension between the endpoint's pinned `activeTripId` behaviour and the shared builder, not something this PR introduces, but it becomes visible here.

**`tripStatus.position` is now shape-projected** for fresh vehicles rather than raw GPS, since that is what the builder produces. Consistent with the other endpoints, but it is a change in the emitted number.

## Cost

Reusing the builder is more expensive per vehicle: it loads that vehicle's stop times and shape and does the projection maths, which is what computing `closestStop` and `distanceAlongTrip` actually requires. The memoization in the prerequisite PR removes the part of that cost that was quadratic in vehicle count. What remains is linear and, as far as I can tell, irreducible without changing what the fields mean.

Against main at 50 vehicles it is still roughly 15x the allocations, all of it per-vehicle work that main was simply not doing. If that trade is not acceptable for large agencies I would rather hear it now than after more of the response is built on it.

## Testing

`TestVehiclesForAgencyHandler_TripStatusSpecFields` parks a vehicle at a real stop on an active trip and asserts the previously-missing fields. I confirmed it fails on main on exactly those assertions and passes with the change, so it is a real regression test rather than one written to fit.

`TestVehiclesForAgencyHandler_StaleVehicleKeepsPosition` covers the Null Island case above.

Also adds `BenchmarkVehiclesForAgency_1Vehicle` and `BenchmarkVehiclesForAgency_50Vehicles`. The existing `BenchmarkVehiclesForAgency` runs against the single-vehicle RABA fixture whose position goes stale during a long run, so it ends up measuring the empty path; these hold the clock still and take a vehicle count.

`go fmt` clean and the full suite passes on the pure-Go path (`CGO_ENABLED=0 go test -tags purego ./...`).
