### PR TITLE
Honor includeReferences in stops-for-location

### DIFF
--- a/internal/restapi/stops_for_location_handler.go
+++ b/internal/restapi/stops_for_location_handler.go
@@ -25,6 +25,7 @@ func (api *RestAPI) stopsForLocationHandler(w http.ResponseWriter, r *http.Reque
 	loc, fieldErrors := api.parseLocationParams(r, fieldErrors)
 	maxCount, fieldErrors := utils.ParseMaxCountClamped(queryParams, models.DefaultMaxCountForStops, fieldErrors)
 	query := queryParams.Get("query")
+	includeReferences := ShouldIncludeReferences(r)
 
 	var routeTypes []int
 	if routeTypeStr := queryParams.Get("routeType"); routeTypeStr != "" {
@@ -223,41 +224,44 @@ func (api *RestAPI) stopsForLocationHandler(w http.ResponseWriter, r *http.Reque
 		isLimitExceeded = true
 	}
 
-	// References describe the returned stops, so they are collected after capping.
-	for _, stopID := range resultRawStopIDs {
-		for _, routeID := range stopRouteIDs[stopID] {
-			agencyID, _, err := utils.ExtractAgencyIDAndCodeID(routeID)
-			if err != nil {
-				continue
-			}
-			agencyIDs[agencyID] = true
-			routeIDs[routeID] = true
-		}
-	}
-
 	// Spec: results are ordered lexicographically by combined stop ID.
 	slices.SortStableFunc(results, func(a, b models.Stop) int {
 		return cmp.Compare(a.ID, b.ID)
 	})
 
-	agencies := utils.FilterAgencies(allAgencies, agencyIDs)
-	routes := utils.FilterRoutes(api.GtfsManager.GtfsDB.Queries, ctx, routeIDs)
-
-	if agencies == nil {
-		agencies = []models.AgencyReference{}
-	}
-	if routes == nil {
-		routes = []models.Route{}
-	}
-
-	// Populate situation references for alerts affecting the returned stops
-	alerts := api.collectAlertsForStops(resultRawStopIDs)
-	situations := api.BuildSituationReferences(alerts)
-
 	references := models.NewEmptyReferences()
-	references.Agencies = agencies
-	references.Routes = routes
-	references.Situations = situations
+
+	// When includeReferences=false the references block is present but empty.
+	if includeReferences {
+		// References describe the returned stops, so they are collected after capping.
+		for _, stopID := range resultRawStopIDs {
+			for _, routeID := range stopRouteIDs[stopID] {
+				agencyID, _, err := utils.ExtractAgencyIDAndCodeID(routeID)
+				if err != nil {
+					continue
+				}
+				agencyIDs[agencyID] = true
+				routeIDs[routeID] = true
+			}
+		}
+
+		agencies := utils.FilterAgencies(allAgencies, agencyIDs)
+		routes := utils.FilterRoutes(api.GtfsManager.GtfsDB.Queries, ctx, routeIDs)
+
+		if agencies == nil {
+			agencies = []models.AgencyReference{}
+		}
+		if routes == nil {
+			routes = []models.Route{}
+		}
+
+		// Populate situation references for alerts affecting the returned stops
+		alerts := api.collectAlertsForStops(resultRawStopIDs)
+
+		references.Agencies = agencies
+		references.Routes = routes
+		references.Situations = api.BuildSituationReferences(alerts)
+	}
 
 	response := models.NewListResponseWithRange(results, *references, outOfRange, api.Clock, isLimitExceeded)
 	api.sendResponse(w, r, response)

--- a/internal/restapi/stops_for_location_handler_test.go
+++ b/internal/restapi/stops_for_location_handler_test.go
@@ -591,3 +591,47 @@ func TestStopsForLocationHandlerWithSituations(t *testing.T) {
 
 	assert.True(t, foundOurAlert, "Expected to find our mock alert in the references.situations")
 }
+
+// Spec extension 8a: includeReferences=false leaves the references block present but empty.
+func TestStopsForLocationHonorsIncludeReferences(t *testing.T) {
+	tests := []struct {
+		name             string
+		param            string
+		expectReferences bool
+	}{
+		{name: "omitted", param: "", expectReferences: true},
+		{name: "true", param: "&includeReferences=true", expectReferences: true},
+		{name: "false", param: "&includeReferences=false", expectReferences: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockClock := clock.NewMockClock(time.Date(2025, 6, 13, 14, 0, 0, 0, time.UTC))
+			api := createTestApiWithClock(t, mockClock)
+
+			stopID := "2042"
+			api.GtfsManager.AddAlertForTest(gtfs.Alert{
+				ID:               "test-alert-stop-2042",
+				InformedEntities: []gtfs.AlertInformedEntity{{StopID: &stopID}},
+				Description:      []gtfs.AlertText{{Text: "Stop 2042 is closed today", Language: "en"}},
+			})
+
+			resp, model := callAPIHandler[StopsResponse](t, api,
+				"/api/where/stops-for-location.json?key=TEST&lat=40.583321&lon=-122.426966&query=2042"+tt.param)
+
+			require.Equal(t, http.StatusOK, resp.StatusCode)
+			require.Len(t, model.Data.List, 1, "the stop itself is returned either way")
+
+			refs := model.Data.References
+			if tt.expectReferences {
+				assert.NotEmpty(t, refs.Agencies)
+				assert.NotEmpty(t, refs.Routes)
+				assert.NotEmpty(t, refs.Situations)
+			} else {
+				assert.Empty(t, refs.Agencies)
+				assert.Empty(t, refs.Routes)
+				assert.Empty(t, refs.Situations)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #1349. Part of the second pass on the #1235 spec-review card.

## Problem

`stopsForLocationHandler` never read `includeReferences` — `ShouldIncludeReferences` was not called anywhere in the file, so the references block was populated identically whether the parameter was `true`, `false`, or absent.

Spec extension 8a: *"includeReferences=false: The references block is present in the response but all its sub-arrays are empty."*

Confirmed against canonical legacy 2.7.1 (maglev-workspace, KCM, `lat=47.6062&lon=-122.3321&radius=1000`):

```
includeReferences=true  -> references: agencies=3  routes=43
includeReferences=false -> references: agencies=0  routes=0
```

Maglev on RABA returned `agencies=1 routes=2` either way.

## Fix

Guard the reference block with `ShouldIncludeReferences(r)`, the same way `routes-for-agency` (#1187), `search-stop` (#1160) and `trip` (#1063) already do. The block is still emitted — `models.NewEmptyReferences()` gives empty (not null) sub-arrays — only its contents are skipped.

The guard also skips the work that fed it: the agency/route ID collection loop, both `Filter*` calls (one of which runs a full `ListRoutes`), and the per-stop alert lookup.

The early "no stops found" return already produced empty sub-arrays — `FilterAgencies`/`FilterRoutes` filter against empty maps there — so it needed no change.

## Testing

`TestStopsForLocationHonorsIncludeReferences` is table-driven over omitted / `true` / `false`, and asserts all three sub-arrays including `situations` (using the existing stop-2042 alert fixture, so the situations arm is non-trivially populated in the `true` cases).

Mutation-verified: forcing the guard true fails all three `false`-case assertions.

Full gauntlet green in both tag modes — gofmt, `go vet`, full suite, race detector, `purego`, `check-openapi`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for controlling whether agency, route, and situation references are included in stop-location responses.
  * Stops continue to be returned regardless of the reference setting.
  * References are included by default and can be omitted with `includeReferences=false`.

* **Bug Fixes**
  * Ensured references are collected consistently after result limits are applied.

* **Tests**
  * Added coverage for omitted, enabled, and disabled reference options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->