### PR TITLE
fix(block): order block configuration trips chronologically

### DIFF
--- a/internal/restapi/block_handler.go
+++ b/internal/restapi/block_handler.go
@@ -94,18 +94,31 @@ func transformBlockToEntry(block []gtfsdb.GetBlockDetailsRow, blockID, agencyID 
 			tripStops[stop.TripID] = append(tripStops[stop.TripID], stop)
 		}
 
+		for _, stops := range tripStops {
+			slices.SortFunc(stops, func(a, b gtfsdb.GetBlockDetailsRow) int {
+				return cmp.Compare(a.StopSequence, b.StopSequence)
+			})
+		}
+
 		tripIDs := make([]string, 0, len(tripStops))
 		for tripID := range tripStops {
 			tripIDs = append(tripIDs, tripID)
 		}
-		slices.Sort(tripIDs)
+		slices.SortFunc(tripIDs, func(a, b string) int {
+			stopsA := tripStops[a]
+			stopsB := tripStops[b]
+
+			if c := cmp.Compare(stopsA[0].DepartureTime, stopsB[0].DepartureTime); c != 0 {
+				return c
+			}
+			if c := cmp.Compare(stopsA[0].ArrivalTime, stopsB[0].ArrivalTime); c != 0 {
+				return c
+			}
+			return cmp.Compare(a, b)
+		})
 
 		for _, tripID := range tripIDs {
 			stops := tripStops[tripID]
-
-			slices.SortFunc(stops, func(a, b gtfsdb.GetBlockDetailsRow) int {
-				return cmp.Compare(a.StopSequence, b.StopSequence)
-			})
 
 			var blockStopTimes []models.BlockStopTime
 			tripStartDistance := blockDistance

--- a/internal/restapi/block_handler_test.go
+++ b/internal/restapi/block_handler_test.go
@@ -10,8 +10,10 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"maglev.onebusaway.org/internal/clock"
 	"maglev.onebusaway.org/internal/models"
 	"maglev.onebusaway.org/internal/restapi/testdata"
+	"maglev.onebusaway.org/internal/utils"
 )
 
 // blockURL builds the /block endpoint URL with key=TEST baked in. Tests that
