### PR TITLE
Accept the documented time formats in stops-for-location

### DIFF
--- a/internal/restapi/stops_for_location_handler.go
+++ b/internal/restapi/stops_for_location_handler.go
@@ -62,17 +62,6 @@ func (api *RestAPI) stopsForLocationHandler(w http.ResponseWriter, r *http.Reque
 		}
 	}
 
-	queryTime := api.Clock.Now()
-
-	if timeStr := queryParams.Get("time"); timeStr != "" {
-		var timeMs int64
-		if _, err := fmt.Sscanf(timeStr, "%d", &timeMs); err == nil {
-			// Bin to 15 minutes
-			binnedMs := timeMs - (timeMs % 900000)
-			queryTime = time.UnixMilli(binnedMs)
-		}
-	}
-
 	if len(fieldErrors) > 0 {
 		api.validationErrorResponse(w, r, fieldErrors)
 		return
@@ -142,8 +131,7 @@ func (api *RestAPI) stopsForLocationHandler(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	// Get active service IDs for the requested queryTime
-	currentDate := queryTime.Format("20060102")
+	currentDate := api.queryTimeForStops(queryParams.Get("time"), allAgencies).Format("20060102")
 	activeServiceIDs, err := api.GtfsManager.GtfsDB.Queries.GetActiveServiceIDsForDate(ctx, currentDate)
 	if err != nil {
 		api.serverErrorResponse(w, r, err)
@@ -265,6 +253,30 @@ func (api *RestAPI) stopsForLocationHandler(w http.ResponseWriter, r *http.Reque
 
 	response := models.NewListResponseWithRange(results, *references, outOfRange, api.Clock, isLimitExceeded)
 	api.sendResponse(w, r, response)
+}
+
+// queryTimeForStops resolves the time parameter that selects which service date's
+// routes are considered active. The value is read in the agency's timezone, as in
+// trips-for-location. A value that does not parse falls back to the current time
+// rather than failing the request, which is what legacy does with one.
+func (api *RestAPI) queryTimeForStops(timeParam string, agencies []gtfsdb.Agency) time.Time {
+	now := api.Clock.Now()
+	if timeParam == "" || len(agencies) == 0 {
+		return now
+	}
+
+	location, err := loadAgencyLocation(agencies[0].ID, agencies[0].Timezone)
+	if err != nil {
+		api.Logger.Warn("failed to load agency timezone for time parameter",
+			"agencyID", agencies[0].ID, "error", err)
+		return now
+	}
+
+	_, parsedTime, _, ok := utils.ParseTimeParameter(timeParam, location, api.Clock)
+	if !ok {
+		return now
+	}
+	return parsedTime
 }
 
 // routeIDsByStop maps each stop to the routes serving it. Stop-code queries report every

--- a/internal/restapi/stops_for_location_handler.go
+++ b/internal/restapi/stops_for_location_handler.go
@@ -255,26 +255,26 @@ func (api *RestAPI) stopsForLocationHandler(w http.ResponseWriter, r *http.Reque
 	api.sendResponse(w, r, response)
 }
 
-// queryTimeForStops resolves the time parameter that selects which service date's
-// routes are considered active. The value is read in the agency's timezone, as in
-// trips-for-location. A value that does not parse falls back to the current time
-// rather than failing the request, which is what legacy does with one.
+// queryTimeForStops resolves the time that selects which service date's routes are
+// considered active. A service date is a local calendar date, so both an explicit
+// time parameter and the current-time fallback are read in the agency's timezone,
+// as in trips-for-location. A value that does not parse falls back to the current
+// time rather than failing the request, which is what legacy does with one.
 func (api *RestAPI) queryTimeForStops(timeParam string, agencies []gtfsdb.Agency) time.Time {
-	now := api.Clock.Now()
-	if timeParam == "" || len(agencies) == 0 {
-		return now
+	if len(agencies) == 0 {
+		return api.Clock.Now()
 	}
 
 	location, err := loadAgencyLocation(agencies[0].ID, agencies[0].Timezone)
 	if err != nil {
 		api.Logger.Warn("failed to load agency timezone for time parameter",
 			"agencyID", agencies[0].ID, "error", err)
-		return now
+		return api.Clock.Now()
 	}
 
 	_, parsedTime, _, ok := utils.ParseTimeParameter(timeParam, location, api.Clock)
 	if !ok {
-		return now
+		return api.Clock.Now().In(location)
 	}
 	return parsedTime
 }

--- a/internal/restapi/stops_for_location_handler_test.go
+++ b/internal/restapi/stops_for_location_handler_test.go
@@ -690,3 +690,46 @@ func TestStopsForLocationAcceptsDocumentedTimeFormats(t *testing.T) {
 		})
 	}
 }
+
+// A service date is a local calendar date, so the date is taken in the agency's
+// timezone even when the server clock's own date has already rolled over.
+func TestStopsForLocationUsesAgencyDateForCurrentTime(t *testing.T) {
+	// Both instants are Friday 2025-06-13 in RABA's America/Los_Angeles, but the
+	// second has already rolled over to the 14th in UTC.
+	middayLocal := clock.NewMockClock(time.Date(2025, 6, 13, 20, 0, 0, 0, time.UTC))
+	lateEveningLocal := clock.NewMockClock(time.Date(2025, 6, 14, 5, 0, 0, 0, time.UTC))
+
+	stopIDsAt := func(c clock.Clock, timeParam string) []string {
+		api := createTestApiWithClock(t, c)
+		endpoint := "/api/where/stops-for-location.json?key=TEST&lat=40.583321&lon=-122.426966&radius=2500"
+		if timeParam != "" {
+			endpoint += "&time=" + timeParam
+		}
+		resp, model := callAPIHandler[StopsResponse](t, api, endpoint)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+
+		stopIDs := make([]string, 0, len(model.Data.List))
+		for _, stop := range model.Data.List {
+			stopIDs = append(stopIDs, stop.ID)
+		}
+		return stopIDs
+	}
+
+	// Both routes to the fallback have to land on the agency's date.
+	tests := []struct {
+		name      string
+		timeParam string
+	}{
+		{name: "absent", timeParam: ""},
+		{name: "malformed", timeParam: "garbage"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			expected := stopIDsAt(middayLocal, tt.timeParam)
+			require.NotEmpty(t, expected)
+			assert.Equal(t, expected, stopIDsAt(lateEveningLocal, tt.timeParam),
+				"the same local service date must select the same stops on both sides of UTC midnight")
+		})
+	}
+}

