### PR TITLE
Stop caching real-time responses as static

### DIFF
--- a/internal/restapi/caching_middleware_test.go
+++ b/internal/restapi/caching_middleware_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCacheControlHeaders(t *testing.T) {
@@ -51,6 +52,41 @@ func TestCacheControlHeaders(t *testing.T) {
 
 			gotHeader := resp.Header.Get("Cache-Control")
 			assert.Equal(t, tt.expectedHeader, gotHeader, "Cache-Control header mismatch for %s", tt.endpoint)
+		})
+	}
+}
+
+// TestRealtimeEndpointsAreNotCachedAsStatic guards the endpoints that put real-time
+// service alerts in references.situations. The ETag is the static feed's file hash, so
+// serving one alongside alert data hands clients a 304 for as long as the feed is
+// unchanged, however often the alerts move.
+func TestRealtimeEndpointsAreNotCachedAsStatic(t *testing.T) {
+	api := createTestApi(t)
+
+	mux := http.NewServeMux()
+	api.SetRoutes(mux)
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	endpoints := []struct {
+		name     string
+		endpoint string
+	}{
+		{"search stop", "/api/where/search/stop.json?input=Buenaventura&key=TEST"},
+		{"search route", "/api/where/search/route.json?input=Route&key=TEST"},
+		{"route", "/api/where/route/25_151.json?key=TEST"},
+	}
+
+	for _, tt := range endpoints {
+		t.Run(tt.name, func(t *testing.T) {
+			resp, err := http.Get(server.URL + tt.endpoint)
+			require.NoError(t, err)
+			defer func() { _ = resp.Body.Close() }()
+
+			assert.Empty(t, resp.Header.Get("ETag"),
+				"%s carries real-time alerts and must not be validated against the static feed hash", tt.endpoint)
+			assert.Equal(t, "public, max-age=30", resp.Header.Get("Cache-Control"),
+				"%s carries real-time alerts and must not be cached as static", tt.endpoint)
 		})
 	}
 }

--- a/internal/restapi/routes.go
+++ b/internal/restapi/routes.go
@@ -77,11 +77,11 @@ func (api *RestAPI) SetRoutes(mux *http.ServeMux) {
 
 	// --- Routes without ID validation ---
 	mux.Handle("GET /api/where/agencies-with-coverage.json", CacheControlMiddleware(models.CacheDurationLong, rateLimitAndValidateAPIKey(api, etagStatic(api, api.agenciesWithCoverageHandler))))
-	mux.Handle("GET /api/where/search/stop.json", CacheControlMiddleware(models.CacheDurationLong, rateLimitAndValidateAPIKey(api, etagStatic(api, api.searchStopsHandler))))
-	mux.Handle("GET /api/where/search/route.json", CacheControlMiddleware(models.CacheDurationLong, rateLimitAndValidateAPIKey(api, etagStatic(api, api.routeSearchHandler))))
 
 	// Non-static endpoints (no ETag)
 	mux.Handle("GET /api/where/current-time.json", CacheControlMiddleware(models.CacheDurationShort, rateLimitAndValidateAPIKey(api, api.currentTimeHandler)))
+	mux.Handle("GET /api/where/search/stop.json", CacheControlMiddleware(models.CacheDurationShort, rateLimitAndValidateAPIKey(api, api.searchStopsHandler)))
+	mux.Handle("GET /api/where/search/route.json", CacheControlMiddleware(models.CacheDurationShort, rateLimitAndValidateAPIKey(api, api.routeSearchHandler)))
 	mux.Handle("GET /api/where/stops-for-location.json", CacheControlMiddleware(models.CacheDurationShort, rateLimitAndValidateAPIKey(api, api.stopsForLocationHandler)))
 	mux.Handle("GET /api/where/routes-for-location.json", CacheControlMiddleware(models.CacheDurationShort, rateLimitAndValidateAPIKey(api, api.routesForLocationHandler)))
 	mux.Handle("GET /api/where/trips-for-location.json", CacheControlMiddleware(models.CacheDurationShort, rateLimitAndValidateAPIKey(api, api.tripsForLocationHandler)))
@@ -99,7 +99,6 @@ func (api *RestAPI) SetRoutes(mux *http.ServeMux) {
 
 	// --- Routes with combined ID validation (agency_id_code format) ---
 	mux.Handle("GET /api/where/trip/{id}", CacheControlMiddleware(models.CacheDurationLong, rateLimitAndValidateAPIKey(api, etagStatic(api, api.tripHandler))))
-	mux.Handle("GET /api/where/route/{id}", CacheControlMiddleware(models.CacheDurationLong, rateLimitAndValidateAPIKey(api, etagStatic(api, api.routeHandler))))
 	mux.Handle("GET /api/where/stop/{id}", CacheControlMiddleware(models.CacheDurationLong, rateLimitAndValidateAPIKey(api, etagStatic(api, api.stopHandler))))
 	mux.Handle("GET /api/where/shape/{id}", CacheControlMiddleware(models.CacheDurationLong, rateLimitAndValidateAPIKey(api, etagStatic(api, api.shapesHandler))))
 	mux.Handle("GET /api/where/stops-for-route/{id}", CacheControlMiddleware(models.CacheDurationLong, rateLimitAndValidateAPIKey(api, etagStatic(api, api.stopsForRouteHandler))))
@@ -108,6 +107,7 @@ func (api *RestAPI) SetRoutes(mux *http.ServeMux) {
 	mux.Handle("GET /api/where/block/{id}", CacheControlMiddleware(models.CacheDurationLong, rateLimitAndValidateAPIKey(api, etagStatic(api, api.blockHandler))))
 
 	// Real-time or transactional combined ID endpoints (no ETag)
+	mux.Handle("GET /api/where/route/{id}", CacheControlMiddleware(models.CacheDurationShort, rateLimitAndValidateAPIKey(api, api.routeHandler)))
 	mux.Handle("GET /api/where/report-problem-with-trip/{id}", CacheControlMiddleware(models.CacheDurationNone, rateLimitAndValidateAPIKey(api, api.reportProblemWithTripHandler)))
 	mux.Handle("GET /api/where/report-problem-with-stop/{id}", CacheControlMiddleware(models.CacheDurationNone, rateLimitAndValidateAPIKey(api, api.reportProblemWithStopHandler)))
 	mux.Handle("GET /api/where/problem-reports-for-trip/{id}", CacheControlMiddleware(models.CacheDurationNone, rateLimitAndValidateProtectedAPIKey(api, api.problemReportsForTripHandler)))


### PR DESCRIPTION
Closes #1370.

`search/stop.json` returns real-time service alerts in `references.situations` but was registered with `etagStatic` and `CacheDurationLong`. That ETag is the static feed's file hash, which does not change when an alert appears or clears — so a conditional request gets a `304` with stale alerts for as long as the feed is unchanged, and an unconditional one can serve a five-minute-old alert set.

`search/route.json` and `route/{id}` have the same defect, so all three move to the short cache with no ETag, next to the other real-time endpoints. The issue names only `search/stop.json`; fixing it alone would leave the siblings broken.

Verified with `make test` and `go vet` under both build tag sets. The added test fails on all three endpoints without the routing change.

Note: if #1371 resolves that `search-stop` should not emit situations at all — the deployed Puget Sound server returns an empty `situations` array for it — then that endpoint becomes genuinely static and this change should be reverted for it. `route/{id}` and `search/route.json` are unaffected either way.
