### PR TITLE
Add frequency-based schedule-for-stop service

### DIFF
--- a/gtfsdb/query.sql
+++ b/gtfsdb/query.sql
@@ -551,12 +551,25 @@ SELECT
     t.min_arrival_time,
     t.max_departure_time,
     t.direction_id,
+    first_st.departure_time AS first_departure_time,
+    f.start_time AS frequency_start_time,
+    f.end_time AS frequency_end_time,
+    f.headway_secs AS frequency_headway_secs,
+    f.exact_times AS frequency_exact_times,
     r.id as route_id,
     r.agency_id
 FROM
     stop_times st
     JOIN trips t ON st.trip_id = t.id
+    JOIN stop_times first_st
+      ON first_st.trip_id = t.id
+     AND first_st.stop_sequence = (
+        SELECT MIN(first_st_lookup.stop_sequence)
+        FROM stop_times first_st_lookup
+        WHERE first_st_lookup.trip_id = t.id
+     )
     JOIN routes r ON t.route_id = r.id
+    LEFT JOIN frequencies f ON f.trip_id = t.id
     LEFT JOIN (
         SELECT c.id AS service_id
         FROM calendar c
@@ -1463,5 +1476,4 @@ FROM
     JOIN stops s ON s.id = st.stop_id
 GROUP BY
     r.agency_id;
-
 

--- a/gtfsdb/query.sql.go
+++ b/gtfsdb/query.sql.go
@@ -2998,12 +2998,25 @@ SELECT
     t.min_arrival_time,
     t.max_departure_time,
     t.direction_id,
+    first_st.departure_time AS first_departure_time,
+    f.start_time AS frequency_start_time,
+    f.end_time AS frequency_end_time,
+    f.headway_secs AS frequency_headway_secs,
+    f.exact_times AS frequency_exact_times,
     r.id as route_id,
     r.agency_id
 FROM
     stop_times st
     JOIN trips t ON st.trip_id = t.id
+    JOIN stop_times first_st
+      ON first_st.trip_id = t.id
+     AND first_st.stop_sequence = (
+        SELECT MIN(first_st_lookup.stop_sequence)
+        FROM stop_times first_st_lookup
+        WHERE first_st_lookup.trip_id = t.id
+     )
     JOIN routes r ON t.route_id = r.id
+    LEFT JOIN frequencies f ON f.trip_id = t.id
     LEFT JOIN (
         SELECT c.id AS service_id
         FROM calendar c
@@ -3049,18 +3062,23 @@ type GetScheduleForStopOnDateParams struct {
 }
 
 type GetScheduleForStopOnDateRow struct {
-	TripID           string
-	ArrivalTime      int64
-	DepartureTime    int64
-	StopHeadsign     sql.NullString
-	ServiceID        string
-	TripHeadsign     sql.NullString
-	BlockID          sql.NullString
-	MinArrivalTime   sql.NullInt64
-	MaxDepartureTime sql.NullInt64
-	DirectionID      sql.NullInt64
-	RouteID          string
-	AgencyID         string
+	TripID               string
+	ArrivalTime          int64
+	DepartureTime        int64
+	StopHeadsign         sql.NullString
+	ServiceID            string
+	TripHeadsign         sql.NullString
+	BlockID              sql.NullString
+	MinArrivalTime       sql.NullInt64
+	MaxDepartureTime     sql.NullInt64
+	DirectionID          sql.NullInt64
+	FirstDepartureTime   int64
+	FrequencyStartTime   sql.NullInt64
+	FrequencyEndTime     sql.NullInt64
+	FrequencyHeadwaySecs sql.NullInt64
+	FrequencyExactTimes  sql.NullInt64
+	RouteID              string
+	AgencyID             string
 }
 
 func (q *Queries) GetScheduleForStopOnDate(ctx context.Context, arg GetScheduleForStopOnDateParams) ([]GetScheduleForStopOnDateRow, error) {
@@ -3096,6 +3114,11 @@ func (q *Queries) GetScheduleForStopOnDate(ctx context.Context, arg GetScheduleF
 			&i.MinArrivalTime,
 			&i.MaxDepartureTime,
 			&i.DirectionID,
+			&i.FirstDepartureTime,
+			&i.FrequencyStartTime,
+			&i.FrequencyEndTime,
+			&i.FrequencyHeadwaySecs,
+			&i.FrequencyExactTimes,
 			&i.RouteID,
 			&i.AgencyID,
 		); err != nil {

--- a/internal/nulls/database.go
+++ b/internal/nulls/database.go
@@ -33,6 +33,17 @@ func Int64OrDefault(ni sql.NullInt64, defaultValue int64) int64 {
 	return defaultValue
 }
 
+// ValidInt64Count returns the number of non-null values.
+func ValidInt64Count(values ...sql.NullInt64) int {
+	count := 0
+	for _, value := range values {
+		if value.Valid {
+			count++
+		}
+	}
+	return count
+}
+
 // WheelchairBoardingOrUnknown returns the wheelchair boarding value if valid, otherwise returns NotSpecified
 func WheelchairBoardingOrUnknown(ni sql.NullInt64) gtfs.WheelchairBoarding {
 	if ni.Valid {

--- a/internal/nulls/database_test.go
+++ b/internal/nulls/database_test.go
@@ -24,6 +24,14 @@ func TestNullInt64OrDefault(t *testing.T) {
 	assert.Equal(t, int64(10), Int64OrDefault(sql.NullInt64{Int64: 42, Valid: false}, 10))
 }
 
+func TestValidInt64Count(t *testing.T) {
+	assert.Equal(t, 2, ValidInt64Count(
+		sql.NullInt64{Int64: 1, Valid: true},
+		sql.NullInt64{},
+		sql.NullInt64{Int64: 3, Valid: true},
+	))
+}
+
 func TestNonEmptyString(t *testing.T) {
 	assert.Equal(t, sql.NullString{String: "test", Valid: true}, NonEmptyString("test"))
 	assert.Equal(t, sql.NullString{String: "", Valid: false}, NonEmptyString(""))

--- a/internal/restapi/schedule_for_stop_handler.go
+++ b/internal/restapi/schedule_for_stop_handler.go
@@ -4,8 +4,8 @@ import (
 	"cmp"
 	"context"
 	"database/sql"
-	"errors"
 	"fmt"
+	"math"
 	"net/http"
 	"slices"
 	"strconv"
@@ -167,11 +167,7 @@ func (api *RestAPI) scheduleForStopHandler(w http.ResponseWriter, r *http.Reques
 		},
 	)
 	if err != nil {
-		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-			api.clientCanceledResponse(w, r, err)
-		} else {
-			api.serverErrorResponse(w, r, err)
-		}
+		api.serverErrorResponse(w, r, err)
 		return
 	}
 
@@ -185,28 +181,7 @@ func (api *RestAPI) scheduleForStopHandler(w http.ResponseWriter, r *http.Reques
 			continue
 		}
 
-		var directionSchedules []models.StopRouteDirectionSchedule
-
-		for _, group := range directionMap {
-			slices.SortStableFunc(group.stopTimes, func(a, b models.ScheduleStopTime) int {
-				return cmp.Compare(a.DepartureTime, b.DepartureTime)
-			})
-			slices.SortStableFunc(group.frequencies, func(a, b models.ScheduleFrequency) int {
-				return cmp.Compare(a.StartTime.UnixMilli(), b.StartTime.UnixMilli())
-			})
-
-			directionSchedule := models.NewStopRouteDirectionSchedule(
-				bestHeadsign(group.headsignCounts),
-				group.stopTimes,
-				group.frequencies,
-			)
-			directionSchedules = append(directionSchedules, directionSchedule)
-		}
-
-		// Sort direction groups alphabetically by headsign
-		slices.SortStableFunc(directionSchedules, func(a, b models.StopRouteDirectionSchedule) int {
-			return cmp.Compare(a.TripHeadsign, b.TripHeadsign)
-		})
+		directionSchedules := buildDirectionSchedules(directionMap)
 
 		routeSchedule := models.NewStopRouteSchedule(combinedRouteID, directionSchedules)
 		routeSchedules = append(routeSchedules, routeSchedule)
@@ -382,6 +357,9 @@ type scheduleFrequencyRow struct {
 	exactTimes  int64
 }
 
+// maxExpandedScheduleStopTimes bounds exact-frequency fan-out for one request.
+const maxExpandedScheduleStopTimes int64 = 10_000
+
 // groupScheduleRowsByRouteAndDirection partitions fixed and frequency-based service
 // first by route, then by GTFS direction_id (defaulting to "0" when absent).
 func groupScheduleRowsByRouteAndDirection(
@@ -390,6 +368,7 @@ func groupScheduleRowsByRouteAndDirection(
 	rowCtx scheduleRowContext,
 ) (map[string]map[string]*scheduleDirectionGroup, error) {
 	groups := make(map[string]map[string]*scheduleDirectionGroup)
+	var expandedStopTimeCount int64
 
 	for _, row := range scheduleRows {
 		if ctx.Err() != nil {
@@ -414,14 +393,22 @@ func groupScheduleRowsByRouteAndDirection(
 		switch frequency.exactTimes {
 		case 0:
 			group.frequencies = append(group.frequencies, buildScheduleFrequency(row, rowCtx, templateStopTime, frequency))
-			runCount := (frequency.endTime - frequency.startTime) /
-				(frequency.headwaySecs * int64(time.Second))
+			runCount := frequencyInstanceCount(frequency)
 			recordHeadsignVotes(group, nulls.StringOrEmpty(row.TripHeadsign), runCount)
 		case 1:
-			expanded, err := expandExactScheduleStopTimes(ctx, row, rowCtx, templateStopTime, frequency)
+			remainingExpansionCapacity := maxExpandedScheduleStopTimes - expandedStopTimeCount
+			expanded, err := expandExactScheduleStopTimes(
+				ctx,
+				row,
+				rowCtx,
+				templateStopTime,
+				frequency,
+				remainingExpansionCapacity,
+			)
 			if err != nil {
 				return nil, err
 			}
+			expandedStopTimeCount += int64(len(expanded))
 			group.stopTimes = append(group.stopTimes, expanded...)
 			recordHeadsignVotes(group, nulls.StringOrEmpty(row.TripHeadsign), int64(len(expanded)))
 		}
@@ -512,6 +499,39 @@ func getScheduleDirectionGroup(
 	return groups[combinedRouteID][directionID]
 }
 
+func buildDirectionSchedules(
+	directionMap map[string]*scheduleDirectionGroup,
+) []models.StopRouteDirectionSchedule {
+	directionIDs := make([]string, 0, len(directionMap))
+	for directionID := range directionMap {
+		directionIDs = append(directionIDs, directionID)
+	}
+	slices.Sort(directionIDs)
+
+	directionSchedules := make([]models.StopRouteDirectionSchedule, 0, len(directionIDs))
+	for _, directionID := range directionIDs {
+		group := directionMap[directionID]
+		slices.SortStableFunc(group.stopTimes, func(a, b models.ScheduleStopTime) int {
+			return cmp.Compare(a.DepartureTime, b.DepartureTime)
+		})
+		slices.SortStableFunc(group.frequencies, func(a, b models.ScheduleFrequency) int {
+			return cmp.Compare(a.StartTime.UnixMilli(), b.StartTime.UnixMilli())
+		})
+
+		directionSchedules = append(directionSchedules, models.NewStopRouteDirectionSchedule(
+			bestHeadsign(group.headsignCounts),
+			group.stopTimes,
+			group.frequencies,
+		))
+	}
+
+	// Stable sorting preserves direction ID order when headsigns match.
+	slices.SortStableFunc(directionSchedules, func(a, b models.StopRouteDirectionSchedule) int {
+		return cmp.Compare(a.TripHeadsign, b.TripHeadsign)
+	})
+	return directionSchedules
+}
+
 func parseScheduleFrequencyRow(row gtfsdb.GetScheduleForStopOnDateRow) (scheduleFrequencyRow, bool, error) {
 	fields := []sql.NullInt64{
 		row.FrequencyStartTime,
@@ -533,7 +553,7 @@ func parseScheduleFrequencyRow(row gtfsdb.GetScheduleForStopOnDateRow) (schedule
 		headwaySecs: nulls.Int64OrDefault(row.FrequencyHeadwaySecs, 0),
 		exactTimes:  nulls.Int64OrDefault(row.FrequencyExactTimes, 0),
 	}
-	const maxHeadwaySeconds = int64(^uint64(0)>>1) / int64(time.Second)
+	const maxHeadwaySeconds = math.MaxInt64 / int64(time.Second)
 	if frequency.startTime < 0 || frequency.endTime <= frequency.startTime {
 		return scheduleFrequencyRow{}, false, fmt.Errorf("invalid frequency window for trip %q", row.TripID)
 	}
@@ -574,13 +594,25 @@ func expandExactScheduleStopTimes(
 	rowCtx scheduleRowContext,
 	templateStopTime models.ScheduleStopTime,
 	frequency scheduleFrequencyRow,
+	maxInstances int64,
 ) ([]models.ScheduleStopTime, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	if row.FirstDepartureTime < 0 {
 		return nil, fmt.Errorf("invalid first departure time for trip %q", row.TripID)
 	}
 
 	headway := frequency.headwaySecs * int64(time.Second)
-	expanded := make([]models.ScheduleStopTime, 0)
+	instanceCount := frequencyInstanceCount(frequency)
+	if instanceCount > maxInstances {
+		return nil, fmt.Errorf(
+			"frequency expansion for trip %q exceeds the %d-stop-time request limit",
+			row.TripID,
+			maxExpandedScheduleStopTimes,
+		)
+	}
+	expanded := make([]models.ScheduleStopTime, 0, int(instanceCount))
 
 	for instanceStart := frequency.startTime; instanceStart < frequency.endTime; {
 		if ctx.Err() != nil {
@@ -612,13 +644,17 @@ func expandExactScheduleStopTimes(
 	return expanded, nil
 }
 
+func frequencyInstanceCount(frequency scheduleFrequencyRow) int64 {
+	headway := frequency.headwaySecs * int64(time.Second)
+	window := frequency.endTime - frequency.startTime
+	return 1 + (window-1)/headway
+}
+
 func addScheduleOffset(base, offset int64) (int64, error) {
-	const maxInt64 = int64(^uint64(0) >> 1)
-	const minInt64 = -maxInt64 - 1
-	if offset > 0 && base > maxInt64-offset {
+	if offset > 0 && base > math.MaxInt64-offset {
 		return 0, fmt.Errorf("time overflow")
 	}
-	if offset < 0 && base < minInt64-offset {
+	if offset < 0 && base < math.MinInt64-offset {
 		return 0, fmt.Errorf("time underflow")
 	}
 	return base + offset, nil

--- a/internal/restapi/schedule_for_stop_handler.go
+++ b/internal/restapi/schedule_for_stop_handler.go
@@ -407,7 +407,7 @@ func groupScheduleRowsByRouteAndDirection(
 		}
 		if !hasFrequency {
 			group.stopTimes = append(group.stopTimes, templateStopTime)
-			recordHeadsignVotes(group, row.TripHeadsign, 1)
+			recordHeadsignVotes(group, nulls.StringOrEmpty(row.TripHeadsign), 1)
 			continue
 		}
 
@@ -416,14 +416,14 @@ func groupScheduleRowsByRouteAndDirection(
 			group.frequencies = append(group.frequencies, buildScheduleFrequency(row, rowCtx, templateStopTime, frequency))
 			runCount := (frequency.endTime - frequency.startTime) /
 				(frequency.headwaySecs * int64(time.Second))
-			recordHeadsignVotes(group, row.TripHeadsign, runCount)
+			recordHeadsignVotes(group, nulls.StringOrEmpty(row.TripHeadsign), runCount)
 		case 1:
 			expanded, err := expandExactScheduleStopTimes(ctx, row, rowCtx, templateStopTime, frequency)
 			if err != nil {
 				return nil, err
 			}
 			group.stopTimes = append(group.stopTimes, expanded...)
-			recordHeadsignVotes(group, row.TripHeadsign, int64(len(expanded)))
+			recordHeadsignVotes(group, nulls.StringOrEmpty(row.TripHeadsign), int64(len(expanded)))
 		}
 	}
 
@@ -513,31 +513,25 @@ func getScheduleDirectionGroup(
 }
 
 func parseScheduleFrequencyRow(row gtfsdb.GetScheduleForStopOnDateRow) (scheduleFrequencyRow, bool, error) {
-	fieldsPresent := []bool{
-		row.FrequencyStartTime.Valid,
-		row.FrequencyEndTime.Valid,
-		row.FrequencyHeadwaySecs.Valid,
-		row.FrequencyExactTimes.Valid,
+	fields := []sql.NullInt64{
+		row.FrequencyStartTime,
+		row.FrequencyEndTime,
+		row.FrequencyHeadwaySecs,
+		row.FrequencyExactTimes,
 	}
-
-	presentCount := 0
-	for _, present := range fieldsPresent {
-		if present {
-			presentCount++
-		}
-	}
+	presentCount := nulls.ValidInt64Count(fields...)
 	if presentCount == 0 {
 		return scheduleFrequencyRow{}, false, nil
 	}
-	if presentCount != len(fieldsPresent) {
+	if presentCount != len(fields) {
 		return scheduleFrequencyRow{}, false, fmt.Errorf("incomplete frequency row for trip %q", row.TripID)
 	}
 
 	frequency := scheduleFrequencyRow{
-		startTime:   row.FrequencyStartTime.Int64,
-		endTime:     row.FrequencyEndTime.Int64,
-		headwaySecs: row.FrequencyHeadwaySecs.Int64,
-		exactTimes:  row.FrequencyExactTimes.Int64,
+		startTime:   nulls.Int64OrDefault(row.FrequencyStartTime, 0),
+		endTime:     nulls.Int64OrDefault(row.FrequencyEndTime, 0),
+		headwaySecs: nulls.Int64OrDefault(row.FrequencyHeadwaySecs, 0),
+		exactTimes:  nulls.Int64OrDefault(row.FrequencyExactTimes, 0),
 	}
 	const maxHeadwaySeconds = int64(^uint64(0)>>1) / int64(time.Second)
 	if frequency.startTime < 0 || frequency.endTime <= frequency.startTime {
@@ -568,7 +562,7 @@ func buildScheduleFrequency(
 		ServiceDate:      models.NewModelTime(rowCtx.startOfDay),
 		ServiceID:        templateStopTime.ServiceID,
 		TripID:           templateStopTime.TripID,
-		StopHeadsign:     row.StopHeadsign.String,
+		StopHeadsign:     templateStopTime.StopHeadsign,
 		ArrivalEnabled:   templateStopTime.ArrivalEnabled,
 		DepartureEnabled: templateStopTime.DepartureEnabled,
 	}
@@ -632,11 +626,11 @@ func addScheduleOffset(base, offset int64) (int64, error) {
 
 // recordHeadsignVotes weights fixed trips once and frequency trips by their estimated
 // number of runs, matching the legacy endpoint's representative-headsign selection.
-func recordHeadsignVotes(group *scheduleDirectionGroup, headsign sql.NullString, count int64) {
-	if !headsign.Valid || headsign.String == "" || count <= 0 {
+func recordHeadsignVotes(group *scheduleDirectionGroup, headsign string, count int64) {
+	if headsign == "" || count <= 0 {
 		return
 	}
-	group.headsignCounts[headsign.String] += count
+	group.headsignCounts[headsign] += count
 }
 
 func bestHeadsign(headsignCounts map[string]int64) string {

--- a/internal/restapi/schedule_for_stop_handler.go
+++ b/internal/restapi/schedule_for_stop_handler.go
@@ -4,6 +4,8 @@ import (
 	"cmp"
 	"context"
 	"database/sql"
+	"errors"
+	"fmt"
 	"net/http"
 	"slices"
 	"strconv"
@@ -155,9 +157,9 @@ func (api *RestAPI) scheduleForStopHandler(w http.ResponseWriter, r *http.Reques
 		}
 	}
 
-	// Group schedule data by route -> direction -> slice of stop times, and track
-	// per-direction headsign vote counts, per spec steps 6-7.
-	routeDirectionScheduleMap, routeDirectionHeadsignCounts, err := groupScheduleRowsByRouteAndDirection(
+	// Group fixed and frequency-based schedule data by route and direction while
+	// tracking the weighted headsign votes required by spec steps 6-7.
+	routeDirectionScheduleGroups, err := groupScheduleRowsByRouteAndDirection(
 		ctx, scheduleRows, scheduleRowContext{
 			agencyID:                   agencyID,
 			startOfDay:                 startOfDay,
@@ -165,7 +167,11 @@ func (api *RestAPI) scheduleForStopHandler(w http.ResponseWriter, r *http.Reques
 		},
 	)
 	if err != nil {
-		api.clientCanceledResponse(w, r, err)
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			api.clientCanceledResponse(w, r, err)
+		} else {
+			api.serverErrorResponse(w, r, err)
+		}
 		return
 	}
 
@@ -174,32 +180,26 @@ func (api *RestAPI) scheduleForStopHandler(w http.ResponseWriter, r *http.Reques
 	var routeSchedules []models.StopRouteSchedule
 	for _, rt := range routesForStop {
 		combinedRouteID := utils.FormCombinedID(agencyID, rt.ID)
-		directionMap, hasSchedule := routeDirectionScheduleMap[combinedRouteID]
+		directionMap, hasSchedule := routeDirectionScheduleGroups[combinedRouteID]
 		if !hasSchedule {
 			continue
 		}
 
 		var directionSchedules []models.StopRouteDirectionSchedule
 
-		for dirID, stopTimes := range directionMap {
-			tripHeadsign := ""
-			maxCount := 0
-			if dirHeadsigns, exists := routeDirectionHeadsignCounts[combinedRouteID][dirID]; exists {
-				headsigns := make([]string, 0, len(dirHeadsigns))
-				for headsign := range dirHeadsigns {
-					headsigns = append(headsigns, headsign)
-				}
-				slices.Sort(headsigns)
-				for _, headsign := range headsigns {
-					count := dirHeadsigns[headsign]
-					if count > maxCount {
-						maxCount = count
-						tripHeadsign = headsign
-					}
-				}
-			}
+		for _, group := range directionMap {
+			slices.SortStableFunc(group.stopTimes, func(a, b models.ScheduleStopTime) int {
+				return cmp.Compare(a.DepartureTime, b.DepartureTime)
+			})
+			slices.SortStableFunc(group.frequencies, func(a, b models.ScheduleFrequency) int {
+				return cmp.Compare(a.StartTime.UnixMilli(), b.StartTime.UnixMilli())
+			})
 
-			directionSchedule := models.NewStopRouteDirectionSchedule(tripHeadsign, stopTimes, nil)
+			directionSchedule := models.NewStopRouteDirectionSchedule(
+				bestHeadsign(group.headsignCounts),
+				group.stopTimes,
+				group.frequencies,
+			)
 			directionSchedules = append(directionSchedules, directionSchedule)
 		}
 
@@ -369,37 +369,65 @@ type scheduleRowContext struct {
 	activeServiceBlockTripsMap map[string][]gtfsdb.GetTripsByBlockIDsRow
 }
 
-// groupScheduleRowsByRouteAndDirection partitions schedule rows first by route, then by
-// GTFS direction_id (defaulting to "0" when absent), per spec steps 6-7. It returns the
-// grouped stop times alongside per-direction headsign vote counts used to pick each
-// direction group's representative tripHeadsign. Returns a non-nil error only if ctx is
-// canceled mid-computation.
+type scheduleDirectionGroup struct {
+	stopTimes      []models.ScheduleStopTime
+	frequencies    []models.ScheduleFrequency
+	headsignCounts map[string]int64
+}
+
+type scheduleFrequencyRow struct {
+	startTime   int64
+	endTime     int64
+	headwaySecs int64
+	exactTimes  int64
+}
+
+// groupScheduleRowsByRouteAndDirection partitions fixed and frequency-based service
+// first by route, then by GTFS direction_id (defaulting to "0" when absent).
 func groupScheduleRowsByRouteAndDirection(
 	ctx context.Context,
 	scheduleRows []gtfsdb.GetScheduleForStopOnDateRow,
 	rowCtx scheduleRowContext,
-) (
-	routeDirectionScheduleMap map[string]map[string][]models.ScheduleStopTime,
-	routeDirectionHeadsignCounts map[string]map[string]map[string]int,
-	err error,
-) {
-	routeDirectionScheduleMap = make(map[string]map[string][]models.ScheduleStopTime)
-	routeDirectionHeadsignCounts = make(map[string]map[string]map[string]int)
+) (map[string]map[string]*scheduleDirectionGroup, error) {
+	groups := make(map[string]map[string]*scheduleDirectionGroup)
 
 	for _, row := range scheduleRows {
 		if ctx.Err() != nil {
-			return nil, nil, ctx.Err()
+			return nil, ctx.Err()
 		}
 
 		directionID := directionIDForRow(row)
 		combinedRouteID := utils.FormCombinedID(rowCtx.agencyID, row.RouteID)
-		stopTime := buildScheduleStopTime(row, rowCtx)
+		group := getScheduleDirectionGroup(groups, combinedRouteID, directionID)
+		templateStopTime := buildScheduleStopTime(row, rowCtx)
 
-		addStopTimeToDirectionGroup(routeDirectionScheduleMap, combinedRouteID, directionID, stopTime)
-		recordHeadsignVote(routeDirectionHeadsignCounts, combinedRouteID, directionID, row.TripHeadsign)
+		frequency, hasFrequency, err := parseScheduleFrequencyRow(row)
+		if err != nil {
+			return nil, err
+		}
+		if !hasFrequency {
+			group.stopTimes = append(group.stopTimes, templateStopTime)
+			recordHeadsignVotes(group, row.TripHeadsign, 1)
+			continue
+		}
+
+		switch frequency.exactTimes {
+		case 0:
+			group.frequencies = append(group.frequencies, buildScheduleFrequency(row, rowCtx, templateStopTime, frequency))
+			runCount := (frequency.endTime - frequency.startTime) /
+				(frequency.headwaySecs * int64(time.Second))
+			recordHeadsignVotes(group, row.TripHeadsign, runCount)
+		case 1:
+			expanded, err := expandExactScheduleStopTimes(ctx, row, rowCtx, templateStopTime, frequency)
+			if err != nil {
+				return nil, err
+			}
+			group.stopTimes = append(group.stopTimes, expanded...)
+			recordHeadsignVotes(group, row.TripHeadsign, int64(len(expanded)))
+		}
 	}
 
-	return routeDirectionScheduleMap, routeDirectionHeadsignCounts, nil
+	return groups, nil
 }
 
 // directionIDForRow returns the row's GTFS direction_id as a string, defaulting to "0"
@@ -467,36 +495,164 @@ func blockBoundaries(
 	return isFirstInBlock, isLastInBlock
 }
 
-// addStopTimeToDirectionGroup appends stopTime to the route's direction bucket, creating
-// the intermediate map when this is the route's first stop time seen so far.
-func addStopTimeToDirectionGroup(
-	routeDirectionScheduleMap map[string]map[string][]models.ScheduleStopTime,
+func getScheduleDirectionGroup(
+	groups map[string]map[string]*scheduleDirectionGroup,
 	combinedRouteID, directionID string,
-	stopTime models.ScheduleStopTime,
-) {
-	if routeDirectionScheduleMap[combinedRouteID] == nil {
-		routeDirectionScheduleMap[combinedRouteID] = make(map[string][]models.ScheduleStopTime)
+) *scheduleDirectionGroup {
+	if groups[combinedRouteID] == nil {
+		groups[combinedRouteID] = make(map[string]*scheduleDirectionGroup)
 	}
-	routeDirectionScheduleMap[combinedRouteID][directionID] = append(routeDirectionScheduleMap[combinedRouteID][directionID], stopTime)
+	if groups[combinedRouteID][directionID] == nil {
+		groups[combinedRouteID][directionID] = &scheduleDirectionGroup{
+			stopTimes:      []models.ScheduleStopTime{},
+			frequencies:    []models.ScheduleFrequency{},
+			headsignCounts: make(map[string]int64),
+		}
+	}
+	return groups[combinedRouteID][directionID]
 }
 
-// recordHeadsignVote tallies one vote for headsign under the route's direction bucket, used
-// later to pick each direction group's plurality tripHeadsign. Blank/absent headsigns cast
-// no vote.
-func recordHeadsignVote(
-	routeDirectionHeadsignCounts map[string]map[string]map[string]int,
-	combinedRouteID, directionID string,
-	headsign sql.NullString,
-) {
-	if !headsign.Valid || headsign.String == "" {
-		return
+func parseScheduleFrequencyRow(row gtfsdb.GetScheduleForStopOnDateRow) (scheduleFrequencyRow, bool, error) {
+	fieldsPresent := []bool{
+		row.FrequencyStartTime.Valid,
+		row.FrequencyEndTime.Valid,
+		row.FrequencyHeadwaySecs.Valid,
+		row.FrequencyExactTimes.Valid,
 	}
 
-	if routeDirectionHeadsignCounts[combinedRouteID] == nil {
-		routeDirectionHeadsignCounts[combinedRouteID] = make(map[string]map[string]int)
+	presentCount := 0
+	for _, present := range fieldsPresent {
+		if present {
+			presentCount++
+		}
 	}
-	if routeDirectionHeadsignCounts[combinedRouteID][directionID] == nil {
-		routeDirectionHeadsignCounts[combinedRouteID][directionID] = make(map[string]int)
+	if presentCount == 0 {
+		return scheduleFrequencyRow{}, false, nil
 	}
-	routeDirectionHeadsignCounts[combinedRouteID][directionID][headsign.String]++
+	if presentCount != len(fieldsPresent) {
+		return scheduleFrequencyRow{}, false, fmt.Errorf("incomplete frequency row for trip %q", row.TripID)
+	}
+
+	frequency := scheduleFrequencyRow{
+		startTime:   row.FrequencyStartTime.Int64,
+		endTime:     row.FrequencyEndTime.Int64,
+		headwaySecs: row.FrequencyHeadwaySecs.Int64,
+		exactTimes:  row.FrequencyExactTimes.Int64,
+	}
+	const maxHeadwaySeconds = int64(^uint64(0)>>1) / int64(time.Second)
+	if frequency.startTime < 0 || frequency.endTime <= frequency.startTime {
+		return scheduleFrequencyRow{}, false, fmt.Errorf("invalid frequency window for trip %q", row.TripID)
+	}
+	if frequency.headwaySecs <= 0 || frequency.headwaySecs > maxHeadwaySeconds {
+		return scheduleFrequencyRow{}, false, fmt.Errorf("invalid frequency headway for trip %q", row.TripID)
+	}
+	if frequency.exactTimes != 0 && frequency.exactTimes != 1 {
+		return scheduleFrequencyRow{}, false, fmt.Errorf("invalid exact_times for trip %q", row.TripID)
+	}
+
+	return frequency, true, nil
+}
+
+func buildScheduleFrequency(
+	row gtfsdb.GetScheduleForStopOnDateRow,
+	rowCtx scheduleRowContext,
+	templateStopTime models.ScheduleStopTime,
+	frequency scheduleFrequencyRow,
+) models.ScheduleFrequency {
+	return models.ScheduleFrequency{
+		FrequencyWindow: models.FrequencyWindow{
+			StartTime: models.NewModelTime(rowCtx.startOfDay.Add(time.Duration(frequency.startTime))),
+			EndTime:   models.NewModelTime(rowCtx.startOfDay.Add(time.Duration(frequency.endTime))),
+			Headway:   models.NewModelDuration(time.Duration(frequency.headwaySecs) * time.Second),
+		},
+		ServiceDate:      models.NewModelTime(rowCtx.startOfDay),
+		ServiceID:        templateStopTime.ServiceID,
+		TripID:           templateStopTime.TripID,
+		StopHeadsign:     row.StopHeadsign.String,
+		ArrivalEnabled:   templateStopTime.ArrivalEnabled,
+		DepartureEnabled: templateStopTime.DepartureEnabled,
+	}
+}
+
+func expandExactScheduleStopTimes(
+	ctx context.Context,
+	row gtfsdb.GetScheduleForStopOnDateRow,
+	rowCtx scheduleRowContext,
+	templateStopTime models.ScheduleStopTime,
+	frequency scheduleFrequencyRow,
+) ([]models.ScheduleStopTime, error) {
+	if row.FirstDepartureTime < 0 {
+		return nil, fmt.Errorf("invalid first departure time for trip %q", row.TripID)
+	}
+
+	headway := frequency.headwaySecs * int64(time.Second)
+	expanded := make([]models.ScheduleStopTime, 0)
+
+	for instanceStart := frequency.startTime; instanceStart < frequency.endTime; {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+
+		shift := instanceStart - row.FirstDepartureTime
+		shiftedArrival, err := addScheduleOffset(row.ArrivalTime, shift)
+		if err != nil {
+			return nil, fmt.Errorf("invalid frequency arrival for trip %q: %w", row.TripID, err)
+		}
+		shiftedDeparture, err := addScheduleOffset(row.DepartureTime, shift)
+		if err != nil {
+			return nil, fmt.Errorf("invalid frequency departure for trip %q: %w", row.TripID, err)
+		}
+		arrivalTime := rowCtx.startOfDay.Add(time.Duration(shiftedArrival)).UnixMilli()
+		departureTime := rowCtx.startOfDay.Add(time.Duration(shiftedDeparture)).UnixMilli()
+		stopTime := templateStopTime
+		stopTime.ArrivalTime = arrivalTime
+		stopTime.DepartureTime = departureTime
+		expanded = append(expanded, stopTime)
+
+		if headway >= frequency.endTime-instanceStart {
+			break
+		}
+		instanceStart += headway
+	}
+
+	return expanded, nil
+}
+
+func addScheduleOffset(base, offset int64) (int64, error) {
+	const maxInt64 = int64(^uint64(0) >> 1)
+	const minInt64 = -maxInt64 - 1
+	if offset > 0 && base > maxInt64-offset {
+		return 0, fmt.Errorf("time overflow")
+	}
+	if offset < 0 && base < minInt64-offset {
+		return 0, fmt.Errorf("time underflow")
+	}
+	return base + offset, nil
+}
+
+// recordHeadsignVotes weights fixed trips once and frequency trips by their estimated
+// number of runs, matching the legacy endpoint's representative-headsign selection.
+func recordHeadsignVotes(group *scheduleDirectionGroup, headsign sql.NullString, count int64) {
+	if !headsign.Valid || headsign.String == "" || count <= 0 {
+		return
+	}
+	group.headsignCounts[headsign.String] += count
+}
+
+func bestHeadsign(headsignCounts map[string]int64) string {
+	headsigns := make([]string, 0, len(headsignCounts))
+	for headsign := range headsignCounts {
+		headsigns = append(headsigns, headsign)
+	}
+	slices.Sort(headsigns)
+
+	best := ""
+	var maxCount int64
+	for _, headsign := range headsigns {
+		if headsignCounts[headsign] > maxCount {
+			best = headsign
+			maxCount = headsignCounts[headsign]
+		}
+	}
+	return best
 }

--- a/internal/restapi/schedule_for_stop_handler_test.go
+++ b/internal/restapi/schedule_for_stop_handler_test.go
@@ -9,8 +9,10 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"maglev.onebusaway.org/gtfsdb"
 	"maglev.onebusaway.org/internal/clock"
+	"maglev.onebusaway.org/internal/models"
 	"maglev.onebusaway.org/internal/utils"
 )
 
@@ -398,6 +400,164 @@ func TestScheduleForStopHandlerEmptyRoutes(t *testing.T) {
 	})
 }
 
+func TestScheduleForStopHandlerFrequencies(t *testing.T) {
+	const targetDate = "20250612"
+	const dateParam = "2025-06-12"
+
+	findActiveScheduleRow := func(t *testing.T, api *RestAPI) (gtfsdb.Agency, gtfsdb.Stop, gtfsdb.GetScheduleForStopOnDateRow, time.Time) {
+		t.Helper()
+		agencies := mustGetAgencies(t, api)
+		require.NotEmpty(t, agencies)
+		agency := agencies[0]
+		location, err := time.LoadLocation(agency.Timezone)
+		require.NoError(t, err)
+		startOfDay, err := time.ParseInLocation("20060102", targetDate, location)
+		require.NoError(t, err)
+
+		for _, stop := range mustGetStops(t, api) {
+			routes, err := api.GtfsManager.GtfsDB.Queries.GetRoutesForStop(context.Background(), stop.ID)
+			require.NoError(t, err)
+			routeIDs := make([]string, 0, len(routes))
+			for _, route := range routes {
+				routeIDs = append(routeIDs, route.ID)
+			}
+			if len(routeIDs) == 0 {
+				continue
+			}
+
+			rows, err := api.GtfsManager.GtfsDB.Queries.GetScheduleForStopOnDate(
+				context.Background(),
+				gtfsdb.GetScheduleForStopOnDateParams{
+					TargetDate: targetDate,
+					Weekday:    "thursday",
+					StopID:     stop.ID,
+					RouteIds:   routeIDs,
+				},
+			)
+			require.NoError(t, err)
+			if len(rows) > 0 {
+				return agency, stop, rows[0], startOfDay
+			}
+		}
+
+		t.Fatal("test feed has no active schedule row")
+		return gtfsdb.Agency{}, gtfsdb.Stop{}, gtfsdb.GetScheduleForStopOnDateRow{}, time.Time{}
+	}
+
+	collectTripEntries := func(
+		t *testing.T,
+		model models.ResponseModel,
+		combinedTripID string,
+	) (frequencies, stopTimes []map[string]any) {
+		t.Helper()
+		require.Equal(t, http.StatusOK, model.Code)
+		data, ok := model.Data.(map[string]any)
+		require.True(t, ok)
+		entry, ok := data["entry"].(map[string]any)
+		require.True(t, ok)
+		routeSchedules, ok := entry["stopRouteSchedules"].([]any)
+		require.True(t, ok)
+
+		for _, routeScheduleValue := range routeSchedules {
+			routeSchedule := routeScheduleValue.(map[string]any)
+			directions := routeSchedule["stopRouteDirectionSchedules"].([]any)
+			for _, directionValue := range directions {
+				direction := directionValue.(map[string]any)
+				for _, frequencyValue := range direction["scheduleFrequencies"].([]any) {
+					frequency := frequencyValue.(map[string]any)
+					if frequency["tripId"] == combinedTripID {
+						frequencies = append(frequencies, frequency)
+					}
+				}
+				for _, stopTimeValue := range direction["scheduleStopTimes"].([]any) {
+					stopTime := stopTimeValue.(map[string]any)
+					if stopTime["tripId"] == combinedTripID {
+						stopTimes = append(stopTimes, stopTime)
+					}
+				}
+			}
+		}
+		return frequencies, stopTimes
+	}
+
+	t.Run("exact_times=0 populates sorted schedule frequencies", func(t *testing.T) {
+		api := createTestApi(t)
+		defer api.Shutdown()
+		agency, stop, row, startOfDay := findActiveScheduleRow(t, api)
+		ctx := context.Background()
+		require.NoError(t, api.GtfsManager.GtfsDB.Queries.ClearFrequencies(ctx))
+
+		const headwaySecs = int64(900)
+		headway := time.Duration(headwaySecs) * time.Second
+		windows := [][2]int64{
+			{row.FirstDepartureTime + int64(2*time.Hour), row.FirstDepartureTime + int64(2*time.Hour+2*headway)},
+			{row.FirstDepartureTime, row.FirstDepartureTime + int64(2*headway)},
+		}
+		for _, window := range windows {
+			require.NoError(t, api.GtfsManager.GtfsDB.Queries.CreateFrequency(ctx, gtfsdb.CreateFrequencyParams{
+				TripID:      row.TripID,
+				StartTime:   window[0],
+				EndTime:     window[1],
+				HeadwaySecs: headwaySecs,
+				ExactTimes:  0,
+			}))
+		}
+
+		stopID := utils.FormCombinedID(agency.ID, stop.ID)
+		_, model := serveApiAndRetrieveEndpoint(
+			t,
+			api,
+			"/api/where/schedule-for-stop/"+stopID+".json?key=TEST&date="+dateParam,
+		)
+		combinedTripID := utils.FormCombinedID(agency.ID, row.TripID)
+		frequencies, stopTimes := collectTripEntries(t, model, combinedTripID)
+
+		require.Len(t, frequencies, 2)
+		assert.Empty(t, stopTimes, "the template trip must not also appear as fixed service")
+		assert.Equal(t, float64(startOfDay.Add(time.Duration(windows[1][0])).UnixMilli()), frequencies[0]["startTime"])
+		assert.Equal(t, float64(startOfDay.Add(time.Duration(windows[0][0])).UnixMilli()), frequencies[1]["startTime"])
+		assert.Equal(t, float64(startOfDay.UnixMilli()), frequencies[0]["serviceDate"])
+		assert.Equal(t, float64(headwaySecs), frequencies[0]["headway"])
+		assert.Equal(t, utils.FormCombinedID(agency.ID, row.ServiceID), frequencies[0]["serviceId"])
+		assert.IsType(t, true, frequencies[0]["arrivalEnabled"])
+		assert.IsType(t, true, frequencies[0]["departureEnabled"])
+	})
+
+	t.Run("exact_times=1 expands deterministic stop times", func(t *testing.T) {
+		api := createTestApi(t)
+		defer api.Shutdown()
+		agency, stop, row, startOfDay := findActiveScheduleRow(t, api)
+		ctx := context.Background()
+		require.NoError(t, api.GtfsManager.GtfsDB.Queries.ClearFrequencies(ctx))
+
+		const headwaySecs = int64(1200)
+		headway := time.Duration(headwaySecs) * time.Second
+		require.NoError(t, api.GtfsManager.GtfsDB.Queries.CreateFrequency(ctx, gtfsdb.CreateFrequencyParams{
+			TripID:      row.TripID,
+			StartTime:   row.FirstDepartureTime,
+			EndTime:     row.FirstDepartureTime + int64(2*headway),
+			HeadwaySecs: headwaySecs,
+			ExactTimes:  1,
+		}))
+
+		stopID := utils.FormCombinedID(agency.ID, stop.ID)
+		_, model := serveApiAndRetrieveEndpoint(
+			t,
+			api,
+			"/api/where/schedule-for-stop/"+stopID+".json?key=TEST&date="+dateParam,
+		)
+		combinedTripID := utils.FormCombinedID(agency.ID, row.TripID)
+		frequencies, stopTimes := collectTripEntries(t, model, combinedTripID)
+
+		assert.Empty(t, frequencies)
+		require.Len(t, stopTimes, 2)
+		assert.Equal(t, float64(startOfDay.Add(time.Duration(row.ArrivalTime)).UnixMilli()), stopTimes[0]["arrivalTime"])
+		assert.Equal(t, float64(startOfDay.Add(time.Duration(row.DepartureTime)).UnixMilli()), stopTimes[0]["departureTime"])
+		assert.Equal(t, float64(startOfDay.Add(time.Duration(row.ArrivalTime)+headway).UnixMilli()), stopTimes[1]["arrivalTime"])
+		assert.Equal(t, float64(startOfDay.Add(time.Duration(row.DepartureTime)+headway).UnixMilli()), stopTimes[1]["departureTime"])
+	})
+}
+
 // TestScheduleForStopQueryValidation verifies the SQL query logic
 func TestScheduleForStopQueryValidation(t *testing.T) {
 	api := createTestApi(t)
@@ -746,6 +906,17 @@ func TestGroupScheduleRowsByRouteAndDirection(t *testing.T) {
 			TripHeadsign:  sql.NullString{String: headsign, Valid: headsign != ""},
 		}
 	}
+	withFrequency := func(
+		row gtfsdb.GetScheduleForStopOnDateRow,
+		startTime, endTime time.Duration,
+		headwaySecs, exactTimes int64,
+	) gtfsdb.GetScheduleForStopOnDateRow {
+		row.FrequencyStartTime = sql.NullInt64{Int64: int64(startTime), Valid: true}
+		row.FrequencyEndTime = sql.NullInt64{Int64: int64(endTime), Valid: true}
+		row.FrequencyHeadwaySecs = sql.NullInt64{Int64: headwaySecs, Valid: true}
+		row.FrequencyExactTimes = sql.NullInt64{Int64: exactTimes, Valid: true}
+		return row
+	}
 
 	t.Run("splits rows on the same route into separate direction groups", func(t *testing.T) {
 		rows := []gtfsdb.GetScheduleForStopOnDateRow{
@@ -753,18 +924,18 @@ func TestGroupScheduleRowsByRouteAndDirection(t *testing.T) {
 			makeRow("trip-in", "10", sql.NullInt64{Int64: 1, Valid: true}, "Uptown"),
 		}
 
-		schedules, _, err := groupScheduleRowsByRouteAndDirection(context.Background(), rows, rowCtx)
+		schedules, err := groupScheduleRowsByRouteAndDirection(context.Background(), rows, rowCtx)
 		assert.NoError(t, err)
 
 		routeGroups, ok := schedules["1_10"]
 		assert.True(t, ok, "expected a group for route 1_10")
 		assert.Len(t, routeGroups, 2, "expected two distinct direction buckets")
 
-		assert.Len(t, routeGroups["0"], 1)
-		assert.Equal(t, "1_trip-out", routeGroups["0"][0].TripID)
+		assert.Len(t, routeGroups["0"].stopTimes, 1)
+		assert.Equal(t, "1_trip-out", routeGroups["0"].stopTimes[0].TripID)
 
-		assert.Len(t, routeGroups["1"], 1)
-		assert.Equal(t, "1_trip-in", routeGroups["1"][0].TripID)
+		assert.Len(t, routeGroups["1"].stopTimes, 1)
+		assert.Equal(t, "1_trip-in", routeGroups["1"].stopTimes[0].TripID)
 	})
 
 	t.Run("groups rows on the same route and direction together", func(t *testing.T) {
@@ -773,12 +944,12 @@ func TestGroupScheduleRowsByRouteAndDirection(t *testing.T) {
 			makeRow("trip-b", "10", sql.NullInt64{Int64: 0, Valid: true}, "Downtown"),
 		}
 
-		schedules, headsignCounts, err := groupScheduleRowsByRouteAndDirection(context.Background(), rows, rowCtx)
+		schedules, err := groupScheduleRowsByRouteAndDirection(context.Background(), rows, rowCtx)
 		assert.NoError(t, err)
 
 		assert.Len(t, schedules["1_10"], 1, "expected a single direction bucket")
-		assert.Len(t, schedules["1_10"]["0"], 2, "expected both stop times grouped together")
-		assert.Equal(t, 2, headsignCounts["1_10"]["0"]["Downtown"])
+		assert.Len(t, schedules["1_10"]["0"].stopTimes, 2, "expected both stop times grouped together")
+		assert.Equal(t, int64(2), schedules["1_10"]["0"].headsignCounts["Downtown"])
 	})
 
 	t.Run("defaults a missing direction_id to bucket 0", func(t *testing.T) {
@@ -786,12 +957,12 @@ func TestGroupScheduleRowsByRouteAndDirection(t *testing.T) {
 			makeRow("trip-a", "10", sql.NullInt64{Valid: false}, "Downtown"),
 		}
 
-		schedules, _, err := groupScheduleRowsByRouteAndDirection(context.Background(), rows, rowCtx)
+		schedules, err := groupScheduleRowsByRouteAndDirection(context.Background(), rows, rowCtx)
 		assert.NoError(t, err)
 
 		assert.Len(t, schedules["1_10"], 1)
 		assert.Contains(t, schedules["1_10"], "0")
-		assert.Len(t, schedules["1_10"]["0"], 1)
+		assert.Len(t, schedules["1_10"]["0"].stopTimes, 1)
 	})
 
 	t.Run("tracks headsign votes separately per direction", func(t *testing.T) {
@@ -801,12 +972,82 @@ func TestGroupScheduleRowsByRouteAndDirection(t *testing.T) {
 			makeRow("trip-in-1", "10", sql.NullInt64{Int64: 1, Valid: true}, "Uptown"),
 		}
 
-		_, headsignCounts, err := groupScheduleRowsByRouteAndDirection(context.Background(), rows, rowCtx)
+		schedules, err := groupScheduleRowsByRouteAndDirection(context.Background(), rows, rowCtx)
 		assert.NoError(t, err)
 
-		assert.Equal(t, 2, headsignCounts["1_10"]["0"]["Downtown"])
-		assert.Equal(t, 1, headsignCounts["1_10"]["1"]["Uptown"])
-		assert.Equal(t, 0, headsignCounts["1_10"]["1"]["Downtown"], "direction 1 should not see direction 0's headsign votes")
+		assert.Equal(t, int64(2), schedules["1_10"]["0"].headsignCounts["Downtown"])
+		assert.Equal(t, int64(1), schedules["1_10"]["1"].headsignCounts["Uptown"])
+		assert.Equal(t, int64(0), schedules["1_10"]["1"].headsignCounts["Downtown"], "direction 1 should not see direction 0's headsign votes")
+	})
+
+	t.Run("represents approximate service as a frequency instead of a template stop time", func(t *testing.T) {
+		row := makeRow("trip-frequency", "10", sql.NullInt64{Int64: 0, Valid: true}, "Downtown")
+		row.StopHeadsign = sql.NullString{String: "Central", Valid: true}
+		row.FirstDepartureTime = int64(7 * time.Hour)
+		row = withFrequency(row, 6*time.Hour, 9*time.Hour, 600, 0)
+
+		schedules, err := groupScheduleRowsByRouteAndDirection(context.Background(), []gtfsdb.GetScheduleForStopOnDateRow{row}, rowCtx)
+		assert.NoError(t, err)
+
+		group := schedules["1_10"]["0"]
+		assert.Empty(t, group.stopTimes, "the GTFS template stop time must not leak into fixed schedules")
+		if assert.Len(t, group.frequencies, 1) {
+			frequency := group.frequencies[0]
+			assert.Equal(t, startOfDay.Add(6*time.Hour), frequency.StartTime.Time)
+			assert.Equal(t, startOfDay.Add(9*time.Hour), frequency.EndTime.Time)
+			assert.Equal(t, 600*time.Second, frequency.Headway.Duration)
+			assert.Equal(t, startOfDay, frequency.ServiceDate.Time)
+			assert.Equal(t, "1_svc1", frequency.ServiceID)
+			assert.Equal(t, "1_trip-frequency", frequency.TripID)
+			assert.Equal(t, "Central", frequency.StopHeadsign)
+			assert.True(t, frequency.ArrivalEnabled)
+			assert.True(t, frequency.DepartureEnabled)
+		}
+		assert.Equal(t, int64(18), group.headsignCounts["Downtown"])
+	})
+
+	t.Run("expands exact service relative to the template first departure", func(t *testing.T) {
+		row := makeRow("trip-exact", "10", sql.NullInt64{Int64: 1, Valid: true}, "Uptown")
+		row.ArrivalTime = int64(8 * time.Hour)
+		row.DepartureTime = int64(8*time.Hour + 2*time.Minute)
+		row.FirstDepartureTime = int64(7 * time.Hour)
+		row = withFrequency(row, 6*time.Hour, 7*time.Hour, 1800, 1)
+
+		schedules, err := groupScheduleRowsByRouteAndDirection(context.Background(), []gtfsdb.GetScheduleForStopOnDateRow{row}, rowCtx)
+		assert.NoError(t, err)
+
+		group := schedules["1_10"]["1"]
+		assert.Empty(t, group.frequencies)
+		if assert.Len(t, group.stopTimes, 2) {
+			assert.Equal(t, startOfDay.Add(7*time.Hour).UnixMilli(), group.stopTimes[0].ArrivalTime)
+			assert.Equal(t, startOfDay.Add(7*time.Hour+2*time.Minute).UnixMilli(), group.stopTimes[0].DepartureTime)
+			assert.Equal(t, startOfDay.Add(7*time.Hour+30*time.Minute).UnixMilli(), group.stopTimes[1].ArrivalTime)
+			assert.Equal(t, startOfDay.Add(7*time.Hour+32*time.Minute).UnixMilli(), group.stopTimes[1].DepartureTime)
+		}
+		assert.Equal(t, int64(2), group.headsignCounts["Uptown"])
+	})
+
+	t.Run("frequency headsign weighting can select the representative headsign", func(t *testing.T) {
+		fixedA := makeRow("trip-fixed-a", "10", sql.NullInt64{Int64: 0, Valid: true}, "Local")
+		fixedB := makeRow("trip-fixed-b", "10", sql.NullInt64{Int64: 0, Valid: true}, "Local")
+		frequency := makeRow("trip-frequency", "10", sql.NullInt64{Int64: 0, Valid: true}, "Express")
+		frequency = withFrequency(frequency, 6*time.Hour, 8*time.Hour, 600, 0)
+
+		schedules, err := groupScheduleRowsByRouteAndDirection(
+			context.Background(),
+			[]gtfsdb.GetScheduleForStopOnDateRow{fixedA, fixedB, frequency},
+			rowCtx,
+		)
+		assert.NoError(t, err)
+		assert.Equal(t, "Express", bestHeadsign(schedules["1_10"]["0"].headsignCounts))
+	})
+
+	t.Run("rejects an invalid frequency before expansion", func(t *testing.T) {
+		row := makeRow("trip-invalid", "10", sql.NullInt64{Int64: 0, Valid: true}, "Downtown")
+		row = withFrequency(row, 6*time.Hour, 7*time.Hour, 0, 1)
+
+		_, err := groupScheduleRowsByRouteAndDirection(context.Background(), []gtfsdb.GetScheduleForStopOnDateRow{row}, rowCtx)
+		assert.ErrorContains(t, err, "invalid frequency headway")
 	})
 
 	t.Run("returns an error when the context is already canceled", func(t *testing.T) {
@@ -817,7 +1058,7 @@ func TestGroupScheduleRowsByRouteAndDirection(t *testing.T) {
 			makeRow("trip-a", "10", sql.NullInt64{Int64: 0, Valid: true}, "Downtown"),
 		}
 
-		_, _, err := groupScheduleRowsByRouteAndDirection(ctx, rows, rowCtx)
+		_, err := groupScheduleRowsByRouteAndDirection(ctx, rows, rowCtx)
 		assert.ErrorIs(t, err, context.Canceled)
 	})
 }

--- a/internal/restapi/schedule_for_stop_handler_test.go
+++ b/internal/restapi/schedule_for_stop_handler_test.go
@@ -13,6 +13,7 @@ import (
 	"maglev.onebusaway.org/gtfsdb"
 	"maglev.onebusaway.org/internal/clock"
 	"maglev.onebusaway.org/internal/models"
+	"maglev.onebusaway.org/internal/nulls"
 	"maglev.onebusaway.org/internal/utils"
 )
 
@@ -911,10 +912,10 @@ func TestGroupScheduleRowsByRouteAndDirection(t *testing.T) {
 		startTime, endTime time.Duration,
 		headwaySecs, exactTimes int64,
 	) gtfsdb.GetScheduleForStopOnDateRow {
-		row.FrequencyStartTime = sql.NullInt64{Int64: int64(startTime), Valid: true}
-		row.FrequencyEndTime = sql.NullInt64{Int64: int64(endTime), Valid: true}
-		row.FrequencyHeadwaySecs = sql.NullInt64{Int64: headwaySecs, Valid: true}
-		row.FrequencyExactTimes = sql.NullInt64{Int64: exactTimes, Valid: true}
+		row.FrequencyStartTime = nulls.Int64(int64(startTime))
+		row.FrequencyEndTime = nulls.Int64(int64(endTime))
+		row.FrequencyHeadwaySecs = nulls.Int64(headwaySecs)
+		row.FrequencyExactTimes = nulls.Int64(exactTimes)
 		return row
 	}
 
@@ -1061,4 +1062,165 @@ func TestGroupScheduleRowsByRouteAndDirection(t *testing.T) {
 		_, err := groupScheduleRowsByRouteAndDirection(ctx, rows, rowCtx)
 		assert.ErrorIs(t, err, context.Canceled)
 	})
+}
+
+func TestParseScheduleFrequencyRow(t *testing.T) {
+	validRow := gtfsdb.GetScheduleForStopOnDateRow{
+		TripID:               "trip-frequency",
+		FrequencyStartTime:   nulls.Int64(int64(6 * time.Hour)),
+		FrequencyEndTime:     nulls.Int64(int64(7 * time.Hour)),
+		FrequencyHeadwaySecs: nulls.Int64(600),
+		FrequencyExactTimes:  nulls.Int64(0),
+	}
+
+	tests := []struct {
+		name        string
+		mutate      func(*gtfsdb.GetScheduleForStopOnDateRow)
+		wantPresent bool
+		wantErr     string
+	}{
+		{
+			name: "no frequency",
+			mutate: func(row *gtfsdb.GetScheduleForStopOnDateRow) {
+				row.FrequencyStartTime = sql.NullInt64{}
+				row.FrequencyEndTime = sql.NullInt64{}
+				row.FrequencyHeadwaySecs = sql.NullInt64{}
+				row.FrequencyExactTimes = sql.NullInt64{}
+			},
+		},
+		{
+			name: "incomplete frequency",
+			mutate: func(row *gtfsdb.GetScheduleForStopOnDateRow) {
+				row.FrequencyEndTime = sql.NullInt64{}
+			},
+			wantErr: "incomplete frequency row",
+		},
+		{
+			name: "negative start",
+			mutate: func(row *gtfsdb.GetScheduleForStopOnDateRow) {
+				row.FrequencyStartTime = nulls.Int64(-1)
+			},
+			wantErr: "invalid frequency window",
+		},
+		{
+			name: "non-increasing window",
+			mutate: func(row *gtfsdb.GetScheduleForStopOnDateRow) {
+				row.FrequencyEndTime = row.FrequencyStartTime
+			},
+			wantErr: "invalid frequency window",
+		},
+		{
+			name: "zero headway",
+			mutate: func(row *gtfsdb.GetScheduleForStopOnDateRow) {
+				row.FrequencyHeadwaySecs = nulls.Int64(0)
+			},
+			wantErr: "invalid frequency headway",
+		},
+		{
+			name: "overflowing headway",
+			mutate: func(row *gtfsdb.GetScheduleForStopOnDateRow) {
+				const maxHeadwaySeconds = int64(^uint64(0)>>1) / int64(time.Second)
+				row.FrequencyHeadwaySecs = nulls.Int64(maxHeadwaySeconds + 1)
+			},
+			wantErr: "invalid frequency headway",
+		},
+		{
+			name: "unsupported exact_times",
+			mutate: func(row *gtfsdb.GetScheduleForStopOnDateRow) {
+				row.FrequencyExactTimes = nulls.Int64(2)
+			},
+			wantErr: "invalid exact_times",
+		},
+		{
+			name:        "valid frequency",
+			mutate:      func(*gtfsdb.GetScheduleForStopOnDateRow) {},
+			wantPresent: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			row := validRow
+			test.mutate(&row)
+
+			frequency, present, err := parseScheduleFrequencyRow(row)
+			if test.wantErr != "" {
+				assert.ErrorContains(t, err, test.wantErr)
+				assert.False(t, present)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, test.wantPresent, present)
+			if present {
+				assert.Equal(t, int64(6*time.Hour), frequency.startTime)
+				assert.Equal(t, int64(7*time.Hour), frequency.endTime)
+				assert.Equal(t, int64(600), frequency.headwaySecs)
+				assert.Equal(t, int64(0), frequency.exactTimes)
+			}
+		})
+	}
+}
+
+func TestExpandExactScheduleStopTimesValidation(t *testing.T) {
+	row := gtfsdb.GetScheduleForStopOnDateRow{
+		TripID:             "trip-frequency",
+		ArrivalTime:        int64(7 * time.Hour),
+		DepartureTime:      int64(7 * time.Hour),
+		FirstDepartureTime: int64(6 * time.Hour),
+	}
+	rowCtx := scheduleRowContext{startOfDay: time.Date(2025, 6, 12, 0, 0, 0, 0, time.UTC)}
+	frequency := scheduleFrequencyRow{
+		startTime:   int64(6 * time.Hour),
+		endTime:     int64(7 * time.Hour),
+		headwaySecs: 600,
+		exactTimes:  1,
+	}
+
+	t.Run("rejects a negative first departure", func(t *testing.T) {
+		invalidRow := row
+		invalidRow.FirstDepartureTime = -1
+		_, err := expandExactScheduleStopTimes(
+			context.Background(), invalidRow, rowCtx, models.ScheduleStopTime{}, frequency,
+		)
+		assert.ErrorContains(t, err, "invalid first departure time")
+	})
+
+	t.Run("honors cancellation during expansion", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		_, err := expandExactScheduleStopTimes(ctx, row, rowCtx, models.ScheduleStopTime{}, frequency)
+		assert.ErrorIs(t, err, context.Canceled)
+	})
+}
+
+func TestAddScheduleOffset(t *testing.T) {
+	const (
+		maxInt64 = int64(^uint64(0) >> 1)
+		minInt64 = -maxInt64 - 1
+	)
+	tests := []struct {
+		name    string
+		base    int64
+		offset  int64
+		want    int64
+		wantErr string
+	}{
+		{name: "adds a positive offset", base: 10, offset: 5, want: 15},
+		{name: "adds a negative offset", base: 10, offset: -5, want: 5},
+		{name: "rejects overflow", base: maxInt64, offset: 1, wantErr: "time overflow"},
+		{name: "rejects underflow", base: minInt64, offset: -1, wantErr: "time underflow"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := addScheduleOffset(test.base, test.offset)
+			if test.wantErr != "" {
+				assert.ErrorContains(t, err, test.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, test.want, got)
+		})
+	}
 }

--- a/internal/restapi/schedule_for_stop_handler_test.go
+++ b/internal/restapi/schedule_for_stop_handler_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"math"
 	"net/http"
 	"testing"
 	"time"
@@ -480,13 +481,39 @@ func TestScheduleForStopHandlerFrequencies(t *testing.T) {
 		}
 		return frequencies, stopTimes
 	}
+	replaceFrequenciesForTest := func(t *testing.T, api *RestAPI) {
+		t.Helper()
+		ctx := context.Background()
+		tripIDs, err := api.GtfsManager.GtfsDB.Queries.GetFrequencyTripIDs(ctx)
+		require.NoError(t, err)
+		originalFrequencies, err := api.GtfsManager.GtfsDB.Queries.GetFrequenciesForTrips(ctx, tripIDs)
+		require.NoError(t, err)
+		require.NoError(t, api.GtfsManager.GtfsDB.Queries.ClearFrequencies(ctx))
+
+		t.Cleanup(func() {
+			cleanupCtx := context.Background()
+			require.NoError(t, api.GtfsManager.GtfsDB.Queries.ClearFrequencies(cleanupCtx))
+			for _, frequency := range originalFrequencies {
+				require.NoError(t, api.GtfsManager.GtfsDB.Queries.CreateFrequency(
+					cleanupCtx,
+					gtfsdb.CreateFrequencyParams{
+						TripID:      frequency.TripID,
+						StartTime:   frequency.StartTime,
+						EndTime:     frequency.EndTime,
+						HeadwaySecs: frequency.HeadwaySecs,
+						ExactTimes:  frequency.ExactTimes,
+					},
+				))
+			}
+		})
+	}
 
 	t.Run("exact_times=0 populates sorted schedule frequencies", func(t *testing.T) {
 		api := createTestApi(t)
 		defer api.Shutdown()
 		agency, stop, row, startOfDay := findActiveScheduleRow(t, api)
 		ctx := context.Background()
-		require.NoError(t, api.GtfsManager.GtfsDB.Queries.ClearFrequencies(ctx))
+		replaceFrequenciesForTest(t, api)
 
 		const headwaySecs = int64(900)
 		headway := time.Duration(headwaySecs) * time.Second
@@ -529,7 +556,7 @@ func TestScheduleForStopHandlerFrequencies(t *testing.T) {
 		defer api.Shutdown()
 		agency, stop, row, startOfDay := findActiveScheduleRow(t, api)
 		ctx := context.Background()
-		require.NoError(t, api.GtfsManager.GtfsDB.Queries.ClearFrequencies(ctx))
+		replaceFrequenciesForTest(t, api)
 
 		const headwaySecs = int64(1200)
 		headway := time.Duration(headwaySecs) * time.Second
@@ -1043,6 +1070,19 @@ func TestGroupScheduleRowsByRouteAndDirection(t *testing.T) {
 		assert.Equal(t, "Express", bestHeadsign(schedules["1_10"]["0"].headsignCounts))
 	})
 
+	t.Run("counts a frequency window shorter than its headway", func(t *testing.T) {
+		row := makeRow("trip-frequency", "10", nulls.Int64(0), "Downtown")
+		row = withFrequency(row, 6*time.Hour, 6*time.Hour+5*time.Minute, 600, 0)
+
+		schedules, err := groupScheduleRowsByRouteAndDirection(
+			context.Background(),
+			[]gtfsdb.GetScheduleForStopOnDateRow{row},
+			rowCtx,
+		)
+		require.NoError(t, err)
+		assert.Equal(t, int64(1), schedules["1_10"]["0"].headsignCounts["Downtown"])
+	})
+
 	t.Run("rejects an invalid frequency before expansion", func(t *testing.T) {
 		row := makeRow("trip-invalid", "10", sql.NullInt64{Int64: 0, Valid: true}, "Downtown")
 		row = withFrequency(row, 6*time.Hour, 7*time.Hour, 0, 1)
@@ -1062,6 +1102,24 @@ func TestGroupScheduleRowsByRouteAndDirection(t *testing.T) {
 		_, err := groupScheduleRowsByRouteAndDirection(ctx, rows, rowCtx)
 		assert.ErrorIs(t, err, context.Canceled)
 	})
+}
+
+func TestBuildDirectionSchedulesUsesDirectionIDForHeadsignTies(t *testing.T) {
+	directionMap := map[string]*scheduleDirectionGroup{
+		"1": {
+			stopTimes:      []models.ScheduleStopTime{{TripID: "trip-direction-1"}},
+			headsignCounts: map[string]int64{"Downtown": 1},
+		},
+		"0": {
+			stopTimes:      []models.ScheduleStopTime{{TripID: "trip-direction-0"}},
+			headsignCounts: map[string]int64{"Downtown": 1},
+		},
+	}
+
+	schedules := buildDirectionSchedules(directionMap)
+	require.Len(t, schedules, 2)
+	assert.Equal(t, "trip-direction-0", schedules[0].ScheduleStopTimes[0].TripID)
+	assert.Equal(t, "trip-direction-1", schedules[1].ScheduleStopTimes[0].TripID)
 }
 
 func TestParseScheduleFrequencyRow(t *testing.T) {
@@ -1119,7 +1177,7 @@ func TestParseScheduleFrequencyRow(t *testing.T) {
 		{
 			name: "overflowing headway",
 			mutate: func(row *gtfsdb.GetScheduleForStopOnDateRow) {
-				const maxHeadwaySeconds = int64(^uint64(0)>>1) / int64(time.Second)
+				const maxHeadwaySeconds = math.MaxInt64 / int64(time.Second)
 				row.FrequencyHeadwaySecs = nulls.Int64(maxHeadwaySeconds + 1)
 			},
 			wantErr: "invalid frequency headway",
@@ -1182,6 +1240,7 @@ func TestExpandExactScheduleStopTimesValidation(t *testing.T) {
 		invalidRow.FirstDepartureTime = -1
 		_, err := expandExactScheduleStopTimes(
 			context.Background(), invalidRow, rowCtx, models.ScheduleStopTime{}, frequency,
+			maxExpandedScheduleStopTimes,
 		)
 		assert.ErrorContains(t, err, "invalid first departure time")
 	})
@@ -1189,16 +1248,30 @@ func TestExpandExactScheduleStopTimesValidation(t *testing.T) {
 	t.Run("honors cancellation during expansion", func(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()
-		_, err := expandExactScheduleStopTimes(ctx, row, rowCtx, models.ScheduleStopTime{}, frequency)
+		_, err := expandExactScheduleStopTimes(
+			ctx, row, rowCtx, models.ScheduleStopTime{}, frequency, maxExpandedScheduleStopTimes,
+		)
 		assert.ErrorIs(t, err, context.Canceled)
+	})
+
+	t.Run("rejects expansions beyond the request limit", func(t *testing.T) {
+		largeFrequency := frequency
+		largeFrequency.headwaySecs = 1
+		largeFrequency.endTime = largeFrequency.startTime +
+			(maxExpandedScheduleStopTimes+1)*int64(time.Second)
+		_, err := expandExactScheduleStopTimes(
+			context.Background(),
+			row,
+			rowCtx,
+			models.ScheduleStopTime{},
+			largeFrequency,
+			maxExpandedScheduleStopTimes,
+		)
+		assert.ErrorContains(t, err, "exceeds the 10000-stop-time request limit")
 	})
 }
 
 func TestAddScheduleOffset(t *testing.T) {
-	const (
-		maxInt64 = int64(^uint64(0) >> 1)
-		minInt64 = -maxInt64 - 1
-	)
 	tests := []struct {
 		name    string
 		base    int64
@@ -1208,8 +1281,8 @@ func TestAddScheduleOffset(t *testing.T) {
 	}{
 		{name: "adds a positive offset", base: 10, offset: 5, want: 15},
 		{name: "adds a negative offset", base: 10, offset: -5, want: 5},
-		{name: "rejects overflow", base: maxInt64, offset: 1, wantErr: "time overflow"},
-		{name: "rejects underflow", base: minInt64, offset: -1, wantErr: "time underflow"},
+		{name: "rejects overflow", base: math.MaxInt64, offset: 1, wantErr: "time overflow"},
+		{name: "rejects underflow", base: math.MinInt64, offset: -1, wantErr: "time underflow"},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
## Summary

- join active stop schedules with GTFS frequency rows in the existing query
- return `exact_times=0` service through `scheduleFrequencies`
- expand `exact_times=1` service into first-stop-relative virtual stop times
- preserve route/direction grouping, block-boundary flags, headsign weighting, and deterministic ordering
- validate malformed frequency data and make large expansions cancellation-aware
- add focused unit and HTTP integration coverage for both frequency modes

## Root cause

The schedule-for-stop query did not read the `frequencies` table, so the endpoint always returned an empty `scheduleFrequencies` array and omitted frequency-defined service.

## Spec notes

- The wiki does not define a distinct response matrix for `exact_times=1`. This implementation follows the explicit clarification in #1031 and expands deterministic frequency service into virtual `scheduleStopTimes`.
- The corrected `ScheduleFrequency` model includes `stopHeadsign`, `arrivalEnabled`, and `departureEnabled`, while the current OpenAPI schema documents only the other six fields. These legacy fields are additive and existing OpenAPI conformance checks pass.

## Scope note

This exceeds the preferred 200-line PR size because the query, generated sqlc row, handler classification, exact-time expansion, and coverage are tightly coupled parts of the same issue. Most of the diff is generated query code and tests; splitting it would leave an intermediate implementation without complete behavior or validation.

## Validation

- `go fmt ./...`
- `go vet -tags "sqlite_fts5 sqlite_math_functions" ./...`
- `go vet -tags "purego" ./...`
- `make test`
- `make test-pure`
- `make check-openapi`
- `git diff --check`

Closes #1031
Refs #993
