### PR TITLE
Default routes-for-location maxCount to 10

### DIFF
--- a/internal/models/constants.go
+++ b/internal/models/constants.go
@@ -24,9 +24,11 @@ const (
 )
 
 const (
-	DefaultMaxCountForRoutes = 50
-	DefaultMaxCountForStops  = 100
-	MaxAllowedCount          = 250
+	DefaultMaxCountForStops = 100
+	MaxAllowedCount         = 250
+	// DefaultMaxCountForRoutesForLocation is the routes-for-location default when the
+	// caller omits maxCount; MaxCountForRoutesForLocation is the ceiling it is clamped to.
+	DefaultMaxCountForRoutesForLocation = 10
 	// MaxCountForRoutesForLocation is the routes-for-location ceiling; the endpoint
 	// silently clamps larger requests instead of rejecting them.
 	MaxCountForRoutesForLocation = 50

--- a/internal/restapi/routes_for_location_handler.go
+++ b/internal/restapi/routes_for_location_handler.go
@@ -18,7 +18,7 @@ func (api *RestAPI) routesForLocationHandler(w http.ResponseWriter, r *http.Requ
 
 	var fieldErrors map[string][]string
 	loc, fieldErrors := api.parseLocationParams(r, fieldErrors)
-	maxCount, fieldErrors := utils.ParseMaxCountClamped(queryParams, models.DefaultMaxCountForRoutes, fieldErrors)
+	maxCount, fieldErrors := utils.ParseMaxCountClamped(queryParams, models.DefaultMaxCountForRoutesForLocation, fieldErrors)
 
 	if len(fieldErrors) > 0 {
 		api.validationErrorResponse(w, r, fieldErrors)

--- a/internal/restapi/routes_for_location_handler_test.go
+++ b/internal/restapi/routes_for_location_handler_test.go
@@ -62,8 +62,11 @@ func TestRoutesForLocationBoundingBoxSizing(t *testing.T) {
 		expectedRouteIDs []string
 	}{
 		{
+			// maxCount is set explicitly above the RABA fixture's route count so this
+			// case stays about box sizing; the endpoint's default maxCount (10) would
+			// otherwise randomly truncate these 13 matches on every run.
 			name:             "spans widen the box beyond the default radius",
-			params:           denseCentre + "&latSpan=0.1&lonSpan=0.1",
+			params:           denseCentre + "&latSpan=0.1&lonSpan=0.1&maxCount=50",
 			expectedRouteIDs: []string{"25_15", "25_151", "25_153", "25_154", "25_157", "25_159", "25_160", "25_161", "25_1885", "25_24", "25_3779", "25_44X", "25_6446"},
 		},
 		{
@@ -385,6 +388,22 @@ func TestRoutesForLocationHandlerClampsMaxCountAboveCap(t *testing.T) {
 			assert.Equal(t, tt.wantExceeds, model.Data.LimitExceeded)
 		})
 	}
+}
+
+func TestRoutesForLocationHandlerDefaultsMaxCountToTen(t *testing.T) {
+	const lat, lon = 40.583321, -122.362535
+	api := createTestApi(t)
+	// Seed past 10 in-bounds routes so the spec default (10, not the endpoint's
+	// 50 clamp ceiling) is actually observable.
+	seedRoutesNearLocation(t, api, lat, lon, 15)
+
+	resp, model := callAPIHandler[RoutesResponse](t, api,
+		fmt.Sprintf("/api/where/routes-for-location.json?key=TEST&lat=%v&lon=%v&radius=5000", lat, lon))
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, http.StatusOK, model.Code)
+	assert.Len(t, model.Data.List, 10)
+	assert.True(t, model.Data.LimitExceeded)
 }
 
 // routesForLocationShuffleIterations bounds the flake probability of


### PR DESCRIPTION
Closes #1355

`maxCount` defaulted to 50 on `routes-for-location`; the spec and Java's
`MaxCountSupport(10, 50)` both use 10 as the default and 50 as the ceiling. The 50 default
predates the spec review and was unrelated to the clamping fix in #1231.

- `DefaultMaxCountForRoutes` (50) replaced by `DefaultMaxCountForRoutesForLocation` (10),
  placed beside the existing ceiling constant.
- New test: no `maxCount` with more than 10 in-bounds routes returns 10 and `limitExceeded: true`.
- The span-sizing case now passes an explicit `maxCount` so it stays about box sizing.