### PR TITLE
Honor includeReferences on routes-for-location

### DIFF
--- a/internal/models/constants.go
+++ b/internal/models/constants.go
@@ -24,9 +24,11 @@ const (
 )
 
 const (
-	DefaultMaxCountForRoutes = 50
-	DefaultMaxCountForStops  = 100
-	MaxAllowedCount          = 250
+	DefaultMaxCountForStops = 100
+	MaxAllowedCount         = 250
+	// DefaultMaxCountForRoutesForLocation is the routes-for-location default when the
+	// caller omits maxCount; MaxCountForRoutesForLocation is the ceiling it is clamped to.
+	DefaultMaxCountForRoutesForLocation = 10
 	// MaxCountForRoutesForLocation is the routes-for-location ceiling; the endpoint
 	// silently clamps larger requests instead of rejecting them.
 	MaxCountForRoutesForLocation = 50

--- a/internal/restapi/routes_for_location_handler.go
+++ b/internal/restapi/routes_for_location_handler.go
@@ -69,18 +69,20 @@ func (api *RestAPI) routesForLocationHandler(w http.ResponseWriter, r *http.Requ
 	}
 
 	references := models.NewEmptyReferences()
+	// When includeReferences=false the references block is present but empty.
+	if ShouldIncludeReferences(r) {
+		agencyIDList := slices.Collect(maps.Keys(agencyIDs))
+		agencies, err := api.GtfsManager.GtfsDB.Queries.GetAgenciesByIDs(ctx, agencyIDList)
+		if err != nil {
+			api.serverErrorResponse(w, r, err)
+			return
+		}
+		references.Agencies = buildAgencyReferences(agencies)
 
-	agencyIDList := slices.Collect(maps.Keys(agencyIDs))
-	agencies, err := api.GtfsManager.GtfsDB.Queries.GetAgenciesByIDs(ctx, agencyIDList)
-	if err != nil {
-		api.serverErrorResponse(w, r, err)
-		return
+		// Populate situation references for alerts affecting the returned routes
+		alerts := api.collectAlertsForRoutes(slices.Collect(maps.Keys(routeIDs)))
+		references.Situations = api.BuildSituationReferences(alerts)
 	}
-	references.Agencies = buildAgencyReferences(agencies)
-
-	// Populate situation references for alerts affecting the returned routes
-	alerts := api.collectAlertsForRoutes(slices.Collect(maps.Keys(routeIDs)))
-	references.Situations = api.BuildSituationReferences(alerts)
 
 	// Results must be sorted by ID after maxCount limit is applied.
 	// See how response changes when calling java API with different maxCounts.

--- a/internal/restapi/routes_for_location_handler.go
+++ b/internal/restapi/routes_for_location_handler.go
@@ -18,7 +18,7 @@ func (api *RestAPI) routesForLocationHandler(w http.ResponseWriter, r *http.Requ
 
 	var fieldErrors map[string][]string
 	loc, fieldErrors := api.parseLocationParams(r, fieldErrors)
-	maxCount, fieldErrors := utils.ParseMaxCountClamped(queryParams, models.DefaultMaxCountForRoutes, fieldErrors)
+	maxCount, fieldErrors := utils.ParseMaxCountClamped(queryParams, models.DefaultMaxCountForRoutesForLocation, fieldErrors)
 
 	if len(fieldErrors) > 0 {
 		api.validationErrorResponse(w, r, fieldErrors)

--- a/internal/restapi/routes_for_location_handler_test.go
+++ b/internal/restapi/routes_for_location_handler_test.go
@@ -34,6 +34,39 @@ func TestRoutesForLocationHandlerEndToEnd(t *testing.T) {
 	assert.ElementsMatch(t, model.Data.References.Agencies, []models.AgencyReference{testdata.Raba})
 }
 
+func TestRoutesForLocationHandlerIncludeReferences(t *testing.T) {
+	const baseURL = "/api/where/routes-for-location.json?key=TEST&lat=40.583321&lon=-122.426966"
+
+	tests := []struct {
+		name           string
+		params         string
+		wantReferences bool
+	}{
+		{"includeReferences=false suppresses references", "&includeReferences=false", false},
+		{"includeReferences=true populates references", "&includeReferences=true", true},
+		{"includeReferences absent defaults to populated", "", true},
+		{"includeReferences unparseable defaults to populated", "&includeReferences=notabool", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			api := createTestApi(t)
+
+			resp, model := callAPIHandler[RoutesResponse](t, api, baseURL+tt.params)
+
+			require.Equal(t, http.StatusOK, resp.StatusCode)
+			assert.ElementsMatch(t, []models.Route{testdata.Route19}, model.Data.List, "list must be unaffected by includeReferences")
+
+			if tt.wantReferences {
+				assert.ElementsMatch(t, []models.AgencyReference{testdata.Raba}, model.Data.References.Agencies)
+			} else {
+				assert.Empty(t, model.Data.References.Agencies)
+				assert.Empty(t, model.Data.References.Situations)
+			}
+		})
+	}
+}
+
 func TestRoutesForLocationQuery(t *testing.T) {
 	api := createTestApi(t)
 

--- a/internal/restapi/routes_for_location_handler_test.go
+++ b/internal/restapi/routes_for_location_handler_test.go
@@ -62,8 +62,11 @@ func TestRoutesForLocationBoundingBoxSizing(t *testing.T) {
 		expectedRouteIDs []string
 	}{
 		{
+			// maxCount is set explicitly above the RABA fixture's route count so this
+			// case stays about box sizing; the endpoint's default maxCount (10) would
+			// otherwise randomly truncate these 13 matches on every run.
 			name:             "spans widen the box beyond the default radius",
-			params:           denseCentre + "&latSpan=0.1&lonSpan=0.1",
+			params:           denseCentre + "&latSpan=0.1&lonSpan=0.1&maxCount=50",
 			expectedRouteIDs: []string{"25_15", "25_151", "25_153", "25_154", "25_157", "25_159", "25_160", "25_161", "25_1885", "25_24", "25_3779", "25_44X", "25_6446"},
 		},
 		{
@@ -385,6 +388,22 @@ func TestRoutesForLocationHandlerClampsMaxCountAboveCap(t *testing.T) {
 			assert.Equal(t, tt.wantExceeds, model.Data.LimitExceeded)
 		})
 	}
+}
+
+func TestRoutesForLocationHandlerDefaultsMaxCountToTen(t *testing.T) {
+	const lat, lon = 40.583321, -122.362535
+	api := createTestApi(t)
+	// Seed past 10 in-bounds routes so the spec default (10, not the endpoint's
+	// 50 clamp ceiling) is actually observable.
+	seedRoutesNearLocation(t, api, lat, lon, 15)
+
+	resp, model := callAPIHandler[RoutesResponse](t, api,
+		fmt.Sprintf("/api/where/routes-for-location.json?key=TEST&lat=%v&lon=%v&radius=5000", lat, lon))
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, http.StatusOK, model.Code)
+	assert.Len(t, model.Data.List, 10)
+	assert.True(t, model.Data.LimitExceeded)
 }
 
 // routesForLocationShuffleIterations bounds the flake probability of


### PR DESCRIPTION
Closes #1356

`routes-for-location` ignored `includeReferences`, always returning populated
`references.agencies` and `references.situations`. Java applies the flag to every V2 endpoint via
`BeanFactoryV2`.

- Reference building gated on `ShouldIncludeReferences(r)`, following `routes_for_agency_handler.go`.
- `data.list` is unchanged in every case; only `data.references` empties.
- Table-driven test covering `false`, `true`, absent and unparseable values.

Stacked on #1357 (maxCount default) — this branch is built on top of it, so the diff will
shrink to just this change once #1357 merges.