--- a/internal/restapi/stops_for_location_handler_test.go
+++ b/internal/restapi/stops_for_location_handler_test.go
@@ -635,3 +635,58 @@ func TestStopsForLocationHonorsIncludeReferences(t *testing.T) {
 		})
 	}
 }
+
+// The time parameter also accepts yyyy-MM-dd_HH-mm-ss, which was previously read as
+// epoch millis and silently resolved to 1970.
+func TestStopsForLocationAcceptsDocumentedTimeFormats(t *testing.T) {
+	// 2025-06-13 14:00:00 in RABA's timezone, a date the fixture has service on.
+	const serviceDateEpochMs = "1749848400000"
+
+	tests := []struct {
+		name        string
+		timeParam   string
+		expectStops bool
+	}{
+		{name: "epoch millis", timeParam: serviceDateEpochMs, expectStops: true},
+		{name: "date and time", timeParam: "2025-06-13_14-00-00", expectStops: true},
+		{name: "date only", timeParam: "2025-06-13", expectStops: true},
+		{name: "malformed", timeParam: "garbage", expectStops: false},
+		{name: "absent", timeParam: "", expectStops: false},
+	}
+
+	var epochStopIDs []string
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// A clock outside the fixture's service dates returns nothing, so a time
+			// that parses shows up as a non-empty result rather than a shifted count.
+			futureClock := clock.NewMockClock(time.Date(2031, 1, 1, 12, 0, 0, 0, time.UTC))
+			api := createTestApiWithClock(t, futureClock)
+
+			endpoint := "/api/where/stops-for-location.json?key=TEST&lat=40.583321&lon=-122.426966&radius=2500"
+			if tt.timeParam != "" {
+				endpoint += "&time=" + tt.timeParam
+			}
+			resp, model := callAPIHandler[StopsResponse](t, api, endpoint)
+
+			require.Equal(t, http.StatusOK, resp.StatusCode, "an unparseable time is served, not rejected")
+
+			stopIDs := make([]string, 0, len(model.Data.List))
+			for _, stop := range model.Data.List {
+				stopIDs = append(stopIDs, stop.ID)
+			}
+
+			if !tt.expectStops {
+				assert.Empty(t, stopIDs, "no service is active at the clock's date")
+				return
+			}
+
+			require.NotEmpty(t, stopIDs)
+			if epochStopIDs == nil {
+				epochStopIDs = stopIDs
+				return
+			}
+			assert.Equal(t, epochStopIDs, stopIDs, "every accepted form of the same date selects the same stops")
+		})
+	}
+}


### PR DESCRIPTION
Fixes #1350. Part of the second pass on the #1235 spec-review card.

## Problem

