### PR TITLE
Reuse resolved situations for arrivals

### DIFF
--- a/internal/restapi/arrivals_and_departures_for_stop_handler.go
+++ b/internal/restapi/arrivals_and_departures_for_stop_handler.go
@@ -442,8 +442,10 @@ func (api *RestAPI) arrivalsAndDeparturesForStopHandler(w http.ResponseWriter, r
 
 		lastUpdateTime := api.GtfsManager.GetVehicleLastUpdateTime(vehicle)
 
-		tripAlerts := api.GtfsManager.GetAlertsForTrip(r.Context(), st.TripID)
-		situationIDs := situations.add(tripAlerts, route.AgencyID)
+		// BuildTripStatus already resolved this trip's situations. Reuse those
+		// references so each arrival does not repeat the alert lookup and its
+		// situationIds are guaranteed to match references.situations.
+		situationIDs := situations.addRefs(statusExtras.situations)
 
 		if alertAgencyID == "" && route.AgencyID != "" {
 			alertAgencyID = route.AgencyID

--- a/internal/restapi/arrivals_and_departures_for_stop_handler_test.go
+++ b/internal/restapi/arrivals_and_departures_for_stop_handler_test.go
@@ -94,6 +94,61 @@ func TestArrivalsAndDeparturesForStopHandlerEndToEnd(t *testing.T) {
 	require.NotEmpty(t, model.Data.References.Stops)
 }
 
+// TestArrivalsAndDeparturesForStopHandler_RouteAlertReferences verifies that a
+// route-level alert appears on the affected arrival and that its situation ID
+// resolves in references.situations.
+func TestArrivalsAndDeparturesForStopHandler_RouteAlertReferences(t *testing.T) {
+	api, cleanup := createTestApiWithRealTimeData(t, clock.NewMockClock(arrivalsTestClock))
+	defer cleanup()
+	t.Cleanup(api.GtfsManager.MockResetRealTimeData)
+
+	requestURL := arrivalsAndDeparturesURL(arrivalsTestStopID,
+		url.Values{"minutesBefore": {"60"}, "minutesAfter": {"240"}})
+	_, initial := callAPIHandler[ArrivalsAndDeparturesResponse](t, api, requestURL)
+	require.NotEmpty(t, initial.Data.Entry.ArrivalsAndDepartures,
+		"fixture stop should have an arrival in the test window")
+
+	target := initial.Data.Entry.ArrivalsAndDepartures[0]
+	agencyID, routeID, err := utils.ExtractAgencyIDAndCodeID(target.RouteID)
+	require.NoError(t, err)
+
+	const alertID = "plural-arrivals-route-alert"
+	api.GtfsManager.MockAddAlert("feed-0", gtfs.Alert{
+		ID:               alertID,
+		InformedEntities: []gtfs.AlertInformedEntity{{RouteID: &routeID}},
+		Header:           []gtfs.AlertText{{Text: "Plural arrivals route alert", Language: "en"}},
+	})
+
+	resp, model := callAPIHandler[ArrivalsAndDeparturesResponse](t, api, requestURL)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	wantSituationID := utils.FormCombinedID(agencyID, alertID)
+	var affectedArrival *models.ArrivalAndDeparture
+	for i := range model.Data.Entry.ArrivalsAndDepartures {
+		arrival := &model.Data.Entry.ArrivalsAndDepartures[i]
+		if arrival.RouteID == target.RouteID {
+			affectedArrival = arrival
+			break
+		}
+	}
+	require.NotNil(t, affectedArrival, "expected an arrival on the alerted route")
+	require.NotNil(t, affectedArrival.TripStatus)
+	assert.Equal(t, affectedArrival.TripStatus.SituationIDs, affectedArrival.SituationIDs,
+		"arrival situationIds must be the ones BuildTripStatus resolved, not a second lookup")
+	assert.Contains(t, affectedArrival.SituationIDs, wantSituationID,
+		"an arrival must include its route-level alert")
+
+	var referenced bool
+	for _, situation := range model.Data.References.Situations {
+		if situation.ID == wantSituationID {
+			referenced = true
+			break
+		}
+	}
+	assert.True(t, referenced,
+		"arrival situationId %q must resolve in references.situations", wantSituationID)
+}
+
 func TestArrivalsAndDeparturesForStopHandlerTimeParams(t *testing.T) {
 	api, cleanup := createTestApiWithRealTimeData(t, clock.NewMockClock(arrivalsTestClock))
 	defer cleanup()


### PR DESCRIPTION
## Summary

- Reuse situation references resolved by `BuildTripStatus` for each plural arrival.
- Add regression coverage for route-level alerts and situation-reference resolution.

## Why

The arrivals-and-departures handler resolved each trip’s alerts twice per arrival row. Reusing the existing references removes that repeated work and keeps entry IDs aligned with `references.situations`.

## Validation

- `go vet -tags "sqlite_fts5 sqlite_math_functions" ./...`
- `go vet -tags "purego" ./...`
- `make test`

Closes #1341

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Route-level service alerts now appear correctly on affected arrival and departure results.
  * Alert situation references are now consistently included with the associated stop information.
  * Resolved situations are handled consistently when displaying alerts for individual arrivals and departures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->