### PR TITLE
Skip the bulk-insert time budget on Windows

### DIFF
--- a/gtfsdb/bulk_insert_test.go
+++ b/gtfsdb/bulk_insert_test.go
@@ -3,6 +3,7 @@ package gtfsdb
 import (
 	"context"
 	"database/sql"
+	"runtime"
 	"testing"
 	"time"
 
@@ -345,9 +346,12 @@ func TestBulkInsertPerformance(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, recordCount, count)
 
-	// Performance assertion: should complete in reasonable time (< 5 seconds for 10k records)
-	assert.Less(t, duration.Seconds(), 5.0,
-		"Bulk insert of %d records should complete in < 5 seconds (took %v)", recordCount, duration)
+	// Windows runners are too slow at SQLite file I/O to hold a wall-clock budget,
+	// the same reason cmd/api and internal/gtfs skip their timing tests there.
+	if runtime.GOOS != "windows" {
+		assert.Less(t, duration.Seconds(), 5.0,
+			"Bulk insert of %d records should complete in < 5 seconds (took %v)", recordCount, duration)
+	}
 
 	t.Logf("Bulk inserted %d stop_times in %v (~%.0f inserts/sec)",
 		recordCount, duration, float64(recordCount)/duration.Seconds())


### PR DESCRIPTION
TestBulkInsertPerformance asserts that inserting 10k stop_times finishes in under five seconds. On #1420 the Windows runner took 5.0675s and failed the build over that, which is a 1.4% overshoot on a wall-clock budget on a shared runner.

cmd/api/lock_safety_test.go and internal/gtfs/reload_test.go already skip on Windows, and both say the same thing, that its SQLite file I/O is too slow for a CI timeout. I gated only the timing assertion here, so the insert and the row-count check still run on Windows.

make test and make lint pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Adjusted bulk-insert performance checks so Windows validates insertion results without enforcing the five-second timing threshold.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->