@@ -243,6 +245,89 @@ func TestBlockHandlerCrossConfigurationDistanceReset(t *testing.T) {
 	// On the merge base, this incorrectly returned 433750.77 instead of 0.0
 	assert.Equal(t, 0.0, config1.Trips[0].BlockStopTimes[0].DistanceAlongBlock, "Configuration 1 first stop should be 0")
 	assert.Greater(t, config1.Trips[0].BlockStopTimes[1].DistanceAlongBlock, 0.0, "Configuration 1 second stop should be > 0")
+}
+
+func TestBlockHandlerChronologicalTripOrdering(t *testing.T) {
+	const agencyID = "test-agency"
+
+	files := map[string]string{
+		"agency.txt": "agency_id,agency_name,agency_url,agency_timezone\n" +
+			agencyID + ",Test Agency,http://example.com,America/Los_Angeles\n",
+		"routes.txt": "route_id,agency_id,route_short_name,route_long_name,route_type\n" +
+			"r1," + agencyID + ",1,Route 1,3\n",
+		"calendar.txt": "service_id,monday,tuesday,wednesday,thursday,friday,saturday,sunday,start_date,end_date\n" +
+			"s1,1,1,1,1,1,1,1,20250101,20251231\n",
+		"stops.txt": "stop_id,stop_name,stop_lat,stop_lon\n" +
+			"stop1,Stop 1,40.0,-122.0\n" +
+			"stop2,Stop 2,40.1,-122.0\n" +
+			"stop3,Stop 3,40.2,-122.0\n",
+		"trips.txt": "trip_id,route_id,service_id,block_id\n" +
+			"trip_Z_morning,r1,s1,b1\n" +
+			"trip_M_midday,r1,s1,b1\n" +
+			"trip_A_evening,r1,s1,b1\n" +
+			"trip_X_night,r1,s1,b1\n",
+		"stop_times.txt": "trip_id,arrival_time,departure_time,stop_id,stop_sequence\n" +
+			// 1. Morning trip (08:00 - 08:30)
+			"trip_Z_morning,08:00:00,08:00:00,stop1,1\n" +
+			"trip_Z_morning,08:30:00,08:30:00,stop2,2\n" +
+			// 2. Midday trip (12:00 - 12:30)
+			"trip_M_midday,12:00:00,12:00:00,stop2,1\n" +
+			"trip_M_midday,12:30:00,12:30:00,stop3,2\n" +
+			// 3. Evening trip (17:00 - 17:30)
+			"trip_A_evening,17:00:00,17:00:00,stop3,1\n" +
+			"trip_A_evening,17:30:00,17:30:00,stop1,2\n" +
+			// 4. Post-midnight trip (25:30 - 26:00 = 01:30 - 02:00 next day)
+			"trip_X_night,25:30:00,25:30:00,stop1,1\n" +
+			"trip_X_night,26:00:00,26:00:00,stop2,2\n",
+	}
+
+	api := createTestApiWithGTFSFixture(t, clock.RealClock{}, "test_block_order.zip", files)
+
+	blockCombinedID := utils.FormCombinedID(agencyID, "b1")
+	resp, model := callAPIHandler[BlockEntryResponse](t, api, "/api/where/block/"+blockCombinedID+".json?key=TEST")
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NotEmpty(t, model.Data.Entry.Configurations)
+	config := model.Data.Entry.Configurations[0]
+	require.Len(t, config.Trips, 4)
+
+	// Explicitly assert operational trip sequence instead of alphabetical ID order:
+	expectedTripIDs := []string{
+		utils.FormCombinedID(agencyID, "trip_Z_morning"),
+		utils.FormCombinedID(agencyID, "trip_M_midday"),
+		utils.FormCombinedID(agencyID, "trip_A_evening"),
+		utils.FormCombinedID(agencyID, "trip_X_night"),
+	}
+	actualTripIDs := make([]string, len(config.Trips))
+	for i, tr := range config.Trips {
+		actualTripIDs[i] = tr.TripId
+	}
+	assert.Equal(t, expectedTripIDs, actualTripIDs, "Trips must be ordered chronologically by scheduled time, not lexicographically by trip ID")
+
+	// Verify chronological monotonicity (departure of trip[i-1] <= arrival of trip[i]):
+	for i := 1; i < len(config.Trips); i++ {
+		prevTrip := config.Trips[i-1]
+		currTrip := config.Trips[i]
+		prevDeparture := prevTrip.BlockStopTimes[len(prevTrip.BlockStopTimes)-1].StopTime.DepartureTime.Duration
+		currArrival := currTrip.BlockStopTimes[0].StopTime.ArrivalTime.Duration
+
+		assert.LessOrEqual(t, prevDeparture, currArrival,
+			"Chronological violation: Trip %d (%s ends at %v) must not end after Trip %d (%s starts at %v)",
+			i-1, prevTrip.TripId, prevDeparture, i, currTrip.TripId, currArrival)
+	}
+
+	// Verify DistanceAlongBlock starts at 0 for the first trip and is monotonically non-decreasing across consecutive trips:
+	assert.Equal(t, 0.0, config.Trips[0].BlockStopTimes[0].DistanceAlongBlock, "First stop of first trip in block must start at DistanceAlongBlock 0.0")
+	for i := 1; i < len(config.Trips); i++ {
+		prevTrip := config.Trips[i-1]
+		currTrip := config.Trips[i]
+		prevEndDist := prevTrip.BlockStopTimes[len(prevTrip.BlockStopTimes)-1].DistanceAlongBlock
+		currStartDist := currTrip.BlockStopTimes[0].DistanceAlongBlock
+
+		assert.GreaterOrEqual(t, currStartDist, prevEndDist,
+			"DistanceAlongBlock violation: Trip %d starts at %.1f m, which is before previous trip ended at %.1f m",
+			i, currStartDist, prevEndDist)
+	}
 }
 
 func BenchmarkBlockHandler(b *testing.B) {


### PR DESCRIPTION
Fixes #1438

### Summary

In `internal/restapi/block_handler.go`, block trips within each `BlockConfiguration` were previously collected from a map and sorted lexicographically by trip ID (`slices.Sort(tripIDs)`). This could produce trips in an order unrelated to their scheduled operation, causing incorrect trip ordering and corrupting cumulative `distanceAlongBlock` values across consecutive trips.

### Changes

- Pre-sort each trip's stops by `StopSequence` before using `stops[0]`.
- Replace lexical sorting of `tripIDs` with chronological ordering:
  1. First stop's scheduled `DepartureTime`
  2. First stop's scheduled `ArrivalTime`
  3. `tripID` as a deterministic tie-breaker
- Preserve GTFS service-day nanosecond time representation so post-midnight times (e.g. `25:30`) sort correctly.
- Add a focused regression test, `TestBlockHandlerChronologicalTripOrdering`, covering deliberately non-chronological trip IDs, including a post-midnight trip.
- Verify chronological trip ordering and non-decreasing `distanceAlongBlock` accumulation.

### Testing

- `go test -tags "purego" ./internal/restapi/...`
- `go test -tags "purego" ./...`

All tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Block trips are now displayed in chronological order based on scheduled departure and arrival times, including trips that continue past midnight.
  - Stop times are processed in sequence order for more accurate trip progression.
  - Distance tracking across consecutive trips is now maintained in non-decreasing order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->