### PR TITLE
fix(block): reset distanceAlongBlock between configurations

### DIFF
--- a/internal/restapi/block_handler.go
+++ b/internal/restapi/block_handler.go
@@ -78,9 +78,9 @@ func transformBlockToEntry(block []gtfsdb.GetBlockDetailsRow, blockID, agencyID 
 
 	configurations := make([]models.BlockConfiguration, 0, len(serviceGroups))
 
-	var blockDistance float64
-
 	for _, serviceID := range serviceIDs {
+		var blockDistance float64
+
 		serviceStops := serviceGroups[serviceID]
 
 		config := &models.BlockConfiguration{

--- a/internal/restapi/block_handler_test.go
+++ b/internal/restapi/block_handler_test.go
@@ -222,41 +222,28 @@ func TestBlockHandlerContextCancellation(t *testing.T) {
 }
 
 func TestBlockHandlerCrossConfigurationDistanceReset(t *testing.T) {
-	// Construct a synthetic block with 2 distinct service IDs
-	rows := []gtfsdb.GetBlockDetailsRow{
-		{
-			ServiceID: "weekday", TripID: "trip1", StopSequence: 1, StopID: "stopA",
-			Lat: 0.0, Lon: 0.0,
-		},
-		{
-			ServiceID: "weekday", TripID: "trip1", StopSequence: 2, StopID: "stopB",
-			Lat: 1.0, Lon: 0.0,
-		},
-		{
-			ServiceID: "weekend", TripID: "trip2", StopSequence: 1, StopID: "stopC",
-			Lat: 0.0, Lon: 0.0,
-		},
-		{
-			ServiceID: "weekend", TripID: "trip2", StopSequence: 2, StopID: "stopD",
-			Lat: 1.0, Lon: 0.0,
-		},
-	}
+	api := createTestApi(t)
+	defer api.Shutdown()
 
-	entry := transformBlockToEntry(rows, "block_1", "agency")
+	resp, model := callAPIHandler[BlockEntryResponse](t, api, blockURL("25_1"))
 
-	require.Len(t, entry.Configurations, 2, "expected exactly 2 configurations")
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	entry := model.Data.Entry
+	require.GreaterOrEqual(t, len(entry.Configurations), 2, "expected at least 2 configurations")
 
 	config0 := entry.Configurations[0]
 	require.NotEmpty(t, config0.Trips)
-	require.NotEmpty(t, config0.Trips[0].BlockStopTimes)
+	require.GreaterOrEqual(t, len(config0.Trips[0].BlockStopTimes), 2, "expected at least 2 BlockStopTimes for config0")
 	assert.Equal(t, 0.0, config0.Trips[0].BlockStopTimes[0].DistanceAlongBlock, "Configuration 0 first stop should be 0")
-	assert.Greater(t, config0.Trips[0].BlockStopTimes[1].DistanceAlongBlock, 0.0, "Configuration 0 distance should accumulate")
+	assert.Greater(t, config0.Trips[0].BlockStopTimes[1].DistanceAlongBlock, 0.0, "Configuration 0 second stop should be > 0")
 
 	config1 := entry.Configurations[1]
 	require.NotEmpty(t, config1.Trips)
-	require.NotEmpty(t, config1.Trips[0].BlockStopTimes)
+	require.GreaterOrEqual(t, len(config1.Trips[0].BlockStopTimes), 2, "expected at least 2 BlockStopTimes for config1")
+	// On the merge base, this incorrectly returned 433750.77 instead of 0.0
 	assert.Equal(t, 0.0, config1.Trips[0].BlockStopTimes[0].DistanceAlongBlock, "Configuration 1 first stop should be 0")
-	assert.Greater(t, config1.Trips[0].BlockStopTimes[1].DistanceAlongBlock, 0.0, "Configuration 1 distance should accumulate normally")
+	assert.Greater(t, config1.Trips[0].BlockStopTimes[1].DistanceAlongBlock, 0.0, "Configuration 1 second stop should be > 0")
 }
 
 func BenchmarkBlockHandler(b *testing.B) {

--- a/internal/restapi/block_handler_test.go
+++ b/internal/restapi/block_handler_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"maglev.onebusaway.org/gtfsdb"
 	"maglev.onebusaway.org/internal/models"
 	"maglev.onebusaway.org/internal/restapi/testdata"
 )

--- a/internal/restapi/block_handler_test.go
+++ b/internal/restapi/block_handler_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"maglev.onebusaway.org/gtfsdb"
 	"maglev.onebusaway.org/internal/models"
 	"maglev.onebusaway.org/internal/restapi/testdata"
 )
@@ -218,6 +219,44 @@ func TestBlockHandlerContextCancellation(t *testing.T) {
 	mux.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusGatewayTimeout, w.Code)
+}
+
+func TestBlockHandlerCrossConfigurationDistanceReset(t *testing.T) {
+	// Construct a synthetic block with 2 distinct service IDs
+	rows := []gtfsdb.GetBlockDetailsRow{
+		{
+			ServiceID: "weekday", TripID: "trip1", StopSequence: 1, StopID: "stopA",
+			Lat: 0.0, Lon: 0.0,
+		},
+		{
+			ServiceID: "weekday", TripID: "trip1", StopSequence: 2, StopID: "stopB",
+			Lat: 1.0, Lon: 0.0,
+		},
+		{
+			ServiceID: "weekend", TripID: "trip2", StopSequence: 1, StopID: "stopC",
+			Lat: 0.0, Lon: 0.0,
+		},
+		{
+			ServiceID: "weekend", TripID: "trip2", StopSequence: 2, StopID: "stopD",
+			Lat: 1.0, Lon: 0.0,
+		},
+	}
+
+	entry := transformBlockToEntry(rows, "block_1", "agency")
+
+	require.Len(t, entry.Configurations, 2, "expected exactly 2 configurations")
+
+	config0 := entry.Configurations[0]
+	require.NotEmpty(t, config0.Trips)
+	require.NotEmpty(t, config0.Trips[0].BlockStopTimes)
+	assert.Equal(t, 0.0, config0.Trips[0].BlockStopTimes[0].DistanceAlongBlock, "Configuration 0 first stop should be 0")
+	assert.Greater(t, config0.Trips[0].BlockStopTimes[1].DistanceAlongBlock, 0.0, "Configuration 0 distance should accumulate")
+
+	config1 := entry.Configurations[1]
+	require.NotEmpty(t, config1.Trips)
+	require.NotEmpty(t, config1.Trips[0].BlockStopTimes)
+	assert.Equal(t, 0.0, config1.Trips[0].BlockStopTimes[0].DistanceAlongBlock, "Configuration 1 first stop should be 0")
+	assert.Greater(t, config1.Trips[0].BlockStopTimes[1].DistanceAlongBlock, 0.0, "Configuration 1 distance should accumulate normally")
 }
 
 func BenchmarkBlockHandler(b *testing.B) {


### PR DESCRIPTION
### Summary
Fixes #1427. Resolves a bug in `transformBlockToEntry` where the `blockDistance` accumulator was being erroneously carried across entirely distinct calendar configurations. This ensures that every new `BlockConfiguration` returned by the `/api/where/block/{id}.json` endpoint accurately tracks its own geometric offsets beginning from `0.0`.

### Root Cause
The `var blockDistance float64` accumulator was previously declared outside the iteration block over `serviceIDs`, meaning its value was never reset between independent service days.

### Fix
Scoped `var blockDistance float64` directly into the individual `serviceIDs` iteration loop.

### Tests
Added `TestBlockHandlerCrossConfigurationDistanceReset` to verify that `DistanceAlongBlock` is strictly `0.0` at the first stop of independent configurations belonging to the same block entity, without harming the distance accumulations on contiguous trips within that block.

### Scope
This PR is narrowly focused to **only** address the cross-configuration `blockDistance` leak described in #1427. It intentionally does **not** address the broader trip ordering mechanisms or the distinct within-trip `BlockSequence` incrementing behavior flagged in #1018.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed distance calculations so each service configuration starts at zero while continuing to accumulate correctly within that configuration.
  - Prevented distance values from carrying over between separate service configurations.

- **Tests**
  - Added coverage verifying distance resets and accumulation across multiple service configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->