### PR TITLE
Keep references.situations empty in routes-for-location

### DIFF
--- a/internal/restapi/routes_for_location_handler.go
+++ b/internal/restapi/routes_for_location_handler.go
@@ -51,11 +51,9 @@ func (api *RestAPI) routesForLocationHandler(w http.ResponseWriter, r *http.Requ
 	}
 
 	var results []models.Route
-	routeIDs := map[string]bool{}
 	agencyIDs := map[string]bool{}
 	for _, route := range routes {
 		agencyIDs[route.AgencyID] = true
-		routeIDs[route.ID] = true
 		results = append(results, models.NewRoute(
 			utils.FormCombinedID(route.AgencyID, route.ID),
 			route.AgencyID,
@@ -69,6 +67,8 @@ func (api *RestAPI) routesForLocationHandler(w http.ResponseWriter, r *http.Requ
 	}
 
 	references := models.NewEmptyReferences()
+	// Only agencies are referenced here: route beans carry no situation IDs, so
+	// references.situations stays empty even when alerts affect the returned routes.
 	// When includeReferences=false the references block is present but empty.
 	if ShouldIncludeReferences(r) {
 		agencyIDList := slices.Collect(maps.Keys(agencyIDs))
@@ -78,10 +78,6 @@ func (api *RestAPI) routesForLocationHandler(w http.ResponseWriter, r *http.Requ
 			return
 		}
 		references.Agencies = buildAgencyReferences(agencies)
-
-		// Populate situation references for alerts affecting the returned routes
-		alerts := api.collectAlertsForRoutes(slices.Collect(maps.Keys(routeIDs)))
-		references.Situations = api.BuildSituationReferences(alerts)
 	}
 
 	// Results must be sorted by ID after maxCount limit is applied.

--- a/internal/restapi/routes_for_location_handler_test.go
+++ b/internal/restapi/routes_for_location_handler_test.go
@@ -68,21 +68,16 @@ func TestRoutesForLocationHandlerIncludeReferences(t *testing.T) {
 	}
 }
 
-// TestRoutesForLocationHandlerSituationReferences verifies that a route-scoped
-// alert surfaces as a situation reference — the alert-collection branch feeding
-// data.references.situations had no coverage before this test.
-//
-// This is current maglev behavior, not the documented spec: the routes-for-location
-// wiki page states that references.situations is present but empty for this endpoint,
-// and its Implementation Decisions section has no entry recording a deviation. The
-// population comes from commit 4e09c1c, which added it across all non-trip handlers
-// (route, route-search, stops-search) rather than specifically for this endpoint.
-func TestRoutesForLocationHandlerSituationReferences(t *testing.T) {
+// TestRoutesForLocationHandlerSituationReferencesStayEmpty pins the spec's
+// references contract: only agencies is populated. An alert affecting a returned
+// route must not surface here, because route beans carry no situation IDs to
+// resolve — callers wanting alerts fetch them from a route- or trip-scoped
+// endpoint instead.
+func TestRoutesForLocationHandlerSituationReferencesStayEmpty(t *testing.T) {
 	api := createTestApi(t)
 
-	// testdata.Route19's combined ID is "25_3779"; GetAlertsForRoute matches on
-	// the raw (un-prefixed) route ID, and BuildSituationReferences keys the
-	// resulting situation by the alert's own ID, not the combined form.
+	// testdata.Route19's combined ID is "25_3779"; alerts are matched on the raw
+	// (un-prefixed) route ID, so this alert does affect a route the search returns.
 	rawRouteID := "3779"
 	api.GtfsManager.AddAlertForTest(gogtfs.Alert{
 		ID:               "test-alert-routes-for-location",
@@ -94,15 +89,11 @@ func TestRoutesForLocationHandlerSituationReferences(t *testing.T) {
 
 	_, model := callAPIHandler[RoutesResponse](t, api, baseURL)
 
-	situationIDs := make([]string, 0, len(model.Data.References.Situations))
-	for _, situation := range model.Data.References.Situations {
-		situationIDs = append(situationIDs, situation.ID)
-	}
-	assert.Contains(t, situationIDs, "test-alert-routes-for-location")
-
-	// With an alert actually present, includeReferences=false must still suppress it.
-	_, suppressedModel := callAPIHandler[RoutesResponse](t, api, baseURL+"&includeReferences=false")
-	assert.Empty(t, suppressedModel.Data.References.Situations)
+	assert.ElementsMatch(t, []models.Route{testdata.Route19}, model.Data.List,
+		"the alerted route is still returned in the list")
+	assert.Empty(t, model.Data.References.Situations)
+	assert.ElementsMatch(t, []models.AgencyReference{testdata.Raba}, model.Data.References.Agencies,
+		"agencies remain the one populated reference array")
 }
 
 func TestRoutesForLocationQuery(t *testing.T) {


### PR DESCRIPTION
Closes #1396

## What changed

`routes-for-location` no longer builds `references.situations`. The spec gives this endpoint one populated reference array, `agencies`, and route objects carry no situation IDs for a caller to resolve against.

Dropped the alert collection in `routesForLocationHandler` and the `routeIDs` map that only fed it. Agencies are untouched and still gated on `includeReferences`.

The existing situations test now asserts the opposite: with an alert injected on a route the search returns, `references.situations` stays empty while the route and its agency still appear.

## Verification

Compared against the deployed OneBusAway server on the same live Puget Sound feed.

Alert `1_92239` selects route `1_100016` with no stop or trip restriction — the only alert shape that reaches maglev's by-route index. At a stop on that route both servers return routes `1_100016` and `1_100017` and agency `1`:

| | situations |
|---|---|
| Deployed OBA | `[]` |
| maglev before | `['1_92239']` |
| maglev after | `[]` |

## Scope

Alerts naming both a route and a stop never enter the by-route index (`internal/gtfs/realtime.go:682`), so 70 of the 71 alerts live on that feed were already absent from this endpoint's output. Only route-only alerts change.

The other five `BuildSituationReferences` callers are out of scope — #1377 tracks those separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Route results now consistently include agency references while leaving situation references empty.
  * Alerted routes continue to appear correctly in route-for-location results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->