### PR TITLE
ci: scope packages:write to the jobs that need it

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -11,12 +11,14 @@ on:
 
 permissions:
   contents: read
-  packages: write
 
 jobs:
   # Push to GHCR on every main branch commit; build-only on PRs
   buildx:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
     steps:

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -5,7 +5,6 @@ on:
 
 permissions:
   contents: read
-  packages: write
 
 jobs:
   # Push to Docker Hub on published releases (non-prerelease only)


### PR DESCRIPTION
Closes #917.

`#917` asks for `packages: write` to move from the workflow level to the jobs that need it. Two
notes from doing it, one of which changes the fix.

**`docker-publish.yml`** pushes to GHCR and authenticates with the workflow token:

```yaml
registry: ghcr.io
username: ${{ github.actor }}
password: ${{ secrets.GITHUB_TOKEN }}
```

so it does need `packages: write`, and this moves it onto the `buildx` job.

**`docker-release.yml`** is the one worth a second look. It logs in to Docker Hub with
`DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN` and pushes `opentransitsoftwarefoundation/maglev`. It
never touches GHCR, and `packages: write` only ever scopes the `GITHUB_TOKEN` against GitHub
Packages. So there the permission is not misplaced, it is unused, and this removes it instead of
relocating it.

The issue lists `buildx-release` as a job in `docker-publish.yml`. It is actually in
`docker-release.yml`, which is why this touches two files rather than one.

One thing this does not fix: `docker-publish.yml` also runs on `pull_request`, where it builds
without pushing (`push: ${{ github.event_name != 'pull_request' }}`). The token still carries
`packages: write` on those runs, because `permissions` cannot be made conditional on the event.
Splitting the PR build into its own job would close that gap. Happy to do it here or leave it,
whichever you prefer.

Each file has a single job today, so this is mostly future-proofing: it means a job added later
does not silently inherit registry write access.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container publishing permissions to follow job-specific access controls.
  * Restricted container release workflows to read-only repository access where publishing permissions are not required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->