### PR TITLE
fix(restapi): account for extra query binds

### DIFF
--- a/internal/restapi/reference_utils.go
+++ b/internal/restapi/reference_utils.go
@@ -2,6 +2,7 @@ package restapi
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -508,19 +509,45 @@ func (api *RestAPI) buildStopModel(ctx context.Context, agencyID string, stop gt
 	}
 }
 
-// idsPerBatchedQuery bounds how many IDs go into one IN (...) list. SQLite
-// rejects a statement carrying more bind variables than it allows rather than
-// truncating it, and these ID sets are only bounded by how much the request
-// matched. Kept well under the oldest limit (999) so the batch size does not
-// depend on which SQLite the build links against.
+// sqliteBindVariableLimit is the oldest SQLite bind variable limit that Maglev
+// supports. Some builds allow more variables, but batching must be portable.
+const sqliteBindVariableLimit = 999
+
+// idsPerBatchedQuery is the largest batch used by a query with no other bind
+// variables. It is deliberately kept below sqliteBindVariableLimit.
 const idsPerBatchedQuery = 900
 
 // queryInBatches runs query over ids in batches small enough to stay under the
 // bind variable limit, concatenating the results.
 func queryInBatches[T any](ctx context.Context, ids []string, query func(context.Context, []string) ([]T, error)) ([]T, error) {
+	return queryInBatchesWithExtraBinds(ctx, ids, 0, query)
+}
+
+// queryInBatchesWithExtraBinds runs query over ids while reserving bind
+// variables used elsewhere in the statement, such as another sqlc.slice.
+// SQLite counts every bind in a statement, not only the list being batched.
+func queryInBatchesWithExtraBinds[ID any, T any](
+	ctx context.Context,
+	ids []ID,
+	extraBinds int,
+	query func(context.Context, []ID) ([]T, error),
+) ([]T, error) {
 	results := make([]T, 0, len(ids))
-	for start := 0; start < len(ids); start += idsPerBatchedQuery {
-		end := min(start+idsPerBatchedQuery, len(ids))
+	if len(ids) == 0 {
+		return results, nil
+	}
+
+	if extraBinds < 0 {
+		return nil, fmt.Errorf("extra bind count cannot be negative: %d", extraBinds)
+	}
+
+	batchSize := min(idsPerBatchedQuery, sqliteBindVariableLimit-extraBinds)
+	if batchSize <= 0 {
+		return nil, fmt.Errorf("query uses %d non-batched bind variables, exceeding SQLite's limit of %d", extraBinds, sqliteBindVariableLimit)
+	}
+
+	for start := 0; start < len(ids); start += batchSize {
+		end := min(start+batchSize, len(ids))
 		batch, err := query(ctx, ids[start:end])
 		if err != nil {
 			return nil, err
@@ -528,6 +555,23 @@ func queryInBatches[T any](ctx context.Context, ids []string, query func(context
 		results = append(results, batch...)
 	}
 	return results, nil
+}
+
+// tripsByBlockIDs loads trips in batches sized for both block IDs and service
+// IDs. GetTripsByBlockIDs has one sqlc.slice for each, so passing a full block
+// batch without reserving the service-ID binds can exceed SQLite's limit.
+func (api *RestAPI) tripsByBlockIDs(
+	ctx context.Context,
+	blockIDs []sql.NullString,
+	serviceIDs []string,
+) ([]gtfsdb.GetTripsByBlockIDsRow, error) {
+	return queryInBatchesWithExtraBinds(ctx, blockIDs, len(serviceIDs),
+		func(ctx context.Context, batch []sql.NullString) ([]gtfsdb.GetTripsByBlockIDsRow, error) {
+			return api.GtfsManager.GtfsDB.Queries.GetTripsByBlockIDs(ctx, gtfsdb.GetTripsByBlockIDsParams{
+				BlockIds:   batch,
+				ServiceIds: serviceIDs,
+			})
+		})
 }
 
 // stopReferences builds the stop reference block for a set of list entries,

--- a/internal/restapi/reference_utils.go
+++ b/internal/restapi/reference_utils.go
@@ -565,9 +565,29 @@ func (api *RestAPI) tripsByBlockIDs(
 	blockIDs []sql.NullString,
 	serviceIDs []string,
 ) ([]gtfsdb.GetTripsByBlockIDsRow, error) {
-	return queryInBatchesWithExtraBinds(ctx, blockIDs, len(serviceIDs),
+	return queryTripsByBlockIDs(ctx, blockIDs, serviceIDs,
+		api.GtfsManager.GtfsDB.Queries.GetTripsByBlockIDs)
+}
+
+func queryTripsByBlockIDs(
+	ctx context.Context,
+	blockIDs []sql.NullString,
+	serviceIDs []string,
+	query func(context.Context, gtfsdb.GetTripsByBlockIDsParams) ([]gtfsdb.GetTripsByBlockIDsRow, error),
+) ([]gtfsdb.GetTripsByBlockIDsRow, error) {
+	uniqueBlockIDs := make([]sql.NullString, 0, len(blockIDs))
+	seen := make(map[sql.NullString]struct{}, len(blockIDs))
+	for _, blockID := range blockIDs {
+		if _, exists := seen[blockID]; exists {
+			continue
+		}
+		seen[blockID] = struct{}{}
+		uniqueBlockIDs = append(uniqueBlockIDs, blockID)
+	}
+
+	return queryInBatchesWithExtraBinds(ctx, uniqueBlockIDs, len(serviceIDs),
 		func(ctx context.Context, batch []sql.NullString) ([]gtfsdb.GetTripsByBlockIDsRow, error) {
-			return api.GtfsManager.GtfsDB.Queries.GetTripsByBlockIDs(ctx, gtfsdb.GetTripsByBlockIDsParams{
+			return query(ctx, gtfsdb.GetTripsByBlockIDsParams{
 				BlockIds:   batch,
 				ServiceIds: serviceIDs,
 			})

--- a/internal/restapi/reference_utils_test.go
+++ b/internal/restapi/reference_utils_test.go
@@ -2,7 +2,9 @@ package restapi
 
 import (
 	"context"
+	"database/sql"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"slices"
@@ -218,6 +220,50 @@ func TestQueryInBatches(t *testing.T) {
 
 		require.Error(t, err)
 	})
+
+	t.Run("Rejects a negative extra bind count without querying", func(t *testing.T) {
+		queried := false
+		_, err := queryInBatchesWithExtraBinds(ctx, []string{"id"}, -1,
+			func(context.Context, []string) ([]string, error) {
+				queried = true
+				return nil, nil
+			})
+
+		require.Error(t, err)
+		assert.False(t, queried)
+	})
+}
+
+func TestQueryTripsByBlockIDs(t *testing.T) {
+	ctx := context.Background()
+	blockIDs := make([]sql.NullString, 0, idsPerBatchedQuery+1)
+	for i := 0; i < idsPerBatchedQuery; i++ {
+		blockIDs = append(blockIDs, sql.NullString{String: fmt.Sprintf("block-%d", i), Valid: true})
+	}
+	blockIDs = append(blockIDs, blockIDs[0]) // Repeated across the input batch boundary.
+
+	batchSizes := make([]int, 0, 2)
+	rows, err := queryTripsByBlockIDs(ctx, blockIDs, make([]string, 100),
+		func(_ context.Context, params gtfsdb.GetTripsByBlockIDsParams) ([]gtfsdb.GetTripsByBlockIDsRow, error) {
+			batchSizes = append(batchSizes, len(params.BlockIds))
+			rows := make([]gtfsdb.GetTripsByBlockIDsRow, 0, len(params.BlockIds))
+			for _, blockID := range params.BlockIds {
+				rows = append(rows, gtfsdb.GetTripsByBlockIDsRow{ID: blockID.String})
+			}
+			return rows, nil
+		})
+
+	require.NoError(t, err)
+	assert.Equal(t, []int{899, 1}, batchSizes)
+	assert.Len(t, rows, idsPerBatchedQuery)
+	returnedIDs := make(map[string]int, len(rows))
+	for _, row := range rows {
+		returnedIDs[row.ID]++
+	}
+	assert.Len(t, returnedIDs, idsPerBatchedQuery)
+	for _, count := range returnedIDs {
+		assert.Equal(t, 1, count)
+	}
 }
 
 func TestStopReferences(t *testing.T) {

--- a/internal/restapi/reference_utils_test.go
+++ b/internal/restapi/reference_utils_test.go
@@ -188,6 +188,36 @@ func TestQueryInBatches(t *testing.T) {
 		require.Error(t, err)
 		assert.Equal(t, 1, batches, "the remaining batches must not run once one fails")
 	})
+
+	t.Run("Reserves binds used by another slice", func(t *testing.T) {
+		// A 900-ID batch plus 99 service IDs and one fixed bind would exceed
+		// SQLite's oldest supported limit of 999. The first ID batch must
+		// therefore be 899.
+		ids := make([]string, idsPerBatchedQuery)
+		batchSizes := make([]int, 0, 2)
+		const extraBinds = 99 + 1
+		results, err := queryInBatchesWithExtraBinds(ctx, ids, extraBinds,
+			func(_ context.Context, batch []string) ([]string, error) {
+				batchSizes = append(batchSizes, len(batch))
+				if len(batch)+extraBinds > sqliteBindVariableLimit {
+					return nil, errors.New("SQLite bind variable limit exceeded")
+				}
+				return batch, nil
+			})
+
+		require.NoError(t, err)
+		assert.Equal(t, []int{899, 1}, batchSizes)
+		assert.Len(t, results, len(ids))
+	})
+
+	t.Run("Rejects too many non-batched binds", func(t *testing.T) {
+		_, err := queryInBatchesWithExtraBinds(ctx, []string{"id"}, sqliteBindVariableLimit,
+			func(context.Context, []string) ([]string, error) {
+				return nil, nil
+			})
+
+		require.Error(t, err)
+	})
 }
 
 func TestStopReferences(t *testing.T) {

--- a/internal/restapi/schedule_for_stop_handler.go
+++ b/internal/restapi/schedule_for_stop_handler.go
@@ -133,10 +133,7 @@ func (api *RestAPI) scheduleForStopHandler(w http.ResponseWriter, r *http.Reques
 			return
 		}
 		if len(activeServiceIDs) > 0 {
-			blockTrips, err := api.GtfsManager.GtfsDB.Queries.GetTripsByBlockIDs(ctx, gtfsdb.GetTripsByBlockIDsParams{
-				BlockIds:   uniqueBlockIDs,
-				ServiceIds: activeServiceIDs,
-			})
+			blockTrips, err := api.tripsByBlockIDs(ctx, uniqueBlockIDs, activeServiceIDs)
 			if err != nil {
 				api.serverErrorResponse(w, r, err)
 				return

--- a/internal/restapi/stops_for_location_handler.go
+++ b/internal/restapi/stops_for_location_handler.go
@@ -316,10 +316,13 @@ func (api *RestAPI) routeIDsByStop(
 		return byStop, nil
 	}
 
-	rows, err := api.GtfsManager.GtfsDB.Queries.GetActiveRouteIDsForStopsOnDate(ctx, gtfsdb.GetActiveRouteIDsForStopsOnDateParams{
-		StopIds:    stopIDs,
-		ServiceIds: activeServiceIDs,
-	})
+	rows, err := queryInBatchesWithExtraBinds(ctx, stopIDs, len(activeServiceIDs),
+		func(ctx context.Context, batch []string) ([]gtfsdb.GetActiveRouteIDsForStopsOnDateRow, error) {
+			return api.GtfsManager.GtfsDB.Queries.GetActiveRouteIDsForStopsOnDate(ctx, gtfsdb.GetActiveRouteIDsForStopsOnDateParams{
+				StopIds:    batch,
+				ServiceIds: activeServiceIDs,
+			})
+		})
 	if err != nil {
 		return nil, err
 	}

--- a/internal/restapi/trips_for_location_handler.go
+++ b/internal/restapi/trips_for_location_handler.go
@@ -399,12 +399,7 @@ func (api *RestAPI) buildTripsForLocationEntries(
 				blockIDsNull = append(blockIDsNull, nulls.String(id))
 			}
 
-			params := gtfsdb.GetTripsByBlockIDsParams{
-				BlockIds:   blockIDsNull,
-				ServiceIds: services[agencyID].QueryDay,
-			}
-
-			blockTripsRaw, err := api.GtfsManager.GtfsDB.Queries.GetTripsByBlockIDs(ctx, params)
+			blockTripsRaw, err := api.tripsByBlockIDs(ctx, blockIDsNull, services[agencyID].QueryDay)
 			if err == nil {
 				missingRouteIDs := make([]string, 0)
 				for _, bt := range blockTripsRaw {

--- a/internal/restapi/trips_for_route_handler.go
+++ b/internal/restapi/trips_for_route_handler.go
@@ -566,10 +566,7 @@ func (api *RestAPI) buildBlockTripForRoute(
 		allServiceIDs = append(allServiceIDs, prevServiceIDs...)
 	}
 
-	blockTrips, err := api.GtfsManager.GtfsDB.Queries.GetTripsByBlockIDs(ctx, gtfsdb.GetTripsByBlockIDsParams{
-		BlockIds:   interlinedBlockIDs,
-		ServiceIds: allServiceIDs,
-	})
+	blockTrips, err := api.tripsByBlockIDs(ctx, interlinedBlockIDs, allServiceIDs)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary

- Reserve SQLite bind capacity for fixed parameters and secondary sqlc.slice values.
- Batch block-trip and active-route queries to stay within the 999-variable compatibility limit.
- Add regression coverage for a full ID batch with service-ID and fixed binds.

Closes #1367

## Testing

- CGO_ENABLED=1 go test -tags "sqlite_fts5 sqlite_math_functions" ./internal/restapi