### PR TITLE
Fix schedule-for-stop references for route-less stops and no-service dates

### DIFF
--- a/internal/restapi/http_test.go
+++ b/internal/restapi/http_test.go
@@ -204,6 +204,18 @@ func mustGetStops(t testing.TB, api *RestAPI) []gtfsdb.Stop {
 	return stops
 }
 
+// mustGetStopWithoutRoutes returns the ID of a stop no trip calls at, which is
+// therefore served by no routes. The RABA fixture has 21 of them.
+func mustGetStopWithoutRoutes(t testing.TB, api *RestAPI) string {
+	t.Helper()
+	var stopID string
+	err := api.GtfsManager.GtfsDB.DB.QueryRowContext(context.Background(),
+		`SELECT id FROM stops WHERE id NOT IN (SELECT DISTINCT stop_id FROM stop_times) LIMIT 1`,
+	).Scan(&stopID)
+	require.NoError(t, err, "test data should contain at least one stop with no stop times")
+	return stopID
+}
+
 // mustGetStop return an active stop from the DB (stop with stop times)
 func mustGetStop(t testing.TB, api *RestAPI) gtfsdb.Stop {
 	t.Helper()

--- a/internal/restapi/schedule_for_stop_handler.go
+++ b/internal/restapi/schedule_for_stop_handler.go
@@ -95,15 +95,8 @@ func (api *RestAPI) scheduleForStopHandler(w http.ResponseWriter, r *http.Reques
 		routeIDs = append(routeIDs, rt.ID)
 	}
 
-	if len(routeIDs) == 0 {
-		api.sendResponse(w, r, models.NewEntryResponse(
-			models.NewScheduleForStopEntry(utils.FormCombinedID(agencyID, stopID), responseDate, nil),
-			*models.NewEmptyReferences(),
-			api.Clock,
-		))
-		return
-	}
-
+	// A stop with no routes falls through the normal path: GetScheduleForStopOnDate
+	// expands an empty route ID slice to IN (NULL) and returns no rows.
 	params := gtfsdb.GetScheduleForStopOnDateParams{
 		StopID:     stopID,
 		TargetDate: targetDate,

--- a/internal/restapi/schedule_for_stop_handler.go
+++ b/internal/restapi/schedule_for_stop_handler.go
@@ -211,7 +211,7 @@ func (api *RestAPI) scheduleForStopHandler(w http.ResponseWriter, r *http.Reques
 
 	references := models.NewEmptyReferences()
 	if ShouldIncludeReferences(r) {
-		references, err = api.buildScheduleForStopReferences(ctx, agencyID, agency, stop, scheduleRows, routeIDs)
+		references, err = api.buildScheduleForStopReferences(ctx, agencyID, stop, routesForStop, routeIDs)
 		if err != nil {
 			api.serverErrorResponse(w, r, err)
 			return
@@ -225,22 +225,18 @@ func (api *RestAPI) scheduleForStopHandler(w http.ResponseWriter, r *http.Reques
 
 // buildScheduleForStopReferences builds the agency, route, and stop references
 // for the schedule-for-stop entry. Only called when includeReferences=true.
+// References describe the routes serving the stop, not just the ones running on
+// the queried date, so they stay populated on dates with no active service.
 func (api *RestAPI) buildScheduleForStopReferences(
 	ctx context.Context,
 	agencyID string,
-	agency gtfsdb.Agency,
 	stop gtfsdb.Stop,
-	scheduleRows []gtfsdb.GetScheduleForStopOnDateRow,
+	routesForStop []gtfsdb.GetRoutesForStopRow,
 	routeIDs []string,
 ) (*models.ReferencesModel, error) {
-	routeIDsToFetch, agencyIDsToFetch := collectRouteAndAgencyIDs(scheduleRows)
+	routeRefs, agencyIDs := buildRouteRefs(agencyID, routesForStop)
 
-	routeRefs, err := api.fetchRouteRefs(ctx, agencyID, routeIDsToFetch)
-	if err != nil {
-		return nil, err
-	}
-
-	agencyRefs, err := api.fetchAgencyRefs(ctx, agency, agencyIDsToFetch)
+	agencyRefs, err := api.fetchAgencyRefs(ctx, agencyIDs)
 	if err != nil {
 		return nil, err
 	}
@@ -253,65 +249,42 @@ func (api *RestAPI) buildScheduleForStopReferences(
 	return references, nil
 }
 
-// collectRouteAndAgencyIDs collects the distinct route and agency IDs referenced
-// across a stop's schedule rows, for batch fetching.
-func collectRouteAndAgencyIDs(scheduleRows []gtfsdb.GetScheduleForStopOnDateRow) (routeIDs, agencyIDs []string) {
-	uniqueRouteIDs := make(map[string]bool)
-	uniqueAgencyIDs := make(map[string]bool)
+// buildRouteRefs converts the stop's routes into a combined-ID-keyed reference map,
+// alongside the distinct agency IDs those routes belong to.
+func buildRouteRefs(agencyID string, routesForStop []gtfsdb.GetRoutesForStopRow) (map[string]models.Route, []string) {
+	routeRefs := make(map[string]models.Route, len(routesForStop))
+	agencyIDs := make([]string, 0, len(routesForStop))
+	seenAgencies := make(map[string]bool, len(routesForStop))
 
-	for _, row := range scheduleRows {
-		uniqueRouteIDs[row.RouteID] = true
-		uniqueAgencyIDs[row.AgencyID] = true
-	}
-
-	routeIDs = make([]string, 0, len(uniqueRouteIDs))
-	for id := range uniqueRouteIDs {
-		routeIDs = append(routeIDs, id)
-	}
-
-	agencyIDs = make([]string, 0, len(uniqueAgencyIDs))
-	for id := range uniqueAgencyIDs {
-		agencyIDs = append(agencyIDs, id)
-	}
-
-	return routeIDs, agencyIDs
-}
-
-// fetchRouteRefs batch-fetches routes by ID and builds their
-// combined-ID-keyed reference map.
-func (api *RestAPI) fetchRouteRefs(ctx context.Context, agencyID string, routeIDs []string) (map[string]models.Route, error) {
-	routeRefs := make(map[string]models.Route)
-	if len(routeIDs) == 0 {
-		return routeRefs, nil
-	}
-
-	fetchedRoutes, err := api.GtfsManager.GtfsDB.Queries.GetRoutesByIDs(ctx, routeIDs)
-	if err != nil {
-		return nil, err
-	}
-
-	for _, route := range fetchedRoutes {
+	for _, route := range routesForStop {
 		combinedRouteID := utils.FormCombinedID(agencyID, route.ID)
 		routeRefs[combinedRouteID] = models.NewRoute(
 			combinedRouteID,
 			route.AgencyID,
-			route.ShortName.String,
-			route.LongName.String,
-			route.Desc.String,
+			nulls.StringOrEmpty(route.ShortName),
+			nulls.StringOrEmpty(route.LongName),
+			nulls.StringOrEmpty(route.Desc),
 			models.RouteType(route.Type),
-			route.Url.String,
-			route.Color.String,
-			route.TextColor.String)
+			nulls.StringOrEmpty(route.Url),
+			nulls.StringOrEmpty(route.Color),
+			nulls.StringOrEmpty(route.TextColor))
+
+		if !seenAgencies[route.AgencyID] {
+			seenAgencies[route.AgencyID] = true
+			agencyIDs = append(agencyIDs, route.AgencyID)
+		}
 	}
 
-	return routeRefs, nil
+	return routeRefs, agencyIDs
 }
 
 // fetchAgencyRefs batch-fetches agencies by ID and builds their
-// ID-keyed reference map, seeded with the stop's own already-fetched agency.
-func (api *RestAPI) fetchAgencyRefs(ctx context.Context, seedAgency gtfsdb.Agency, agencyIDs []string) (map[string]models.AgencyReference, error) {
-	agencyRefs := make(map[string]models.AgencyReference)
-	agencyRefs[seedAgency.ID] = models.AgencyReferenceFromDatabase(&seedAgency)
+// ID-keyed reference map.
+func (api *RestAPI) fetchAgencyRefs(ctx context.Context, agencyIDs []string) (map[string]models.AgencyReference, error) {
+	agencyRefs := make(map[string]models.AgencyReference, len(agencyIDs))
+	if len(agencyIDs) == 0 {
+		return agencyRefs, nil
+	}
 
 	fetchedAgencies, err := api.GtfsManager.GtfsDB.Queries.GetAgenciesByIDs(ctx, agencyIDs)
 	if err != nil {
@@ -319,9 +292,7 @@ func (api *RestAPI) fetchAgencyRefs(ctx context.Context, seedAgency gtfsdb.Agenc
 	}
 
 	for _, a := range fetchedAgencies {
-		if _, exists := agencyRefs[a.ID]; !exists {
-			agencyRefs[a.ID] = models.AgencyReferenceFromDatabase(&a)
-		}
+		agencyRefs[a.ID] = models.AgencyReferenceFromDatabase(&a)
 	}
 
 	return agencyRefs, nil

--- a/internal/restapi/schedule_for_stop_handler_test.go
+++ b/internal/restapi/schedule_for_stop_handler_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"fmt"
 	"net/http"
+	"slices"
 	"testing"
 	"time"
 
@@ -373,44 +374,72 @@ func TestScheduleForStopHandlerScheduleContent(t *testing.T) {
 	})
 }
 
+// referenceIDs pulls the id out of each record in a references list, for comparing a
+// response's references against the set the fixture says it should contain.
+func referenceIDs(t testing.TB, referenceList any) []string {
+	t.Helper()
+
+	records, ok := referenceList.([]any)
+	require.True(t, ok, "reference list should be an array")
+
+	ids := make([]string, 0, len(records))
+	for _, record := range records {
+		id, ok := record.(map[string]any)["id"].(string)
+		require.True(t, ok, "every reference record should carry a string id")
+		ids = append(ids, id)
+	}
+
+	return ids
+}
+
 func TestScheduleForStopHandlerReferencesWithoutSchedule(t *testing.T) {
 	api := createTestApi(t)
 	defer api.Shutdown()
 
 	agencyID := mustGetAgencies(t, api)[0].ID
 	routelessStopID := utils.FormCombinedID(agencyID, mustGetStopWithoutRoutes(t, api))
-	servedStopID := utils.FormCombinedID(agencyID, mustGetStop(t, api).ID)
+
+	// The served stop's own routes are the reference set the handler is expected to
+	// return, whatever the queried date, so derive both expectations from them.
+	servedStop := mustGetStop(t, api)
+	servingRoutes, err := api.GtfsManager.GtfsDB.Queries.GetRoutesForStop(context.Background(), servedStop.ID)
+	require.NoError(t, err)
+	require.NotEmpty(t, servingRoutes, "the served stop should have routes to reference")
+
+	wantRouteIDs := make([]string, 0, len(servingRoutes))
+	wantAgencyIDs := make([]string, 0, len(servingRoutes))
+	for _, route := range servingRoutes {
+		wantRouteIDs = append(wantRouteIDs, utils.FormCombinedID(agencyID, route.ID))
+		if !slices.Contains(wantAgencyIDs, route.AgencyID) {
+			wantAgencyIDs = append(wantAgencyIDs, route.AgencyID)
+		}
+	}
 
 	tests := []struct {
-		name              string
-		endpoint          string
-		wantStopRef       bool
-		wantRoutesEmpty   bool
-		wantAgenciesEmpty bool
+		name          string
+		endpoint      string
+		wantStopRef   bool
+		wantRouteIDs  []string
+		wantAgencyIDs []string
 	}{
 		{
 			// The stop still has to be resolvable from entry.stopId even though
 			// it has nothing scheduled.
-			name:              "stop with no routes still references the stop",
-			endpoint:          "/api/where/schedule-for-stop/" + routelessStopID + ".json?key=org.onebusaway.iphone",
-			wantStopRef:       true,
-			wantRoutesEmpty:   true,
-			wantAgenciesEmpty: true,
+			name:        "stop with no routes still references the stop",
+			endpoint:    "/api/where/schedule-for-stop/" + routelessStopID + ".json?key=org.onebusaway.iphone",
+			wantStopRef: true,
 		},
 		{
-			name:              "stop with no routes honors includeReferences=false",
-			endpoint:          "/api/where/schedule-for-stop/" + routelessStopID + ".json?key=org.onebusaway.iphone&includeReferences=false",
-			wantStopRef:       false,
-			wantRoutesEmpty:   true,
-			wantAgenciesEmpty: true,
+			name:     "stop with no routes honors includeReferences=false",
+			endpoint: "/api/where/schedule-for-stop/" + routelessStopID + ".json?key=org.onebusaway.iphone&includeReferences=false",
 		},
 		{
 			// NOTE: Hardcoded date falls outside the GTFS data's validity period.
-			name:              "routes stay referenced on a date with no service",
-			endpoint:          "/api/where/schedule-for-stop/" + servedStopID + ".json?key=org.onebusaway.iphone&date=2030-01-01",
-			wantStopRef:       true,
-			wantRoutesEmpty:   false,
-			wantAgenciesEmpty: false,
+			name:          "routes stay referenced on a date with no service",
+			endpoint:      "/api/where/schedule-for-stop/" + utils.FormCombinedID(agencyID, servedStop.ID) + ".json?key=org.onebusaway.iphone&date=2030-01-01",
+			wantStopRef:   true,
+			wantRouteIDs:  wantRouteIDs,
+			wantAgencyIDs: wantAgencyIDs,
 		},
 	}
 
@@ -439,17 +468,8 @@ func TestScheduleForStopHandlerReferencesWithoutSchedule(t *testing.T) {
 				assert.Empty(t, stops)
 			}
 
-			if tt.wantRoutesEmpty {
-				assert.Empty(t, references["routes"])
-			} else {
-				assert.NotEmpty(t, references["routes"])
-			}
-
-			if tt.wantAgenciesEmpty {
-				assert.Empty(t, references["agencies"])
-			} else {
-				assert.NotEmpty(t, references["agencies"])
-			}
+			assert.ElementsMatch(t, tt.wantRouteIDs, referenceIDs(t, references["routes"]))
+			assert.ElementsMatch(t, tt.wantAgencyIDs, referenceIDs(t, references["agencies"]))
 		})
 	}
 }

--- a/internal/restapi/schedule_for_stop_handler_test.go
+++ b/internal/restapi/schedule_for_stop_handler_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"maglev.onebusaway.org/gtfsdb"
 	"maglev.onebusaway.org/internal/clock"
 	"maglev.onebusaway.org/internal/utils"
@@ -372,30 +373,85 @@ func TestScheduleForStopHandlerScheduleContent(t *testing.T) {
 	})
 }
 
-func TestScheduleForStopHandlerEmptyRoutes(t *testing.T) {
-	clk := clock.NewMockClock(time.Date(2025, 12, 26, 12, 0, 0, 0, time.UTC))
-	api := createTestApiWithClock(t, clk)
+func TestScheduleForStopHandlerReferencesWithoutSchedule(t *testing.T) {
+	api := createTestApi(t)
 	defer api.Shutdown()
 
-	agencies := mustGetAgencies(t, api)
-	stops := mustGetStops(t, api)
+	agencyID := mustGetAgencies(t, api)[0].ID
+	routelessStopID := utils.FormCombinedID(agencyID, mustGetStopWithoutRoutes(t, api))
+	servedStopID := utils.FormCombinedID(agencyID, mustGetStop(t, api).ID)
 
-	t.Run("Stop with no routes returns empty schedule", func(t *testing.T) {
-		stopID := utils.FormCombinedID(agencies[0].ID, stops[0].ID)
-		// NOTE: Hardcoded date matches GTFS data validity
-		endpoint := "/api/where/schedule-for-stop/" + stopID + ".json?key=TEST&date=2025-06-12"
-		resp, model := serveApiAndRetrieveEndpoint(t, api, endpoint)
+	tests := []struct {
+		name              string
+		endpoint          string
+		wantStopRef       bool
+		wantRoutesEmpty   bool
+		wantAgenciesEmpty bool
+	}{
+		{
+			// The stop still has to be resolvable from entry.stopId even though
+			// it has nothing scheduled.
+			name:              "stop with no routes still references the stop",
+			endpoint:          "/api/where/schedule-for-stop/" + routelessStopID + ".json?key=org.onebusaway.iphone",
+			wantStopRef:       true,
+			wantRoutesEmpty:   true,
+			wantAgenciesEmpty: true,
+		},
+		{
+			name:              "stop with no routes honors includeReferences=false",
+			endpoint:          "/api/where/schedule-for-stop/" + routelessStopID + ".json?key=org.onebusaway.iphone&includeReferences=false",
+			wantStopRef:       false,
+			wantRoutesEmpty:   true,
+			wantAgenciesEmpty: true,
+		},
+		{
+			// NOTE: Hardcoded date falls outside the GTFS data's validity period.
+			name:              "routes stay referenced on a date with no service",
+			endpoint:          "/api/where/schedule-for-stop/" + servedStopID + ".json?key=org.onebusaway.iphone&date=2030-01-01",
+			wantStopRef:       true,
+			wantRoutesEmpty:   false,
+			wantAgenciesEmpty: false,
+		},
+	}
 
-		assert.Equal(t, http.StatusOK, resp.StatusCode)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp, model := serveApiAndRetrieveEndpoint(t, api, tt.endpoint)
+			assert.Equal(t, http.StatusOK, resp.StatusCode)
 
-		data, ok := model.Data.(map[string]any)
-		assert.True(t, ok)
+			data, ok := model.Data.(map[string]any)
+			require.True(t, ok)
 
-		entry, ok := data["entry"].(map[string]any)
-		assert.True(t, ok)
+			entry, ok := data["entry"].(map[string]any)
+			require.True(t, ok)
+			assert.Empty(t, entry["stopRouteSchedules"])
 
-		assert.NotNil(t, entry["stopRouteSchedules"])
-	})
+			references, ok := data["references"].(map[string]any)
+			require.True(t, ok)
+
+			stops, _ := references["stops"].([]any)
+			if tt.wantStopRef {
+				require.Len(t, stops, 1)
+				stopRef, ok := stops[0].(map[string]any)
+				require.True(t, ok)
+				assert.Equal(t, entry["stopId"], stopRef["id"])
+			} else {
+				assert.Empty(t, stops)
+			}
+
+			if tt.wantRoutesEmpty {
+				assert.Empty(t, references["routes"])
+			} else {
+				assert.NotEmpty(t, references["routes"])
+			}
+
+			if tt.wantAgenciesEmpty {
+				assert.Empty(t, references["agencies"])
+			} else {
+				assert.NotEmpty(t, references["agencies"])
+			}
+		})
+	}
 }
 
 // TestScheduleForStopQueryValidation verifies the SQL query logic


### PR DESCRIPTION
Fixes #1376
Fixes #1381

## What changed

Two defects in the references block of `schedule-for-stop`, three lines apart in the same handler.

**Stops with no routes returned empty references.** The handler bailed out with an empty references block as soon as a stop had no routes, before the `includeReferences` check further down. So a valid stop answered with its own ID in `entry.stopId` and no matching record in `references.stops`. The early return was only an optimization — `GetScheduleForStopOnDate` expands an empty route ID slice to `IN (NULL)` and returns no rows — so deleting it lets the normal path handle the case.

**Route and agency references were built from the queried day's schedule rows.** Both lists emptied out whenever no service was active: a holiday, a date outside the feed's validity period, or an expired feed. They now come from the routes serving the stop. `GetRoutesForStop` already selects every column the route reference needs, so the `GetRoutesByIDs` round trip goes away, and agencies derive from those routes instead of being seeded with the queried stop's agency.

## Spec

[Success Guarantees](https://github.com/OneBusAway/maglev/wiki/schedule-for-stop#success-guarantees) require the queried stop to appear in `data.references.stops`. Verified against `api.pugetsound.onebusaway.org`:

```
GET schedule-for-stop/40_C03.json           (Westlake Link station, no routes)
  references: stops 1, routes 0, agencies 0

GET schedule-for-stop/1_1010.json?date=2030-01-01   (outside feed validity)
  stopRouteSchedules []   references: stops 1, routes 2, agencies 1
```

Note that agencies are route-derived, so a stop with no routes returns an empty `agencies` list — #1376 asked for the stop's own agency there, which the reference server does not do.

## Tests

`TestScheduleForStopHandlerReferencesWithoutSchedule` covers a route-less stop, the same stop with `includeReferences=false`, and a served stop on a date with no active service.

`TestScheduleForStopHandlerEmptyRoutes` was replaced: it claimed to cover "stop with no routes" but used `mustGetStops`, which only returns stops that have stop times, so it never entered the path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stop schedule responses when no routes or scheduled service are available.
  * Preserved relevant stop, route, and agency references even when schedules are empty.
  * Respecting reference inclusion settings continues to provide only the requested data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->