### PR TITLE
Fix stop reference location and parent

### DIFF
--- a/internal/restapi/reference_utils.go
+++ b/internal/restapi/reference_utils.go
@@ -553,15 +553,23 @@ func (api *RestAPI) stopReferences(ctx context.Context, stops []gtfsdb.Stop, ids
 			direction = models.UnknownValue
 		}
 
+		parentID := ""
+		if parentStation := nulls.StringOrEmpty(stop.ParentStation); parentStation != "" {
+			agencyID, err := utils.ExtractAgencyID(idsByBareID[stop.ID])
+			if err == nil {
+				parentID = utils.FormCombinedID(agencyID, parentStation)
+			}
+		}
+
 		stopList = append(stopList, models.Stop{
 			Code:               nulls.StringOrEmpty(stop.Code),
 			Direction:          direction,
 			ID:                 idsByBareID[stop.ID],
 			Lat:                stop.Lat,
 			Lon:                stop.Lon,
-			LocationType:       0,
+			LocationType:       int(nulls.Int64OrDefault(stop.LocationType, 0)),
 			Name:               nulls.StringOrEmpty(stop.Name),
-			Parent:             "",
+			Parent:             parentID,
 			RouteIDs:           routeIDs,
 			StaticRouteIDs:     routeIDs,
 			WheelchairBoarding: utils.MapWheelchairBoarding(nulls.WheelchairBoardingOrUnknown(stop.WheelchairBoarding)),

--- a/internal/restapi/reference_utils_test.go
+++ b/internal/restapi/reference_utils_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"maglev.onebusaway.org/gtfsdb"
 	"maglev.onebusaway.org/internal/models"
+	"maglev.onebusaway.org/internal/nulls"
 	"maglev.onebusaway.org/internal/utils"
 )
 
@@ -198,7 +199,13 @@ func TestStopReferences(t *testing.T) {
 	require.NoError(t, err)
 
 	// No stop_times point at this stop, so no route resolves for it.
-	routelessStop := gtfsdb.Stop{ID: "stop-served-by-no-route", Lat: 40.5, Lon: -122.3}
+	routelessStop := gtfsdb.Stop{
+		ID:            "stop-served-by-no-route",
+		Lat:           40.5,
+		Lon:           -122.3,
+		LocationType:  nulls.Int64(1),
+		ParentStation: nulls.String("parent-station"),
+	}
 
 	referringIDs := map[string]string{
 		servedStopID:     utils.FormCombinedID("referring-agency", servedStopID),
@@ -213,6 +220,8 @@ func TestStopReferences(t *testing.T) {
 	assert.Equal(t, routeIDsByStop[servedStopID], refs[0].RouteIDs)
 
 	assert.Equal(t, referringIDs[routelessStop.ID], refs[1].ID)
+	assert.Equal(t, 1, refs[1].LocationType)
+	assert.Equal(t, utils.FormCombinedID("referring-agency", "parent-station"), refs[1].Parent)
 	assert.Empty(t, refs[1].RouteIDs)
 	assert.NotNil(t, refs[1].RouteIDs, "an unresolved route list is empty, not null")
 	assert.Equal(t, refs[1].RouteIDs, refs[1].StaticRouteIDs)

--- a/internal/restapi/reference_utils_test.go
+++ b/internal/restapi/reference_utils_test.go
@@ -206,14 +206,24 @@ func TestStopReferences(t *testing.T) {
 		LocationType:  nulls.Int64(1),
 		ParentStation: nulls.String("parent-station"),
 	}
-
-	referringIDs := map[string]string{
-		servedStopID:     utils.FormCombinedID("referring-agency", servedStopID),
-		routelessStop.ID: utils.FormCombinedID("referring-agency", routelessStop.ID),
+	defaultStop := gtfsdb.Stop{ID: "default-stop", Lat: 40.6, Lon: -122.4}
+	malformedReferenceStop := gtfsdb.Stop{
+		ID:            "malformed-reference-stop",
+		Lat:           40.7,
+		Lon:           -122.5,
+		ParentStation: nulls.String("parent-station"),
 	}
 
-	refs, routeIDsByStop := api.stopReferences(ctx, []gtfsdb.Stop{servedStop, routelessStop}, referringIDs)
-	require.Len(t, refs, 2, "a stop with no resolvable routes still gets a reference")
+	referringIDs := map[string]string{
+		servedStopID:              utils.FormCombinedID("referring-agency", servedStopID),
+		routelessStop.ID:          utils.FormCombinedID("referring-agency", routelessStop.ID),
+		defaultStop.ID:            utils.FormCombinedID("referring-agency", defaultStop.ID),
+		malformedReferenceStop.ID: "malformed-reference-id",
+	}
+
+	refs, routeIDsByStop := api.stopReferences(ctx,
+		[]gtfsdb.Stop{servedStop, routelessStop, defaultStop, malformedReferenceStop}, referringIDs)
+	require.Len(t, refs, 4, "a stop with no resolvable routes still gets a reference")
 
 	assert.Equal(t, referringIDs[servedStopID], refs[0].ID, "the referring entry's ID labels the reference")
 	assert.NotEmpty(t, refs[0].RouteIDs)
@@ -227,6 +237,12 @@ func TestStopReferences(t *testing.T) {
 	assert.Equal(t, refs[1].RouteIDs, refs[1].StaticRouteIDs)
 	// No stop_times and no shape, so nothing supports a direction.
 	assert.Equal(t, models.UnknownValue, refs[1].Direction)
+
+	assert.Equal(t, 0, refs[2].LocationType)
+	assert.Empty(t, refs[2].Parent)
+
+	assert.Equal(t, 0, refs[3].LocationType)
+	assert.Empty(t, refs[3].Parent)
 }
 
 func TestBuildStopReferencesAndRouteIDsForStops_DeduplicatesStopIDs(t *testing.T) {


### PR DESCRIPTION
## Summary

- preserve GTFS location types in trip stop references
- emit parent station IDs using the reference stop agency
- add regression coverage for both fields

## Root cause

The shared stop-reference builder hardcoded locationType to 0 and parent to an empty string.

## Validation

- go vet -tags "sqlite_fts5 sqlite_math_functions" ./...
- go vet -tags "purego" ./...
- make test
- go fmt ./...

Closes #1340

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Stop references now preserve location type information from the database.
  * Parent station references now include the appropriate agency context when available.
  * Improved handling of missing location type and parent station values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->