### PR TITLE
Add nulls.ValidInt64Count helper

### DIFF
--- a/internal/nulls/database.go
+++ b/internal/nulls/database.go
@@ -33,6 +33,17 @@ func Int64OrDefault(ni sql.NullInt64, defaultValue int64) int64 {
 	return defaultValue
 }
 
+// ValidInt64Count returns the number of non-null values.
+func ValidInt64Count(values ...sql.NullInt64) int {
+	count := 0
+	for _, value := range values {
+		if value.Valid {
+			count++
+		}
+	}
+	return count
+}
+
 // WheelchairBoardingOrUnknown returns the wheelchair boarding value if valid, otherwise returns NotSpecified
 func WheelchairBoardingOrUnknown(ni sql.NullInt64) gtfs.WheelchairBoarding {
 	if ni.Valid {

--- a/internal/nulls/database_test.go
+++ b/internal/nulls/database_test.go
@@ -24,6 +24,14 @@ func TestNullInt64OrDefault(t *testing.T) {
 	assert.Equal(t, int64(10), Int64OrDefault(sql.NullInt64{Int64: 42, Valid: false}, 10))
 }
 
+func TestValidInt64Count(t *testing.T) {
+	assert.Equal(t, 2, ValidInt64Count(
+		sql.NullInt64{Int64: 1, Valid: true},
+		sql.NullInt64{},
+		sql.NullInt64{Int64: 3, Valid: true},
+	))
+}
+
 func TestNonEmptyString(t *testing.T) {
 	assert.Equal(t, sql.NullString{String: "test", Valid: true}, NonEmptyString("test"))
 	assert.Equal(t, sql.NullString{String: "", Valid: false}, NonEmptyString(""))


### PR DESCRIPTION
## Summary

- Add `nulls.ValidInt64Count`, a small helper that counts how many `sql.NullInt64` values in a variadic list are valid.

## Context

Extracted from #1343 ("Add frequency-based schedule-for-stop service"). That PR's `schedule_for_stop_handler.go` changes collide with the in-flight #1348 ("GTFS Frequencies Phase 3"), which is taking over that file. This helper has no dependency on the rest of #1343's changes and is general-purpose (counting valid frequency-row fields to decide whether a row is usable), so it's being carved out on its own rather than getting lost when #1343 closes.

## Validation

- `go vet -tags "sqlite_fts5 sqlite_math_functions" ./...`
- `go vet -tags "purego" ./...`
- `make test`
- `go fmt ./...`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for counting valid numeric values while ignoring null entries.

* **Tests**
  * Added coverage to verify accurate counting when valid and null values are mixed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->