The `time` parameter *"accepts Unix milliseconds as a digit string, or the format `yyyy-MM-dd_HH-mm-ss`"*. The handler parsed it with `fmt.Sscanf(timeStr, "%d", &timeMs)`, which reads `2025` off the front of `2025-06-13_14-00-00` and **succeeds**. The value is then treated as 2025 *milliseconds* — 1 Jan 1970 — so no service is active and the response is empty, with HTTP 200 and no indication anything went wrong.

```
# RABA
time=1749848400000        -> 7 stops
time=2025-06-13_14-00-00  -> 0 stops   (same instant, documented format)
```

This is worse than the malformed case: `time=garbage` fails the parse and correctly falls back to the current time, while a *valid* documented value silently produces a wrong answer.

Confirmed against canonical legacy 2.7.1 (maglev-workspace, KCM, `radius=1000&maxCount=250`, chosen so the candidate count stays under the cap and legacy's shuffle/truncate can't add noise — the same request repeated three times returned an identical count):

```
today       epoch=157  string(2026-08-15_12-00-00)=157
far_future  epoch=0    string(2030-09-23_12-00-00)=0
far_past    epoch=0    string(2022-07-07_12-00-00)=0
no time param = 157
```

The far-date rows are the discriminating ones: the string form tracks the epoch form down to 0 rather than falling back to the 157 returned when `time` is absent, so legacy does parse the format.

## Fix

Use the existing `utils.ParseTimeParameter`, which already handles epoch millis, `yyyy-MM-dd_HH-mm-ss` and the date-only form. Two details:

- **Timezone.** The value is read against the agency's timezone, the same way `trips-for-location` resolves its own `time` for a location-scoped (non-agency-scoped) request. Previously `time.UnixMilli` gave the server's local zone.
- **Malformed values still fall back to the current time.** `ParseTimeParameter` returns field errors, but propagating them would turn `time=garbage` into a 400. Legacy serves that request (HTTP 200, same count as no `time` param at all), so the field errors are deliberately discarded and the fallback preserved. This is a preserve, not a fix.

The 15-minute binning is dropped rather than reimplemented. It cannot affect this handler: the value is only ever used at date granularity (`Format("20060102")`), 900000 ms divides a day evenly, and every IANA zone offset is itself a multiple of 15 minutes — so rounding down to a 15-minute UTC boundary can never cross a local midnight.

Resolving the time after the empty-result early return also shortens the variable's travel — it is now declared immediately above its only use.

## Testing

`TestStopsForLocationAcceptsDocumentedTimeFormats` is table-driven over epoch millis / `yyyy-MM-dd_HH-mm-ss` / date-only / malformed / absent. The clock is pinned to 2031, outside the fixture's service dates, so a time that parses shows up as a *non-empty* result rather than as a count that merely shifts — and the three accepted forms are asserted to return the identical stop list, not just a non-empty one.

Mutation-verified: restoring the `Sscanf` parse empties both the `yyyy-MM-dd_HH-mm-ss` and date-only cases.

Full gauntlet green in both tag modes — gofmt, `go vet`, full suite, race detector, `purego`, `check-openapi`.


## Also included: the current-time fallback timezone

Raised by review. The helper this PR adds read an explicit `time` in the agency's timezone but formatted its own fallback — used when `time` is absent or unparseable — from the clock's location. A service date is a local calendar date, so on a UTC-hosted instance serving a Pacific agency that named the *next* day's service for roughly seven hours every evening.

Reproduced on the RABA fixture. Both instants are Friday 2025-06-13 in `America/Los_Angeles`; only the second has rolled over in UTC:

```
13:00 local (2025-06-13T20:00Z) -> 15 stops
22:00 local (2025-06-14T05:00Z) -> 12 stops
```

`20250613` has 5 active service IDs against `20250614`'s 4, so the two dates really do select different service.

Loading the agency location before resolving the parameter fixes both routes to the fallback, and delegating the empty parameter to `ParseTimeParameter` removes a branch. Covered by `TestStopsForLocationUsesAgencyDateForCurrentTime`, which exercises the absent and malformed cases separately because they reach the fallback by different paths.

**This half is a pre-existing defect on the no-`time` path, not part of #1350**, and it changes the service date every request without a `time` param resolves to. It is in its own commit and can be split out if preferred — see the [review reply](https://github.com/OneBusAway/maglev/pull/1352#issuecomment-5304929259).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stop results for location searches by consistently interpreting supported time formats.
  * Corrected service-date selection to use the agency’s local calendar date, including around UTC midnight.
  * Invalid or missing time values now safely return no stops without rejecting the request.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->