### PR TITLE
Prefix situation IDs on the remaining endpoints

### DIFF
--- a/internal/restapi/reference_utils.go
+++ b/internal/restapi/reference_utils.go
@@ -717,6 +717,18 @@ func (api *RestAPI) situationReferences(refs []situationRef) []models.Situation 
 	return situations
 }
 
+// situationReferencesForAlerts builds a situation reference block carrying the
+// agency-prefixed IDs that trip-details and trip-for-vehicle already publish,
+// rather than the raw feed IDs BuildSituationReferences stamps.
+//
+// fallbackAgencyID is consulted only for an alert that names no agency of its
+// own. Callers whose result set spans agencies pass "", because there is no
+// single agency the alert can honestly be scoped to; such an alert keeps its
+// raw ID, as it did before.
+func (api *RestAPI) situationReferencesForAlerts(alerts []gtfs.Alert, fallbackAgencyID string) []models.Situation {
+	return api.situationReferences(situationRefsFromAlerts(alerts, fallbackAgencyID))
+}
+
 func (rb *referenceBuilder) getAgenciesList() []models.AgencyReference {
 	agencies := make([]models.AgencyReference, 0, len(rb.presentAgencies))
 	for _, agency := range rb.presentAgencies {

--- a/internal/restapi/route_handler.go
+++ b/internal/restapi/route_handler.go
@@ -63,7 +63,7 @@ func (api *RestAPI) routeHandler(w http.ResponseWriter, r *http.Request) {
 
 	// Populate situation references for alerts affecting this route
 	alerts := api.GtfsManager.GetAlertsForRoute(routeID)
-	situations := api.BuildSituationReferences(alerts)
+	situations := api.situationReferencesForAlerts(alerts, agencyID)
 	references.Situations = append(references.Situations, situations...)
 
 	response := models.NewEntryResponse(routeData, *references, api.Clock)

--- a/internal/restapi/route_handler_test.go
+++ b/internal/restapi/route_handler_test.go
@@ -129,7 +129,10 @@ func TestRouteHandlerWithSituations(t *testing.T) {
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.Len(t, model.Data.References.Situations, 1,
 		"expected exactly one situation matching the seeded alert")
-	assert.Equal(t, alertID, model.Data.References.Situations[0].ID)
+	// The alert names no agency of its own, so the situation ID carries the
+	// prefix of the agency whose route was requested, matching trip-details.
+	assert.Equal(t, utils.FormCombinedID(testdata.Route1.AgencyID, alertID),
+		model.Data.References.Situations[0].ID)
 }
 
 // TestRouteHandler_IncludeReferencesFalse verifies that when includeReferences=false,

--- a/internal/restapi/route_search_handler.go
+++ b/internal/restapi/route_search_handler.go
@@ -79,7 +79,7 @@ func (api *RestAPI) routeSearchHandler(w http.ResponseWriter, r *http.Request) {
 			resultRawRouteIDs = append(resultRawRouteIDs, routeRow.ID)
 		}
 		alerts := api.collectAlertsForRoutes(resultRawRouteIDs)
-		situations := api.BuildSituationReferences(alerts)
+		situations := api.situationReferencesForAlerts(alerts, "")
 
 		references.Agencies = agencies
 		references.Situations = situations

--- a/internal/restapi/search_stops_handler.go
+++ b/internal/restapi/search_stops_handler.go
@@ -234,7 +234,7 @@ func (api *RestAPI) searchStopsHandler(w http.ResponseWriter, r *http.Request) {
 
 		// Populate situation references for alerts affecting the returned stops
 		alerts := api.collectAlertsForStops(keptStopIDs)
-		situations := api.BuildSituationReferences(alerts)
+		situations := api.situationReferencesForAlerts(alerts, "")
 		references.Situations = append(references.Situations, situations...)
 
 		var parentRoutes map[string]gtfsdb.GetRoutesForStopsRow

--- a/internal/restapi/situation_references_test.go
+++ b/internal/restapi/situation_references_test.go
@@ -288,6 +288,56 @@ func TestSituationRefsFromAlertsAgencyScope(t *testing.T) {
 	}
 }
 
+// TestSituationReferencesForAlertsNoFallbackAgency covers the endpoints whose
+// result set spans agencies and therefore pass no fallback: an alert naming its
+// own agency is still prefixed, and only an alert naming none keeps its raw ID.
+func TestSituationReferencesForAlertsNoFallbackAgency(t *testing.T) {
+	api := createTestApi(t)
+	defer api.Shutdown()
+
+	informedAgencyID := "1"
+	stopID := "10190"
+
+	tests := []struct {
+		name   string
+		alert  gogtfs.Alert
+		wantID string
+	}{
+		{
+			name: "The alert's own agency is used even with no fallback",
+			alert: gogtfs.Alert{
+				ID:               "86736",
+				InformedEntities: []gogtfs.AlertInformedEntity{{AgencyID: &informedAgencyID}},
+			},
+			wantID: "1_86736",
+		},
+		{
+			name: "An alert naming no agency keeps the raw feed ID",
+			alert: gogtfs.Alert{
+				ID:               "86736",
+				InformedEntities: []gogtfs.AlertInformedEntity{{StopID: &stopID}},
+			},
+			wantID: "86736",
+		},
+		{
+			name: "A self-prefixed feed ID is not prefixed twice",
+			alert: gogtfs.Alert{
+				ID:               "1_86736",
+				InformedEntities: []gogtfs.AlertInformedEntity{{AgencyID: &informedAgencyID}},
+			},
+			wantID: "1_86736",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			situations := api.situationReferencesForAlerts([]gogtfs.Alert{tt.alert}, "")
+			require.Len(t, situations, 1)
+			assert.Equal(t, tt.wantID, situations[0].ID)
+		})
+	}
+}
+
 func TestSituationID(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/internal/restapi/stops_for_location_handler.go
+++ b/internal/restapi/stops_for_location_handler.go
@@ -248,7 +248,7 @@ func (api *RestAPI) stopsForLocationHandler(w http.ResponseWriter, r *http.Reque
 
 		references.Agencies = agencies
 		references.Routes = routes
-		references.Situations = api.BuildSituationReferences(alerts)
+		references.Situations = api.situationReferencesForAlerts(alerts, "")
 	}
 
 	response := models.NewListResponseWithRange(results, *references, outOfRange, api.Clock, isLimitExceeded)

--- a/internal/restapi/vehicles_for_agency_handler.go
+++ b/internal/restapi/vehicles_for_agency_handler.go
@@ -250,7 +250,7 @@ func (api *RestAPI) vehiclesForAgencyHandler(w http.ResponseWriter, r *http.Requ
 			api.collectAlertsForRoutes(routeIDs),
 			api.GtfsManager.GetAlertsByIDs("", "", id),
 		)
-		references.Situations = append(references.Situations, api.BuildSituationReferences(alerts)...)
+		references.Situations = append(references.Situations, api.situationReferencesForAlerts(alerts, id)...)
 	}
 
 	// Spec: this endpoint returns all matching vehicles, so limitExceeded is always false.

--- a/internal/restapi/vehicles_for_agency_handler_test.go
+++ b/internal/restapi/vehicles_for_agency_handler_test.go
@@ -25,6 +25,7 @@ import (
 	"maglev.onebusaway.org/internal/models"
 	"maglev.onebusaway.org/internal/nulls"
 	"maglev.onebusaway.org/internal/restapi/testdata"
+	"maglev.onebusaway.org/internal/utils"
 )
 
 // vehiclesForAgencyURL builds the /vehicles-for-agency URL with key=TEST baked in.
@@ -199,14 +200,17 @@ func TestVehiclesForAgencyHandler_SituationsPopulatedInReferences(t *testing.T) 
 
 	require.NotEmpty(t, model.Data.List, "mock vehicle not returned by VehiclesForAgencyID")
 	require.NotEmpty(t, model.Data.References.Situations, "expected at least one situation in references")
+	// The alert names only a route, so the ID falls back to the agency the
+	// request asked about.
+	wantID := utils.FormCombinedID(testdata.Raba.ID, alertID)
 	found := false
 	for _, sit := range model.Data.References.Situations {
-		if sit.ID == alertID {
+		if sit.ID == wantID {
 			found = true
 			break
 		}
 	}
-	assert.True(t, found, "expected situation with id %q in references.situations", alertID)
+	assert.True(t, found, "expected situation with id %q in references.situations", wantID)
 }
 
 // TestVehiclesForAgencyHandler_AgencySituationsPopulatedInReferences verifies that
@@ -232,14 +236,16 @@ func TestVehiclesForAgencyHandler_AgencySituationsPopulatedInReferences(t *testi
 
 	require.NotEmpty(t, model.Data.List, "mock vehicle not returned by VehiclesForAgencyID")
 	require.NotEmpty(t, model.Data.References.Situations, "expected agency-wide alert in references.situations")
+	// The alert names the agency itself, so that is the prefix it carries.
+	wantID := utils.FormCombinedID(agencyID, alertID)
 	found := false
 	for _, sit := range model.Data.References.Situations {
-		if sit.ID == alertID {
+		if sit.ID == wantID {
 			found = true
 			break
 		}
 	}
-	assert.True(t, found, "expected situation with id %q in references.situations", alertID)
+	assert.True(t, found, "expected situation with id %q in references.situations", wantID)
 }
 
 func TestVehiclesForAgencyHandler_RouteIDUsesCombinedID(t *testing.T) {


### PR DESCRIPTION
Migrates the five endpoints that still stamp raw feed IDs onto the agency-prefixed convention `trip-details` and `trip-for-vehicle` already use.

The archaeology #1377 asks for is in [my comment there](https://github.com/OneBusAway/maglev/issues/1377#issuecomment-5461499185). Short version: `BuildSituationReferences` has stamped `ID: alert.ID` since `0c4e274` on 2025-12-16, when raw IDs were the only convention that existed. `situationID()` and `agencyIDForAlert()` arrived eight months later in `0af3b41`, `9185418` and `6033fa4`, applied only where the trip work needed them. Nothing in the history argues for keeping raw IDs at the other callers, so this reads as drift rather than a decision.

## What changed

One helper, `situationReferencesForAlerts`, composing the two existing functions, and five call sites moved onto it.

| Endpoint | Fallback agency |
|---|---|
| `route_handler.go` | the requested agency |
| `vehicles_for_agency_handler.go` | the requested agency |
| `search_stops_handler.go` | none |
| `route_search_handler.go` | none |
| `stops_for_location_handler.go` | none |

`agencyIDForAlert` prefers the alert's own informed entity and only consults the fallback when the alert names no agency. So the three multi-agency endpoints, which can return results from several agencies in one response and therefore have no honest single agency to use, still prefix any alert that names its own, and leave the rest exactly as they are today.

**Note the issue lists six endpoints and only five remain.** `routes_for_location_handler.go` stopped calling `BuildSituationReferences` at some point and now leaves `references.situations` empty entirely, with a comment at line 71 saying as much. That looks like a separate bug and is deliberately not touched here.

## Blast radius

Exactly **three existing assertions changed**, all at the two single-agency endpoints: `TestRouteHandlerWithSituations` and the two `TestVehiclesForAgencyHandler_*SituationsPopulatedInReferences`. Nothing in the multi-agency tests moved, which is the evidence that the empty fallback is a no-op there rather than an assertion I quietly relaxed.

Added `TestSituationReferencesForAlertsNoFallbackAgency` covering the empty-fallback path that no handler test reaches: alert names its own agency and is prefixed, alert names none and keeps its raw ID, feed ID already self-prefixed and is not prefixed twice.

Since Puget Sound's feed self-prefixes its alert IDs, `situationID` is idempotent on production data and published IDs do not move for the deployment this actually hits.

## One behaviour change worth flagging

`situationRefsFromAlerts` skips alerts with an empty ID, which `BuildSituationReferences` included. An alert with no ID cannot be referenced by any entry's `situationIds`, so it was already unreachable, but it does mean such an alert now disappears from `references.situations` instead of appearing as a blank-ID entry. Say the word if you would rather preserve it.

## Deliberately left out

The residual gap on the three multi-agency endpoints. Closing it properly means threading the matched stop or route back to each alert so the alert's agency can be derived from what it matched, and `collectAlertsForStops` discards that association today. That is a larger change than this issue calls for, and it is a design question rather than a fix, so it belongs to you rather than to this PR.

The wiki updates in the issue's third bullet are held until the migration question is settled, since the text depends on the answer.

## Checks

`go vet` under both `sqlite_fts5 sqlite_math_functions` and `purego`, `go fmt`, and `make test` all pass locally.

Refs #1377


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Situation references now include the correct agency context across routes, vehicles, stops, and searches.
  * Alerts without an agency continue using their original identifiers when results span multiple agencies.
  * Prevented agency prefixes from being duplicated on already-prefixed alert IDs.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->