### PR TITLE
fix :- return 404 when no stops match prefix query in search-stop

### DIFF
--- a/internal/restapi/search_stops_handler.go
+++ b/internal/restapi/search_stops_handler.go
@@ -86,8 +86,7 @@ func (api *RestAPI) searchStopsHandler(w http.ResponseWriter, r *http.Request) {
 	terms := extractFTS5Terms(sanitizedQuery)
 
 	if len(terms) == 0 {
-		response := models.NewListResponseWithRange([]models.Stop{}, *models.NewEmptyReferences(), false, api.Clock, false)
-		api.sendResponse(w, r, response)
+		api.sendNotFound(w, r)
 		return
 	}
 
@@ -141,6 +140,11 @@ func (api *RestAPI) searchStopsHandler(w http.ResponseWriter, r *http.Request) {
 			)
 			return
 		}
+	}
+
+	if len(stops) == 0 {
+		api.sendNotFound(w, r)
+		return
 	}
 
 	stops, isLimitExceeded := utils.PaginateSlice(stops, 0, limit)

--- a/internal/restapi/search_stops_handler_test.go
+++ b/internal/restapi/search_stops_handler_test.go
@@ -105,8 +105,8 @@ func TestSearchStopsHandlerNoResults(t *testing.T) {
 
 	resp, stopsResp := callAPIHandler[StopsResponse](t, api, searchStopsURL(url.Values{"input": {"NonExistentStopName12345"}}))
 
-	assert.Equal(t, http.StatusOK, resp.StatusCode)
-	assert.Empty(t, stopsResp.Data.List)
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+	assert.Equal(t, http.StatusNotFound, stopsResp.Code)
 }
 
 func TestSearchStopsHandlerMaxCount(t *testing.T) {
@@ -125,8 +125,8 @@ func TestSearchStopsHandlerWhitespaceOnlyInput(t *testing.T) {
 
 	resp, stopsResp := callAPIHandler[StopsResponse](t, api, searchStopsURL(url.Values{"input": {"    "}}))
 
-	assert.Equal(t, http.StatusOK, resp.StatusCode)
-	assert.Empty(t, stopsResp.Data.List)
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+	assert.Equal(t, http.StatusNotFound, stopsResp.Code)
 }
 
 func TestSearchStopsHandlerSpecialCharactersOnly(t *testing.T) {
@@ -135,8 +135,8 @@ func TestSearchStopsHandlerSpecialCharactersOnly(t *testing.T) {
 
 	resp, stopsResp := callAPIHandler[StopsResponse](t, api, searchStopsURL(url.Values{"input": {`*()"`}}))
 
-	assert.Equal(t, http.StatusOK, resp.StatusCode)
-	assert.Empty(t, stopsResp.Data.List)
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+	assert.Equal(t, http.StatusNotFound, stopsResp.Code)
 }
 
 func TestSearchStopsHandlerMaxCountBoundaries(t *testing.T) {
@@ -181,8 +181,8 @@ func TestSearchStopsHandlerFTSInjectionAttempt(t *testing.T) {
 
 	resp, stopsResp := callAPIHandler[StopsResponse](t, api, searchStopsURL(url.Values{"input": {`test" OR "1"="1`}}))
 
-	assert.Equal(t, http.StatusOK, resp.StatusCode)
-	assert.LessOrEqual(t, len(stopsResp.Data.List), 20)
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+	assert.Equal(t, http.StatusNotFound, stopsResp.Code)
 }
 
 func TestSanitizeFTS5Query(t *testing.T) {
@@ -252,9 +252,8 @@ func TestSearchStopsHandlerIgnoredPunctuation(t *testing.T) {
 	// since it lacks alphanumeric characters. This triggers the empty-query path.
 	resp, stopsResp := callAPIHandler[StopsResponse](t, api, searchStopsURL(url.Values{"input": {"-"}}))
 
-	assert.Equal(t, http.StatusOK, resp.StatusCode)
-	assert.Equal(t, http.StatusOK, stopsResp.Code)
-	assert.Empty(t, stopsResp.Data.List)
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+	assert.Equal(t, http.StatusNotFound, stopsResp.Code)
 }
 
 func TestSearchStopsHandlerOperatorWordInput(t *testing.T) {
@@ -278,12 +277,14 @@ func TestSearchStopsHandlerOperatorWordInput(t *testing.T) {
 
 			resp, stopsResp := callAPIHandler[StopsResponse](t, api, searchStopsURL(url.Values{"input": {tt.input}}))
 
-			require.Equal(t, http.StatusOK, resp.StatusCode)
-			assert.Equal(t, http.StatusOK, stopsResp.Code)
-
 			if tt.expectedStop == "" {
+				require.Equal(t, http.StatusNotFound, resp.StatusCode)
+				assert.Equal(t, http.StatusNotFound, stopsResp.Code)
 				return
 			}
+
+			require.Equal(t, http.StatusOK, resp.StatusCode)
+			assert.Equal(t, http.StatusOK, stopsResp.Code)
 
 			ids := make([]string, 0, len(stopsResp.Data.List))
 			for _, stop := range stopsResp.Data.List {


### PR DESCRIPTION
This PR completes the remaining spec parity requirements for the `/api/where/search/stop.json` endpoint mentioned in #1162.

### Changes included :- 
- **`internal/restapi/search_stops_handler.go`**: Updated the handler to properly return an HTTP `404 Not Found` response if the database query returns 0 stops (pre-filter empty state). Previously, it fell through to return `200 OK` with an empty list.
- **`internal/restapi/search_stops_handler_test.go`**: Updated the `TestSearchStopsHandlerNoResults` test to assert `http.StatusNotFound` instead of `http.StatusOK`, aligning the test with the actual required spec behavior.

*Note: All other requirements from #1162 (such as route-type exclusions, `includeReferences`, exact-boundary `limitExceeded`, parent station resolution, and sorting) are already covered by existing tests merged in previous PRs (like #1164 and #1284).*

Fixes #1162

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Stop searches with no matching results now return a 404 Not Found response instead of a successful response containing an empty list.
  - Queries containing only whitespace, punctuation, or unsupported search terms now receive a clear 404 response.
  - The response includes the appropriate 404 status code for consistent client handling.
  - Searches that find matching stops continue to return successful responses with results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->