### PR TITLE
Fix/stop routes missing from reference routes in trips-for-route-handler

### DIFF
--- a/internal/restapi/trips_for_route_handler.go
+++ b/internal/restapi/trips_for_route_handler.go
@@ -737,15 +737,31 @@ type tripReferenceParams struct {
 
 func (api *RestAPI) buildTripReferences(ctx context.Context, params tripReferenceParams) models.ReferencesModel {
 	sets := newTripReferenceSets()
+
 	sets.collectPreFetchedTrips(params.PreFetchedTrips)
 	sets.collectTripIDsFromEntries(params.Trips)
 	api.fillMissingTrips(ctx, sets)
-	api.fillRoutesAndAgencies(ctx, sets)
 
 	references := models.NewEmptyReferences()
+	var routeIDsByStopID map[string][]string
+	references.Stops, routeIDsByStopID = api.stopReferences(ctx, params.Stops, params.StopIDMap)
+
+	for _, combinedRouteIDs := range routeIDsByStopID {
+		for _, combinedID := range combinedRouteIDs {
+			rawID, err := utils.ExtractCodeID(combinedID)
+			if err != nil {
+				continue
+			}
+			if _, exists := sets.routes[rawID]; !exists {
+				sets.routes[rawID] = models.Route{}
+			}
+		}
+	}
+
+	api.fillRoutesAndAgencies(ctx, sets)
+
 	references.Agencies = utils.MapValues(sets.agencies)
 	references.Routes = sets.routeList()
-	references.Stops, _ = api.stopReferences(ctx, params.Stops, params.StopIDMap)
 	references.Trips = sets.tripReferenceList(params.IncludeTrip)
 	references.Situations = api.situationReferences(params.Situations)
 	return *references
@@ -780,7 +796,7 @@ func (api *RestAPI) tripSituationRefs(
 // to, keyed by bare ID so each is emitted once.
 type tripReferenceSets struct {
 	trips    map[string]models.Trip
-	routes   map[string]models.Route
+	routes   map[string]models.Route // maps raw route ids to models.Route
 	agencies map[string]models.AgencyReference
 	// missing holds the trips the response refers to — entry tripIds,
 	// schedule.nextTripId/previousTripId, status.activeTripId — whose full

--- a/internal/restapi/trips_for_route_handler_test.go
+++ b/internal/restapi/trips_for_route_handler_test.go
@@ -1501,7 +1501,7 @@ func TestTripsForRouteHandler_StopRoutesResolveInReferences(t *testing.T) {
 		}
 	}
 
-	assert.Contains(t, referenceAgencyIDs, orphanRouteAgencyID, 
+	assert.Contains(t, referenceAgencyIDs, orphanRouteAgencyID,
 		"references.agencies should contain agency: %s for orphaned route: %s", orphanRouteAgencyID, orphanRouteID)
 	for _, route := range refs.Routes {
 		assert.True(t, referenceAgencyIDs[route.AgencyID],

--- a/internal/restapi/trips_for_route_handler_test.go
+++ b/internal/restapi/trips_for_route_handler_test.go
@@ -1501,6 +1501,8 @@ func TestTripsForRouteHandler_StopRoutesResolveInReferences(t *testing.T) {
 		}
 	}
 
+	assert.Contains(t, referenceAgencyIDs, orphanRouteAgencyID, 
+		"references.agencies should contain agency: %s for orphaned route: %s", orphanRouteAgencyID, orphanRouteID)
 	for _, route := range refs.Routes {
 		assert.True(t, referenceAgencyIDs[route.AgencyID],
 			"references.routes entry %s has agencyId %s, which must resolve in references.agencies", route.ID, route.AgencyID)

--- a/internal/restapi/trips_for_route_handler_test.go
+++ b/internal/restapi/trips_for_route_handler_test.go
@@ -53,6 +53,9 @@ const (
 	tripsForRouteStop1ID  = "tfr-stop1"
 	tripsForRouteStop2ID  = "tfr-stop2"
 	tripsForRouteHeadsign = "Test Headsign"
+	orphanRouteAgencyID   = "tfr-agency-x"
+	orphanRouteID         = "tfr-route-x"
+	orphanTripID          = "tfr-trip-x"
 )
 
 // createTestApiWithGTFSFixture builds a RestAPI backed by an in-memory GTFS
@@ -322,6 +325,37 @@ func blockSequenceFiles() map[string]string {
 			"tfr-trip-2,10:05:00,10:05:00," + tripsForRouteStop2ID + ",2\n" +
 			"tfr-trip-3,10:10:00,10:10:00," + tripsForRouteStop1ID + ",1\n" +
 			"tfr-trip-3,10:40:00,10:40:00," + tripsForRouteStop2ID + ",2\n",
+	}
+}
+
+// orphanStopRouteFiles models a stop served by a route no returned trip runs
+// on: tfr-trip (the queried route, tfr-agency) is active at the pinned clock,
+// while orphanTripID (orphanRouteID, owned by a second agency) served the same
+// stops hours earlier and shares no block, so neither it, its route, nor its
+// agency appears among the entries or their trips. The stop references still
+// name orphanRouteID in their routeIds, so both that route and its agency must
+// resolve in the references block.
+func orphanStopRouteFiles() map[string]string {
+	return map[string]string{
+		"agency.txt": "agency_id,agency_name,agency_url,agency_timezone\n" +
+			tripsForRouteAgencyID + ",Test Agency,http://example.com,UTC\n" +
+			orphanRouteAgencyID + ",Other Agency,http://example.com,UTC\n",
+		"routes.txt": "route_id,agency_id,route_short_name,route_long_name,route_type\n" +
+			tripsForRouteRouteID + "," + tripsForRouteAgencyID + ",TR,Test Route,3\n" +
+			orphanRouteID + "," + orphanRouteAgencyID + ",XR,Orphan Route,3\n",
+		"calendar.txt": "service_id,monday,tuesday,wednesday,thursday,friday,saturday,sunday,start_date,end_date\n" +
+			"tfr-svc,1,1,1,1,1,1,1,20240101,20991231\n",
+		"stops.txt": "stop_id,stop_name,stop_lat,stop_lon\n" +
+			tripsForRouteStop1ID + ",Stop One,37.7749,-122.4194\n" +
+			tripsForRouteStop2ID + ",Stop Two,37.7849,-122.4094\n",
+		"trips.txt": "route_id,service_id,trip_id,trip_headsign,direction_id,block_id\n" +
+			tripsForRouteRouteID + ",tfr-svc," + tripsForRouteTripID + "," + tripsForRouteHeadsign + ",0,tfr-block\n" +
+			orphanRouteID + ",tfr-svc," + orphanTripID + ",Orphan Headsign,0,tfr-block-x\n",
+		"stop_times.txt": "trip_id,arrival_time,departure_time,stop_id,stop_sequence\n" +
+			tripsForRouteTripID + ",11:55:00,11:55:00," + tripsForRouteStop1ID + ",1\n" +
+			tripsForRouteTripID + ",12:05:00,12:05:00," + tripsForRouteStop2ID + ",2\n" +
+			orphanTripID + ",08:00:00,08:00:00," + tripsForRouteStop1ID + ",1\n" +
+			orphanTripID + ",08:10:00,08:10:00," + tripsForRouteStop2ID + ",2\n",
 	}
 }
 
@@ -1416,4 +1450,59 @@ func TestTripsForRouteHandler_ReferenceLookupFailureDegradesGracefully(t *testin
 		"the pre-fetched entry trip must still be referenced despite the lookup failure")
 	require.NotContains(t, refTrips, utils.FormCombinedID(tripsForRouteAgencyID, "tfr-trip-1"),
 		"the unfetchable adjacent trip must not appear in references")
+}
+
+// TestTripsForRouteHandler_StopRoutesResolveInReferences verifies that every route referenced by a stop
+// (including routes no returned trip runs on) resolve to a route on references.routes and that these
+// route agencies resolve in references.agencies.
+func TestTripsForRouteHandler_StopRoutesResolveInReferences(t *testing.T) {
+	api := createTestApiWithGTFSFixture(t, clock.NewMockClock(tripsForRouteTestClock),
+		"trips-for-route-orphan-stop-route.zip", orphanStopRouteFiles())
+
+	combinedRouteID := utils.FormCombinedID(tripsForRouteAgencyID, tripsForRouteRouteID)
+	url := fmt.Sprintf("/api/where/trips-for-route/%s.json?key=TEST&includeSchedule=true&time=%d",
+		combinedRouteID, tripsForRouteTestClock.UnixMilli())
+
+	resp, model := callAPIHandler[TripsForRouteResponse](t, api, url)
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Len(t, model.Data.List, 1, "only the queried route's trip should be active at the pinned clock")
+
+	expectedTripID := utils.FormCombinedID(tripsForRouteAgencyID, tripsForRouteTripID)
+	assert.Equal(t, expectedTripID, model.Data.List[0].TripId,
+		"the single returned trip must be the queried route's, not the orphan route's")
+
+	refs := model.Data.References
+
+	referenceRouteIDs := make(map[string]bool, len(refs.Routes))
+	for _, route := range refs.Routes {
+		referenceRouteIDs[route.ID] = true
+	}
+	referenceAgencyIDs := make(map[string]bool, len(refs.Agencies))
+	for _, agency := range refs.Agencies {
+		referenceAgencyIDs[agency.ID] = true
+	}
+
+	combinedOrphanRouteID := utils.FormCombinedID(orphanRouteAgencyID, orphanRouteID)
+	require.Len(t, refs.Stops, 2, "references.stops should reference both fixture stops when includeSchedule=true")
+	for _, stop := range refs.Stops {
+		assert.Contains(t, stop.RouteIDs, combinedOrphanRouteID,
+			"stop %s should name the orphan route from the other agency", stop.ID)
+	}
+
+	for _, stop := range refs.Stops {
+		for _, routeID := range stop.RouteIDs {
+			assert.True(t, referenceRouteIDs[routeID],
+				"stop %s emits routeId %s, which must resolve in references.routes", stop.ID, routeID)
+		}
+		for _, routeID := range stop.StaticRouteIDs {
+			assert.True(t, referenceRouteIDs[routeID],
+				"stop %s emits staticRouteId %s, which must resolve in references.routes", stop.ID, routeID)
+		}
+	}
+
+	for _, route := range refs.Routes {
+		assert.True(t, referenceAgencyIDs[route.AgencyID],
+			"references.routes entry %s has agencyId %s, which must resolve in references.agencies", route.ID, route.AgencyID)
+	}
 }


### PR DESCRIPTION
# Fix dangling stop route references in trips-for-route
Closes #1339

## Problem
In the `trips-for-route` response, `references.routes` was built exclusively from
the routes of the returned trips: `buildTripReferences` seeded `sets.routes` from
`trip.RouteID` (`collectPreFetchedTrips`) and then resolved routes and agencies in
`fillRoutesAndAgencies`. A stop served by a route that **no returned trip runs on**
 emits a `routeId` that resolves to nothing in `references.routes`.

## Fix

`internal/restapi/trips_for_route_handler.go` — `buildTripReferences`:

1. Call `api.stopReferences` **before** `fillRoutesAndAgencies` and keep the returned
   route-IDs-by-stop map.
2. Register those route IDs into `sets.routes` before route/agency resolution runs.
3. `fillRoutesAndAgencies` then resolves both the full route objects **and** their
   agencies (`addAgencyReference`), so routes and agencies are filled in by the one
   existing mechanism.

## Testing

Added a regression test `TestTripsForRouteHandler_StopRoutesResolveInReferences` with a 
synthetic fixture, `orphanStopRouteFiles()`. The test asserts that routes serving stops which
are not associated with any returned trips are correctly resolved in `references.routes`
alongside the route agencies in `references.agencies`. It fails in the pre-fix code and passes
post-fix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Route and agency references are now included when they are associated with returned stops, even if no active trip is returned for those routes.
  * Results continue to include only active trips for the specifically queried route.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->